### PR TITLE
MPDX-6944-Add-Delete-Button-Task-Detail-Drawer

### DIFF
--- a/pages/accountLists/[accountListId]/contacts.test.tsx
+++ b/pages/accountLists/[accountListId]/contacts.test.tsx
@@ -37,6 +37,6 @@ it('should render list of people', async () => {
   );
   // TODO: Fix custom mocks so we don't have to rely on finding first and checking if it matches a hardcoded random value
   expect((await findAllByRole('row'))[0]).toHaveTextContent(
-    'Stomach BrainCoffee Elephant Bee',
+    'Cup SandwichStar God Baby',
   );
 });

--- a/pages/accountLists/[accountListId]/contacts.test.tsx
+++ b/pages/accountLists/[accountListId]/contacts.test.tsx
@@ -28,15 +28,14 @@ it('should render list of people', async () => {
     <TestRouter router={router}>
       <GqlMockedProvider<ContactsQuery>
         mocks={{
-          contacts: { nodes: [{ name }] },
+          Contacts: {
+            contacts: { nodes: [{ name }] },
+          },
         }}
       >
         <Contacts />
       </GqlMockedProvider>
     </TestRouter>,
   );
-  // TODO: Fix custom mocks so we don't have to rely on finding first and checking if it matches a hardcoded random value
-  expect((await findAllByRole('row'))[0]).toHaveTextContent(
-    'Cup SandwichStar God Baby',
-  );
+  expect((await findAllByRole('row'))[0]).toHaveTextContent(name);
 });

--- a/src/components/Task/Drawer/Drawer.tsx
+++ b/src/components/Task/Drawer/Drawer.tsx
@@ -19,6 +19,7 @@ import { useApp } from '../../App';
 import Loading from '../../Loading';
 import TaskStatus from '../Status';
 import { Task } from '../../../../graphql/types.generated';
+import { TaskFilter } from '../List/List';
 import TaskDrawerForm from './Form';
 import TaskDrawerContactList from './ContactList';
 import TaskDrawerCommentList from './CommentList';
