### PR TITLE
Fix-Contact-Right-Panel-Scroll

### DIFF
--- a/src/components/Layouts/SidePanelsLayout.tsx
+++ b/src/components/Layouts/SidePanelsLayout.tsx
@@ -142,7 +142,7 @@ export const SidePanelsLayout: FC<SidePanelsLayoutProps> = ({
       flexBasis={rightWidth}
       breakpoint="md"
     >
-      {rightPanel}
+      <ScrollBox isscroll={isScrollBox ? 1 : 0}>{rightPanel}</ScrollBox>
     </RightPanelWrapper>
   </CollapsibleWrapper>
 );


### PR DESCRIPTION
So I just realized for the first time today as I was trying to scroll down to the mailing section of the contact details tab... that I couldn't actually scroll lol. This was true for the whole right panel. Adding this scroll box around the right panel seemed to fix that, but let me know if there's a better way to wrap this. 