### PR TITLE
Only show remove button if task id exist

### DIFF
--- a/src/components/Task/Drawer/Form/Form.test.tsx
+++ b/src/components/Task/Drawer/Form/Form.test.tsx
@@ -49,7 +49,7 @@ describe('TaskDrawerForm', () => {
 
   it('default', async () => {
     const onClose = jest.fn();
-    const { getByText, getByRole, findByText } = render(
+    const { getByText, getByRole, findByText, queryByText } = render(
       <MuiPickersUtilsProvider utils={LuxonUtils}>
         <SnackbarProvider>
           <MockedProvider
@@ -74,6 +74,7 @@ describe('TaskDrawerForm', () => {
     onClose.mockClear();
     userEvent.click(getByText('Save'));
     expect(await findByText('Field is required')).toBeInTheDocument();
+    expect(await queryByText('Remove')).not.toBeInTheDocument();
     userEvent.type(getByRole('textbox', { name: 'Subject' }), accountListId);
     userEvent.click(getByRole('checkbox', { name: 'Notification' }));
     userEvent.type(getByRole('spinbutton', { name: 'Period' }), '20');

--- a/src/components/Task/Drawer/Form/Form.tsx
+++ b/src/components/Task/Drawer/Form/Form.tsx
@@ -569,15 +569,17 @@ const TaskDrawerForm = ({
           <Box m={2}>
             <Grid container spacing={1} justify="flex-end">
               <Grid container item xs={8} justify="flex-start">
-                <Button
-                  size="large"
-                  variant="contained"
-                  className={classes.removeButton}
-                  onClick={() => handleRemoveDialog(true)}
-                >
-                  <DeleteIcon />
-                  {t('Remove')}
-                </Button>
+                {task?.id ? (
+                  <Button
+                    size="large"
+                    variant="contained"
+                    className={classes.removeButton}
+                    onClick={() => handleRemoveDialog(true)}
+                  >
+                    <DeleteIcon />
+                    {t('Remove')}
+                  </Button>
+                ) : null}
               </Grid>
               <Grid item xs={2}>
                 <Button size="large" disabled={isSubmitting} onClick={onClose}>


### PR DESCRIPTION
I noticed yesterday that the remove button always shows in the task drawer, even when creating a new task... I missed this in the initial implementation! Now it will only display if a task is passed into the task drawer(meaning they are currently completing or editing an existing task).