### PR TITLE
Fix-Dashboard-Late-Commitment-Dates

### DIFF
--- a/src/components/Dashboard/ThisWeek/LateCommitments/LateCommitments.stories.tsx
+++ b/src/components/Dashboard/ThisWeek/LateCommitments/LateCommitments.stories.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Box } from '@material-ui/core';
 import { GetThisWeekQuery } from '../GetThisWeek.generated';
-import LateCommitments from '.';
+import LateCommitments from './LateCommitments';
 
 export default {
   title: 'Dashboard/ThisWeek/LateCommitments',

--- a/src/components/Dashboard/ThisWeek/LateCommitments/LateCommitments.test.tsx
+++ b/src/components/Dashboard/ThisWeek/LateCommitments/LateCommitments.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '../../../../../__tests__/util/testingLibraryReactMock';
-import LateCommitments from '.';
+import LateCommitments from './LateCommitments';
 
 describe('LateCommitments', () => {
   it('default', () => {

--- a/src/components/Dashboard/ThisWeek/LateCommitments/LateCommitments.tsx
+++ b/src/components/Dashboard/ThisWeek/LateCommitments/LateCommitments.tsx
@@ -1,7 +1,5 @@
 import React, { ReactElement } from 'react';
 import {
-  makeStyles,
-  Theme,
   CardHeader,
   CardActions,
   Button,
@@ -9,6 +7,7 @@ import {
   ListItem,
   ListItemText,
   CardContent,
+  styled,
 } from '@material-ui/core';
 import { DateTime } from 'luxon';
 import { Skeleton } from '@material-ui/lab';
@@ -19,35 +18,36 @@ import HandoffLink from '../../../HandoffLink';
 import illustration14 from '../../../../images/drawkit/grape/drawkit-grape-pack-illustration-14.svg';
 import { GetThisWeekQuery } from '../GetThisWeek.generated';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  div: {
-    flex: 1,
-    display: 'flex',
-    flexDirection: 'column',
-    overflow: 'auto',
+const LateCommitmentsContainer = styled(AnimatedCard)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '322px',
+  [theme.breakpoints.down('xs')]: {
+    height: 'auto',
   },
-  list: {
-    flex: 1,
-    padding: 0,
-    overflow: 'auto',
-  },
-  card: {
-    display: 'flex',
-    flexDirection: 'column',
-    height: '322px',
-    [theme.breakpoints.down('xs')]: {
-      height: 'auto',
-    },
-  },
-  cardContent: {
-    padding: theme.spacing(2),
-    display: 'flex',
-    flex: 1,
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  img: {
+}));
+
+const MotionDiv = styled(motion.div)(() => ({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'auto',
+}));
+
+const CardList = styled(List)(() => ({
+  flex: 1,
+  padding: 0,
+  overflow: 'auto',
+}));
+
+const LateCommitmentsCardContent = styled(CardContent)(({ theme }) => ({
+  padding: theme.spacing(2),
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  '& > img': {
     height: '150px',
     marginBottom: theme.spacing(2),
   },
@@ -62,21 +62,19 @@ const LateCommitments = ({
   loading,
   latePledgeContacts,
 }: Props): ReactElement => {
-  const classes = useStyles();
   const { t } = useTranslation();
 
   return (
-    <AnimatedCard className={classes.card}>
+    <LateCommitmentsContainer>
       <CardHeader title={t('Late Commitments')} />
       {loading && (
-        <motion.div
+        <MotionDiv
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          className={classes.div}
           data-testid="LateCommitmentsDivLoading"
         >
-          <List className={classes.list}>
+          <CardList>
             {[0, 1, 2].map((index) => (
               <ListItem key={index}>
                 <ListItemText
@@ -85,36 +83,29 @@ const LateCommitments = ({
                 />
               </ListItem>
             ))}
-          </List>
+          </CardList>
           <CardActions>
             <Button size="small" color="primary" disabled>
               {t('View All ({{ totalCount, number }})', { totalCount: 0 })}
             </Button>
           </CardActions>
-        </motion.div>
+        </MotionDiv>
       )}
       {!loading && (
-        <motion.div
+        <MotionDiv
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          className={classes.div}
         >
           {(!latePledgeContacts || latePledgeContacts.nodes.length === 0) && (
-            <CardContent
-              className={classes.cardContent}
-              data-testid="LateCommitmentsCardContentEmpty"
-            >
-              <img src={illustration14} className={classes.img} alt="empty" />
+            <LateCommitmentsCardContent data-testid="LateCommitmentsCardContentEmpty">
+              <img src={illustration14} alt="empty" />
               {t('No late commitments to show.')}
-            </CardContent>
+            </LateCommitmentsCardContent>
           )}
           {latePledgeContacts && latePledgeContacts.nodes.length > 0 && (
             <>
-              <List
-                className={classes.list}
-                data-testid="LateCommitmentsListContacts"
-              >
+              <CardList data-testid="LateCommitmentsListContacts">
                 {latePledgeContacts.nodes.map((contact) => {
                   if (!contact.lateAt) {
                     return null;
@@ -146,7 +137,7 @@ const LateCommitments = ({
                     </HandoffLink>
                   );
                 })}
-              </List>
+              </CardList>
               <CardActions>
                 <HandoffLink
                   path={`/contacts?filters=${encodeURIComponent(
@@ -171,9 +162,9 @@ const LateCommitments = ({
               </CardActions>
             </>
           )}
-        </motion.div>
+        </MotionDiv>
       )}
-    </AnimatedCard>
+    </LateCommitmentsContainer>
   );
 };
 

--- a/src/components/Dashboard/ThisWeek/LateCommitments/LateCommitments.tsx
+++ b/src/components/Dashboard/ThisWeek/LateCommitments/LateCommitments.tsx
@@ -110,10 +110,13 @@ const LateCommitments = ({
                   if (!contact.lateAt) {
                     return null;
                   }
-                  const count = DateTime.local().diff(
-                    DateTime.fromISO(contact.lateAt),
-                    'days',
-                  ).days;
+                  const count = Math.round(
+                    DateTime.local().diff(
+                      DateTime.fromISO(contact.lateAt),
+                      'days',
+                    ).days,
+                  );
+
                   return (
                     <HandoffLink
                       key={contact.id}

--- a/src/components/Dashboard/ThisWeek/LateCommitments/index.tsx
+++ b/src/components/Dashboard/ThisWeek/LateCommitments/index.tsx
@@ -1,3 +1,0 @@
-import LateCommitments from './LateCommitments';
-
-export default LateCommitments;

--- a/src/components/Dashboard/ThisWeek/ThisWeek.tsx
+++ b/src/components/Dashboard/ThisWeek/ThisWeek.tsx
@@ -5,7 +5,7 @@ import { DateTime } from 'luxon';
 import AnimatedBox from '../../AnimatedBox';
 import PartnerCare from './PartnerCare/PartnerCare';
 import TasksDueThisWeek from './TasksDueThisWeek/TasksDueThisWeek';
-import LateCommitments from './LateCommitments';
+import LateCommitments from './LateCommitments/LateCommitments';
 import Referrals from './Referrals';
 import Appeals from './Appeals';
 import WeeklyActivity from './WeeklyActivity';


### PR DESCRIPTION
Noticed that the days for the late commitments weren't being rounded.
<img width="453" alt="Screen Shot 2021-05-07 at 9 48 49 AM" src="https://user-images.githubusercontent.com/39680460/117466970-4321c400-af21-11eb-96ed-5d023641ca05.png">
Went ahead and switched to named exports and the styled API while I was as it 🙂 