### PR TITLE
Nav-Menu-Grid-Fix

### DIFF
--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.tsx
@@ -28,7 +28,7 @@ const NavMenu = (): ReactElement => {
   return (
     <>
       {state.accountListId ? (
-        <Grid container alignItems="center" xs="auto" md={6}>
+        <Grid container item alignItems="center" xs="auto" md={6}>
           <Grid item className={classes.navListItem}>
             <NextLink
               href="/accountLists/[accountListId]"

--- a/src/components/Layouts/Primary/TopBar/TopBar.tsx
+++ b/src/components/Layouts/Primary/TopBar/TopBar.tsx
@@ -75,7 +75,7 @@ const TopBar = (): ReactElement => {
       >
         <Toolbar className={classes.toolbar}>
           <Grid container alignItems="center">
-            <Grid container alignItems="center" xs="auto" md={1}>
+            <Grid container item alignItems="center" xs="auto" md={1}>
               <Grid item className={classes.logoGrid}>
                 <Hidden smDown>
                   <Box className={classes.logo}>
@@ -86,6 +86,7 @@ const TopBar = (): ReactElement => {
             </Grid>
             <NavMenu />
             <Grid
+              item
               xs={12}
               md={state.accountListId ? 5 : 11}
               container


### PR DESCRIPTION
I noticed these warnings in the console while working on another PR. It's from my previous work on https://github.com/CruGlobal/mpdx-react/pull/28. This PR just adds the ```item``` attribute to fix the warnings in the console, styling remains unaffected.
<img width="838" alt="Screen Shot 2021-04-26 at 1 49 23 PM" src="https://user-images.githubusercontent.com/39680460/116128771-4bfbd580-a697-11eb-8180-46b272756f11.png">
