### PR TITLE
MPDX-6943-Add-Newsletter-Dropdown-Functionality

### DIFF
--- a/src/components/Dashboard/ThisWeek/NewsletterMenu.graphql
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu.graphql
@@ -1,0 +1,21 @@
+query GetTaskAnalytics($accountListId: ID!) {
+  taskAnalytics(accountListId: $accountListId) {
+    lastElectronicNewsletterCompletedAt
+    lastPhysicalNewsletterCompletedAt
+  }
+}
+
+query GetEmailNewsletterContacts($accountListId: ID!) {
+  contacts(accountListId: $accountListId, newsletter: EMAIL, status: ACTIVE) {
+    nodes {
+      id
+      primaryPerson {
+        id
+        primaryEmailAddress {
+          id
+          email
+        }
+      }
+    }
+  }
+}

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/ExportEmail.stories.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/ExportEmail.stories.tsx
@@ -1,0 +1,58 @@
+import { MockedProvider } from '@apollo/client/testing';
+import React, { ReactElement } from 'react';
+import { GqlMockedProvider } from '../../../../../../../__tests__/util/graphqlMocking';
+import ExportEmail from './ExportEmail';
+import {
+  GetEmailNewsletterContactsDocument,
+  GetEmailNewsletterContactsQuery,
+} from './GetNewsletterContacts.generated';
+
+export default {
+  title: 'Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail',
+};
+
+const accountListId = '111';
+
+export const Default = (): ReactElement => {
+  return (
+    <GqlMockedProvider<GetEmailNewsletterContactsQuery>>
+      <ExportEmail accountListId={accountListId} handleClose={() => {}} />
+    </GqlMockedProvider>
+  );
+};
+
+export const Loading = (): ReactElement => {
+  return (
+    <MockedProvider
+      mocks={[
+        {
+          request: {
+            query: GetEmailNewsletterContactsDocument,
+            variables: {
+              accountListId,
+            },
+          },
+          result: {},
+          delay: 100931731455,
+        },
+      ]}
+    >
+      <ExportEmail accountListId={accountListId} handleClose={() => {}} />
+    </MockedProvider>
+  );
+};
+
+export const Empty = (): ReactElement => {
+  const mocks = {
+    GetEmailNewsletterContacts: {
+      contacts: {
+        nodes: [],
+      },
+    },
+  };
+  return (
+    <GqlMockedProvider<GetEmailNewsletterContactsQuery> mocks={mocks}>
+      <ExportEmail accountListId={accountListId} handleClose={() => {}} />
+    </GqlMockedProvider>
+  );
+};

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/ExportEmail.test.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/ExportEmail.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GqlMockedProvider } from '../../../../../../../__tests__/util/graphqlMocking';
+import ExportEmail from './ExportEmail';
+import { GetEmailNewsletterContactsQuery } from './GetNewsletterContacts.generated';
+
+const accountListId = '111';
+const handleClose = jest.fn();
+
+describe('LogNewsletter', () => {
+  it('default', () => {
+    const { queryByText } = render(
+      <GqlMockedProvider<GetEmailNewsletterContactsQuery>>
+        <ExportEmail accountListId={accountListId} handleClose={handleClose} />
+      </GqlMockedProvider>,
+    );
+    expect(queryByText('Email Newsletter List')).toBeInTheDocument();
+  });
+
+  it('creates emailList string', async () => {
+    const email1 = 'fakeemail1@fake.com';
+    const email2 = 'fakeemail2@fake.com';
+    const mocks = {
+      GetEmailNewsletterContacts: {
+        contacts: {
+          nodes: [
+            {
+              primaryPerson: {
+                primaryEmailAddress: {
+                  email: email1,
+                },
+              },
+            },
+            {
+              primaryPerson: {
+                primaryEmailAddress: {
+                  email: email2,
+                },
+              },
+            },
+            {
+              primaryPerson: null,
+            },
+          ],
+        },
+      },
+    };
+    const { queryByTestId } = render(
+      <GqlMockedProvider<GetEmailNewsletterContactsQuery> mocks={mocks}>
+        <ExportEmail accountListId={accountListId} handleClose={handleClose} />
+      </GqlMockedProvider>,
+    );
+    await waitFor(() => expect(queryByTestId('emailList')).not.toBeNull());
+    expect(queryByTestId('emailList')).toHaveValue(`${email1},${email2}`);
+  });
+
+  it('copies emailList to clipboard', async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn(),
+      },
+    });
+    const email1 = 'fakeemail1@fake.com';
+    const email2 = 'fakeemail2@fake.com';
+    const mocks = {
+      GetEmailNewsletterContacts: {
+        contacts: {
+          nodes: [
+            {
+              primaryPerson: {
+                primaryEmailAddress: {
+                  email: email1,
+                },
+              },
+            },
+            {
+              primaryPerson: {
+                primaryEmailAddress: {
+                  email: email2,
+                },
+              },
+            },
+            {
+              primaryPerson: null,
+            },
+          ],
+        },
+      },
+    };
+    const { queryByTestId, queryByText } = render(
+      <GqlMockedProvider<GetEmailNewsletterContactsQuery> mocks={mocks}>
+        <ExportEmail accountListId={accountListId} handleClose={handleClose} />
+      </GqlMockedProvider>,
+    );
+    await waitFor(() => expect(queryByTestId('emailList')).not.toBeNull());
+    userEvent.click(queryByText('Copy All'));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      `${email1},${email2}`,
+    );
+  });
+});

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/ExportEmail.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/ExportEmail.tsx
@@ -1,0 +1,110 @@
+import React, { ReactElement, useMemo } from 'react';
+import {
+  Button,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  IconButton,
+  styled,
+  TextareaAutosize,
+} from '@material-ui/core';
+import { Skeleton } from '@material-ui/lab';
+import CloseIcon from '@material-ui/icons/Close';
+import { useTranslation } from 'react-i18next';
+import { useGetEmailNewsletterContactsQuery } from './GetNewsletterContacts.generated';
+
+interface Props {
+  accountListId: string;
+  handleClose: () => void;
+}
+
+const ExportEmailTitle = styled(DialogTitle)(() => ({
+  textTransform: 'uppercase',
+  textAlign: 'center',
+}));
+
+const CloseButton = styled(IconButton)(({ theme }) => ({
+  position: 'absolute',
+  right: theme.spacing(1),
+  top: theme.spacing(1),
+  color: theme.palette.text.primary,
+  '&:hover': {
+    backgroundColor: '#EBECEC',
+  },
+}));
+
+const TextArea = styled(TextareaAutosize)(() => ({
+  width: '100%',
+}));
+
+const ExportEmail = ({
+  accountListId,
+  handleClose,
+}: Props): ReactElement<Props> => {
+  const { t } = useTranslation();
+
+  const { data, loading } = useGetEmailNewsletterContactsQuery({
+    variables: { accountListId },
+  });
+
+  const emailList = useMemo(
+    () =>
+      data?.contacts?.nodes
+        .map((contact) => contact.primaryPerson?.primaryEmailAddress?.email)
+        .filter(Boolean)
+        .join(','),
+    [data],
+  );
+
+  return (
+    <>
+      <ExportEmailTitle>
+        {t('Email Newsletter List')}
+        <CloseButton role="closeButton" onClick={handleClose}>
+          <CloseIcon />
+        </CloseButton>
+      </ExportEmailTitle>
+      <DialogContent dividers>
+        <>
+          <DialogContentText>
+            {t(
+              'This is the primary email for every person in contacts marked as Newsletter-Email or Newsletter-Both. If they are marked as "Opted out of Email Newsletter", they are not included in this list.',
+            )}
+          </DialogContentText>
+          <br />
+          <DialogContentText>
+            {t(
+              'Reminder: Please only use the Bcc: field when sending emails to groups of partners.',
+            )}
+          </DialogContentText>
+          {loading || !data?.contacts ? (
+            <Skeleton
+              variant="text"
+              style={{ display: 'inline-block' }}
+              width={90}
+            />
+          ) : (
+            <TextArea
+              disabled={true}
+              data-testid="emailList"
+              value={emailList}
+            />
+          )}
+        </>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          disabled={!emailList}
+          variant="contained"
+          color="primary"
+          onClick={() => navigator.clipboard.writeText(emailList)}
+        >
+          {t('Copy All')}
+        </Button>
+      </DialogActions>
+    </>
+  );
+};
+
+export default ExportEmail;

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/GetNewsletterContacts.graphql
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/GetNewsletterContacts.graphql
@@ -1,10 +1,3 @@
-query GetTaskAnalytics($accountListId: ID!) {
-  taskAnalytics(accountListId: $accountListId) {
-    lastElectronicNewsletterCompletedAt
-    lastPhysicalNewsletterCompletedAt
-  }
-}
-
 query GetEmailNewsletterContacts($accountListId: ID!) {
   contacts(accountListId: $accountListId, newsletter: EMAIL, status: ACTIVE) {
     nodes {

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportPhysical/ExportPhysical.stories.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportPhysical/ExportPhysical.stories.tsx
@@ -1,0 +1,17 @@
+import React, { ReactElement } from 'react';
+import { GqlMockedProvider } from '../../../../../../../__tests__/util/graphqlMocking';
+import ExportPhysical from './ExportPhysical';
+
+export default {
+  title: 'Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportPhysical',
+};
+
+const accountListId = '111';
+
+export const Default = (): ReactElement => {
+  return (
+    <GqlMockedProvider>
+      <ExportPhysical accountListId={accountListId} handleClose={() => {}} />
+    </GqlMockedProvider>
+  );
+};

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportPhysical/ExportPhysical.test.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportPhysical/ExportPhysical.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import ExportPhysical from './ExportPhysical';
+
+const accountListId = '111';
+const handleClose = jest.fn();
+
+describe('ExportPhysical', () => {
+  it('default', () => {
+    const { queryByText } = render(
+      <ExportPhysical
+        accountListId={accountListId}
+        handleClose={handleClose}
+      />,
+    );
+    expect(queryByText('Export Contacts')).toBeInTheDocument();
+  });
+});

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportPhysical/ExportPhysical.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportPhysical/ExportPhysical.tsx
@@ -1,0 +1,59 @@
+import React, { ReactElement } from 'react';
+import {
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  IconButton,
+  styled,
+} from '@material-ui/core';
+
+import CloseIcon from '@material-ui/icons/Close';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  accountListId: string;
+  handleClose: () => void;
+}
+
+const ExportPhysicalTitle = styled(DialogTitle)(() => ({
+  textTransform: 'uppercase',
+  textAlign: 'center',
+}));
+
+const CloseButton = styled(IconButton)(({ theme }) => ({
+  position: 'absolute',
+  right: theme.spacing(1),
+  top: theme.spacing(1),
+  color: theme.palette.text.primary,
+  '&:hover': {
+    backgroundColor: '#EBECEC',
+  },
+}));
+
+const ExportPhysical = ({ handleClose }: Props): ReactElement<Props> => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <ExportPhysicalTitle>
+        {t('Export Contacts')}
+        <CloseButton role="closeButton" onClick={handleClose}>
+          <CloseIcon />
+        </CloseButton>
+      </ExportPhysicalTitle>
+      <DialogContent dividers>
+        <>
+          <DialogContentText>
+            {t('Export Phyical place holder text')}
+          </DialogContentText>
+          <br />
+          <DialogContentText>{t('placeholder')}</DialogContentText>
+        </>
+      </DialogContent>
+      <DialogActions></DialogActions>
+    </>
+  );
+};
+
+export default ExportPhysical;

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.stories.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.stories.tsx
@@ -1,0 +1,17 @@
+import React, { ReactElement } from 'react';
+import { GqlMockedProvider } from '../../../../../../../__tests__/util/graphqlMocking';
+import LogNewsletter from './LogNewsletter';
+
+export default {
+  title: 'Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsletter',
+};
+
+const accountListId = '111';
+
+export const Default = (): ReactElement => {
+  return (
+    <GqlMockedProvider>
+      <LogNewsletter accountListId={accountListId} handleClose={() => {}} />
+    </GqlMockedProvider>
+  );
+};

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.test.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import LogNewsletter from './LogNewsletter';
+
+const accountListId = '111';
+const handleClose = jest.fn();
+
+describe('LogNewsletter', () => {
+  it('default', () => {
+    const { queryByText } = render(
+      <LogNewsletter accountListId={accountListId} handleClose={handleClose} />,
+    );
+    expect(queryByText('Log Newsletter')).toBeInTheDocument();
+  });
+});

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.tsx
@@ -1,0 +1,59 @@
+import React, { ReactElement } from 'react';
+import {
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  IconButton,
+  styled,
+} from '@material-ui/core';
+
+import CloseIcon from '@material-ui/icons/Close';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  accountListId: string;
+  handleClose: () => void;
+}
+
+const LogNewsletterTitle = styled(DialogTitle)(() => ({
+  textTransform: 'uppercase',
+  textAlign: 'center',
+}));
+
+const CloseButton = styled(IconButton)(({ theme }) => ({
+  position: 'absolute',
+  right: theme.spacing(1),
+  top: theme.spacing(1),
+  color: theme.palette.text.primary,
+  '&:hover': {
+    backgroundColor: '#EBECEC',
+  },
+}));
+
+const LogNewsletter = ({ handleClose }: Props): ReactElement<Props> => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <LogNewsletterTitle>
+        {t('Log Newsletter')}
+        <CloseButton role="closeButton" onClick={handleClose}>
+          <CloseIcon />
+        </CloseButton>
+      </LogNewsletterTitle>
+      <DialogContent dividers>
+        <>
+          <DialogContentText>
+            {t('Log newsletter place holder text')}
+          </DialogContentText>
+          <br />
+          <DialogContentText>{t('placeholder')}</DialogContentText>
+        </>
+      </DialogContent>
+      <DialogActions></DialogActions>
+    </>
+  );
+};
+
+export default LogNewsletter;

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.graphql
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.graphql
@@ -1,0 +1,6 @@
+query GetTaskAnalytics($accountListId: ID!) {
+  taskAnalytics(accountListId: $accountListId) {
+    lastElectronicNewsletterCompletedAt
+    lastPhysicalNewsletterCompletedAt
+  }
+}

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.stories.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.stories.tsx
@@ -3,11 +3,13 @@ import { GraphQLError } from 'graphql';
 import React, { ReactElement } from 'react';
 import { GqlMockedProvider } from '../../../../../__tests__/util/graphqlMocking';
 import {
-  GetEmailNewsletterContactsDocument,
-  GetEmailNewsletterContactsQuery,
   GetTaskAnalyticsDocument,
   GetTaskAnalyticsQuery,
-} from '../NewsletterMenu.generated';
+} from './NewsletterMenu.generated';
+import {
+  GetEmailNewsletterContactsQuery,
+  GetEmailNewsletterContactsDocument,
+} from './MenuItems/ExportEmail/GetNewsletterContacts.generated';
 import NewsletterMenu from './NewsletterMenu';
 
 export default {

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.stories.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.stories.tsx
@@ -1,0 +1,104 @@
+import React, { ReactElement } from 'react';
+import { GqlMockedProvider } from '../../../../../__tests__/util/graphqlMocking';
+import {
+  GetEmailNewsletterContactsQuery,
+  GetTaskAnalyticsQuery,
+} from '../NewsletterMenu.generated';
+import NewsletterMenu from './NewsletterMenu';
+
+export default {
+  title: 'Dashboard/ThisWeek/NewsletterMenu',
+};
+
+const accountListId = '111';
+
+export const Default = (): ReactElement => {
+  const mocks = {
+    GetTaskAnalytics: {
+      taskAnalytics: {
+        lastElectronicNewsletterCompletedAt: '2020-10-27T16:20:06Z',
+        lastPhysicalNewsletterCompletedAt: '2020-11-11T19:42:03Z',
+      },
+    },
+  };
+  return (
+    <GqlMockedProvider<GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery>
+      mocks={mocks}
+    >
+      <NewsletterMenu accountListId={accountListId} />
+    </GqlMockedProvider>
+  );
+};
+
+export const Loading = (): ReactElement => {
+  const mocks = {
+    GetEmailNewsletterContacts: {
+      contacts: {
+        nodes: [],
+      },
+    },
+
+    GetTaskAnalytics: {
+      taskAnalytics: {
+        lastElectronicNewsletterCompletedAt: undefined,
+        lastPhysicalNewsletterCompletedAt: undefined,
+      },
+    },
+  };
+  return (
+    <GqlMockedProvider<GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery>
+      mocks={mocks}
+    >
+      <NewsletterMenu accountListId={accountListId} />
+    </GqlMockedProvider>
+  );
+};
+
+export const Empty = (): ReactElement => {
+  const mocks = {
+    GetEmailNewsletterContacts: {
+      contacts: {
+        nodes: [],
+      },
+    },
+
+    GetTaskAnalytics: {
+      taskAnalytics: {
+        lastElectronicNewsletterCompletedAt: null,
+        lastPhysicalNewsletterCompletedAt: null,
+      },
+    },
+  };
+  return (
+    <GqlMockedProvider<GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery>
+      mocks={mocks}
+    >
+      <NewsletterMenu accountListId={accountListId} />
+    </GqlMockedProvider>
+  );
+};
+
+export const Error = (): ReactElement => {
+  const mocks = {
+    GetEmailNewsletterContacts: {
+      contacts: {
+        nodes: [],
+      },
+    },
+
+    GetTaskAnalytics: {
+      taskAnalytics: {
+        lastElectronicNewsletterCompletedAt: null,
+        lastPhysicalNewsletterCompletedAt: null,
+      },
+    },
+    error: { name: 'error', message: 'Error loading data. Try again.' },
+  };
+  return (
+    <GqlMockedProvider<GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery>
+      mocks={mocks}
+    >
+      <NewsletterMenu accountListId={accountListId} />
+    </GqlMockedProvider>
+  );
+};

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.stories.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.stories.tsx
@@ -1,4 +1,4 @@
-import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { MockedProvider } from '@apollo/client/testing';
 import { GraphQLError } from 'graphql';
 import React, { ReactElement } from 'react';
 import { GqlMockedProvider } from '../../../../../__tests__/util/graphqlMocking';

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.stories.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.stories.tsx
@@ -1,7 +1,11 @@
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { GraphQLError } from 'graphql';
 import React, { ReactElement } from 'react';
 import { GqlMockedProvider } from '../../../../../__tests__/util/graphqlMocking';
 import {
+  GetEmailNewsletterContactsDocument,
   GetEmailNewsletterContactsQuery,
+  GetTaskAnalyticsDocument,
   GetTaskAnalyticsQuery,
 } from '../NewsletterMenu.generated';
 import NewsletterMenu from './NewsletterMenu';
@@ -31,26 +35,33 @@ export const Default = (): ReactElement => {
 };
 
 export const Loading = (): ReactElement => {
-  const mocks = {
-    GetEmailNewsletterContacts: {
-      contacts: {
-        nodes: [],
-      },
-    },
-
-    GetTaskAnalytics: {
-      taskAnalytics: {
-        lastElectronicNewsletterCompletedAt: undefined,
-        lastPhysicalNewsletterCompletedAt: undefined,
-      },
-    },
-  };
   return (
-    <GqlMockedProvider<GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery>
-      mocks={mocks}
+    <MockedProvider
+      mocks={[
+        {
+          request: {
+            query: GetTaskAnalyticsDocument,
+            variables: {
+              accountListId,
+            },
+          },
+          result: {},
+          delay: 100931731455,
+        },
+        {
+          request: {
+            query: GetEmailNewsletterContactsDocument,
+            variables: {
+              accountListId,
+            },
+          },
+          result: {},
+          delay: 100931731455,
+        },
+      ]}
     >
       <NewsletterMenu accountListId={accountListId} />
-    </GqlMockedProvider>
+    </MockedProvider>
   );
 };
 
@@ -81,18 +92,14 @@ export const Empty = (): ReactElement => {
 export const Error = (): ReactElement => {
   const mocks = {
     GetEmailNewsletterContacts: {
-      contacts: {
-        nodes: [],
-      },
+      contacts: new GraphQLError('Graphql Error #42: Error loading contacts'),
     },
 
     GetTaskAnalytics: {
-      taskAnalytics: {
-        lastElectronicNewsletterCompletedAt: null,
-        lastPhysicalNewsletterCompletedAt: null,
-      },
+      taskAnalytics: new GraphQLError(
+        'Graphql Error #42: Error loading task newsletter date data',
+      ),
     },
-    error: { name: 'error', message: 'Error loading data. Try again.' },
   };
   return (
     <GqlMockedProvider<GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery>

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
@@ -40,6 +40,121 @@ describe('NewsletterMenu', () => {
     expect(queryByText('Export Physical')).toBeInTheDocument();
   });
 
+  describe('Newsletter Date', () => {
+    it('Shows most recent date out of two valid dates', async () => {
+      const mocks = {
+        GetTaskAnalytics: {
+          taskAnalytics: {
+            lastElectronicNewsletterCompletedAt: '2021-10-27T16:20:06Z',
+            lastPhysicalNewsletterCompletedAt: '2020-11-11T19:42:03Z',
+          },
+        },
+      };
+      const { queryByTestId } = render(
+        <GqlMockedProvider<
+          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
+        >
+          mocks={mocks}
+        >
+          <NewsletterMenu accountListId={accountListId} />
+        </GqlMockedProvider>,
+      );
+      await waitFor(() =>
+        expect(
+          queryByTestId('NewsletterMenuButton').textContent,
+        ).not.toBeNull(),
+      );
+      expect(queryByTestId('NewsletterMenuButton').textContent).toEqual(
+        'NewsletterLatest: 10/27/2021',
+      );
+    });
+
+    it('Shows most recent date | Electronic', async () => {
+      const mocks = {
+        GetTaskAnalytics: {
+          taskAnalytics: {
+            lastElectronicNewsletterCompletedAt: '2021-10-27T16:20:06Z',
+            lastPhysicalNewsletterCompletedAt: null,
+          },
+        },
+      };
+      const { queryByTestId } = render(
+        <GqlMockedProvider<
+          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
+        >
+          mocks={mocks}
+        >
+          <NewsletterMenu accountListId={accountListId} />
+        </GqlMockedProvider>,
+      );
+      await waitFor(() =>
+        expect(
+          queryByTestId('NewsletterMenuButton').textContent,
+        ).not.toBeNull(),
+      );
+      expect(queryByTestId('NewsletterMenuButton').textContent).toEqual(
+        'NewsletterLatest: 10/27/2021',
+      );
+    });
+
+    it('Shows most recent date | Physical', async () => {
+      const mocks = {
+        GetTaskAnalytics: {
+          taskAnalytics: {
+            lastElectronicNewsletterCompletedAt: null,
+            lastPhysicalNewsletterCompletedAt: '2020-11-11T19:42:03Z',
+          },
+        },
+      };
+      const { queryByTestId } = render(
+        <GqlMockedProvider<
+          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
+        >
+          mocks={mocks}
+        >
+          <NewsletterMenu accountListId={accountListId} />
+        </GqlMockedProvider>,
+      );
+      await waitFor(() =>
+        expect(
+          queryByTestId('NewsletterMenuButton').textContent,
+        ).not.toBeNull(),
+      );
+      expect(queryByTestId('NewsletterMenuButton').textContent).toEqual(
+        'NewsletterLatest: 11/11/2020',
+      );
+    });
+
+    it('Shows "never" if no date data', async () => {
+      const mocks = {
+        GetTaskAnalytics: {
+          taskAnalytics: {
+            lastElectronicNewsletterCompletedAt: null,
+            lastPhysicalNewsletterCompletedAt: null,
+          },
+        },
+      };
+      const { queryByTestId } = render(
+        <GqlMockedProvider<
+          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
+        >
+          mocks={mocks}
+        >
+          <NewsletterMenu accountListId={accountListId} />
+        </GqlMockedProvider>,
+      );
+      await waitFor(() =>
+        expect(
+          queryByTestId('NewsletterMenuButton').textContent,
+        ).not.toBeNull(),
+      );
+
+      expect(queryByTestId('NewsletterMenuButton').textContent).toEqual(
+        'NewsletterLatest: never',
+      );
+    });
+  });
+
   describe('Log Newsletter', () => {
     it('should open Log Newsletter menu', () => {
       const { queryByText, queryByTestId } = render(

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
@@ -41,7 +41,7 @@ describe('NewsletterMenu', () => {
   });
 
   describe('Newsletter Date', () => {
-    it('Shows most recent date out of two valid dates', async () => {
+    it('Shows most recent date out of two valid dates | Electronic', async () => {
       const mocks = {
         GetTaskAnalytics: {
           taskAnalytics: {
@@ -66,6 +66,34 @@ describe('NewsletterMenu', () => {
       );
       expect(queryByTestId('NewsletterMenuButton').textContent).toEqual(
         'NewsletterLatest: 10/27/2021',
+      );
+    });
+
+    it('Shows most recent date out of two valid dates | Physical', async () => {
+      const mocks = {
+        GetTaskAnalytics: {
+          taskAnalytics: {
+            lastElectronicNewsletterCompletedAt: '2020-10-27T16:20:06Z',
+            lastPhysicalNewsletterCompletedAt: '2020-11-11T19:42:03Z',
+          },
+        },
+      };
+      const { queryByTestId } = render(
+        <GqlMockedProvider<
+          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
+        >
+          mocks={mocks}
+        >
+          <NewsletterMenu accountListId={accountListId} />
+        </GqlMockedProvider>,
+      );
+      await waitFor(() =>
+        expect(
+          queryByTestId('NewsletterMenuButton').textContent,
+        ).not.toBeNull(),
+      );
+      expect(queryByTestId('NewsletterMenuButton').textContent).toEqual(
+        'NewsletterLatest: 11/11/2020',
       );
     });
 
@@ -196,6 +224,9 @@ describe('NewsletterMenu', () => {
                     email: email2,
                   },
                 },
+              },
+              {
+                primaryPerson: null,
               },
             ],
           },

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GqlMockedProvider } from '../../../../../__tests__/util/graphqlMocking';
-import {
-  GetEmailNewsletterContactsQuery,
-  GetTaskAnalyticsQuery,
-} from '../NewsletterMenu.generated';
+import { GetTaskAnalyticsQuery } from './NewsletterMenu.generated';
 import NewsletterMenu from './NewsletterMenu';
 
 const accountListId = '111';
@@ -13,9 +10,7 @@ const accountListId = '111';
 describe('NewsletterMenu', () => {
   it('default', async () => {
     const { queryByText } = render(
-      <GqlMockedProvider<
-        GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
-      >>
+      <GqlMockedProvider<GetTaskAnalyticsQuery>>
         <NewsletterMenu accountListId={accountListId} />
       </GqlMockedProvider>,
     );
@@ -26,9 +21,7 @@ describe('NewsletterMenu', () => {
 
   it('should open newsletter menu', async () => {
     const { queryByText, queryByTestId } = render(
-      <GqlMockedProvider<
-        GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
-      >>
+      <GqlMockedProvider<GetTaskAnalyticsQuery>>
         <NewsletterMenu accountListId={accountListId} />
       </GqlMockedProvider>,
     );
@@ -56,9 +49,7 @@ describe('NewsletterMenu', () => {
     };
     it('Shows most recent date out of two valid dates | Electronic', async () => {
       const { queryByTestId } = render(
-        <GqlMockedProvider<
-          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
-        >
+        <GqlMockedProvider<GetTaskAnalyticsQuery>
           mocks={createDateMock('2021-10-27T16:20:06Z', '2020-11-11T19:42:03Z')}
         >
           <NewsletterMenu accountListId={accountListId} />
@@ -76,9 +67,7 @@ describe('NewsletterMenu', () => {
 
     it('Shows most recent date out of two valid dates | Physical', async () => {
       const { queryByTestId } = render(
-        <GqlMockedProvider<
-          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
-        >
+        <GqlMockedProvider<GetTaskAnalyticsQuery>
           mocks={createDateMock('2020-10-27T16:20:06Z', '2020-11-11T19:42:03Z')}
         >
           <NewsletterMenu accountListId={accountListId} />
@@ -96,9 +85,7 @@ describe('NewsletterMenu', () => {
 
     it('Shows most recent date | Electronic', async () => {
       const { queryByTestId } = render(
-        <GqlMockedProvider<
-          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
-        >
+        <GqlMockedProvider<GetTaskAnalyticsQuery>
           mocks={createDateMock('2021-10-27T16:20:06Z', null)}
         >
           <NewsletterMenu accountListId={accountListId} />
@@ -116,9 +103,7 @@ describe('NewsletterMenu', () => {
 
     it('Shows most recent date | Physical', async () => {
       const { queryByTestId } = render(
-        <GqlMockedProvider<
-          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
-        >
+        <GqlMockedProvider<GetTaskAnalyticsQuery>
           mocks={createDateMock(null, '2020-11-11T19:42:03Z')}
         >
           <NewsletterMenu accountListId={accountListId} />
@@ -136,9 +121,7 @@ describe('NewsletterMenu', () => {
 
     it('Shows "never" if no date data', async () => {
       const { queryByTestId } = render(
-        <GqlMockedProvider<
-          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
-        >
+        <GqlMockedProvider<GetTaskAnalyticsQuery>
           mocks={createDateMock(null, null)}
         >
           <NewsletterMenu accountListId={accountListId} />
@@ -153,165 +136,6 @@ describe('NewsletterMenu', () => {
       expect(queryByTestId('NewsletterMenuButton').textContent).toEqual(
         'NewsletterLatest: never',
       );
-    });
-  });
-
-  describe('Log Newsletter', () => {
-    it('should open Log Newsletter menu', () => {
-      const { queryByText, queryByTestId } = render(
-        <GqlMockedProvider<
-          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
-        >>
-          <NewsletterMenu accountListId={accountListId} />
-        </GqlMockedProvider>,
-      );
-
-      userEvent.click(queryByTestId('NewsletterMenuButton'));
-      userEvent.click(queryByText('Log Newsletter'));
-
-      expect(
-        queryByText('Log Newsletter placeholder text'),
-      ).toBeInTheDocument();
-    });
-
-    it('should close Log Newsletter menu', () => {
-      const { queryByText, queryByTestId, queryByRole } = render(
-        <GqlMockedProvider<
-          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
-        >>
-          <NewsletterMenu accountListId={accountListId} />
-        </GqlMockedProvider>,
-      );
-
-      userEvent.click(queryByTestId('NewsletterMenuButton'));
-      userEvent.click(queryByText('Log Newsletter'));
-
-      expect(
-        queryByText('Log Newsletter placeholder text'),
-      ).toBeInTheDocument();
-
-      userEvent.click(queryByRole('closeButton'));
-
-      expect(
-        queryByText('Log Newsletter placeholder text'),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Export Email', () => {
-    it('should open Export Email dialog', async () => {
-      const email1 = 'fakeemail1@fake.com';
-      const email2 = 'fakeemail2@fake.com';
-
-      const mocks = {
-        GetEmailNewsletterContacts: {
-          contacts: {
-            nodes: [
-              {
-                primaryPerson: {
-                  primaryEmailAddress: {
-                    email: email1,
-                  },
-                },
-              },
-              {
-                primaryPerson: {
-                  primaryEmailAddress: {
-                    email: email2,
-                  },
-                },
-              },
-              {
-                primaryPerson: null,
-              },
-            ],
-          },
-        },
-      };
-      const { queryByText, queryByTestId } = render(
-        <GqlMockedProvider<
-          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
-        >
-          mocks={mocks}
-        >
-          <NewsletterMenu accountListId={accountListId} />
-        </GqlMockedProvider>,
-      );
-
-      userEvent.click(queryByTestId('NewsletterMenuButton'));
-      userEvent.click(queryByText('Export Email'));
-
-      expect(queryByText('Copy All')).toBeInTheDocument();
-      await waitFor(() => expect(queryByTestId('emailList')).not.toBeNull());
-      expect(queryByTestId('emailList')).toHaveValue(`${email1},${email2}`);
-    });
-  });
-
-  it('should copy email list to clipboard', async () => {
-    Object.assign(navigator, {
-      clipboard: {
-        writeText: () => {},
-      },
-    });
-    const email1 = 'fakeemail1@fake.com';
-    const email2 = 'fakeemail2@fake.com';
-    jest.spyOn(navigator.clipboard, 'writeText');
-    const mocks = {
-      GetEmailNewsletterContacts: {
-        contacts: {
-          nodes: [
-            {
-              primaryPerson: {
-                primaryEmailAddress: {
-                  email: email1,
-                },
-              },
-            },
-            {
-              primaryPerson: {
-                primaryEmailAddress: {
-                  email: email2,
-                },
-              },
-            },
-          ],
-        },
-      },
-    };
-    const { queryByText, queryByTestId } = render(
-      <GqlMockedProvider<
-        GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
-      >
-        mocks={mocks}
-      >
-        <NewsletterMenu accountListId={accountListId} />
-      </GqlMockedProvider>,
-    );
-
-    userEvent.click(queryByTestId('NewsletterMenuButton'));
-    userEvent.click(queryByText('Export Email'));
-
-    await waitFor(() => expect(queryByTestId('emailList')).not.toBeNull());
-    userEvent.click(queryByText('Copy All'));
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      `${email1},${email2}`,
-    );
-  });
-
-  describe('Export Physical', () => {
-    it('should open Export Physical menu', () => {
-      const { queryByText, queryByTestId } = render(
-        <GqlMockedProvider<
-          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
-        >>
-          <NewsletterMenu accountListId={accountListId} />
-        </GqlMockedProvider>,
-      );
-
-      userEvent.click(queryByTestId('NewsletterMenuButton'));
-      userEvent.click(queryByText('Export Physical'));
-
-      expect(queryByText('Export Contacts')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
@@ -41,20 +41,25 @@ describe('NewsletterMenu', () => {
   });
 
   describe('Newsletter Date', () => {
-    it('Shows most recent date out of two valid dates | Electronic', async () => {
-      const mocks = {
+    const createDateMock = (
+      electronic: string | null,
+      physical: string | null,
+    ) => {
+      return {
         GetTaskAnalytics: {
           taskAnalytics: {
-            lastElectronicNewsletterCompletedAt: '2021-10-27T16:20:06Z',
-            lastPhysicalNewsletterCompletedAt: '2020-11-11T19:42:03Z',
+            lastElectronicNewsletterCompletedAt: electronic,
+            lastPhysicalNewsletterCompletedAt: physical,
           },
         },
       };
+    };
+    it('Shows most recent date out of two valid dates | Electronic', async () => {
       const { queryByTestId } = render(
         <GqlMockedProvider<
           GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
         >
-          mocks={mocks}
+          mocks={createDateMock('2021-10-27T16:20:06Z', '2020-11-11T19:42:03Z')}
         >
           <NewsletterMenu accountListId={accountListId} />
         </GqlMockedProvider>,
@@ -70,19 +75,11 @@ describe('NewsletterMenu', () => {
     });
 
     it('Shows most recent date out of two valid dates | Physical', async () => {
-      const mocks = {
-        GetTaskAnalytics: {
-          taskAnalytics: {
-            lastElectronicNewsletterCompletedAt: '2020-10-27T16:20:06Z',
-            lastPhysicalNewsletterCompletedAt: '2020-11-11T19:42:03Z',
-          },
-        },
-      };
       const { queryByTestId } = render(
         <GqlMockedProvider<
           GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
         >
-          mocks={mocks}
+          mocks={createDateMock('2020-10-27T16:20:06Z', '2020-11-11T19:42:03Z')}
         >
           <NewsletterMenu accountListId={accountListId} />
         </GqlMockedProvider>,
@@ -98,19 +95,11 @@ describe('NewsletterMenu', () => {
     });
 
     it('Shows most recent date | Electronic', async () => {
-      const mocks = {
-        GetTaskAnalytics: {
-          taskAnalytics: {
-            lastElectronicNewsletterCompletedAt: '2021-10-27T16:20:06Z',
-            lastPhysicalNewsletterCompletedAt: null,
-          },
-        },
-      };
       const { queryByTestId } = render(
         <GqlMockedProvider<
           GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
         >
-          mocks={mocks}
+          mocks={createDateMock('2021-10-27T16:20:06Z', null)}
         >
           <NewsletterMenu accountListId={accountListId} />
         </GqlMockedProvider>,
@@ -126,19 +115,11 @@ describe('NewsletterMenu', () => {
     });
 
     it('Shows most recent date | Physical', async () => {
-      const mocks = {
-        GetTaskAnalytics: {
-          taskAnalytics: {
-            lastElectronicNewsletterCompletedAt: null,
-            lastPhysicalNewsletterCompletedAt: '2020-11-11T19:42:03Z',
-          },
-        },
-      };
       const { queryByTestId } = render(
         <GqlMockedProvider<
           GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
         >
-          mocks={mocks}
+          mocks={createDateMock(null, '2020-11-11T19:42:03Z')}
         >
           <NewsletterMenu accountListId={accountListId} />
         </GqlMockedProvider>,
@@ -154,19 +135,11 @@ describe('NewsletterMenu', () => {
     });
 
     it('Shows "never" if no date data', async () => {
-      const mocks = {
-        GetTaskAnalytics: {
-          taskAnalytics: {
-            lastElectronicNewsletterCompletedAt: null,
-            lastPhysicalNewsletterCompletedAt: null,
-          },
-        },
-      };
       const { queryByTestId } = render(
         <GqlMockedProvider<
           GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
         >
-          mocks={mocks}
+          mocks={createDateMock(null, null)}
         >
           <NewsletterMenu accountListId={accountListId} />
         </GqlMockedProvider>,

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
@@ -10,8 +10,6 @@ import NewsletterMenu from './NewsletterMenu';
 
 const accountListId = '111';
 
-const mockEnqueue = jest.fn();
-
 describe('NewsletterMenu', () => {
   it('default', async () => {
     const { queryByText } = render(

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
@@ -200,6 +200,29 @@ describe('NewsletterMenu', () => {
         queryByText('Log Newsletter placeholder text'),
       ).toBeInTheDocument();
     });
+
+    it('should close Log Newsletter menu', () => {
+      const { queryByText, queryByTestId, queryByRole } = render(
+        <GqlMockedProvider<
+          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
+        >>
+          <NewsletterMenu accountListId={accountListId} />
+        </GqlMockedProvider>,
+      );
+
+      userEvent.click(queryByTestId('NewsletterMenuButton'));
+      userEvent.click(queryByText('Log Newsletter'));
+
+      expect(
+        queryByText('Log Newsletter placeholder text'),
+      ).toBeInTheDocument();
+
+      userEvent.click(queryByRole('closeButton'));
+
+      expect(
+        queryByText('Log Newsletter placeholder text'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('Export Email', () => {

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.test.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GqlMockedProvider } from '../../../../../__tests__/util/graphqlMocking';
+import {
+  GetEmailNewsletterContactsQuery,
+  GetTaskAnalyticsQuery,
+} from '../NewsletterMenu.generated';
+import NewsletterMenu from './NewsletterMenu';
+
+const accountListId = '111';
+
+const mockEnqueue = jest.fn();
+
+describe('NewsletterMenu', () => {
+  it('default', async () => {
+    const { queryByText } = render(
+      <GqlMockedProvider<
+        GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
+      >>
+        <NewsletterMenu accountListId={accountListId} />
+      </GqlMockedProvider>,
+    );
+
+    expect(queryByText('Never')).toBeNull();
+    expect(queryByText('Newsletter')).toBeVisible();
+  });
+
+  it('should open newsletter menu', async () => {
+    const { queryByText, queryByTestId } = render(
+      <GqlMockedProvider<
+        GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
+      >>
+        <NewsletterMenu accountListId={accountListId} />
+      </GqlMockedProvider>,
+    );
+
+    userEvent.click(queryByTestId('NewsletterMenuButton'));
+
+    expect(queryByText('Log Newsletter')).toBeInTheDocument();
+    expect(queryByText('Export Email')).toBeInTheDocument();
+    expect(queryByText('Export Physical')).toBeInTheDocument();
+  });
+
+  describe('Log Newsletter', () => {
+    it('should open Log Newsletter menu', () => {
+      const { queryByText, queryByTestId } = render(
+        <GqlMockedProvider<
+          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
+        >>
+          <NewsletterMenu accountListId={accountListId} />
+        </GqlMockedProvider>,
+      );
+
+      userEvent.click(queryByTestId('NewsletterMenuButton'));
+      userEvent.click(queryByText('Log Newsletter'));
+
+      expect(
+        queryByText('Log Newsletter placeholder text'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Export Email', () => {
+    it('should open Export Email dialog', async () => {
+      const email1 = 'fakeemail1@fake.com';
+      const email2 = 'fakeemail2@fake.com';
+
+      const mocks = {
+        GetEmailNewsletterContacts: {
+          contacts: {
+            nodes: [
+              {
+                primaryPerson: {
+                  primaryEmailAddress: {
+                    email: email1,
+                  },
+                },
+              },
+              {
+                primaryPerson: {
+                  primaryEmailAddress: {
+                    email: email2,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      };
+      const { queryByText, queryByTestId } = render(
+        <GqlMockedProvider<
+          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
+        >
+          mocks={mocks}
+        >
+          <NewsletterMenu accountListId={accountListId} />
+        </GqlMockedProvider>,
+      );
+
+      userEvent.click(queryByTestId('NewsletterMenuButton'));
+      userEvent.click(queryByText('Export Email'));
+
+      expect(queryByText('Copy All')).toBeInTheDocument();
+      await waitFor(() => expect(queryByTestId('emailList')).not.toBeNull());
+      expect(queryByTestId('emailList')).toHaveValue(`${email1},${email2}`);
+    });
+  });
+
+  it('should copy email list to clipboard', async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: () => {},
+      },
+    });
+    const email1 = 'fakeemail1@fake.com';
+    const email2 = 'fakeemail2@fake.com';
+    jest.spyOn(navigator.clipboard, 'writeText');
+    const mocks = {
+      GetEmailNewsletterContacts: {
+        contacts: {
+          nodes: [
+            {
+              primaryPerson: {
+                primaryEmailAddress: {
+                  email: email1,
+                },
+              },
+            },
+            {
+              primaryPerson: {
+                primaryEmailAddress: {
+                  email: email2,
+                },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const { queryByText, queryByTestId } = render(
+      <GqlMockedProvider<
+        GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
+      >
+        mocks={mocks}
+      >
+        <NewsletterMenu accountListId={accountListId} />
+      </GqlMockedProvider>,
+    );
+
+    userEvent.click(queryByTestId('NewsletterMenuButton'));
+    userEvent.click(queryByText('Export Email'));
+
+    await waitFor(() => expect(queryByTestId('emailList')).not.toBeNull());
+    userEvent.click(queryByText('Copy All'));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      `${email1},${email2}`,
+    );
+  });
+
+  describe('Export Physical', () => {
+    it('should open Export Physical menu', () => {
+      const { queryByText, queryByTestId } = render(
+        <GqlMockedProvider<
+          GetTaskAnalyticsQuery & GetEmailNewsletterContactsQuery
+        >>
+          <NewsletterMenu accountListId={accountListId} />
+        </GqlMockedProvider>,
+      );
+
+      userEvent.click(queryByTestId('NewsletterMenuButton'));
+      userEvent.click(queryByText('Export Physical'));
+
+      expect(queryByText('Export Contacts')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.tsx
@@ -120,7 +120,7 @@ const NewsletterMenu = ({ accountListId }: Props): ReactElement<Props> => {
     return (
       <Dialog
         open={newsletterMenuDialogOpen}
-        aria-labelledby={t('')}
+        aria-labelledby={t('Newsletter Dialog')}
         fullWidth
         maxWidth="md"
       >

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.tsx
@@ -241,7 +241,7 @@ const NewsletterMenu = ({ accountListId }: Props): ReactElement<Props> => {
       >
         <NewsletterMenuDialogTitle>
           {title()}
-          <CloseButton onClick={handleDialogClose}>
+          <CloseButton role="closeButton" onClick={handleDialogClose}>
             <CloseIcon />
           </CloseButton>
         </NewsletterMenuDialogTitle>

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.tsx
@@ -1,0 +1,303 @@
+import React, { ReactElement, useState, useEffect } from 'react';
+import {
+  Button,
+  Menu,
+  MenuItem,
+  Dialog,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  ListItemText,
+  IconButton,
+  styled,
+  TextareaAutosize,
+} from '@material-ui/core';
+import ArrowDropDown from '@material-ui/icons/ArrowDropDown';
+import CloseIcon from '@material-ui/icons/Close';
+import { useTranslation } from 'react-i18next';
+import { DateTime } from 'luxon';
+import { Skeleton } from '@material-ui/lab';
+import {
+  useGetTaskAnalyticsQuery,
+  useGetEmailNewsletterContactsLazyQuery,
+} from '../NewsletterMenu.generated';
+
+interface Props {
+  accountListId: string;
+}
+
+const CloseButton = styled(IconButton)(({ theme }) => ({
+  position: 'absolute',
+  right: theme.spacing(1),
+  top: theme.spacing(1),
+  color: theme.palette.grey[500],
+}));
+
+const NewsletterTextContainer = styled(ListItemText)(({}) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+}));
+
+const TextArea = styled(TextareaAutosize)(({}) => ({
+  width: '100%',
+}));
+
+const NewsletterMenuDialogTitle = styled(DialogTitle)(({}) => ({
+  textTransform: 'uppercase',
+  textAlign: 'center',
+}));
+
+const NewsletterMenu = ({ accountListId }: Props): ReactElement<Props> => {
+  const { t } = useTranslation();
+
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [selectedMenuItem, changeSelectedMenuItem] = useState(-1);
+  const [newsletterMenuDialogOpen, changeNewsletterMenuDialogOpen] = useState(
+    false,
+  );
+  const [emailList, changeEmailList] = useState('');
+
+  const {
+    data: {
+      taskAnalytics: {
+        lastElectronicNewsletterCompletedAt,
+        lastPhysicalNewsletterCompletedAt,
+      } = {},
+    } = {},
+    loading,
+  } = useGetTaskAnalyticsQuery({
+    variables: { accountListId },
+  });
+
+  const [
+    loadEmailNewsletterContacts,
+    { data: newsletterContactsData, loading: contactsLoading },
+  ] = useGetEmailNewsletterContactsLazyQuery({
+    variables: { accountListId },
+  });
+
+  useEffect(() => {
+    if (newsletterContactsData?.contacts.nodes.length > 0) {
+      changeEmailList(
+        newsletterContactsData.contacts.nodes.reduce(
+          (result, contact, index) => {
+            return contact?.primaryPerson?.primaryEmailAddress
+              ? index === 0
+                ? `${contact.primaryPerson.primaryEmailAddress.email}`
+                : `${result},${contact.primaryPerson.primaryEmailAddress.email}`
+              : result;
+          },
+          '',
+        ),
+      );
+    }
+  }, [newsletterContactsData]);
+
+  const handleMenuOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleMenuItemClick = (menuItem) => {
+    changeSelectedMenuItem(menuItem);
+    changeNewsletterMenuDialogOpen(true);
+    switch (menuItem) {
+      case 0:
+        break;
+      case 1:
+        loadEmailNewsletterContacts();
+        break;
+      case 2:
+        break;
+    }
+  };
+
+  const handleDialogClose = () => {
+    changeNewsletterMenuDialogOpen(false);
+    changeSelectedMenuItem(-1);
+  };
+
+  const latestNewsletterDate = () => {
+    const electronicDate = DateTime.fromISO(
+      lastElectronicNewsletterCompletedAt,
+    );
+    const physicalDate = DateTime.fromISO(lastPhysicalNewsletterCompletedAt);
+
+    if (
+      !lastElectronicNewsletterCompletedAt &&
+      !lastPhysicalNewsletterCompletedAt
+    ) {
+      return t('never');
+    } else if (
+      lastElectronicNewsletterCompletedAt &&
+      !lastPhysicalNewsletterCompletedAt
+    ) {
+      return electronicDate.toLocaleString();
+    } else if (
+      !lastElectronicNewsletterCompletedAt &&
+      lastPhysicalNewsletterCompletedAt
+    ) {
+      return physicalDate.toLocaleString();
+    } else {
+      return electronicDate < physicalDate
+        ? physicalDate.toLocaleString()
+        : electronicDate.toLocaleString();
+    }
+  };
+  // TODO: Finish creating dialog for "Log Newsletter" and "Export Physical"
+  const renderDialog = () => {
+    const title = () => {
+      switch (selectedMenuItem) {
+        case 0:
+          return t('Log Newsletter');
+        case 1:
+          return t('Email Newsletter List');
+        case 2:
+          return t('Export Contacts');
+      }
+    };
+
+    const content = () => {
+      switch (selectedMenuItem) {
+        case 0:
+          return (
+            <>
+              <DialogContentText>
+                {t('Log Newsletter placeholder text')}
+              </DialogContentText>
+            </>
+          );
+        case 1:
+          return (
+            <>
+              <DialogContentText>
+                {t(
+                  'This is the primary email for every person in contacts marked as Newsletter-Email or Newsletter-Both. If they are marked as "Opted out of Email Newsletter", they are not included in this list.',
+                )}
+              </DialogContentText>
+              <br />
+              <DialogContentText>
+                {t(
+                  'Reminder: Please only use the Bcc: field when sending emails to groups of partners.',
+                )}
+              </DialogContentText>
+              {contactsLoading || !newsletterContactsData?.contacts ? (
+                <Skeleton
+                  variant="text"
+                  style={{ display: 'inline-block' }}
+                  width={90}
+                />
+              ) : (
+                <TextArea
+                  disabled={true}
+                  data-testid="emailList"
+                  value={emailList}
+                />
+              )}
+            </>
+          );
+        case 2:
+          return (
+            <>
+              <DialogContentText>
+                {t('Export contacts placeholder')}
+              </DialogContentText>
+            </>
+          );
+      }
+    };
+
+    const actions = () => {
+      switch (selectedMenuItem) {
+        case 0:
+          return null;
+        case 1:
+          return (
+            <Button
+              disabled={emailList === ''}
+              variant="contained"
+              color="primary"
+              onClick={() => navigator.clipboard.writeText(emailList)}
+            >
+              {t('Copy All')}
+            </Button>
+          );
+        case 2:
+          return null;
+      }
+    };
+    return (
+      <Dialog
+        open={newsletterMenuDialogOpen}
+        aria-labelledby={t('')}
+        fullWidth
+        maxWidth="md"
+      >
+        <NewsletterMenuDialogTitle>
+          {title()}
+          <CloseButton onClick={handleDialogClose}>
+            <CloseIcon />
+          </CloseButton>
+        </NewsletterMenuDialogTitle>
+        <DialogContent dividers>{content()}</DialogContent>
+        {selectedMenuItem === 2 ? null : (
+          <DialogActions>{actions()}</DialogActions>
+        )}
+      </Dialog>
+    );
+  };
+  return (
+    <>
+      <Button
+        style={{ textTransform: 'uppercase' }}
+        data-testid="NewsletterMenuButton"
+        onClick={handleMenuOpen}
+      >
+        <ArrowDropDown />
+
+        <NewsletterTextContainer
+          primary={t('Newsletter')}
+          secondary={
+            loading ? (
+              <Skeleton
+                variant="text"
+                style={{ display: 'inline-block' }}
+                width={90}
+              />
+            ) : (
+              `${t('Latest')}: ${latestNewsletterDate()}`
+            )
+          }
+        />
+      </Button>
+      <Menu
+        id="newsletter-menu"
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleMenuClose}
+        anchorEl={anchorEl}
+        getContentAnchorEl={null}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+      >
+        <MenuItem onClick={() => handleMenuItemClick(0)}>
+          <ListItemText primary={t('Log Newsletter')} />
+        </MenuItem>
+        <MenuItem onClick={() => handleMenuItemClick(1)}>
+          <ListItemText primary={t('Export Email')} />
+        </MenuItem>
+        <MenuItem onClick={() => handleMenuItemClick(2)}>
+          <ListItemText primary={t('Export Physical')} />
+        </MenuItem>
+      </Menu>
+      {renderDialog()}
+    </>
+  );
+};
+
+export default NewsletterMenu;

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/NewsletterMenu.tsx
@@ -31,13 +31,14 @@ const CloseButton = styled(IconButton)(({ theme }) => ({
   position: 'absolute',
   right: theme.spacing(1),
   top: theme.spacing(1),
-  color: theme.palette.grey[500],
+  color: theme.palette.text.primary,
+  '&:hover': {
+    backgroundColor: '#EBECEC',
+  },
 }));
 
 const NewsletterTextContainer = styled(ListItemText)(({}) => ({
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'flex-start',
+  textAlign: 'left',
 }));
 
 const TextArea = styled(TextareaAutosize)(({}) => ({

--- a/src/components/Dashboard/ThisWeek/ThisWeek.tsx
+++ b/src/components/Dashboard/ThisWeek/ThisWeek.tsx
@@ -1,8 +1,7 @@
 import React, { ReactElement } from 'react';
-import { Box, Typography, Grid, Button } from '@material-ui/core';
+import { Box, Typography, Grid } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import { DateTime } from 'luxon';
-import { ArrowDropDown } from '@material-ui/icons';
 import AnimatedBox from '../../AnimatedBox';
 import PartnerCare from './PartnerCare/PartnerCare';
 import TasksDueThisWeek from './TasksDueThisWeek/TasksDueThisWeek';
@@ -11,6 +10,7 @@ import Referrals from './Referrals';
 import Appeals from './Appeals';
 import WeeklyActivity from './WeeklyActivity';
 import { useGetThisWeekQuery } from './GetThisWeek.generated';
+import NewsletterMenu from './NewsletterMenu/NewsletterMenu';
 
 interface Props {
   accountListId: string;
@@ -49,11 +49,7 @@ const ThisWeek = ({ accountListId }: Props): ReactElement => {
           <Typography variant="h6">
             <Box display="flex">
               <Box flexGrow={1}>{t('To Do This Week')}</Box>
-              {/*TODO: This button should open menu for the Newsletter: https://jira.cru.org/browse/MPDX-6943 */}
-              <Button style={{ textTransform: 'uppercase' }}>
-                <ArrowDropDown />
-                {t('Newsletter')}
-              </Button>
+              <NewsletterMenu accountListId={accountListId} />
             </Box>
           </Typography>
         </AnimatedBox>


### PR DESCRIPTION
So this ticket adds functionality to the newsletter menu, but to a certain degree. This menu has three dropdown options:
1. Log Newsletter
2. Export Email
3. Export Physical

Only "Export Email" has full functionality and design in this PR, and I plan to create separate tickets/prs to address the other two. I did this as I didn't want the pr to get too large. "Log Newsletter" and "Export Physical" are just the barebones for those dialogs and tests.  Let me know what you think and if you have any questions 🙂 