### PR TITLE
MPDX-6961: Improve theme

### DIFF
--- a/__tests__/util/setup.ts
+++ b/__tests__/util/setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { Settings } from 'luxon';
+import matchMediaMock from './matchMediaMock';
 
 window.document.createRange = (): Range =>
   (({
@@ -15,6 +16,7 @@ window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
 beforeEach(() => {
   Settings.now = () => new Date(2020, 0, 1).valueOf();
+  matchMediaMock({ width: window.innerWidth });
 });
 
 afterEach(() => {

--- a/pages/_document.page.tsx
+++ b/pages/_document.page.tsx
@@ -15,7 +15,7 @@ class MyDocument extends Document {
     return (
       <Html lang="en">
         <Head>
-          <meta name="theme-color" content={theme.palette.primary.main} />
+          <meta name="theme-color" content={theme.palette.mpdxBlue.main} />
         </Head>
         <body>
           <Main />

--- a/pages/accountLists/[accountListId]/contacts.test.tsx
+++ b/pages/accountLists/[accountListId]/contacts.test.tsx
@@ -1,8 +1,10 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@material-ui/core';
 import { GqlMockedProvider } from '../../../__tests__/util/graphqlMocking';
 import TestRouter from '../../../__tests__/util/TestRouter';
+import theme from '../../../src/theme';
 import Contacts from './contacts.page';
 import { ContactsQuery } from './Contacts.generated';
 
@@ -14,11 +16,13 @@ const router = {
 
 it('should show loading state', () => {
   const { getByText } = render(
-    <TestRouter router={router}>
-      <GqlMockedProvider>
-        <Contacts />
-      </GqlMockedProvider>
-    </TestRouter>,
+    <ThemeProvider theme={theme}>
+      <TestRouter router={router}>
+        <GqlMockedProvider>
+          <Contacts />
+        </GqlMockedProvider>
+      </TestRouter>
+    </ThemeProvider>,
   );
   expect(getByText('Loading')).toBeInTheDocument();
 });
@@ -27,17 +31,19 @@ it('should render list of people', async () => {
   const name = 'Test Person';
 
   const { findAllByRole } = render(
-    <TestRouter router={router}>
-      <GqlMockedProvider<ContactsQuery>
-        mocks={{
-          Contacts: {
-            contacts: { nodes: [{ name }] },
-          },
-        }}
-      >
-        <Contacts />
-      </GqlMockedProvider>
-    </TestRouter>,
+    <ThemeProvider theme={theme}>
+      <TestRouter router={router}>
+        <GqlMockedProvider<ContactsQuery>
+          mocks={{
+            Contacts: {
+              contacts: { nodes: [{ name }] },
+            },
+          }}
+        >
+          <Contacts />
+        </GqlMockedProvider>
+      </TestRouter>
+    </ThemeProvider>,
   );
   expect((await findAllByRole('row'))[0]).toHaveTextContent(name);
 });
@@ -46,17 +52,19 @@ it('should render contact detail panel', async () => {
   const contactId = '1';
 
   const { findAllByRole } = render(
-    <TestRouter router={router}>
-      <GqlMockedProvider<ContactsQuery>
-        mocks={{
-          Contacts: {
-            contacts: { nodes: [{ id: contactId }] },
-          },
-        }}
-      >
-        <Contacts />
-      </GqlMockedProvider>
-    </TestRouter>,
+    <ThemeProvider theme={theme}>
+      <TestRouter router={router}>
+        <GqlMockedProvider<ContactsQuery>
+          mocks={{
+            Contacts: {
+              contacts: { nodes: [{ id: contactId }] },
+            },
+          }}
+        >
+          <Contacts />
+        </GqlMockedProvider>
+      </TestRouter>
+    </ThemeProvider>,
   );
 
   const row = (await findAllByRole('rowButton'))[0];

--- a/src/components/AccountLists/AccountLists.test.tsx
+++ b/src/components/AccountLists/AccountLists.test.tsx
@@ -1,42 +1,46 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import AccountLists from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../theme';
 
 describe('AccountLists', () => {
   it('has correct defaults', () => {
     const { getByTestId } = render(
-      <AccountLists
-        data={{
-          accountLists: {
-            nodes: [
-              {
-                id: 'abc',
-                name: 'My Personal Staff Account',
-                monthlyGoal: 100,
-                receivedPledges: 10,
-                totalPledges: 20,
-                currency: 'USD',
-              },
-              {
-                id: 'def',
-                name: 'My Ministry Account',
-                monthlyGoal: null,
-                receivedPledges: 10,
-                totalPledges: 20,
-                currency: 'USD',
-              },
-              {
-                id: 'ghi',
-                name: "My Friend's Staff Account",
-                monthlyGoal: 100,
-                receivedPledges: 0,
-                totalPledges: 0,
-                currency: 'USD',
-              },
-            ],
-          },
-        }}
-      />,
+      <ThemeProvider theme={theme}>
+        <AccountLists
+          data={{
+            accountLists: {
+              nodes: [
+                {
+                  id: 'abc',
+                  name: 'My Personal Staff Account',
+                  monthlyGoal: 100,
+                  receivedPledges: 10,
+                  totalPledges: 20,
+                  currency: 'USD',
+                },
+                {
+                  id: 'def',
+                  name: 'My Ministry Account',
+                  monthlyGoal: null,
+                  receivedPledges: 10,
+                  totalPledges: 20,
+                  currency: 'USD',
+                },
+                {
+                  id: 'ghi',
+                  name: "My Friend's Staff Account",
+                  monthlyGoal: 100,
+                  receivedPledges: 0,
+                  totalPledges: 0,
+                  currency: 'USD',
+                },
+              ],
+            },
+          }}
+        />
+      </ThemeProvider>,
     );
     expect(getByTestId('abc')).toHaveTextContent('My Personal Staff Account');
     expect(getByTestId('def')).toHaveTextContent('My Ministry Account');

--- a/src/components/AccountLists/AccountLists.test.tsx
+++ b/src/components/AccountLists/AccountLists.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import AccountLists from '.';
 import { ThemeProvider } from '@material-ui/core';
 import theme from '../../theme';
+import AccountLists from '.';
 
 describe('AccountLists', () => {
   it('has correct defaults', () => {

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/ContactDetailsTabPeople.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/ContactDetailsTabPeople.tsx
@@ -67,7 +67,7 @@ export const ContactDetailsTabPeople: React.FC<ContactDetailsPeopleProp> = ({
             <Typography variant="h6">
               {`${person.firstName} ${person.lastName}`}
             </Typography>
-            {primaryPerson?.id == person.id ? (
+            {primaryPerson?.id === person.id ? (
               <ContactPersonPrimaryText variant="subtitle1">
                 {`- ${t('Primary')}`}
               </ContactPersonPrimaryText>

--- a/src/components/Contacts/ContactsHeader/ContactsHeader.test.tsx
+++ b/src/components/Contacts/ContactsHeader/ContactsHeader.test.tsx
@@ -1,72 +1,57 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createMuiTheme, MuiThemeProvider } from '@material-ui/core';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../theme';
 import { ContactsHeader } from './ContactsHeader';
 
 describe('ContactFilters', () => {
   it('checkbox is unchecked', async () => {
-    const theme = createMuiTheme({
-      props: { MuiWithWidth: { initialWidth: 'md' } },
-    });
-
     const { getByRole } = render(
-      <MuiThemeProvider theme={theme}>
+      <ThemeProvider theme={theme}>
         <ContactsHeader
           activeFilters={false}
           filterPanelOpen={false}
           toggleFilterPanel={() => {}}
         />
-        ,
-      </MuiThemeProvider>,
+      </ThemeProvider>,
     );
 
     const checkbox = getByRole('checkbox');
 
     await userEvent.click(checkbox);
+    await userEvent.click(checkbox);
 
-    expect(checkbox.getAttribute('class')).toEqual('PrivateSwitchBase-input-9');
+    expect(checkbox).toHaveProperty('checked', false);
   });
 
   it('checkbox is checked', async () => {
-    const theme = createMuiTheme({
-      props: { MuiWithWidth: { initialWidth: 'md' } },
-    });
-
     const { getByRole } = render(
-      <MuiThemeProvider theme={theme}>
+      <ThemeProvider theme={theme}>
         <ContactsHeader
           activeFilters={false}
           filterPanelOpen={false}
           toggleFilterPanel={() => {}}
         />
-        ,
-      </MuiThemeProvider>,
+      </ThemeProvider>,
     );
 
     const checkbox = getByRole('checkbox');
 
     await userEvent.click(checkbox);
 
-    expect(checkbox.getAttribute('class')).toEqual(
-      'PrivateSwitchBase-input-37',
-    );
+    expect(checkbox).toHaveProperty('checked', true);
   });
 
   it('filters button displays for no filters', async () => {
-    const theme = createMuiTheme({
-      props: { MuiWithWidth: { initialWidth: 'md' } },
-    });
-
     const { getByRole } = render(
-      <MuiThemeProvider theme={theme}>
+      <ThemeProvider theme={theme}>
         <ContactsHeader
           activeFilters={false}
           filterPanelOpen={false}
           toggleFilterPanel={() => {}}
         />
-        ,
-      </MuiThemeProvider>,
+      </ThemeProvider>,
     );
 
     const filterButton = getByRole('FilterButton');
@@ -76,19 +61,14 @@ describe('ContactFilters', () => {
   });
 
   it('filters button displays for open filter panel', async () => {
-    const theme = createMuiTheme({
-      props: { MuiWithWidth: { initialWidth: 'md' } },
-    });
-
     const { getByRole } = render(
-      <MuiThemeProvider theme={theme}>
+      <ThemeProvider theme={theme}>
         <ContactsHeader
           activeFilters={false}
           filterPanelOpen={true}
           toggleFilterPanel={() => {}}
         />
-        ,
-      </MuiThemeProvider>,
+      </ThemeProvider>,
     );
 
     const filterButton = getByRole('FilterButton');
@@ -98,19 +78,14 @@ describe('ContactFilters', () => {
   });
 
   it('filters button displays for active filters', async () => {
-    const theme = createMuiTheme({
-      props: { MuiWithWidth: { initialWidth: 'md' } },
-    });
-
     const { getByRole } = render(
-      <MuiThemeProvider theme={theme}>
+      <ThemeProvider theme={theme}>
         <ContactsHeader
           activeFilters={true}
           filterPanelOpen={false}
           toggleFilterPanel={() => {}}
         />
-        ,
-      </MuiThemeProvider>,
+      </ThemeProvider>,
     );
 
     const filterButton = getByRole('FilterButton');
@@ -120,19 +95,14 @@ describe('ContactFilters', () => {
   });
 
   it('filters button displays for active filters and filter panel open', async () => {
-    const theme = createMuiTheme({
-      props: { MuiWithWidth: { initialWidth: 'md' } },
-    });
-
     const { getByRole } = render(
-      <MuiThemeProvider theme={theme}>
+      <ThemeProvider theme={theme}>
         <ContactsHeader
           activeFilters={true}
           filterPanelOpen={false}
           toggleFilterPanel={() => {}}
         />
-        ,
-      </MuiThemeProvider>,
+      </ThemeProvider>,
     );
 
     const filterButton = getByRole('FilterButton');

--- a/src/components/Contacts/ContactsTable/ContactsTable.test.tsx
+++ b/src/components/Contacts/ContactsTable/ContactsTable.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@material-ui/core';
 import { GqlMockedProvider } from '../../../../__tests__/util/graphqlMocking';
 import { ContactsQuery } from '../../../../pages/accountLists/[accountListId]/Contacts.generated';
+import theme from '../../../theme';
 import { ContactsTable } from './ContactsTable';
 
 const accountListId = '111';
@@ -14,15 +16,17 @@ const onContactSelected = jest.fn();
 describe('ContactFilters', () => {
   it('loading', async () => {
     const { queryByTestId, queryByText } = render(
-      <GqlMockedProvider<ContactsQuery>>
-        <ContactsTable
-          accountListId={accountListId}
-          onContactSelected={onContactSelected}
-          activeFilters={false}
-          filterPanelOpen={false}
-          toggleFilterPanel={() => {}}
-        />
-      </GqlMockedProvider>,
+      <ThemeProvider theme={theme}>
+        <GqlMockedProvider<ContactsQuery>>
+          <ContactsTable
+            accountListId={accountListId}
+            onContactSelected={onContactSelected}
+            activeFilters={false}
+            filterPanelOpen={false}
+            toggleFilterPanel={() => {}}
+          />
+        </GqlMockedProvider>
+      </ThemeProvider>,
     );
 
     expect(queryByText('Loading')).toBeVisible();
@@ -33,15 +37,17 @@ describe('ContactFilters', () => {
 
   it('contacts loaded', async () => {
     const { getByTestId, queryByText } = render(
-      <GqlMockedProvider<ContactsQuery>>
-        <ContactsTable
-          accountListId={accountListId}
-          onContactSelected={onContactSelected}
-          activeFilters={false}
-          filterPanelOpen={false}
-          toggleFilterPanel={() => {}}
-        />
-      </GqlMockedProvider>,
+      <ThemeProvider theme={theme}>
+        <GqlMockedProvider<ContactsQuery>>
+          <ContactsTable
+            accountListId={accountListId}
+            onContactSelected={onContactSelected}
+            activeFilters={false}
+            filterPanelOpen={false}
+            toggleFilterPanel={() => {}}
+          />
+        </GqlMockedProvider>
+      </ThemeProvider>,
     );
 
     await waitFor(() => expect(queryByText('Loading')).not.toBeInTheDocument());
@@ -62,15 +68,17 @@ describe('ContactFilters', () => {
     };
 
     const { queryByTestId, queryByText } = render(
-      <GqlMockedProvider<ContactsQuery> mocks={mocks}>
-        <ContactsTable
-          accountListId={accountListId}
-          onContactSelected={onContactSelected}
-          activeFilters={false}
-          filterPanelOpen={false}
-          toggleFilterPanel={() => {}}
-        />
-      </GqlMockedProvider>,
+      <ThemeProvider theme={theme}>
+        <GqlMockedProvider<ContactsQuery> mocks={mocks}>
+          <ContactsTable
+            accountListId={accountListId}
+            onContactSelected={onContactSelected}
+            activeFilters={false}
+            filterPanelOpen={false}
+            toggleFilterPanel={() => {}}
+          />
+        </GqlMockedProvider>
+      </ThemeProvider>,
     );
 
     await waitFor(() => expect(queryByText('Loading')).not.toBeInTheDocument());
@@ -91,15 +99,17 @@ describe('ContactFilters', () => {
     };
 
     const { findAllByRole, queryByText } = render(
-      <GqlMockedProvider<ContactsQuery> mocks={mocks}>
-        <ContactsTable
-          accountListId={accountListId}
-          onContactSelected={onContactSelected}
-          activeFilters={false}
-          filterPanelOpen={false}
-          toggleFilterPanel={() => {}}
-        />
-      </GqlMockedProvider>,
+      <ThemeProvider theme={theme}>
+        <GqlMockedProvider<ContactsQuery> mocks={mocks}>
+          <ContactsTable
+            accountListId={accountListId}
+            onContactSelected={onContactSelected}
+            activeFilters={false}
+            filterPanelOpen={false}
+            toggleFilterPanel={() => {}}
+          />
+        </GqlMockedProvider>
+      </ThemeProvider>,
     );
 
     await waitFor(() => expect(queryByText('Loading')).not.toBeInTheDocument());

--- a/src/components/Dashboard/Dashboard.test.tsx
+++ b/src/components/Dashboard/Dashboard.test.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
 import { SnackbarProvider } from 'notistack';
+import { ThemeProvider } from '@material-ui/core';
 import matchMediaMock from '../../../__tests__/util/matchMediaMock';
 import { AppProviderContext } from '../App/Provider';
 import { GetDashboardQuery } from '../../../pages/accountLists/GetDashboard.generated';
+import theme from '../../theme';
 import { GetThisWeekDefaultMocks } from './ThisWeek/ThisWeek.mock';
 import Dashboard from '.';
-import { ThemeProvider } from '@material-ui/core';
-import theme from '../../theme';
 
 jest.mock('../App', () => ({
   useApp: (): Partial<AppProviderContext> => ({

--- a/src/components/Dashboard/Dashboard.test.tsx
+++ b/src/components/Dashboard/Dashboard.test.tsx
@@ -7,6 +7,8 @@ import { AppProviderContext } from '../App/Provider';
 import { GetDashboardQuery } from '../../../pages/accountLists/GetDashboard.generated';
 import { GetThisWeekDefaultMocks } from './ThisWeek/ThisWeek.mock';
 import Dashboard from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../theme';
 
 jest.mock('../App', () => ({
   useApp: (): Partial<AppProviderContext> => ({
@@ -111,11 +113,13 @@ describe('Dashboard', () => {
 
   it('default', async () => {
     const { getByTestId, queryByTestId } = render(
-      <SnackbarProvider>
-        <MockedProvider mocks={GetThisWeekDefaultMocks()} addTypename={false}>
-          <Dashboard accountListId="abc" data={data} />
-        </MockedProvider>
-      </SnackbarProvider>,
+      <ThemeProvider theme={theme}>
+        <SnackbarProvider>
+          <MockedProvider mocks={GetThisWeekDefaultMocks()} addTypename={false}>
+            <Dashboard accountListId="abc" data={data} />
+          </MockedProvider>
+        </SnackbarProvider>
+      </ThemeProvider>,
     );
     await waitFor(() =>
       expect(
@@ -150,21 +154,23 @@ describe('Dashboard', () => {
 
   it('handles null fields', async () => {
     const { getByTestId, queryByTestId } = render(
-      <SnackbarProvider>
-        <MockedProvider mocks={GetThisWeekDefaultMocks()} addTypename={false}>
-          <Dashboard
-            accountListId="abc"
-            data={{
-              ...data,
-              accountList: {
-                ...data.accountList,
-                monthlyGoal: null,
-                currency: 'USD',
-              },
-            }}
-          />
-        </MockedProvider>
-      </SnackbarProvider>,
+      <ThemeProvider theme={theme}>
+        <SnackbarProvider>
+          <MockedProvider mocks={GetThisWeekDefaultMocks()} addTypename={false}>
+            <Dashboard
+              accountListId="abc"
+              data={{
+                ...data,
+                accountList: {
+                  ...data.accountList,
+                  monthlyGoal: null,
+                  currency: 'USD',
+                },
+              }}
+            />
+          </MockedProvider>
+        </SnackbarProvider>
+      </ThemeProvider>,
     );
     await waitFor(() =>
       expect(

--- a/src/components/Dashboard/ThisWeek/TasksDueThisWeek/TasksDueThisWeek.test.tsx
+++ b/src/components/Dashboard/ThisWeek/TasksDueThisWeek/TasksDueThisWeek.test.tsx
@@ -5,6 +5,8 @@ import { useApp } from '../../../App';
 import { GetThisWeekQuery } from '../GetThisWeek.generated';
 import { ActivityTypeEnum } from '../../../../../graphql/types.generated';
 import TasksDueThisWeek from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../../theme';
 
 jest.mock('../../../App', () => ({
   useApp: jest.fn(),
@@ -21,7 +23,9 @@ beforeEach(() => {
 describe('TasksDueThisWeek', () => {
   it('default', () => {
     const { getByTestId, queryByTestId } = render(
-      <TasksDueThisWeek accountListId="abc" />,
+      <ThemeProvider theme={theme}>
+        <TasksDueThisWeek accountListId="abc" />
+      </ThemeProvider>,
     );
     expect(getByTestId('TasksDueThisWeekCardContentEmpty')).toBeInTheDocument();
     expect(queryByTestId('TasksDueThisWeekList')).not.toBeInTheDocument();
@@ -32,7 +36,9 @@ describe('TasksDueThisWeek', () => {
 
   it('loading', () => {
     const { getByTestId, queryByTestId } = render(
-      <TasksDueThisWeek loading accountListId="abc" />,
+      <ThemeProvider theme={theme}>
+        <TasksDueThisWeek loading accountListId="abc" />
+      </ThemeProvider>,
     );
     expect(getByTestId('TasksDueThisWeekListLoading')).toBeInTheDocument();
     expect(queryByTestId('TasksDueThisWeekList')).not.toBeInTheDocument();
@@ -47,7 +53,9 @@ describe('TasksDueThisWeek', () => {
       totalCount: 0,
     };
     const { getByTestId, queryByTestId } = render(
-      <TasksDueThisWeek dueTasks={dueTasks} accountListId="abc" />,
+      <ThemeProvider theme={theme}>
+        <TasksDueThisWeek dueTasks={dueTasks} accountListId="abc" />
+      </ThemeProvider>,
     );
     expect(getByTestId('TasksDueThisWeekCardContentEmpty')).toBeInTheDocument();
     expect(queryByTestId('TasksDueThisWeekList')).not.toBeInTheDocument();
@@ -80,7 +88,9 @@ describe('TasksDueThisWeek', () => {
         totalCount: 1234,
       };
       const { getByTestId, queryByTestId } = render(
-        <TasksDueThisWeek dueTasks={dueTasks} accountListId="abc" />,
+        <ThemeProvider theme={theme}>
+          <TasksDueThisWeek dueTasks={dueTasks} accountListId="abc" />
+        </ThemeProvider>,
       );
       expect(getByTestId('TasksDueThisWeekList')).toBeInTheDocument();
       expect(

--- a/src/components/Dashboard/ThisWeek/TasksDueThisWeek/TasksDueThisWeek.test.tsx
+++ b/src/components/Dashboard/ThisWeek/TasksDueThisWeek/TasksDueThisWeek.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@material-ui/core';
 import { render } from '../../../../../__tests__/util/testingLibraryReactMock';
 import { useApp } from '../../../App';
 import { GetThisWeekQuery } from '../GetThisWeek.generated';
 import { ActivityTypeEnum } from '../../../../../graphql/types.generated';
-import TasksDueThisWeek from '.';
-import { ThemeProvider } from '@material-ui/core';
 import theme from '../../../../theme';
+import TasksDueThisWeek from '.';
 
 jest.mock('../../../App', () => ({
   useApp: jest.fn(),

--- a/src/components/Dashboard/ThisWeek/ThisWeek.test.tsx
+++ b/src/components/Dashboard/ThisWeek/ThisWeek.test.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
 import { SnackbarProvider } from 'notistack';
+import { ThemeProvider } from '@material-ui/core';
 import { AppProviderContext } from '../../App/Provider';
+import theme from '../../../theme';
 import {
   GetThisWeekEmptyMocks,
   GetThisWeekLoadingMocks,
   GetThisWeekDefaultMocks,
 } from './ThisWeek.mock';
 import ThisWeek from '.';
-import { ThemeProvider } from '@material-ui/core';
-import theme from '../../../theme';
 
 jest.mock('../../App', () => ({
   useApp: (): Partial<AppProviderContext> => ({

--- a/src/components/Dashboard/ThisWeek/ThisWeek.test.tsx
+++ b/src/components/Dashboard/ThisWeek/ThisWeek.test.tsx
@@ -9,6 +9,8 @@ import {
   GetThisWeekDefaultMocks,
 } from './ThisWeek.mock';
 import ThisWeek from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../theme';
 
 jest.mock('../../App', () => ({
   useApp: (): Partial<AppProviderContext> => ({
@@ -19,11 +21,13 @@ jest.mock('../../App', () => ({
 describe('ThisWeek', () => {
   it('default', async () => {
     const { getByTestId, queryByTestId } = render(
-      <SnackbarProvider>
-        <MockedProvider mocks={GetThisWeekDefaultMocks()} addTypename={false}>
-          <ThisWeek accountListId="abc" />
-        </MockedProvider>
-      </SnackbarProvider>,
+      <ThemeProvider theme={theme}>
+        <SnackbarProvider>
+          <MockedProvider mocks={GetThisWeekDefaultMocks()} addTypename={false}>
+            <ThisWeek accountListId="abc" />
+          </MockedProvider>
+        </SnackbarProvider>
+      </ThemeProvider>,
     );
     await waitFor(() =>
       expect(
@@ -39,11 +43,13 @@ describe('ThisWeek', () => {
 
   it('loading', () => {
     const { getByTestId } = render(
-      <SnackbarProvider>
-        <MockedProvider mocks={GetThisWeekLoadingMocks()} addTypename={false}>
-          <ThisWeek accountListId="abc" />
-        </MockedProvider>
-      </SnackbarProvider>,
+      <ThemeProvider theme={theme}>
+        <SnackbarProvider>
+          <MockedProvider mocks={GetThisWeekLoadingMocks()} addTypename={false}>
+            <ThisWeek accountListId="abc" />
+          </MockedProvider>
+        </SnackbarProvider>
+      </ThemeProvider>,
     );
     expect(getByTestId('PartnerCarePrayerListLoading')).toBeInTheDocument();
     expect(getByTestId('TasksDueThisWeekListLoading')).toBeInTheDocument();
@@ -53,11 +59,13 @@ describe('ThisWeek', () => {
 
   it('empty', async () => {
     const { getByTestId, queryByTestId } = render(
-      <SnackbarProvider>
-        <MockedProvider mocks={GetThisWeekEmptyMocks()} addTypename={false}>
-          <ThisWeek accountListId="abc" />
-        </MockedProvider>
-      </SnackbarProvider>,
+      <ThemeProvider theme={theme}>
+        <SnackbarProvider>
+          <MockedProvider mocks={GetThisWeekEmptyMocks()} addTypename={false}>
+            <ThisWeek accountListId="abc" />
+          </MockedProvider>
+        </SnackbarProvider>
+      </ThemeProvider>,
     );
     await waitFor(() =>
       expect(

--- a/src/components/Dashboard/Welcome/Welcome.test.tsx
+++ b/src/components/Dashboard/Welcome/Welcome.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Settings } from 'luxon';
-import { render } from '../../../../__tests__/util/testingLibraryReactMock';
-import Welcome from '.';
 import { ThemeProvider } from '@material-ui/core';
+import { render } from '../../../../__tests__/util/testingLibraryReactMock';
 import theme from '../../../theme';
+import Welcome from '.';
 
 describe('Welcome', () => {
   afterEach(() => {

--- a/src/components/Dashboard/Welcome/Welcome.test.tsx
+++ b/src/components/Dashboard/Welcome/Welcome.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Settings } from 'luxon';
 import { render } from '../../../../__tests__/util/testingLibraryReactMock';
 import Welcome from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../theme';
 
 describe('Welcome', () => {
   afterEach(() => {
@@ -14,14 +16,22 @@ describe('Welcome', () => {
     });
 
     it('default', () => {
-      const { getByTestId } = render(<Welcome />);
+      const { getByTestId } = render(
+        <ThemeProvider theme={theme}>
+          <Welcome />
+        </ThemeProvider>,
+      );
       expect(getByTestId('PageHeadingHeading').textContent).toEqual(
         'Good Morning,',
       );
     });
 
     it('props', () => {
-      const { getByTestId } = render(<Welcome firstName="John" />);
+      const { getByTestId } = render(
+        <ThemeProvider theme={theme}>
+          <Welcome firstName="John" />
+        </ThemeProvider>,
+      );
       expect(getByTestId('PageHeadingHeading').textContent).toEqual(
         'Good Morning, John.',
       );
@@ -33,14 +43,22 @@ describe('Welcome', () => {
     });
 
     it('default', () => {
-      const { getByTestId } = render(<Welcome />);
+      const { getByTestId } = render(
+        <ThemeProvider theme={theme}>
+          <Welcome />
+        </ThemeProvider>,
+      );
       expect(getByTestId('PageHeadingHeading').textContent).toEqual(
         'Good Afternoon,',
       );
     });
 
     it('props', () => {
-      const { getByTestId } = render(<Welcome firstName="John" />);
+      const { getByTestId } = render(
+        <ThemeProvider theme={theme}>
+          <Welcome firstName="John" />
+        </ThemeProvider>,
+      );
       expect(getByTestId('PageHeadingHeading').textContent).toEqual(
         'Good Afternoon, John.',
       );
@@ -53,14 +71,22 @@ describe('Welcome', () => {
     });
 
     it('default', () => {
-      const { getByTestId } = render(<Welcome />);
+      const { getByTestId } = render(
+        <ThemeProvider theme={theme}>
+          <Welcome />
+        </ThemeProvider>,
+      );
       expect(getByTestId('PageHeadingHeading').textContent).toEqual(
         'Good Evening,',
       );
     });
 
     it('props', () => {
-      const { getByTestId } = render(<Welcome firstName="John" />);
+      const { getByTestId } = render(
+        <ThemeProvider theme={theme}>
+          <Welcome firstName="John" />
+        </ThemeProvider>,
+      );
       expect(getByTestId('PageHeadingHeading').textContent).toEqual(
         'Good Evening, John.',
       );

--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { render } from '../../../__tests__/util/testingLibraryReactMock';
-import Footer from '.';
 import { ThemeProvider } from '@material-ui/core';
+import { render } from '../../../__tests__/util/testingLibraryReactMock';
 import theme from '../../theme';
+import Footer from '.';
 
 describe('Footer', () => {
   it('contains privacy link', () => {

--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { render } from '../../../__tests__/util/testingLibraryReactMock';
 import Footer from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../theme';
 
 describe('Footer', () => {
   it('contains privacy link', () => {
-    const { getByTestId } = render(<Footer />);
+    const { getByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <Footer />
+      </ThemeProvider>,
+    );
     expect(getByTestId('privacy')).toHaveAttribute(
       'href',
       'https://get.mpdx.org/privacy-policy/',
@@ -12,7 +18,11 @@ describe('Footer', () => {
   });
 
   it('contains whats-new link', () => {
-    const { getByTestId } = render(<Footer />);
+    const { getByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <Footer />
+      </ThemeProvider>,
+    );
     expect(getByTestId('whats-new')).toHaveAttribute(
       'href',
       'https://get.mpdx.org/release-notes/',
@@ -20,7 +30,11 @@ describe('Footer', () => {
   });
 
   it('contains terms-of-use link', () => {
-    const { getByTestId } = render(<Footer />);
+    const { getByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <Footer />
+      </ThemeProvider>,
+    );
     expect(getByTestId('terms-of-use')).toHaveAttribute(
       'href',
       'https://get.mpdx.org/terms-of-use/',
@@ -29,7 +43,11 @@ describe('Footer', () => {
 
   describe('mocked Date', () => {
     it('has correct text', () => {
-      const { getByTestId } = render(<Footer />);
+      const { getByTestId } = render(
+        <ThemeProvider theme={theme}>
+          <Footer />
+        </ThemeProvider>,
+      );
       expect(getByTestId('copyright').textContent).toEqual(
         '© 2020, Cru. All Rights Reserved.',
       );

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -8,14 +8,14 @@ import logo from '../../images/logo.svg';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     box: {
-      backgroundColor: '#323232',
+      backgroundColor: theme.palette.cruGrayDark.main,
     },
     link: {
-      color: '#fff',
+      color: theme.palette.common.white,
     },
     copyright: {
       textAlign: 'right',
-      color: '#fff',
+      color: theme.palette.common.white,
       [theme.breakpoints.down('sm')]: {
         paddingTop: theme.spacing(3),
         textAlign: 'left',

--- a/src/components/Layouts/Basic/Basic.test.tsx
+++ b/src/components/Layouts/Basic/Basic.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import Basic from '.';
 import { ThemeProvider } from '@material-ui/core';
 import theme from '../../../theme';
+import Basic from '.';
 
 describe('Basic', () => {
   it('has correct defaults', () => {

--- a/src/components/Layouts/Basic/Basic.test.tsx
+++ b/src/components/Layouts/Basic/Basic.test.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Basic from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../theme';
 
 describe('Basic', () => {
   it('has correct defaults', () => {
     const { getByTestId } = render(
-      <Basic>
-        <div data-testid="PrimaryTestChildren"></div>
-      </Basic>,
+      <ThemeProvider theme={theme}>
+        <Basic>
+          <div data-testid="PrimaryTestChildren"></div>
+        </Basic>
+      </ThemeProvider>,
     );
     expect(getByTestId('PrimaryTestChildren')).toBeInTheDocument();
   });

--- a/src/components/Layouts/Basic/TopBar/TopBar.test.tsx
+++ b/src/components/Layouts/Basic/TopBar/TopBar.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import TestRouter from '../../../../../__tests__/util/TestRouter';
-import TopBar from '.';
 import { ThemeProvider } from '@material-ui/core';
+import TestRouter from '../../../../../__tests__/util/TestRouter';
 import theme from '../../../../theme';
+import TopBar from '.';
 
 describe('TopBar', () => {
   it('has correct defaults', () => {

--- a/src/components/Layouts/Basic/TopBar/TopBar.test.tsx
+++ b/src/components/Layouts/Basic/TopBar/TopBar.test.tsx
@@ -2,15 +2,19 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import TestRouter from '../../../../../__tests__/util/TestRouter';
 import TopBar from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../../theme';
 
 describe('TopBar', () => {
   it('has correct defaults', () => {
     const { getByTestId } = render(
-      <TestRouter>
-        <TopBar>
-          <div data-testid="PrimaryTestChildren"></div>
-        </TopBar>
-      </TestRouter>,
+      <ThemeProvider theme={theme}>
+        <TestRouter>
+          <TopBar>
+            <div data-testid="PrimaryTestChildren"></div>
+          </TopBar>
+        </TestRouter>
+      </ThemeProvider>,
     );
     expect(getByTestId('PrimaryTestChildren')).toBeInTheDocument();
   });

--- a/src/components/Layouts/Basic/TopBar/TopBar.tsx
+++ b/src/components/Layouts/Basic/TopBar/TopBar.tsx
@@ -13,10 +13,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingTop: `env(safe-area-inset-top)`,
     paddingLeft: `env(safe-area-inset-left)`,
     paddingRight: `env(safe-area-inset-right)`,
-    backgroundColor: theme.palette.primary.main,
+    backgroundColor: theme.palette.mpdxBlue.main,
   },
   toolbar: {
-    backgroundColor: theme.palette.primary.main,
+    backgroundColor: theme.palette.mpdxBlue.main,
   },
   container: {
     minHeight: '48px',

--- a/src/components/Layouts/Primary/Primary.test.tsx
+++ b/src/components/Layouts/Primary/Primary.test.tsx
@@ -6,6 +6,8 @@ import { getNotificationsMocks } from './TopBar/Items/NotificationMenu/Notificat
 
 import { getTopBarMock } from './TopBar/TopBar.mock';
 import Primary from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../theme';
 
 describe('Primary', () => {
   const mocks = [...getNotificationsMocks(), getTopBarMock()];
@@ -15,14 +17,16 @@ describe('Primary', () => {
 
   it('has correct defaults', () => {
     const { getByTestId, getByRole } = render(
-      <TestWrapper
-        mocks={mocks}
-        initialState={{ accountListId: '1', breadcrumb: 'Dashboard' }}
-      >
-        <Primary>
-          <div data-testid="PrimaryTestChildren"></div>
-        </Primary>
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper
+          mocks={mocks}
+          initialState={{ accountListId: '1', breadcrumb: 'Dashboard' }}
+        >
+          <Primary>
+            <div data-testid="PrimaryTestChildren"></div>
+          </Primary>
+        </TestWrapper>
+      </ThemeProvider>,
     );
     expect(getByTestId('PrimaryTestChildren')).toBeInTheDocument();
     expect(getByRole('menuitem', { name: 'Dashboard' })).toBeVisible();

--- a/src/components/Layouts/Primary/Primary.test.tsx
+++ b/src/components/Layouts/Primary/Primary.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { ThemeProvider } from '@material-ui/core';
 import matchMediaMock from '../../../../__tests__/util/matchMediaMock';
 import TestWrapper from '../../../../__tests__/util/TestWrapper';
+import theme from '../../../theme';
 import { getNotificationsMocks } from './TopBar/Items/NotificationMenu/NotificationMenu.mock';
 
 import { getTopBarMock } from './TopBar/TopBar.mock';
 import Primary from '.';
-import { ThemeProvider } from '@material-ui/core';
-import theme from '../../../theme';
 
 describe('Primary', () => {
   const mocks = [...getNotificationsMocks(), getTopBarMock()];

--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.test.tsx
@@ -9,6 +9,8 @@ import { useApp } from '../../../../../App';
 import { getTopBarMock } from '../../TopBar.mock';
 import TestWrapper from '../../../../../../../__tests__/util/TestWrapper';
 import ProfileMenu from './ProfileMenu';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../../../../theme';
 
 let state: AppState;
 const dispatch = jest.fn();
@@ -24,12 +26,14 @@ describe('ProfileMenu', () => {
     });
 
     const { getByTestId, queryByText, getByText } = render(
-      <TestWrapper
-        initialState={{ accountListId: '1' }}
-        mocks={[getTopBarMock()]}
-      >
-        <ProfileMenu />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper
+          initialState={{ accountListId: '1' }}
+          mocks={[getTopBarMock()]}
+        >
+          <ProfileMenu />
+        </TestWrapper>
+      </ThemeProvider>,
     );
     await waitFor(() => expect(getByText('John Smith')).toBeInTheDocument());
     userEvent.click(getByTestId('profileMenuButton'));

--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@material-ui/core';
 import {
   render,
   waitFor,
@@ -8,9 +9,8 @@ import { AppState } from '../../../../../App/rootReducer';
 import { useApp } from '../../../../../App';
 import { getTopBarMock } from '../../TopBar.mock';
 import TestWrapper from '../../../../../../../__tests__/util/TestWrapper';
-import ProfileMenu from './ProfileMenu';
-import { ThemeProvider } from '@material-ui/core';
 import theme from '../../../../../../theme';
+import ProfileMenu from './ProfileMenu';
 
 let state: AppState;
 const dispatch = jest.fn();

--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: '0px 8px',
   },
   avatar: {
-    color: theme.palette.secondary.dark,
+    color: theme.palette.cruGrayMedium.main,
   },
   menuList: {
     paddingTop: 0,

--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
@@ -22,7 +22,7 @@ import { User } from '../../../../../../../graphql/types.generated';
 
 const useStyles = makeStyles((theme: Theme) => ({
   accountName: {
-    color: '#FFFFFF',
+    color: theme.palette.common.white,
     padding: '0px 8px',
   },
   avatar: {

--- a/src/components/Layouts/Primary/TopBar/TopBar.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/TopBar.test.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
 import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@material-ui/core';
 import { AppState } from '../../../App/rootReducer';
 import { useApp } from '../../../App';
+import theme from '../../../../theme';
 import { getNotificationsMocks } from './Items/NotificationMenu/NotificationMenu.mock';
 import { getTopBarMultipleMock } from './TopBar.mock';
 import TopBar from './TopBar';
-import { ThemeProvider } from '@material-ui/core';
-import theme from '../../../../theme';
 
 let state: AppState;
 const dispatch = jest.fn();

--- a/src/components/Layouts/Primary/TopBar/TopBar.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/TopBar.test.tsx
@@ -7,6 +7,8 @@ import { useApp } from '../../../App';
 import { getNotificationsMocks } from './Items/NotificationMenu/NotificationMenu.mock';
 import { getTopBarMultipleMock } from './TopBar.mock';
 import TopBar from './TopBar';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../../theme';
 
 let state: AppState;
 const dispatch = jest.fn();
@@ -27,9 +29,11 @@ describe('TopBar', () => {
 
   it('has correct defaults', () => {
     const { queryByText, getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <TopBar />
-      </MockedProvider>,
+      <ThemeProvider theme={theme}>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <TopBar />
+        </MockedProvider>
+      </ThemeProvider>,
     );
     userEvent.click(getByTestId('profileMenuButton'));
     expect(queryByText('Manage Organizations')).not.toBeInTheDocument();

--- a/src/components/Layouts/Primary/TopBar/TopBar.tsx
+++ b/src/components/Layouts/Primary/TopBar/TopBar.tsx
@@ -22,10 +22,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingTop: `env(safe-area-inset-top)`,
     paddingLeft: `env(safe-area-inset-left)`,
     paddingRight: `env(safe-area-inset-right)`,
-    backgroundColor: theme.palette.primary.dark,
+    backgroundColor: theme.palette.cruGrayDark.main,
   },
   toolbar: {
-    backgroundColor: theme.palette.primary.dark,
+    backgroundColor: theme.palette.cruGrayDark.main,
     minHeight: '60px',
   },
   logoGrid: {

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -12,10 +12,10 @@ const useStyles = makeStyles((_theme: Theme) => ({
     marginTop: '-28px',
   },
   fab: {
-    backgroundColor: '#fff',
+    backgroundColor: _theme.palette.common.white,
     cursor: 'default',
     '&:hover': {
-      backgroundColor: '#fff',
+      backgroundColor: _theme.palette.common.white,
     },
   },
 }));

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -3,7 +3,7 @@ import { makeStyles, Theme, Fab, CircularProgress } from '@material-ui/core';
 import { useRouter } from 'next/router';
 import { motion, AnimatePresence } from 'framer-motion';
 
-const useStyles = makeStyles((_theme: Theme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   box: {
     position: 'fixed',
     top: '50%',
@@ -12,10 +12,10 @@ const useStyles = makeStyles((_theme: Theme) => ({
     marginTop: '-28px',
   },
   fab: {
-    backgroundColor: _theme.palette.common.white,
+    backgroundColor: theme.palette.common.white,
     cursor: 'default',
     '&:hover': {
-      backgroundColor: _theme.palette.common.white,
+      backgroundColor: theme.palette.common.white,
     },
   },
 }));

--- a/src/components/PageHeading/PageHeading.test.tsx
+++ b/src/components/PageHeading/PageHeading.test.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import PageHeading from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../theme';
 
 describe('PageHeading', () => {
   it('has correct defaults', () => {
     const { getByTestId } = render(
-      <PageHeading heading="test heading" subheading="test subheading" />,
+      <ThemeProvider theme={theme}>
+        <PageHeading heading="test heading" subheading="test subheading" />
+      </ThemeProvider>,
     );
     expect(getByTestId('PageHeading')).toHaveStyle('margin-bottom: -20px');
     expect(getByTestId('PageHeadingContainer')).toHaveStyle(
@@ -23,12 +27,14 @@ describe('PageHeading', () => {
 
   it('has correct overrides', () => {
     const { getByTestId, queryByTestId } = render(
-      <PageHeading
-        heading="test heading"
-        imgSrc={require(`../../images/drawkit/grape/drawkit-grape-pack-illustration-1.svg`)}
-        overlap={100}
-        height={400}
-      />,
+      <ThemeProvider theme={theme}>
+        <PageHeading
+          heading="test heading"
+          imgSrc={require(`../../images/drawkit/grape/drawkit-grape-pack-illustration-1.svg`)}
+          overlap={100}
+          height={400}
+        />
+      </ThemeProvider>,
     );
     expect(getByTestId('PageHeading')).toHaveStyle('margin-bottom: -100px');
     expect(getByTestId('PageHeading')).toHaveStyle('height: 400px');
@@ -44,7 +50,9 @@ describe('PageHeading', () => {
 
   it('has correct overrides for image', () => {
     const { queryByTestId } = render(
-      <PageHeading heading="test heading" image={false} />,
+      <ThemeProvider theme={theme}>
+        <PageHeading heading="test heading" image={false} />
+      </ThemeProvider>,
     );
     expect(queryByTestId('PageHeadingImg')).not.toBeInTheDocument();
   });

--- a/src/components/PageHeading/PageHeading.test.tsx
+++ b/src/components/PageHeading/PageHeading.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import PageHeading from '.';
 import { ThemeProvider } from '@material-ui/core';
 import theme from '../../theme';
+import PageHeading from '.';
 
 describe('PageHeading', () => {
   it('has correct defaults', () => {

--- a/src/components/PageHeading/PageHeading.tsx
+++ b/src/components/PageHeading/PageHeading.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   pageHeading: {
     flex: 1,
-    color: '#FFF',
+    color: theme.palette.common.white,
   },
 }));
 

--- a/src/components/PageHeading/PageHeading.tsx
+++ b/src/components/PageHeading/PageHeading.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 const useStyles = makeStyles((theme: Theme) => ({
   div: {
-    backgroundColor: theme.palette.primary.main,
+    backgroundColor: theme.palette.mpdxBlue.main,
     height: '250px',
     display: 'flex',
     alignItems: 'flex-end',

--- a/src/components/Task/Drawer/CommentList/CommentList.test.tsx
+++ b/src/components/Task/Drawer/CommentList/CommentList.test.tsx
@@ -11,6 +11,8 @@ import {
 } from './CommentList.mock';
 import { createTaskCommentMutationMock } from './Form/Form.mock';
 import TaskDrawerCommentList from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../../theme';
 
 const accountListId = 'abc';
 const taskId = 'task-1';
@@ -35,17 +37,19 @@ jest.mock('uuid', () => ({
 describe('TaskDrawerCommentList', () => {
   it('default', async () => {
     const { queryByTestId, getAllByTestId, getByRole } = render(
-      <TestWrapper
-        initialState={{
-          user: { id: 'user-1', firstName: 'John', lastName: 'Smith' } as User,
-        }}
-        mocks={[
-          getCommentsForTaskDrawerCommentListMock(accountListId, taskId),
-          createTaskCommentMutationMock(),
-        ]}
-      >
-        <TaskDrawerCommentList accountListId={accountListId} taskId={taskId} />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper
+          initialState={{
+            user: { id: 'user-1', firstName: 'John', lastName: 'Smith' } as User,
+          }}
+          mocks={[
+            getCommentsForTaskDrawerCommentListMock(accountListId, taskId),
+            createTaskCommentMutationMock(),
+          ]}
+        >
+          <TaskDrawerCommentList accountListId={accountListId} taskId={taskId} />
+        </TestWrapper>
+      </ThemeProvider>,
     );
     await waitFor(() =>
       expect(
@@ -71,32 +75,36 @@ describe('TaskDrawerCommentList', () => {
 
   it('loading', () => {
     const { getByTestId } = render(
-      <TestWrapper
-        initialState={{
-          user: { id: 'user-1', firstName: 'John', lastName: 'Smith' } as User,
-        }}
-        mocks={[
-          getCommentsForTaskDrawerCommentListLoadingMock(accountListId, taskId),
-        ]}
-      >
-        <TaskDrawerCommentList accountListId={accountListId} taskId={taskId} />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper
+          initialState={{
+            user: { id: 'user-1', firstName: 'John', lastName: 'Smith' } as User,
+          }}
+          mocks={[
+            getCommentsForTaskDrawerCommentListLoadingMock(accountListId, taskId),
+          ]}
+        >
+          <TaskDrawerCommentList accountListId={accountListId} taskId={taskId} />
+        </TestWrapper>
+      </ThemeProvider>,
     );
     expect(getByTestId('TaskDrawerCommentListLoading')).toBeInTheDocument();
   });
 
   it('empty', async () => {
     const { queryByTestId, getByTestId } = render(
-      <TestWrapper
-        initialState={{
-          user: { id: 'user-1', firstName: 'John', lastName: 'Smith' } as User,
-        }}
-        mocks={[
-          getCommentsForTaskDrawerCommentListEmptyMock(accountListId, taskId),
-        ]}
-      >
-        <TaskDrawerCommentList accountListId={accountListId} taskId={taskId} />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper
+          initialState={{
+            user: { id: 'user-1', firstName: 'John', lastName: 'Smith' } as User,
+          }}
+          mocks={[
+            getCommentsForTaskDrawerCommentListEmptyMock(accountListId, taskId),
+          ]}
+        >
+          <TaskDrawerCommentList accountListId={accountListId} taskId={taskId} />
+        </TestWrapper>
+      </ThemeProvider>,
     );
     await waitFor(() =>
       expect(
@@ -108,16 +116,18 @@ describe('TaskDrawerCommentList', () => {
 
   it('error', async () => {
     render(
-      <TestWrapper
-        initialState={{
-          user: { id: 'user-1', firstName: 'John', lastName: 'Smith' } as User,
-        }}
-        mocks={[
-          getCommentsForTaskDrawerCommentListErrorMock(accountListId, taskId),
-        ]}
-      >
-        <TaskDrawerCommentList accountListId={accountListId} taskId={taskId} />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper
+          initialState={{
+            user: { id: 'user-1', firstName: 'John', lastName: 'Smith' } as User,
+          }}
+          mocks={[
+            getCommentsForTaskDrawerCommentListErrorMock(accountListId, taskId),
+          ]}
+        >
+          <TaskDrawerCommentList accountListId={accountListId} taskId={taskId} />
+        </TestWrapper>
+      </ThemeProvider>,
     );
 
     await waitFor(() =>

--- a/src/components/Task/Drawer/CommentList/CommentList.test.tsx
+++ b/src/components/Task/Drawer/CommentList/CommentList.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@material-ui/core';
 import TestWrapper from '../../../../../__tests__/util/TestWrapper';
 import { User } from '../../../../../graphql/types.generated';
+import theme from '../../../../theme';
 import {
   getCommentsForTaskDrawerCommentListMock,
   getCommentsForTaskDrawerCommentListEmptyMock,
@@ -11,8 +13,6 @@ import {
 } from './CommentList.mock';
 import { createTaskCommentMutationMock } from './Form/Form.mock';
 import TaskDrawerCommentList from '.';
-import { ThemeProvider } from '@material-ui/core';
-import theme from '../../../../theme';
 
 const accountListId = 'abc';
 const taskId = 'task-1';
@@ -40,14 +40,21 @@ describe('TaskDrawerCommentList', () => {
       <ThemeProvider theme={theme}>
         <TestWrapper
           initialState={{
-            user: { id: 'user-1', firstName: 'John', lastName: 'Smith' } as User,
+            user: {
+              id: 'user-1',
+              firstName: 'John',
+              lastName: 'Smith',
+            } as User,
           }}
           mocks={[
             getCommentsForTaskDrawerCommentListMock(accountListId, taskId),
             createTaskCommentMutationMock(),
           ]}
         >
-          <TaskDrawerCommentList accountListId={accountListId} taskId={taskId} />
+          <TaskDrawerCommentList
+            accountListId={accountListId}
+            taskId={taskId}
+          />
         </TestWrapper>
       </ThemeProvider>,
     );
@@ -78,13 +85,23 @@ describe('TaskDrawerCommentList', () => {
       <ThemeProvider theme={theme}>
         <TestWrapper
           initialState={{
-            user: { id: 'user-1', firstName: 'John', lastName: 'Smith' } as User,
+            user: {
+              id: 'user-1',
+              firstName: 'John',
+              lastName: 'Smith',
+            } as User,
           }}
           mocks={[
-            getCommentsForTaskDrawerCommentListLoadingMock(accountListId, taskId),
+            getCommentsForTaskDrawerCommentListLoadingMock(
+              accountListId,
+              taskId,
+            ),
           ]}
         >
-          <TaskDrawerCommentList accountListId={accountListId} taskId={taskId} />
+          <TaskDrawerCommentList
+            accountListId={accountListId}
+            taskId={taskId}
+          />
         </TestWrapper>
       </ThemeProvider>,
     );
@@ -96,13 +113,20 @@ describe('TaskDrawerCommentList', () => {
       <ThemeProvider theme={theme}>
         <TestWrapper
           initialState={{
-            user: { id: 'user-1', firstName: 'John', lastName: 'Smith' } as User,
+            user: {
+              id: 'user-1',
+              firstName: 'John',
+              lastName: 'Smith',
+            } as User,
           }}
           mocks={[
             getCommentsForTaskDrawerCommentListEmptyMock(accountListId, taskId),
           ]}
         >
-          <TaskDrawerCommentList accountListId={accountListId} taskId={taskId} />
+          <TaskDrawerCommentList
+            accountListId={accountListId}
+            taskId={taskId}
+          />
         </TestWrapper>
       </ThemeProvider>,
     );
@@ -119,13 +143,20 @@ describe('TaskDrawerCommentList', () => {
       <ThemeProvider theme={theme}>
         <TestWrapper
           initialState={{
-            user: { id: 'user-1', firstName: 'John', lastName: 'Smith' } as User,
+            user: {
+              id: 'user-1',
+              firstName: 'John',
+              lastName: 'Smith',
+            } as User,
           }}
           mocks={[
             getCommentsForTaskDrawerCommentListErrorMock(accountListId, taskId),
           ]}
         >
-          <TaskDrawerCommentList accountListId={accountListId} taskId={taskId} />
+          <TaskDrawerCommentList
+            accountListId={accountListId}
+            taskId={taskId}
+          />
         </TestWrapper>
       </ThemeProvider>,
     );

--- a/src/components/Task/Drawer/CommentList/Item/Item.test.tsx
+++ b/src/components/Task/Drawer/CommentList/Item/Item.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { GetCommentsForTaskDrawerCommentListQuery } from '../TaskListComments.generated';
 import Item from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../../../theme';
 
 describe('Item', () => {
   const comment: GetCommentsForTaskDrawerCommentListQuery['task']['comments']['nodes'][0] = {
@@ -17,7 +19,11 @@ describe('Item', () => {
   };
 
   it('has correct defaults', () => {
-    const { getByTestId, getByText } = render(<Item comment={comment} />);
+    const { getByTestId, getByText } = render(
+      <ThemeProvider theme={theme}>
+        <Item comment={comment} />
+      </ThemeProvider>,
+    );
     expect(getByTestId('TaskDrawerCommentListItemAvatar')).toBeInTheDocument();
     expect(
       getByText('The quick brown fox jumped over the lazy dog.'),
@@ -27,14 +33,22 @@ describe('Item', () => {
   });
 
   it('has correct overrides', () => {
-    const { queryByTestId } = render(<Item comment={comment} reverse={true} />);
+    const { queryByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <Item comment={comment} reverse={true} />
+      </ThemeProvider>,
+    );
     expect(
       queryByTestId('TaskDrawerCommentListItemAvatar'),
     ).not.toBeInTheDocument();
   });
 
   it('has loading state', () => {
-    const { queryByTestId } = render(<Item />);
+    const { queryByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <Item />
+      </ThemeProvider>,
+    );
     expect(
       queryByTestId('TaskDrawerCommentListItemAvatar'),
     ).not.toBeInTheDocument();

--- a/src/components/Task/Drawer/CommentList/Item/Item.test.tsx
+++ b/src/components/Task/Drawer/CommentList/Item/Item.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { GetCommentsForTaskDrawerCommentListQuery } from '../TaskListComments.generated';
-import Item from '.';
 import { ThemeProvider } from '@material-ui/core';
+import { GetCommentsForTaskDrawerCommentListQuery } from '../TaskListComments.generated';
 import theme from '../../../../../theme';
+import Item from '.';
 
 describe('Item', () => {
   const comment: GetCommentsForTaskDrawerCommentListQuery['task']['comments']['nodes'][0] = {

--- a/src/components/Task/Drawer/CommentList/Item/Item.tsx
+++ b/src/components/Task/Drawer/CommentList/Item/Item.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     '& $triangle': {
       gridColumn: 2,
       gridRow: 1,
-      borderLeft: `5px solid ${theme.palette.primary.main}`,
+      borderLeft: `5px solid ${theme.palette.mpdxBlue.main}`,
       borderRight: 0,
     },
     '& $content': {
@@ -53,7 +53,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       textAlign: 'right',
     },
     '& $box': {
-      backgroundColor: theme.palette.primary.main,
+      backgroundColor: theme.palette.mpdxBlue.main,
       color: theme.palette.primary.contrastText,
       borderBottomLeftRadius: '8px',
       borderBottomRightRadius: 0,

--- a/src/components/Task/Drawer/Drawer.test.tsx
+++ b/src/components/Task/Drawer/Drawer.test.tsx
@@ -16,6 +16,8 @@ import {
   getCompleteTaskForTaskDrawerMock,
 } from './CompleteForm/CompleteForm.mock';
 import TaskDrawer from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../theme';
 
 const accountListId = 'abc';
 const taskId = 'task-1';
@@ -29,9 +31,11 @@ describe('TaskDrawer', () => {
       createTaskMutationMock(),
     ];
     const { getByText, getByRole, getByTestId } = render(
-      <TestWrapper mocks={mocks}>
-        <TaskDrawer onClose={onClose} defaultValues={{ subject: 'abc' }} />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper mocks={mocks}>
+          <TaskDrawer onClose={onClose} defaultValues={{ subject: 'abc' }} />
+        </TestWrapper>
+      </ThemeProvider>,
     );
     expect(
       getByRole('tab', { name: 'Contacts ({{ contactCount }})' }),
@@ -52,9 +56,11 @@ describe('TaskDrawer', () => {
       getTaskForTaskDrawerMock(),
     ];
     const { findByTestId } = render(
-      <TestWrapper mocks={mocks}>
-        <TaskDrawer onClose={onClose} taskId={taskId} />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper mocks={mocks}>
+          <TaskDrawer onClose={onClose} taskId={taskId} />
+        </TestWrapper>
+      </ThemeProvider>,
     );
     expect(await findByTestId('TaskDrawerTitle')).toHaveTextContent(
       ActivityTypeEnum.NewsletterEmail,
@@ -71,9 +77,11 @@ describe('TaskDrawer', () => {
       getCompleteTaskForTaskDrawerMock(accountListId, taskId),
     ];
     const { findByTestId } = render(
-      <TestWrapper mocks={mocks}>
-        <TaskDrawer onClose={onClose} taskId={taskId} showCompleteForm />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper mocks={mocks}>
+          <TaskDrawer onClose={onClose} taskId={taskId} showCompleteForm />
+        </TestWrapper>
+      </ThemeProvider>,
     );
     expect(await findByTestId('TaskDrawerTitle')).toHaveTextContent(
       'Complete {{activityType}}',

--- a/src/components/Task/Drawer/Drawer.test.tsx
+++ b/src/components/Task/Drawer/Drawer.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@material-ui/core';
 import TestWrapper from '../../../../__tests__/util/TestWrapper';
 import { ActivityTypeEnum } from '../../../../graphql/types.generated';
+import theme from '../../../theme';
 import {
   getDataForTaskDrawerMock,
   createTaskMutationMock,
@@ -16,8 +18,6 @@ import {
   getCompleteTaskForTaskDrawerMock,
 } from './CompleteForm/CompleteForm.mock';
 import TaskDrawer from '.';
-import { ThemeProvider } from '@material-ui/core';
-import theme from '../../../theme';
 
 const accountListId = 'abc';
 const taskId = 'task-1';

--- a/src/components/Task/Home/Home.test.tsx
+++ b/src/components/Task/Home/Home.test.tsx
@@ -8,6 +8,8 @@ import {
 } from '../List/List.mock';
 import { ActivityTypeEnum } from '../../../../graphql/types.generated';
 import TaskHome from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../theme';
 
 const accountListId = 'abc';
 
@@ -18,9 +20,11 @@ describe('TaskHome', () => {
       getDataForTaskDrawerMock(accountListId),
     ];
     const { findByText } = render(
-      <TestWrapper mocks={mocks}>
-        <TaskHome />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper mocks={mocks}>
+          <TaskHome />
+        </TestWrapper>
+      </ThemeProvider>,
     );
     expect(
       await findByText('On the Journey with the Johnson Family'),
@@ -38,14 +42,16 @@ describe('TaskHome', () => {
       wildcardSearch: 'journey',
     };
     const { findByText } = render(
-      <TestWrapper
-        mocks={[
-          getFilteredTasksForTaskListMock(accountListId, filter),
-          getDataForTaskDrawerMock(accountListId),
-        ]}
-      >
-        <TaskHome initialFilter={filter} />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper
+          mocks={[
+            getFilteredTasksForTaskListMock(accountListId, filter),
+            getDataForTaskDrawerMock(accountListId),
+          ]}
+        >
+          <TaskHome initialFilter={filter} />
+        </TestWrapper>
+      </ThemeProvider>,
     );
     expect(
       await findByText('On the Journey with the Johnson Family'),

--- a/src/components/Task/Home/Home.test.tsx
+++ b/src/components/Task/Home/Home.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ThemeProvider } from '@material-ui/core';
 import TestWrapper from '../../../../__tests__/util/TestWrapper';
 import { getDataForTaskDrawerMock } from '../Drawer/Form/Form.mock';
 import { render } from '../../../../__tests__/util/testingLibraryReactMock';
@@ -7,9 +8,8 @@ import {
   getFilteredTasksForTaskListMock,
 } from '../List/List.mock';
 import { ActivityTypeEnum } from '../../../../graphql/types.generated';
-import TaskHome from '.';
-import { ThemeProvider } from '@material-ui/core';
 import theme from '../../../theme';
+import TaskHome from '.';
 
 const accountListId = 'abc';
 

--- a/src/components/Task/List/List.test.tsx
+++ b/src/components/Task/List/List.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@material-ui/core';
 import TestWrapper from '../../../../__tests__/util/TestWrapper';
 import { getDataForTaskDrawerMock } from '../Drawer/Form/Form.mock';
 import {
@@ -8,6 +9,7 @@ import {
 } from '../../../../__tests__/util/testingLibraryReactMock';
 import { useApp } from '../../App';
 import { ActivityTypeEnum } from '../../../../graphql/types.generated';
+import theme from '../../../theme';
 import {
   getTasksForTaskListMock,
   getFilteredTasksForTaskListMock,
@@ -15,8 +17,6 @@ import {
   getTasksForTaskListErrorMock,
 } from './List.mock';
 import TaskList from '.';
-import { ThemeProvider } from '@material-ui/core';
-import theme from '../../../theme';
 
 const accountListId = 'abc';
 

--- a/src/components/Task/List/List.test.tsx
+++ b/src/components/Task/List/List.test.tsx
@@ -15,6 +15,8 @@ import {
   getTasksForTaskListErrorMock,
 } from './List.mock';
 import TaskList from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../theme';
 
 const accountListId = 'abc';
 
@@ -115,9 +117,11 @@ describe('TaskList', () => {
       }),
     ];
     const { findByText, getByRole, getAllByRole } = render(
-      <TestWrapper mocks={mocks} disableAppProvider>
-        <TaskList />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper mocks={mocks} disableAppProvider>
+          <TaskList />
+        </TestWrapper>
+      </ThemeProvider>,
     );
     userEvent.click(await findByText('On the Journey with the Johnson Family'));
     expect(openTaskDrawer).toHaveBeenCalledWith({
@@ -178,15 +182,17 @@ describe('TaskList', () => {
       startAt: { min: '2020-10-10', max: '2020-12-10' },
     };
     const { getByRole, getByText, findByText } = render(
-      <TestWrapper
-        mocks={[
-          getFilteredTasksForTaskListMock(accountListId, filter),
-          getDataForTaskDrawerMock(accountListId),
-        ]}
-        disableAppProvider
-      >
-        <TaskList initialFilter={filter} />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper
+          mocks={[
+            getFilteredTasksForTaskListMock(accountListId, filter),
+            getDataForTaskDrawerMock(accountListId),
+          ]}
+          disableAppProvider
+        >
+          <TaskList initialFilter={filter} />
+        </TestWrapper>
+      </ThemeProvider>,
     );
     expect(getByText('Appointment')).toBeInTheDocument();
     expect(getByText('Complete')).toBeInTheDocument();
@@ -211,29 +217,33 @@ describe('TaskList', () => {
       },
     ];
     const { getAllByRole } = render(
-      <TestWrapper mocks={mocks} disableAppProvider>
-        <TaskList
-          initialFilter={{
-            userIds: ['user-1'],
-            contactIds: ['contact-1'],
-          }}
-        />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper mocks={mocks} disableAppProvider>
+          <TaskList
+            initialFilter={{
+              userIds: ['user-1'],
+              contactIds: ['contact-1'],
+            }}
+          />
+        </TestWrapper>
+      </ThemeProvider>,
     );
     expect(getAllByRole('button', { name: 'Loading' }).length).toEqual(2);
   });
 
   it('has empty state', () => {
     const { queryByTestId } = render(
-      <TestWrapper
-        mocks={[
-          getEmptyTasksForTaskListMock(accountListId),
-          getDataForTaskDrawerMock(accountListId),
-        ]}
-        disableAppProvider
-      >
-        <TaskList />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper
+          mocks={[
+            getEmptyTasksForTaskListMock(accountListId),
+            getDataForTaskDrawerMock(accountListId),
+          ]}
+          disableAppProvider
+        >
+          <TaskList />
+        </TestWrapper>
+      </ThemeProvider>,
     );
     expect(
       queryByTestId('TaskDrawerCommentListItemAvatar'),
@@ -242,15 +252,17 @@ describe('TaskList', () => {
 
   it('error', async () => {
     render(
-      <TestWrapper
-        mocks={[
-          getTasksForTaskListErrorMock(accountListId),
-          getDataForTaskDrawerMock(accountListId),
-        ]}
-        disableAppProvider
-      >
-        <TaskList />
-      </TestWrapper>,
+      <ThemeProvider theme={theme}>
+        <TestWrapper
+          mocks={[
+            getTasksForTaskListErrorMock(accountListId),
+            getDataForTaskDrawerMock(accountListId),
+          ]}
+          disableAppProvider
+        >
+          <TaskList />
+        </TestWrapper>
+      </ThemeProvider>,
     );
 
     await waitFor(() =>

--- a/src/components/Task/Status/Status.test.tsx
+++ b/src/components/Task/Status/Status.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useApp } from '../../App';
-import TaskStatus from '.';
 import { ThemeProvider } from '@material-ui/core';
+import { useApp } from '../../App';
 import theme from '../../../theme';
+import TaskStatus from '.';
 
 jest.mock('../../App', () => ({
   useApp: jest.fn(),

--- a/src/components/Task/Status/Status.test.tsx
+++ b/src/components/Task/Status/Status.test.tsx
@@ -3,6 +3,8 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useApp } from '../../App';
 import TaskStatus from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../../theme';
 
 jest.mock('../../App', () => ({
   useApp: jest.fn(),
@@ -18,14 +20,20 @@ beforeEach(() => {
 
 describe('TaskStatus', () => {
   it('default', async () => {
-    const { getByRole, findByText } = render(<TaskStatus />);
+    const { getByRole, findByText } = render(
+      <ThemeProvider theme={theme}>
+        <TaskStatus />
+      </ThemeProvider>,
+    );
     userEvent.hover(getByRole('button'));
     expect(await findByText('No Due Date')).toBeInTheDocument();
   });
 
   it('completedAt', async () => {
     const { getByRole, findByText } = render(
-      <TaskStatus completedAt="2009-12-31T11:00:00.000Z" />,
+      <ThemeProvider theme={theme}>
+        <TaskStatus completedAt="2009-12-31T11:00:00.000Z" />
+      </ThemeProvider>,
     );
     userEvent.hover(getByRole('button'));
     expect(await findByText('Completed 10 years ago')).toBeInTheDocument();
@@ -33,7 +41,9 @@ describe('TaskStatus', () => {
 
   it('startAt in past', async () => {
     const { getByRole, findByText } = render(
-      <TaskStatus startAt="2009-12-31T11:00:00.000Z" />,
+      <ThemeProvider theme={theme}>
+        <TaskStatus startAt="2009-12-31T11:00:00.000Z" />
+      </ThemeProvider>,
     );
     userEvent.hover(getByRole('button'));
     expect(await findByText('Overdue 10 years ago')).toBeInTheDocument();
@@ -41,14 +51,20 @@ describe('TaskStatus', () => {
 
   it('startAt in future', async () => {
     const { getByRole, findByText } = render(
-      <TaskStatus startAt="2050-12-31T11:00:00.000Z" />,
+      <ThemeProvider theme={theme}>
+        <TaskStatus startAt="2050-12-31T11:00:00.000Z" />
+      </ThemeProvider>,
     );
     userEvent.hover(getByRole('button'));
     expect(await findByText('Due in 30 years')).toBeInTheDocument();
   });
 
   it('taskId', async () => {
-    const { getByRole } = render(<TaskStatus taskId="task-1" />);
+    const { getByRole } = render(
+      <ThemeProvider theme={theme}>
+        <TaskStatus taskId="task-1" />
+      </ThemeProvider>,
+    );
     userEvent.click(getByRole('button'));
     expect(openTaskDrawer).toHaveBeenCalledWith({
       taskId: 'task-1',

--- a/src/components/Task/Status/Status.tsx
+++ b/src/components/Task/Status/Status.tsx
@@ -11,19 +11,19 @@ import { useApp } from '../../App';
 
 const useStyles = makeStyles((theme: Theme) => ({
   buttonGreen: {
-    color: '#fff',
-    backgroundColor: green[500],
+    color: theme.palette.common.white,
+    backgroundColor: theme.palette.mpdxGreen.main,
     cursor: 'default',
     '&:hover': {
-      backgroundColor: green[500],
+      backgroundColor: theme.palette.mpdxGreen.main,
     },
   },
-  buttonOrange: {
-    color: '#fff',
-    backgroundColor: orange[500],
+  buttonRed: {
+    color: theme.palette.common.white,
+    backgroundColor: theme.palette.error.main,
   },
   buttonPrimary: {
-    color: '#fff',
+    color: theme.palette.common.white,
     backgroundColor: theme.palette.mpdxBlue.main,
   },
   buttonSmall: {
@@ -37,7 +37,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       duration: theme.transitions.duration.short,
     }),
     '&:hover': {
-      backgroundColor: green[500],
+      backgroundColor: theme.palette.mpdxGreen.main,
     },
     '&:hover $icon': {
       opacity: 0,
@@ -60,7 +60,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     opacity: 0,
     left: '6px',
     transform: 'rotate(-45deg)',
-    color: '#fff',
+    color: theme.palette.common.white,
   },
 }));
 
@@ -135,7 +135,7 @@ const TaskStatus = ({
           <Fab
             className={[
               classes.buttonSmall,
-              classes.buttonOrange,
+              classes.buttonRed,
               classes.buttonWithHover,
             ].join(' ')}
             onClick={handleClick}

--- a/src/components/Task/Status/Status.tsx
+++ b/src/components/Task/Status/Status.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   buttonPrimary: {
     color: '#fff',
-    backgroundColor: theme.palette.primary.main,
+    backgroundColor: theme.palette.mpdxBlue.main,
   },
   buttonSmall: {
     width: theme.spacing(4.5),

--- a/src/components/Task/Status/Status.tsx
+++ b/src/components/Task/Status/Status.tsx
@@ -4,7 +4,6 @@ import { DateTime } from 'luxon';
 import AssignmentLateIcon from '@material-ui/icons/AssignmentLate';
 import AssignmentIcon from '@material-ui/icons/Assignment';
 import AssignmentTurnedInIcon from '@material-ui/icons/AssignmentTurnedIn';
-import { green, orange } from '@material-ui/core/colors';
 import { useTranslation } from 'react-i18next';
 import DoneIcon from '@material-ui/icons/Done';
 import { useApp } from '../../App';

--- a/src/components/Welcome/Welcome.test.tsx
+++ b/src/components/Welcome/Welcome.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import Welcome from '.';
 import { ThemeProvider } from '@material-ui/core';
 import theme from '../../theme';
+import Welcome from '.';
 
 describe('Welcome', () => {
   it('has correct defaults', () => {

--- a/src/components/Welcome/Welcome.test.tsx
+++ b/src/components/Welcome/Welcome.test.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Welcome from '.';
+import { ThemeProvider } from '@material-ui/core';
+import theme from '../../theme';
 
 describe('Welcome', () => {
   it('has correct defaults', () => {
     const { getByTestId } = render(
-      <Welcome title="test title" subtitle="test subtitle">
-        <div data-testid="children">children</div>
-      </Welcome>,
+      <ThemeProvider theme={theme}>
+        <Welcome title="test title" subtitle="test subtitle">
+          <div data-testid="children">children</div>
+        </Welcome>
+      </ThemeProvider>,
     );
     expect(getByTestId('welcomeTitle')).toHaveTextContent('test title');
     expect(getByTestId('welcomeSubtitle')).toHaveTextContent('test subtitle');
@@ -20,11 +24,13 @@ describe('Welcome', () => {
 
   it('has correct overrides', () => {
     const { getByTestId } = render(
-      <Welcome
-        title={<div data-testid="testTitle">test title</div>}
-        subtitle={<div data-testid="testSubtitle">test subtitle</div>}
-        imgSrc={require(`../../images/drawkit/grape/drawkit-grape-pack-illustration-1.svg`)}
-      />,
+      <ThemeProvider theme={theme}>
+        <Welcome
+          title={<div data-testid="testTitle">test title</div>}
+          subtitle={<div data-testid="testSubtitle">test subtitle</div>}
+          imgSrc={require(`../../images/drawkit/grape/drawkit-grape-pack-illustration-1.svg`)}
+        />
+      </ThemeProvider>,
     );
     expect(() => getByTestId('welcomeTitle')).toThrowError();
     expect(() => getByTestId('welcomeSubtitle')).toThrowError();

--- a/src/components/Welcome/Welcome.tsx
+++ b/src/components/Welcome/Welcome.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     minHeight: '100vh',
     minWidth: '100vw',
     backgroundColor: theme.palette.mpdxBlue.main,
-    color: '#fff',
+    color: theme.palette.common.white,
   },
   subtitle: {
     maxWidth: '450px',

--- a/src/components/Welcome/Welcome.tsx
+++ b/src/components/Welcome/Welcome.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignItems: 'center',
     minHeight: '100vh',
     minWidth: '100vw',
-    backgroundColor: theme.palette.primary.main,
+    backgroundColor: theme.palette.mpdxBlue.main,
     color: '#fff',
   },
   subtitle: {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -132,7 +132,7 @@ const theme = createMuiTheme({
           backgroundColor: '#f6f7f9',
         },
         body: {
-          backgroundColor: '#05699b',
+          backgroundColor: mpdxColors.blue,
         },
       },
     },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -10,6 +10,13 @@ const cruColors = {
   grayLight: '#EBECEC',
 };
 
+const mpdxColors = {
+  green: '#00CA99',
+  blue: '#05699B',
+  yellow: '#FFF5CD',
+  gray: '#DCDCDC',
+};
+
 // https://material-ui.com/customization/palette/#adding-new-colors
 declare module '@material-ui/core/styles/createPalette' {
   interface Palette {
@@ -17,12 +24,20 @@ declare module '@material-ui/core/styles/createPalette' {
     cruGrayDark: Palette['primary'];
     cruGrayMedium: Palette['primary'];
     cruGrayLight: Palette['primary'];
+    mpdxGreen: Palette['primary'];
+    mpdxBlue: Palette['primary'];
+    mpdxYellow: Palette['primary'];
+    mpdxGray: Palette['primary'];
   }
   interface PaletteOptions {
     cruYellow: PaletteOptions['primary'];
     cruGrayDark: PaletteOptions['primary'];
     cruGrayMedium: PaletteOptions['primary'];
     cruGrayLight: PaletteOptions['primary'];
+    mpdxGreen: PaletteOptions['primary'];
+    mpdxBlue: PaletteOptions['primary'];
+    mpdxYellow: PaletteOptions['primary'];
+    mpdxGray: PaletteOptions['primary'];
   }
 }
 
@@ -31,31 +46,17 @@ const theme = createMuiTheme({
     fontFamily: "'Source Sans Pro', sans-serif",
   },
   palette: {
-    common: {
-      black: '#000',
-      white: '#fff',
-    },
-    background: {
-      paper: '#fff',
-      default: '#fafafa',
-    },
     primary: {
-      dark: '#383F43',
-      main: '#05699b',
-      light: '#3787a',
+      dark: cruColors.grayDark,
+      main: mpdxColors.blue,
     },
     secondary: {
-      main: '#f5be19',
-      light: '#F7CB47',
-      dark: '#9C9FA1',
-    },
-    error: {
-      main: '#F44336',
-      dark: '#C9302F',
+      main: cruColors.yellow,
+      dark: cruColors.grayMedium,
     },
     text: {
-      primary: '#383F43',
-      secondary: '#9C9FA1',
+      primary: cruColors.grayDark,
+      secondary: cruColors.grayMedium,
     },
     cruYellow: {
       main: cruColors.yellow,
@@ -68,6 +69,18 @@ const theme = createMuiTheme({
     },
     cruGrayLight: {
       main: cruColors.grayLight,
+    },
+    mpdxGreen: {
+      main: mpdxColors.green,
+    },
+    mpdxBlue: {
+      main: mpdxColors.blue,
+    },
+    mpdxYellow: {
+      main: mpdxColors.yellow,
+    },
+    mpdxGray: {
+      main: mpdxColors.gray,
     },
   },
   overrides: {


### PR DESCRIPTION
Added Cru and MPDX colors to the theme. Any values I just straight up deleted were either invalid, unnecessary, or duplicates from the default theme values. I still want to go through the files we've already got and swap out color values and references, but I wanted to get some eyes on what I've done so far first. I made each color its own key, thinking that the `light`, `dark`, and `contrastText` values would be automatically created, but those don't seem to be working at the moment.