### PR TITLE
Fix-Dropdown-Menu-Item

### DIFF
--- a/src/components/Layouts/Primary/TopBar/TopBar.tsx
+++ b/src/components/Layouts/Primary/TopBar/TopBar.tsx
@@ -381,7 +381,7 @@ const TopBar = ({ open, handleOpenChange }: Props): ReactElement => {
                         <ListItemText primary={t('Manage Coaches')} />
                     </MenuItem>
                 </HandoffLink>
-                {(data?.user?.admin || data?.user?.administrativeOrganizations?.nodes?.length) && (
+                {(data?.user?.admin || !!data?.user?.administrativeOrganizations?.nodes?.length) && (
                     <HandoffLink path="/preferences/organizations">
                         <MenuItem onClick={handleProfileMenuClose} component="a">
                             <ListItemText primary={t('Manage Organizations')} />


### PR DESCRIPTION
I noticed a small bug in the menu item so decided to fix it quickly(the zero under the ```Manage Coaches``` menu item). The issue was it was returning a number instead of a boolean.
<img width="252" alt="Screen Shot 2021-02-18 at 9 36 27 AM" src="https://user-images.githubusercontent.com/39680460/108373164-919aae80-71cd-11eb-9bad-ab15fe6691e1.png">
