### PR TITLE
MPDX-7048: Expected Monthly Total Report - REST to GraphQL

### DIFF
--- a/pages/api/Schema/index.ts
+++ b/pages/api/Schema/index.ts
@@ -9,6 +9,8 @@ import { TaskAnalyticsResolvers } from './TaskAnalytics/resolvers';
 import TaskAnalyticsTypeDefs from './TaskAnalytics/taskAnalytics.graphql';
 import FourteenMonthReportTypeDefs from './reports/fourteenMonth/fourteenMonth.graphql';
 import { FourteenMonthReportResolvers } from './reports/fourteenMonth/resolvers';
+import ExpectedMonthlyTotalReportTypeDefs from './reports/expectedMonthlyTotal/expectedMonthlyTotal.graphql';
+import { ExpectedMonthlyTotalReportResolvers } from './reports/expectedMonthlyTotal/resolvers';
 
 const schema = buildFederatedSchema([
   { typeDefs: ScalarTypeDefs, resolvers: ScalarResolvers },
@@ -18,6 +20,10 @@ const schema = buildFederatedSchema([
   {
     typeDefs: FourteenMonthReportTypeDefs,
     resolvers: FourteenMonthReportResolvers,
+  },
+  {
+    typeDefs: ExpectedMonthlyTotalReportTypeDefs,
+    resolvers: ExpectedMonthlyTotalReportResolvers,
   },
 ]);
 

--- a/pages/api/Schema/reports/expectedMonthlyTotal/datahandler.ts
+++ b/pages/api/Schema/reports/expectedMonthlyTotal/datahandler.ts
@@ -56,16 +56,33 @@ const mapDonation = (
 
 export const mapExpectedMonthlyTotalReport = (
   data: ExpectedMonthlyTotalResponse,
-): ExpectedMonthlyTotalReport => ({
-  received: data.attributes.expected_donations
+): ExpectedMonthlyTotalReport => {
+  const received = data.attributes.expected_donations
     .filter(({ type }) => type === 'received')
-    .map(mapDonation),
-  likely: data.attributes.expected_donations
+    .map(mapDonation);
+  const likely = data.attributes.expected_donations
     .filter(({ type }) => type === 'likely')
-    .map(mapDonation),
-  unlikely: data.attributes.expected_donations
+    .map(mapDonation);
+  const unlikely = data.attributes.expected_donations
     .filter(({ type }) => type === 'unlikely')
-    .map(mapDonation),
-  currency: data.attributes.total_currency,
-  currencySymbol: data.attributes.total_currency_symbol,
-});
+    .map(mapDonation);
+  return {
+    received,
+    likely,
+    unlikely,
+    receivedTotal: received.reduce(
+      (total, donation) => total + donation.convertedAmount,
+      0,
+    ),
+    likelyTotal: likely.reduce(
+      (total, donation) => total + donation.convertedAmount,
+      0,
+    ),
+    unlikelyTotal: unlikely.reduce(
+      (total, donation) => total + donation.convertedAmount,
+      0,
+    ),
+    currency: data.attributes.total_currency,
+    currencySymbol: data.attributes.total_currency_symbol,
+  };
+};

--- a/pages/api/Schema/reports/expectedMonthlyTotal/datahandler.ts
+++ b/pages/api/Schema/reports/expectedMonthlyTotal/datahandler.ts
@@ -54,35 +54,28 @@ const mapDonation = (
   pledgeFrequency: donation.pledge_frequency,
 });
 
-export const mapExpectedMonthlyTotalReport = (
-  data: ExpectedMonthlyTotalResponse,
-): ExpectedMonthlyTotalReport => {
-  const received = data.attributes.expected_donations
-    .filter(({ type }) => type === 'received')
-    .map(mapDonation);
-  const likely = data.attributes.expected_donations
-    .filter(({ type }) => type === 'likely')
-    .map(mapDonation);
-  const unlikely = data.attributes.expected_donations
-    .filter(({ type }) => type === 'unlikely')
+const createDonationGroup = (
+  allDonations: ExpectedMonthlyTotalResponse['attributes']['expected_donations'],
+  expectedType: ExpectedMonthlyTotalResponse['attributes']['expected_donations'][0]['type'],
+) => {
+  const donations = allDonations
+    .filter(({ type }) => type === expectedType)
     .map(mapDonation);
   return {
-    received,
-    likely,
-    unlikely,
-    receivedTotal: received.reduce(
+    donations,
+    total: donations.reduce(
       (total, donation) => total + donation.convertedAmount,
       0,
     ),
-    likelyTotal: likely.reduce(
-      (total, donation) => total + donation.convertedAmount,
-      0,
-    ),
-    unlikelyTotal: unlikely.reduce(
-      (total, donation) => total + donation.convertedAmount,
-      0,
-    ),
-    currency: data.attributes.total_currency,
-    currencySymbol: data.attributes.total_currency_symbol,
   };
 };
+
+export const mapExpectedMonthlyTotalReport = (
+  data: ExpectedMonthlyTotalResponse,
+): ExpectedMonthlyTotalReport => ({
+  received: createDonationGroup(data.attributes.expected_donations, 'received'),
+  likely: createDonationGroup(data.attributes.expected_donations, 'likely'),
+  unlikely: createDonationGroup(data.attributes.expected_donations, 'unlikely'),
+  currency: data.attributes.total_currency,
+  currencySymbol: data.attributes.total_currency_symbol,
+});

--- a/pages/api/Schema/reports/expectedMonthlyTotal/datahandler.ts
+++ b/pages/api/Schema/reports/expectedMonthlyTotal/datahandler.ts
@@ -1,0 +1,71 @@
+import { ExpectedMonthlyTotalReport } from '../../../graphql-rest.page.generated';
+
+export interface ExpectedMonthlyTotalResponse {
+  id: string;
+  type: string;
+  attributes: {
+    created_at: string;
+    expected_donations: {
+      contact_id: string;
+      contact_name: string;
+      contact_status: string;
+      converted_amount: number;
+      converted_currency: string;
+      converted_currency_symbol: string;
+      donation_amount: number;
+      donation_currency: string;
+      donation_currency_symbol: string;
+      pledge_amount: number;
+      pledge_currency: string;
+      pledge_currency_symbol: string;
+      pledge_frequency: string;
+      type: 'received' | 'likely' | 'unlikely';
+    }[];
+    total_currency: string;
+    total_currency_symbol: string;
+    updated_at: string | null;
+    updated_in_db_at: string | null;
+  };
+  relationships: {
+    account_list: {
+      data: {
+        id: string;
+        type: string;
+      };
+    };
+  };
+}
+
+const mapDonation = (
+  donation: ExpectedMonthlyTotalResponse['attributes']['expected_donations'][0],
+) => ({
+  contactId: donation.contact_id,
+  contactName: donation.contact_name,
+  contactStatus: donation.contact_status,
+  convertedAmount: donation.converted_amount,
+  convertedCurrency: donation.converted_currency,
+  convertedCurrencySymbol: donation.converted_currency_symbol,
+  donationAmount: donation.donation_amount,
+  donationCurrency: donation.donation_currency,
+  donationCurrencySymbol: donation.donation_currency_symbol,
+  pledgeAmount: donation.pledge_amount,
+  pledgeCurrency: donation.pledge_currency,
+  pledgeCurrencySymbol: donation.pledge_currency_symbol,
+  pledgeFrequency: donation.pledge_frequency,
+});
+
+export const mapExpectedMonthlyTotalReport = (
+  data: ExpectedMonthlyTotalResponse,
+): ExpectedMonthlyTotalReport => ({
+  received: data.attributes.expected_donations
+    .filter(({ type }) => type === 'received')
+    .map(mapDonation),
+  likely: data.attributes.expected_donations
+    .filter(({ type }) => type === 'likely')
+    .map(mapDonation),
+  unlikely: data.attributes.expected_donations
+    .filter(({ type }) => type === 'unlikely')
+    .map(mapDonation),
+  currency: data.attributes.total_currency,
+  currencySymbol: data.attributes.total_currency_symbol,
+});

--- a/pages/api/Schema/reports/expectedMonthlyTotal/expectedMonthlyTotal.graphql
+++ b/pages/api/Schema/reports/expectedMonthlyTotal/expectedMonthlyTotal.graphql
@@ -3,14 +3,16 @@ extend type Query {
 }
 
 type ExpectedMonthlyTotalReport {
-  received: [ExpectedMonthlyTotalDonation!]!
-  likely: [ExpectedMonthlyTotalDonation!]!
-  unlikely: [ExpectedMonthlyTotalDonation!]!
-  receivedTotal: Float!
-  likelyTotal: Float!
-  unlikelyTotal: Float!
+  received: ExpectedMonthlyTotalGroup!
+  likely: ExpectedMonthlyTotalGroup!
+  unlikely: ExpectedMonthlyTotalGroup!
   currency: String
   currencySymbol: String
+}
+
+type ExpectedMonthlyTotalGroup {
+  donations: [ExpectedMonthlyTotalDonation!]!
+  total: Float!
 }
 
 type ExpectedMonthlyTotalDonation {

--- a/pages/api/Schema/reports/expectedMonthlyTotal/expectedMonthlyTotal.graphql
+++ b/pages/api/Schema/reports/expectedMonthlyTotal/expectedMonthlyTotal.graphql
@@ -6,6 +6,9 @@ type ExpectedMonthlyTotalReport {
   received: [ExpectedMonthlyTotalDonation!]!
   likely: [ExpectedMonthlyTotalDonation!]!
   unlikely: [ExpectedMonthlyTotalDonation!]!
+  receivedTotal: Float!
+  likelyTotal: Float!
+  unlikelyTotal: Float!
   currency: String
   currencySymbol: String
 }

--- a/pages/api/Schema/reports/expectedMonthlyTotal/expectedMonthlyTotal.graphql
+++ b/pages/api/Schema/reports/expectedMonthlyTotal/expectedMonthlyTotal.graphql
@@ -1,0 +1,27 @@
+extend type Query {
+  expectedMonthlyTotalReport(accountListId: ID!): ExpectedMonthlyTotalReport!
+}
+
+type ExpectedMonthlyTotalReport {
+  received: [ExpectedMonthlyTotalDonation!]!
+  likely: [ExpectedMonthlyTotalDonation!]!
+  unlikely: [ExpectedMonthlyTotalDonation!]!
+  currency: String
+  currencySymbol: String
+}
+
+type ExpectedMonthlyTotalDonation {
+  contactId: String
+  contactName: String
+  contactStatus: String
+  convertedAmount: Float
+  convertedCurrency: String
+  convertedCurrencySymbol: String
+  donationAmount: Float
+  donationCurrency: String
+  donationCurrencySymbol: String
+  pledgeAmount: Float
+  pledgeCurrency: String
+  pledgeCurrencySymbol: String
+  pledgeFrequency: String
+}

--- a/pages/api/Schema/reports/expectedMonthlyTotal/resolvers.ts
+++ b/pages/api/Schema/reports/expectedMonthlyTotal/resolvers.ts
@@ -1,0 +1,15 @@
+import { Resolvers } from '../../../graphql-rest.page.generated';
+
+export const ExpectedMonthlyTotalReportResolvers: Resolvers = {
+  Query: {
+    expectedMonthlyTotalReport: (
+      _source,
+      { accountListId },
+      { dataSources },
+    ) => {
+      return dataSources.mpdxRestApi.getExpectedMonthlyTotalReport(
+        accountListId,
+      );
+    },
+  },
+};

--- a/pages/api/graphql-rest.page.ts
+++ b/pages/api/graphql-rest.page.ts
@@ -22,6 +22,10 @@ import {
   FourteenMonthReportResponse,
   mapFourteenMonthReport,
 } from './Schema/reports/fourteenMonth/datahandler';
+import {
+  ExpectedMonthlyTotalResponse,
+  mapExpectedMonthlyTotalReport,
+} from './Schema/reports/expectedMonthlyTotal/datahandler';
 
 class MpdxRestApi extends RESTDataSource {
   constructor() {
@@ -136,6 +140,13 @@ class MpdxRestApi extends RESTDataSource {
         .replace('/', '...')}`,
     );
     return mapFourteenMonthReport(data, currencyType);
+  }
+
+  async getExpectedMonthlyTotalReport(accountListId: string) {
+    const { data }: { data: ExpectedMonthlyTotalResponse } = await this.get(
+      `reports/expected_monthly_totals?filter[account_list_id]=${accountListId}`,
+    );
+    return mapExpectedMonthlyTotalReport(data);
   }
 }
 


### PR DESCRIPTION
Here's the query I was using to test this:
```graphql
query ExpectedMonthlyTotalReport($accountListId: ID!) {
  expectedMonthlyTotalReport(accountListId: $accountListId) {
    received {
      donations {
        ...Donation
      }
      total
    }
    likely {
      donations {
        ...Donation
      }
      total
    }
    unlikely {
      donations {
        ...Donation
      }
      total
    }
    currency
    currencySymbol
  }
}

fragment Donation on ExpectedMonthlyTotalDonation {
  contactId
  contactName
  contactStatus
  convertedAmount
  convertedCurrency
  convertedCurrencySymbol
  donationAmount
  donationCurrency
  donationCurrencySymbol
  pledgeAmount
  pledgeCurrency
  pledgeCurrencySymbol
  pledgeFrequency
}
```