### PR TITLE
MPDX-6919 - Removing vertical scrollbar

### DIFF
--- a/src/components/Layouts/Basic/TopBar/TopBar.tsx
+++ b/src/components/Layouts/Basic/TopBar/TopBar.tsx
@@ -44,11 +44,6 @@ const TopBar = ({ children }: Props): ReactElement => {
           </Grid>
         </Toolbar>
       </AppBar>
-      <AppBar position="static" className={classes.appBar} elevation={0}>
-        <Toolbar className={classes.toolbar}>
-          <Grid className={classes.container} />
-        </Toolbar>
-      </AppBar>
     </>
   );
 };


### PR DESCRIPTION
I'm genuinely not sure what the purpose of the additional `AppBar` was, but it was causing the page to needlessly extend beyond the height of the browser. Feel free to yell at me to put it back.