### PR TITLE
Remove-Duplicate-Starred-Definition-in-TaskSchema

### DIFF
--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.tsx
@@ -92,7 +92,7 @@ const taskSchema: yup.SchemaOf<
   id: yup.string().nullable(),
   activityType: yup.mixed<ActivityTypeEnum>(),
   subject: yup.string().required(),
-  starred: yup.boolean().required(),
+  starred: yup.boolean().nullable(),
   startAt: yup.string().nullable(),
   completedAt: yup.string().nullable(),
   tagList: yup.array().of(yup.string()).default([]),
@@ -101,7 +101,6 @@ const taskSchema: yup.SchemaOf<
   notificationTimeBefore: yup.number().nullable(),
   notificationType: yup.mixed<NotificationTypeEnum>(),
   notificationTimeUnit: yup.mixed<NotificationTimeUnitEnum>(),
-  starred: yup.boolean().nullable(),
 });
 
 const LogNewsletter = ({

--- a/src/components/Task/Drawer/Form/Form.tsx
+++ b/src/components/Task/Drawer/Form/Form.tsx
@@ -86,7 +86,7 @@ const taskSchema: yup.SchemaOf<
   id: yup.string().nullable(),
   activityType: yup.mixed<ActivityTypeEnum>(),
   subject: yup.string().required(),
-  starred: yup.boolean().required(),
+  starred: yup.boolean().nullable(),
   startAt: yup.string().nullable(),
   completedAt: yup.string().nullable(),
   tagList: yup.array().of(yup.string()).default([]),
@@ -95,7 +95,6 @@ const taskSchema: yup.SchemaOf<
   notificationTimeBefore: yup.number().nullable(),
   notificationType: yup.mixed<NotificationTypeEnum>(),
   notificationTimeUnit: yup.mixed<NotificationTimeUnitEnum>(),
-  starred: yup.boolean().nullable(),
 });
 
 interface Props {


### PR DESCRIPTION
I assumed that we did not need this to be required in the task schema, as the api will automatically set it to false upon task creation(?). It also looks like we aren't currently grabbing the ```starred``` field in the query ```GetTaskForTaskDrawer```, so it was preventing that update of the task. Not sure if that field needs to be added. It also wasn't set in the ```initialTask``` values we use when creating a new task, but I assume the api will set that field upon the task creation so it feels like extra work for the client to set it. 