@@ -62,6 +63,8 @@ export interface TaskDrawerProps {
   onClose?: () => void;
   showCompleteForm?: boolean;
   defaultValues?: Partial<Task>;
+  filter?: TaskFilter;
+  rowsPerPage?: number;
 }
 
 const TaskDrawer = ({
@@ -69,6 +72,8 @@ const TaskDrawer = ({
   onClose,
   showCompleteForm,
   defaultValues,
+  filter,
+  rowsPerPage,
 }: TaskDrawerProps): ReactElement => {
   const { state } = useApp();
   const classes = useStyles();
@@ -209,6 +214,8 @@ const TaskDrawer = ({
                           task={task as Task} // TODO: Use fragments to ensure all required fields are loaded
                           onClose={onDrawerClose}
                           defaultValues={defaultValues}
+                          filter={filter}
+                          rowsPerPage={rowsPerPage}
                         />
                       )}
                     </>

--- a/src/components/Task/Drawer/Form/Form.mock.tsx
+++ b/src/components/Task/Drawer/Form/Form.mock.tsx
@@ -11,6 +11,8 @@ import { GetTaskForTaskDrawerQuery } from '../TaskDrawerTask.generated';
 import {
   CreateTaskDocument,
   CreateTaskMutation,
+  DeleteTaskDocument,
+  DeleteTaskMutation,
   GetDataForTaskDrawerDocument,
   GetDataForTaskDrawerQuery,
   UpdateTaskDocument,
@@ -131,6 +133,44 @@ export const updateTaskMutationMock = (): MockedResponse => {
       variables: {
         accountListId: 'abc',
         attributes,
+      },
+    },
+    result: { data },
+  };
+};
+
+export const deleteTaskMutationMock = (): MockedResponse => {
+  const task: GetTaskForTaskDrawerQuery['task'] = {
+    id: 'task-1',
+    activityType: ActivityTypeEnum.NewsletterEmail,
+    subject: 'On the Journey with the Johnson Family',
+    startAt: DateTime.local(2013, 1, 5, 1, 2).toISO(),
+    completedAt: DateTime.local(2016, 1, 5, 1, 2).toISO(),
+    tagList: ['tag-1', 'tag-2'],
+    contacts: {
+      nodes: [
+        { id: 'contact-1', name: 'Anderson, Robert' },
+        { id: 'contact-2', name: 'Smith, John' },
+      ],
+    },
+    user: { id: 'user-1', firstName: 'Robert', lastName: 'Anderson' },
+    notificationTimeBefore: 20,
+    notificationType: NotificationTypeEnum.Both,
+    notificationTimeUnit: NotificationTimeUnitEnum.Hours,
+  };
+
+  const data: DeleteTaskMutation = {
+    deleteTask: {
+      id: task.id,
+    },
+  };
+
+  return {
+    request: {
+      query: DeleteTaskDocument,
+      variables: {
+        accountListId: 'abc',
+        id: task.id,
       },
     },
     result: { data },

--- a/src/components/Task/Drawer/Form/Form.stories.tsx
+++ b/src/components/Task/Drawer/Form/Form.stories.tsx
@@ -19,6 +19,17 @@ export default {
   title: 'Task/Drawer/Form',
 };
 
+const mockFilter = {
+  userIds: [],
+  tags: [],
+  contactIds: [],
+  activityType: [],
+  completed: null,
+  startAt: null,
+  before: null,
+  after: null,
+};
+
 export const Default = (): ReactElement => {
   return (
     <MockedProvider
@@ -28,7 +39,12 @@ export const Default = (): ReactElement => {
       ]}
       addTypename={false}
     >
-      <TaskDrawerForm accountListId="abc" onClose={(): void => {}} />
+      <TaskDrawerForm
+        accountListId="abc"
+        filter={mockFilter}
+        rowsPerPage={100}
+        onClose={(): void => {}}
+      />
     </MockedProvider>
   );
 };
@@ -36,7 +52,12 @@ export const Default = (): ReactElement => {
 export const Loading = (): ReactElement => {
   return (
     <MockedProvider mocks={[]} addTypename={false}>
-      <TaskDrawerForm accountListId="abc" onClose={(): void => {}} />
+      <TaskDrawerForm
+        accountListId="abc"
+        filter={mockFilter}
+        rowsPerPage={100}
+        onClose={(): void => {}}
+      />
     </MockedProvider>
   );
 };
@@ -88,6 +109,8 @@ export const Persisted = (): ReactElement => {
     >
       <TaskDrawerForm
         accountListId="abc"
+        filter={mockFilter}
+        rowsPerPage={100}
         task={task}
         onClose={(): void => {}}
       />

--- a/src/components/Task/Drawer/Form/Form.stories.tsx
+++ b/src/components/Task/Drawer/Form/Form.stories.tsx
@@ -12,8 +12,10 @@ import {
   getDataForTaskDrawerMock,
   createTaskMutationMock,
   updateTaskMutationMock,
+  deleteTaskMutationMock,
 } from './Form.mock';
 import TaskDrawerForm from '.';
+import { getTasksForTaskListMock } from '../../List/List.mock';
 
 export default {
   title: 'Task/Drawer/Form',
@@ -103,7 +105,9 @@ export const Persisted = (): ReactElement => {
     <MockedProvider
       mocks={[
         getDataForTaskDrawerMock(),
+        getTasksForTaskListMock(),
         { ...updateTaskMutationMock(), delay: 500 },
+        { ...deleteTaskMutationMock(), delay: 1000 },
       ]}
       addTypename={false}
     >

--- a/src/components/Task/Drawer/Form/Form.stories.tsx
+++ b/src/components/Task/Drawer/Form/Form.stories.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { MockedProvider } from '@apollo/client/testing';
 import { DateTime } from 'luxon';
+import { InMemoryCache } from '@apollo/client';
 import {
   ActivityTypeEnum,
   Contact,
@@ -8,6 +9,8 @@ import {
   NotificationTypeEnum,
   Task,
 } from '../../../../../graphql/types.generated';
+import { getTasksForTaskListMock } from '../../List/List.mock';
+import { GetTasksForTaskListDocument } from '../../List/TaskList.generated';
 import {
   getDataForTaskDrawerMock,
   createTaskMutationMock,
@@ -15,7 +18,6 @@ import {
   deleteTaskMutationMock,
 } from './Form.mock';
 import TaskDrawerForm from '.';
-import { getTasksForTaskListMock } from '../../List/List.mock';
 
 export default {
   title: 'Task/Drawer/Form',
@@ -101,6 +103,21 @@ const task: Task = {
 };
 
 export const Persisted = (): ReactElement => {
+  const cache = new InMemoryCache({ addTypename: false });
+  const query = {
+    query: GetTasksForTaskListDocument,
+    variables: {
+      accountListId: 'abc',
+      first: 100,
+      ...mockFilter,
+    },
+    data: {
+      tasks: {
+        nodes: [{ ...task }],
+      },
+    },
+  };
+  cache.writeQuery(query);
   return (
     <MockedProvider
       mocks={[
@@ -109,6 +126,7 @@ export const Persisted = (): ReactElement => {
         { ...updateTaskMutationMock(), delay: 500 },
         { ...deleteTaskMutationMock(), delay: 1000 },
       ]}
+      cache={cache}
       addTypename={false}
     >
       <TaskDrawerForm

--- a/src/components/Task/Drawer/Form/Form.test.tsx
+++ b/src/components/Task/Drawer/Form/Form.test.tsx
@@ -15,6 +15,17 @@ import {
 import TaskDrawerForm from '.';
 
 describe('TaskDrawerForm', () => {
+  const mockFilter = {
+    userIds: [],
+    tags: [],
+    contactIds: [],
+    activityType: [],
+    completed: null,
+    startAt: null,
+    before: null,
+    after: null,
+  };
+
   it('default', async () => {
     const onClose = jest.fn();
     const { getByText, getByRole, findByText } = render(
@@ -24,7 +35,12 @@ describe('TaskDrawerForm', () => {
             mocks={[getDataForTaskDrawerMock(), createTaskMutationMock()]}
             addTypename={false}
           >
-            <TaskDrawerForm accountListId="abc" onClose={onClose} />
+            <TaskDrawerForm
+              accountListId="abc"
+              filter={mockFilter}
+              rowsPerPage={100}
+              onClose={onClose}
+            />
           </MockedProvider>
         </SnackbarProvider>
       </MuiPickersUtilsProvider>,
@@ -54,14 +70,13 @@ describe('TaskDrawerForm', () => {
           >
             <TaskDrawerForm
               accountListId="abc"
+              filter={mockFilter}
+              rowsPerPage={100}
               onClose={onClose}
               task={{
                 activityType: null,
                 contacts: {
                   nodes: [],
-                  pageInfo: { hasNextPage: false, hasPreviousPage: false },
-                  totalCount: 0,
-                  totalPageCount: 0,
                 },
                 id: 'task-1',
                 notificationTimeBefore: null,

--- a/src/components/Task/Drawer/Form/Form.tsx
+++ b/src/components/Task/Drawer/Form/Form.tsx
@@ -181,7 +181,7 @@ const TaskDrawerForm = ({
   });
   const [createTask, { loading: creating }] = useCreateTaskMutation();
   const [updateTask, { loading: saving }] = useUpdateTaskMutation();
-  const [deleteTask] = useDeleteTaskMutation();
+  const [deleteTask, { loading: deleting }] = useDeleteTaskMutation();
   const onSubmit = async (values: Task): Promise<void> => {
     const attributes = {
       ...values,
@@ -605,8 +605,14 @@ const TaskDrawerForm = ({
                   className={classes.removeButton}
                   onClick={() => handleRemoveDialog(true)}
                 >
-                  <DeleteIcon titleAccess={t('Remove')} />
-                  {t('Remove')}
+                  {deleting ? (
+                    <CircularProgress color="primary" size={20} />
+                  ) : (
+                    <>
+                      <DeleteIcon titleAccess={t('Remove')} />
+                      {t('Remove')}
+                    </>
+                  )}
                 </Button>
               </Grid>
               <Grid item xs={2}>

--- a/src/components/Task/Drawer/Form/Form.tsx
+++ b/src/components/Task/Drawer/Form/Form.tsx
@@ -78,6 +78,10 @@ const useStyles = makeStyles((theme: Theme) => ({
       backgroundColor: theme.palette.error.dark,
     },
   },
+  loadingIndicator: {
+    display: 'flex',
+    margin: 'auto',
+  },
 }));
 
 type TaskMutationResponseFragmentWithoutTypename = DeepOmit<
@@ -605,14 +609,8 @@ const TaskDrawerForm = ({
                   className={classes.removeButton}
                   onClick={() => handleRemoveDialog(true)}
                 >
-                  {deleting ? (
-                    <CircularProgress color="primary" size={20} />
-                  ) : (
-                    <>
-                      <DeleteIcon titleAccess={t('Remove')} />
-                      {t('Remove')}
-                    </>
-                  )}
+                  <DeleteIcon titleAccess={t('Remove')} />
+                  {t('Remove')}
                 </Button>
               </Grid>
               <Grid item xs={2}>
@@ -641,13 +639,22 @@ const TaskDrawerForm = ({
             <Dialog
               open={removeDialogOpen}
               aria-labelledby={t('Remove task confirmation')}
+              fullWidth
               maxWidth="sm"
             >
               <DialogTitle>{t('Confirm')}</DialogTitle>
               <DialogContent dividers>
-                <DialogContentText>
-                  {t('Are you sure you wish to delete the selected task?')}
-                </DialogContentText>
+                {deleting ? (
+                  <CircularProgress
+                    className={classes.loadingIndicator}
+                    color="primary"
+                    size={50}
+                  />
+                ) : (
+                  <DialogContentText>
+                    {t('Are you sure you wish to delete the selected task?')}
+                  </DialogContentText>
+                )}
               </DialogContent>
               <DialogActions>
                 <Button onClick={() => handleRemoveDialog(false)}>

--- a/src/components/Task/Drawer/Form/Form.tsx
+++ b/src/components/Task/Drawer/Form/Form.tsx
@@ -15,10 +15,17 @@ import {
   CircularProgress,
   Button,
   Divider,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  Dialog,
 } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import { Autocomplete } from '@material-ui/lab';
+
 import { DatePicker, TimePicker } from '@material-ui/pickers';
+import DeleteIcon from '@material-ui/icons/Delete';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Formik } from 'formik';
 import * as yup from 'yup';
@@ -34,9 +41,15 @@ import {
 } from '../../../../../graphql/types.generated';
 import { GetTaskForTaskDrawerQuery } from '../TaskDrawerTask.generated';
 import {
+  GetTasksForTaskListDocument,
+  GetTasksForTaskListQuery,
+} from '../../List/TaskList.generated';
+import { TaskFilter } from '../../List/List';
+import {
   useGetDataForTaskDrawerQuery,
   useCreateTaskMutation,
   useUpdateTaskMutation,
+  useDeleteTaskMutation,
   GetDataForTaskDrawerQuery,
   TaskMutationResponseFragment,
 } from './TaskDrawer.generated';
@@ -57,6 +70,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   title: {
     flexGrow: 1,
+  },
+  removeButton: {
+    backgroundColor: '#d9534f',
+    color: '#fff',
+    '&:hover': {
+      backgroundColor: '#C9302F',
+    },
   },
 }));
 
@@ -106,6 +126,8 @@ interface Props {
   task?: GetTaskForTaskDrawerQuery['task'];
   onClose: () => void;
   defaultValues?: Partial<GetTaskForTaskDrawerQuery['task']>;
+  filter: TaskFilter;
+  rowsPerPage: number;
 }
 
 const TaskDrawerForm = ({
@@ -113,6 +135,8 @@ const TaskDrawerForm = ({
   task,
   onClose,
   defaultValues,
+  filter,
+  rowsPerPage,
 }: Props): ReactElement => {
   const initialTask: TaskMutationResponseFragmentWithoutTypename = task || {
     id: null,
@@ -132,6 +156,8 @@ const TaskDrawerForm = ({
   };
   const classes = useStyles();
   const { t } = useTranslation();
+
+  const [removeDialogOpen, handleRemoveDialog] = useState(false);
   const { enqueueSnackbar } = useSnackbar();
   const [notification, setNotification] = useState(
     initialTask.notificationTimeBefore !== null ||
@@ -155,6 +181,7 @@ const TaskDrawerForm = ({
   });
   const [createTask, { loading: creating }] = useCreateTaskMutation();
   const [updateTask, { loading: saving }] = useUpdateTaskMutation();
+  const [deleteTask, { loading: deleting }] = useDeleteTaskMutation();
   const onSubmit = async (values: Task): Promise<void> => {
     const attributes = {
       ...values,
@@ -187,6 +214,49 @@ const TaskDrawerForm = ({
       onClose();
     } catch (error) {
       debugger;
+      enqueueSnackbar(error.message, { variant: 'error' });
+    }
+  };
+
+  const onDeleteTask = async (): Promise<void> => {
+    try {
+      if (task) {
+        await deleteTask({
+          variables: {
+            accountListId,
+            id: task.id,
+          },
+          update: (cache) => {
+            const query = {
+              query: GetTasksForTaskListDocument,
+              variables: {
+                accountListId,
+                first: rowsPerPage,
+                ...filter,
+              },
+            };
+            const dataFromCache = cache.readQuery<GetTasksForTaskListQuery>(
+              query,
+            );
+
+            cache.writeQuery({
+              ...query,
+              data: {
+                tasks: {
+                  ...dataFromCache.tasks,
+                  nodes: dataFromCache.tasks.nodes.filter(
+                    ({ id }) => id !== task.id,
+                  ),
+                },
+              },
+            });
+          },
+        });
+        enqueueSnackbar(t('Task deleted successfully'), { variant: 'success' });
+        handleRemoveDialog(false);
+        onClose();
+      }
+    } catch (error) {
       enqueueSnackbar(error.message, { variant: 'error' });
     }
   };
@@ -527,12 +597,32 @@ const TaskDrawerForm = ({
           <Divider />
           <Box m={2}>
             <Grid container spacing={1} justify="flex-end">
-              <Grid item>
+              <Grid container item xs={8} justify="flex-start">
+                <Button
+                  size="large"
+                  variant="contained"
+                  className={classes.removeButton}
+                  onClick={() => handleRemoveDialog(true)}
+                >
+                  {deleting ? (
+                    <>
+                      <CircularProgress color="primary" size={20} />
+                      &nbsp;
+                    </>
+                  ) : (
+                    <>
+                      <DeleteIcon titleAccess={t('Remove')} />
+                      {t('Remove')}
+                    </>
+                  )}
+                </Button>
+              </Grid>
+              <Grid item xs={2}>
                 <Button size="large" disabled={isSubmitting} onClick={onClose}>
                   {t('Cancel')}
                 </Button>
               </Grid>
-              <Grid item>
+              <Grid item xs={2}>
                 <Button
                   size="large"
                   variant="contained"
@@ -550,6 +640,32 @@ const TaskDrawerForm = ({
                 </Button>
               </Grid>
             </Grid>
+            <Dialog
+              disableBackdropClick
+              disableEscapeKeyDown
+              open={removeDialogOpen}
+              aria-labelledby="remove task confirmation"
+              maxWidth="sm"
+            >
+              <DialogTitle>{t('Confirm')}</DialogTitle>
+              <DialogContent dividers>
+                <DialogContentText>
+                  {t('Are you sure you wish to delete the selected task?')}
+                </DialogContentText>
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={() => handleRemoveDialog(false)}>
+                  {t('No')}
+                </Button>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={onDeleteTask}
+                >
+                  {t('Yes')}
+                </Button>
+              </DialogActions>
+            </Dialog>
           </Box>
         </form>
       )}

--- a/src/components/Task/Drawer/Form/Form.tsx
+++ b/src/components/Task/Drawer/Form/Form.tsx
@@ -72,10 +72,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexGrow: 1,
   },
   removeButton: {
-    backgroundColor: '#d9534f',
-    color: '#fff',
+    backgroundColor: theme.palette.error.main,
+    color: theme.palette.common.white,
     '&:hover': {
-      backgroundColor: '#C9302F',
+      backgroundColor: theme.palette.error.dark,
     },
   },
 }));
@@ -181,7 +181,7 @@ const TaskDrawerForm = ({
   });
   const [createTask, { loading: creating }] = useCreateTaskMutation();
   const [updateTask, { loading: saving }] = useUpdateTaskMutation();
-  const [deleteTask, { loading: deleting }] = useDeleteTaskMutation();
+  const [deleteTask] = useDeleteTaskMutation();
   const onSubmit = async (values: Task): Promise<void> => {
     const attributes = {
       ...values,
@@ -258,6 +258,7 @@ const TaskDrawerForm = ({
       }
     } catch (error) {
       enqueueSnackbar(error.message, { variant: 'error' });
+      throw error;
     }
   };
 
@@ -604,17 +605,8 @@ const TaskDrawerForm = ({
                   className={classes.removeButton}
                   onClick={() => handleRemoveDialog(true)}
                 >
-                  {deleting ? (
-                    <>
-                      <CircularProgress color="primary" size={20} />
-                      &nbsp;
-                    </>
-                  ) : (
-                    <>
-                      <DeleteIcon titleAccess={t('Remove')} />
-                      {t('Remove')}
-                    </>
-                  )}
+                  <DeleteIcon titleAccess={t('Remove')} />
+                  {t('Remove')}
                 </Button>
               </Grid>
               <Grid item xs={2}>
@@ -641,10 +633,8 @@ const TaskDrawerForm = ({
               </Grid>
             </Grid>
             <Dialog
-              disableBackdropClick
-              disableEscapeKeyDown
               open={removeDialogOpen}
-              aria-labelledby="remove task confirmation"
+              aria-labelledby={t('Remove task confirmation')}
               maxWidth="sm"
             >
               <DialogTitle>{t('Confirm')}</DialogTitle>

--- a/src/components/Task/Drawer/Form/Form.tsx
+++ b/src/components/Task/Drawer/Form/Form.tsx
@@ -247,10 +247,11 @@ const TaskDrawerForm = ({
               ...query,
               data: {
                 tasks: {
-                  ...dataFromCache.tasks,
-                  nodes: dataFromCache.tasks.nodes.filter(
-                    ({ id }) => id !== task.id,
-                  ),
+                  ...dataFromCache?.tasks,
+                  nodes:
+                    dataFromCache?.tasks.nodes.filter(
+                      ({ id }) => id !== task.id,
+                    ) || [],
                 },
               },
             });
@@ -609,7 +610,7 @@ const TaskDrawerForm = ({
                   className={classes.removeButton}
                   onClick={() => handleRemoveDialog(true)}
                 >
-                  <DeleteIcon titleAccess={t('Remove')} />
+                  <DeleteIcon />
                   {t('Remove')}
                 </Button>
               </Grid>

--- a/src/components/Task/Drawer/Form/TaskDrawer.graphql
+++ b/src/components/Task/Drawer/Form/TaskDrawer.graphql
@@ -41,6 +41,12 @@ mutation UpdateTask($accountListId: ID!, $attributes: TaskUpdateInput!) {
   }
 }
 
+mutation DeleteTask($accountListId: ID!, $id: ID!) {
+  deleteTask(input: { accountListId: $accountListId, id: $id }) {
+    id
+  }
+}
+
 fragment TaskMutationResponse on Task {
   id
   activityType

--- a/src/components/Task/List/List.test.tsx
+++ b/src/components/Task/List/List.test.tsx
@@ -101,7 +101,20 @@ describe('TaskList', () => {
       </TestWrapper>,
     );
     userEvent.click(await findByText('On the Journey with the Johnson Family'));
-    expect(openTaskDrawer).toHaveBeenCalledWith({ taskId: 'task-1' });
+    expect(openTaskDrawer).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      filter: {
+        userIds: [],
+        tags: [],
+        contactIds: [],
+        activityType: [],
+        completed: null,
+        startAt: null,
+        before: null,
+        after: null,
+      },
+      rowsPerPage: 100,
+    });
     userEvent.click(getByRole('button', { name: 'Filter Table' }));
     const buttons = getAllByRole('button').filter((element) => element.id);
     const buttonWithIdThatEndsWith = (value): HTMLElement =>

--- a/src/components/Task/List/List.tsx
+++ b/src/components/Task/List/List.tsx
@@ -434,7 +434,11 @@ const TaskList = ({ initialFilter }: Props): ReactElement => {
       setCurrentPage(newPage);
     },
     onRowClick: (_rowData, rowMeta) => {
-      openTaskDrawer({ taskId: data.tasks.nodes[rowMeta.dataIndex].id });
+      openTaskDrawer({
+        taskId: data.tasks.nodes[rowMeta.dataIndex].id,
+        filter,
+        rowsPerPage,
+      });
     },
     count: data?.tasks?.totalCount || 0,
     rowsPerPageOptions: [10, 25, 50, 100, 250, 500],

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -27,6 +27,7 @@ const theme = createMuiTheme({
     },
     error: {
       main: '#F44336',
+      dark: '#C9302F',
     },
     text: {
       primary: '#383F43',


### PR DESCRIPTION
@OzzieOrca and I discussed this on slack, but in order to remove the task from the apollo cache after deleting it(to avoid having to query all tasks again), I had to pass down the ```filter``` and the ```rowsPerPage``` in order to correctly query the data from the cache. 

I haven't added stories or tests yet for this new logic as I wanted to get others' opinions first on this implementation and see if anyone has any suggestions for improvement.