### PR TITLE
Fix-Delete-Task-and-Update-Cache-Bug

### DIFF
--- a/src/components/Task/Drawer/Form/Form.test.tsx
+++ b/src/components/Task/Drawer/Form/Form.test.tsx
@@ -209,30 +209,5 @@ describe('TaskDrawerForm', () => {
     ).toBeInTheDocument();
 
     userEvent.click(getByRole('button', { name: 'Yes' }));
-    await waitFor(() =>
-      expect(cache.readQuery).toHaveBeenCalledWith({
-        query: GetTasksForTaskListDocument,
-        variables: {
-          accountListId,
-          first: 100,
-          ...mockFilter,
-        },
-      }),
-    );
-    await waitFor(() =>
-      expect(cache.writeQuery).toHaveBeenCalledWith({
-        query: GetTasksForTaskListDocument,
-        variables: {
-          accountListId,
-          first: 100,
-          ...mockFilter,
-        },
-        data: {
-          tasks: {
-            nodes: [],
-          },
-        },
-      }),
-    );
   });
 });


### PR DESCRIPTION
This PR aims to fix a bug that occurs when trying to update the cache after deleting a task. This bug was introduced in the [PR](https://github.com/CruGlobal/mpdx-react/pull/40) that added the ability to delete tasks. The main reason for this bug is the fact that the task drawer can be opened from a couple of different places throughout the app. The main two places are on the dashboard and on the task page. My logic to delete a task and then update the cache after only took into account deleting on the task page, where the query ```GetTasksForTaskListQuery``` would have been called. However, there is a scenario where the user could delete a task on the dashboard, without ever going to the tasks page, therefore ```GetTasksForTaskListQuery``` has not been called, and trying to update the cache would error. 

The solution I first tried was to only update ```GetTaskForTaskListQuery``` data if that query has been called and then add logic to also update ```GetThisWeekQuery``` data as well in the cache. But I soon quickly realized, there's a lot of data coming from that query haha. And it was going to be a mess/monster of code to get that cache update to work. So I've instead moved in favor of using ```refetchQueries``` in this particular case in order to refresh the data after deleting a task. I still believe we should manually update the cache when we can, but in this particular scenario, I think it's worth the two extra API calls to get this to work. Let me know what you guys think 🙂 