### PR TITLE
MPDX-6998-Edit-Contact-Addresses

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.graphql
@@ -2,13 +2,6 @@ query ContactDetailsTab($accountListId: ID!, $contactId: ID!) {
   contact(accountListId: $accountListId, id: $contactId) {
     id
     name
-    primaryAddress {
-      street
-      city
-      state
-      postalCode
-      country
-    }
     tagList
     envelopeGreeting
     preferredContactMethod

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.test.tsx
@@ -61,12 +61,17 @@ describe('ContactDetailTab', () => {
         contact: {
           id: contactId,
           name: 'Person, Test',
-          primaryAddress: {
-            street: '123 Sesame Street',
-            city: 'New York',
-            state: 'NY',
-            postalCode: '10001',
-            country: 'USA',
+          addresses: {
+            nodes: [
+              {
+                street: '123 Sesame Street',
+                city: 'New York',
+                state: 'NY',
+                postalCode: '10001',
+                country: 'USA',
+                primaryMailingAddress: true,
+              },
+            ],
           },
           tagList: ['tag1', 'tag2', 'tag3'],
           people: {
@@ -201,7 +206,7 @@ describe('ContactDetailTab', () => {
       </SnackbarProvider>,
     );
     await waitFor(() => expect(queryByText('Loading')).not.toBeInTheDocument());
-    userEvent.click(getAllByRole('img', { name: 'Edit Icon' })[5]);
+    userEvent.click(getAllByRole('img', { name: 'Edit Icon' })[8]);
     await waitFor(() =>
       expect(queryByText('Edit Contact Other Details')).toBeInTheDocument(),
     );
@@ -225,7 +230,7 @@ describe('ContactDetailTab', () => {
       </SnackbarProvider>,
     );
     await waitFor(() => expect(queryByText('Loading')).not.toBeInTheDocument());
-    userEvent.click(getAllByRole('img', { name: 'Edit Icon' })[5]);
+    userEvent.click(getAllByRole('img', { name: 'Edit Icon' })[8]);
     await waitFor(() =>
       expect(queryByText('Edit Contact Other Details')).toBeInTheDocument(),
     );
@@ -243,12 +248,17 @@ describe('ContactDetailTab', () => {
         contact: {
           id: contactId,
           name: 'Person, Test',
-          primaryAddress: {
-            street: '123 Sesame Street',
-            city: 'New York',
-            state: 'NY',
-            postalCode: '10001',
-            country: 'USA',
+          addresses: {
+            nodes: [
+              {
+                street: '123 Sesame Street',
+                city: 'New York',
+                state: 'NY',
+                postalCode: '10001',
+                country: 'USA',
+                primaryMailingAddress: true,
+              },
+            ],
           },
           tagList: ['tag1', 'tag2', 'tag3'],
           people: {

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.test.tsx
@@ -23,6 +23,52 @@ const router = {
   push: jest.fn(),
 };
 
+const mocks = {
+  ContactDetailsTab: {
+    contact: {
+      id: contactId,
+      name: 'Person, Test',
+      addresses: {
+        nodes: [
+          {
+            id: '123',
+            street: '123 Sesame Street',
+            city: 'New York',
+            state: 'NY',
+            postalCode: '10001',
+            country: 'USA',
+            primaryMailingAddress: true,
+          },
+          {
+            id: '321',
+            street: '4321 Sesame Street',
+            city: 'Florida',
+            state: 'FL',
+            postalCode: '10001',
+            country: 'USA',
+            primaryMailingAddress: false,
+          },
+        ],
+      },
+      tagList: ['tag1', 'tag2', 'tag3'],
+      people: {
+        nodes: [
+          {
+            id: contactId,
+            firstName: 'Test',
+            lastName: 'Person',
+            primaryPhoneNumber: { number: '555-555-5555' },
+            primaryEmailAddress: {
+              email: 'testperson@fake.com',
+            },
+          },
+        ],
+      },
+      website: 'testperson.com',
+    },
+  },
+};
+
 const mockEnqueue = jest.fn();
 
 jest.mock('notistack', () => ({
@@ -56,41 +102,6 @@ describe('ContactDetailTab', () => {
   });
 
   it('should render contact details', async () => {
-    const mocks = {
-      ContactDetailsTab: {
-        contact: {
-          id: contactId,
-          name: 'Person, Test',
-          addresses: {
-            nodes: [
-              {
-                street: '123 Sesame Street',
-                city: 'New York',
-                state: 'NY',
-                postalCode: '10001',
-                country: 'USA',
-                primaryMailingAddress: true,
-              },
-            ],
-          },
-          tagList: ['tag1', 'tag2', 'tag3'],
-          people: {
-            nodes: [
-              {
-                id: contactId,
-                firstName: 'Test',
-                lastName: 'Person',
-                primaryPhoneNumber: { number: '555-555-5555' },
-                primaryEmailAddress: {
-                  email: 'testperson@fake.com',
-                },
-              },
-            ],
-          },
-          website: 'testperson.com',
-        },
-      },
-    };
     const { queryAllByText, queryByText } = render(
       <SnackbarProvider>
         <TestRouter router={router}>
@@ -237,6 +248,86 @@ describe('ContactDetailTab', () => {
     userEvent.click(getByRole('button', { name: 'Close' }));
     await waitFor(() =>
       expect(queryByText('Edit Address')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('should open show more section | Addresses', async () => {
+    const { queryByText, getByText } = render(
+      <SnackbarProvider>
+        <TestRouter router={router}>
+          <MuiPickersUtilsProvider utils={LuxonUtils}>
+            <ThemeProvider theme={theme}>
+              <GqlMockedProvider<ContactDetailsTabQuery> mocks={mocks}>
+                <ContactDetailsTab
+                  accountListId={accountListId}
+                  contactId={contactId}
+                />
+              </GqlMockedProvider>
+            </ThemeProvider>
+          </MuiPickersUtilsProvider>
+        </TestRouter>
+      </SnackbarProvider>,
+    );
+    await waitFor(() => expect(queryByText('Loading')).not.toBeInTheDocument());
+    userEvent.click(getByText('Show More'));
+    await waitFor(() =>
+      expect(getByText('4321 Sesame Street')).toBeInTheDocument(),
+    );
+  });
+
+  it('should close show more section | Addresses', async () => {
+    const { queryByText, getByText } = render(
+      <SnackbarProvider>
+        <TestRouter router={router}>
+          <MuiPickersUtilsProvider utils={LuxonUtils}>
+            <ThemeProvider theme={theme}>
+              <GqlMockedProvider<ContactDetailsTabQuery> mocks={mocks}>
+                <ContactDetailsTab
+                  accountListId={accountListId}
+                  contactId={contactId}
+                />
+              </GqlMockedProvider>
+            </ThemeProvider>
+          </MuiPickersUtilsProvider>
+        </TestRouter>
+      </SnackbarProvider>,
+    );
+    await waitFor(() => expect(queryByText('Loading')).not.toBeInTheDocument());
+    userEvent.click(getByText('Show More'));
+    await waitFor(() =>
+      expect(getByText('4321 Sesame Street')).toBeInTheDocument(),
+    );
+    userEvent.click(getByText('Show Less'));
+    await waitFor(() =>
+      expect(queryByText('4321 Sesame Street')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('should open edit contact addresses from show more section | Addresses', async () => {
+    const { queryByText, getByText, getAllByRole } = render(
+      <SnackbarProvider>
+        <TestRouter router={router}>
+          <MuiPickersUtilsProvider utils={LuxonUtils}>
+            <ThemeProvider theme={theme}>
+              <GqlMockedProvider<ContactDetailsTabQuery> mocks={mocks}>
+                <ContactDetailsTab
+                  accountListId={accountListId}
+                  contactId={contactId}
+                />
+              </GqlMockedProvider>
+            </ThemeProvider>
+          </MuiPickersUtilsProvider>
+        </TestRouter>
+      </SnackbarProvider>,
+    );
+    await waitFor(() => expect(queryByText('Loading')).not.toBeInTheDocument());
+    userEvent.click(getByText('Show More'));
+    await waitFor(() =>
+      expect(getByText('4321 Sesame Street')).toBeInTheDocument(),
+    );
+    userEvent.click(getAllByRole('img', { name: 'Edit Icon' })[5]);
+    await waitFor(() =>
+      expect(queryByText('Edit Address')).toBeInTheDocument(),
     );
   });
 

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.test.tsx
@@ -188,6 +188,58 @@ describe('ContactDetailTab', () => {
     );
   });
 
+  it('should open edit contact address modal', async () => {
+    const { queryByText, getAllByRole } = render(
+      <SnackbarProvider>
+        <TestRouter router={router}>
+          <MuiPickersUtilsProvider utils={LuxonUtils}>
+            <ThemeProvider theme={theme}>
+              <GqlMockedProvider<ContactDetailsTabQuery>>
+                <ContactDetailsTab
+                  accountListId={accountListId}
+                  contactId={contactId}
+                />
+              </GqlMockedProvider>
+            </ThemeProvider>
+          </MuiPickersUtilsProvider>
+        </TestRouter>
+      </SnackbarProvider>,
+    );
+    await waitFor(() => expect(queryByText('Loading')).not.toBeInTheDocument());
+    userEvent.click(getAllByRole('img', { name: 'Edit Icon' })[7]);
+    await waitFor(() =>
+      expect(queryByText('Edit Address')).toBeInTheDocument(),
+    );
+  });
+
+  it('should close edit contact address modal', async () => {
+    const { queryByText, getAllByRole, getByRole } = render(
+      <SnackbarProvider>
+        <TestRouter router={router}>
+          <MuiPickersUtilsProvider utils={LuxonUtils}>
+            <ThemeProvider theme={theme}>
+              <GqlMockedProvider<ContactDetailsTabQuery>>
+                <ContactDetailsTab
+                  accountListId={accountListId}
+                  contactId={contactId}
+                />
+              </GqlMockedProvider>
+            </ThemeProvider>
+          </MuiPickersUtilsProvider>
+        </TestRouter>
+      </SnackbarProvider>,
+    );
+    await waitFor(() => expect(queryByText('Loading')).not.toBeInTheDocument());
+    userEvent.click(getAllByRole('img', { name: 'Edit Icon' })[7]);
+    await waitFor(() =>
+      expect(queryByText('Edit Address')).toBeInTheDocument(),
+    );
+    userEvent.click(getByRole('button', { name: 'Close' }));
+    await waitFor(() =>
+      expect(queryByText('Edit Address')).not.toBeInTheDocument(),
+    );
+  });
+
   it('should open edit contact other details modal', async () => {
     const { queryByText, getAllByRole } = render(
       <SnackbarProvider>

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.tsx
@@ -254,7 +254,10 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
               <ContactDetailLoadingPlaceHolder variant="rect" />
             </>
           ) : (
-            <ContactDetailsTabMailing data={data.contact} />
+            <ContactDetailsTabMailing
+              accountListId={accountListId}
+              data={data.contact}
+            />
           )}
         </ContactDetailSectionContainer>
         <Divider />

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactDetailsTabMailing.stories.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactDetailsTabMailing.stories.tsx
@@ -15,7 +15,7 @@ export const Default = (): ReactElement => {
   const mock = gqlMock<ContactMailingFragment>(ContactMailingFragmentDoc);
   return (
     <Box m={2}>
-      <ContactDetailsTabMailing data={mock} />
+      <ContactDetailsTabMailing accountListId={'123'} data={mock} />
     </Box>
   );
 };

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactDetailsTabMailing.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactDetailsTabMailing.tsx
@@ -12,6 +12,7 @@ import LocationOn from '@material-ui/icons/LocationOn';
 import CreateIcon from '@material-ui/icons/Create';
 import AddIcon from '@material-ui/icons/Add';
 import { ContactMailingFragment } from './ContactMailing.generated';
+import { EditContactAddressModal } from './EditContactAddressModal/EditContactAddressModal';
 
 const ContactDetailsMailingMainContainer = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -73,12 +74,17 @@ const AddressAddIcon = styled(AddIcon)(() => ({
 }));
 
 interface MailingProp {
+  accountListId: string;
   data: ContactMailingFragment;
 }
 
-export const ContactDetailsTabMailing: React.FC<MailingProp> = ({ data }) => {
+export const ContactDetailsTabMailing: React.FC<MailingProp> = ({
+  data,
+  accountListId,
+}) => {
   const { t } = useTranslation();
   const { addresses, greeting, sendNewsletter } = data;
+  const [editingAddressId, setEditingAddressId] = useState<string>();
   const primaryAddress = addresses.nodes.filter(
     (address) => address.primaryMailingAddress === true,
   )[0];
@@ -86,118 +92,135 @@ export const ContactDetailsTabMailing: React.FC<MailingProp> = ({ data }) => {
     (address) => address.primaryMailingAddress !== true,
   );
 
+  const selectedAddress =
+    editingAddressId &&
+    addresses.nodes.filter((address) => address.id === editingAddressId)[0];
+
   const [showMoreOpen, setShowMoreOpen] = useState(false);
   return (
-    <Box>
-      <ContactDetailsMailingMainContainer>
-        <ContactDetailsMailingIcon />
-        <ContactDetailsMailingTextContainer>
-          {/* Address Section */}
-          {primaryAddress && (
-            <>
-              <ContactAddressRowContainer>
-                <Typography variant="subtitle1">
-                  <Box fontWeight="fontWeightBold">{primaryAddress.street}</Box>
-                </Typography>
-                <ContactAddressPrimaryText variant="subtitle1">
-                  {`- ${t('Primary')}`}
-                </ContactAddressPrimaryText>
-                <AddressEditIconContainer
-                  onClick={() => {
-                    console.log('hi');
-                  }}
-                >
-                  <AddressEditIcon titleAccess={t('Edit Icon')} />
-                </AddressEditIconContainer>
-              </ContactAddressRowContainer>
+    <>
+      <Box>
+        <ContactDetailsMailingMainContainer>
+          <ContactDetailsMailingIcon />
+          <ContactDetailsMailingTextContainer>
+            {/* Address Section */}
+            {primaryAddress && (
+              <>
+                <ContactAddressRowContainer>
+                  <Typography variant="subtitle1">
+                    <Box fontWeight="fontWeightBold">
+                      {primaryAddress.street}
+                    </Box>
+                  </Typography>
+                  <ContactAddressPrimaryText variant="subtitle1">
+                    {`- ${t('Primary')}`}
+                  </ContactAddressPrimaryText>
+                  <AddressEditIconContainer
+                    onClick={() => {
+                      setEditingAddressId(primaryAddress.id);
+                    }}
+                  >
+                    <AddressEditIcon titleAccess={t('Edit Icon')} />
+                  </AddressEditIconContainer>
+                </ContactAddressRowContainer>
 
-              <ContactAddressRowContainer>
-                <Typography variant="subtitle1">
-                  {`${primaryAddress.city}, ${primaryAddress.state} ${primaryAddress.postalCode}`}
-                </Typography>
-              </ContactAddressRowContainer>
-              <ContactAddressRowContainer>
-                <Typography variant="subtitle1">
-                  {primaryAddress.country}
-                </Typography>
-              </ContactAddressRowContainer>
-              <ContactAddressRowContainer>
-                <Typography variant="subtitle1">
-                  {t(`Source: ${primaryAddress.source}`)}
-                </Typography>
-              </ContactAddressRowContainer>
-            </>
-          )}
-          {/* Show More Section */}
-          {nonPrimaryAddresses.length > 0 ? (
-            <ContactDetailsMailingLabelTextContainer>
-              <Link href="#">
-                <ContactMailingShowMoreLabel
-                  variant="subtitle1"
-                  onClick={() => setShowMoreOpen(!showMoreOpen)}
-                >
-                  {showMoreOpen ? t('Show Less') : t('Show More')}
-                </ContactMailingShowMoreLabel>
-              </Link>
-            </ContactDetailsMailingLabelTextContainer>
-          ) : null}
-          {showMoreOpen
-            ? nonPrimaryAddresses.map((address) => (
-                <ContactDetailsMailingTextContainer key={address.id}>
-                  <ContactAddressRowContainer>
+                <ContactAddressRowContainer>
+                  <Typography variant="subtitle1">
+                    {`${primaryAddress.city}, ${primaryAddress.state} ${primaryAddress.postalCode}`}
+                  </Typography>
+                </ContactAddressRowContainer>
+                <ContactAddressRowContainer>
+                  <Typography variant="subtitle1">
+                    {primaryAddress.country}
+                  </Typography>
+                </ContactAddressRowContainer>
+                <ContactAddressRowContainer>
+                  <Typography variant="subtitle1">
+                    {t(`Source: ${primaryAddress.source}`)}
+                  </Typography>
+                </ContactAddressRowContainer>
+              </>
+            )}
+            {/* Show More Section */}
+            {nonPrimaryAddresses.length > 0 ? (
+              <ContactDetailsMailingLabelTextContainer>
+                <Link href="#">
+                  <ContactMailingShowMoreLabel
+                    variant="subtitle1"
+                    onClick={() => setShowMoreOpen(!showMoreOpen)}
+                  >
+                    {showMoreOpen ? t('Show Less') : t('Show More')}
+                  </ContactMailingShowMoreLabel>
+                </Link>
+              </ContactDetailsMailingLabelTextContainer>
+            ) : null}
+            {showMoreOpen
+              ? nonPrimaryAddresses.map((address) => (
+                  <ContactDetailsMailingTextContainer key={address.id}>
+                    <ContactAddressRowContainer>
+                      <Typography variant="subtitle1">
+                        <Box fontWeight="fontWeightBold">{address.street}</Box>
+                      </Typography>
+                      <AddressEditIconContainer
+                        onClick={() => {
+                          setEditingAddressId(address.id);
+                        }}
+                      >
+                        <AddressEditIcon titleAccess={t('Edit Icon')} />
+                      </AddressEditIconContainer>
+                    </ContactAddressRowContainer>
                     <Typography variant="subtitle1">
-                      <Box fontWeight="fontWeightBold">{address.street}</Box>
+                      {`${address.city}, ${address.state} ${address.postalCode}`}
                     </Typography>
-                    <AddressEditIconContainer
-                      onClick={() => {
-                        console.log('hi');
-                      }}
-                    >
-                      <AddressEditIcon titleAccess={t('Edit Icon')} />
-                    </AddressEditIconContainer>
-                  </ContactAddressRowContainer>
-                  <Typography variant="subtitle1">
-                    {`${address.city}, ${address.state} ${address.postalCode}`}
-                  </Typography>
-                  <Typography variant="subtitle1">{address.country}</Typography>
-                  <Typography variant="subtitle1">
-                    {t(`Source: ${address.source}`)}
-                  </Typography>
-                </ContactDetailsMailingTextContainer>
-              ))
-            : null}
-          {/* Greeting Section */}
-          <ContactDetailsMailingLabelTextContainer>
-            <ContactDetailsMailingLabel variant="subtitle1">
-              {t('Greeting')}
-            </ContactDetailsMailingLabel>
-            <Typography variant="subtitle1">{greeting}</Typography>
-          </ContactDetailsMailingLabelTextContainer>
-          {/* Newsletter Section */}
-          <ContactDetailsMailingLabelTextContainer>
-            <ContactDetailsMailingLabel variant="subtitle1">
-              {t('Newsletter')}
-            </ContactDetailsMailingLabel>
-            <Typography variant="subtitle1">{sendNewsletter}</Typography>
-          </ContactDetailsMailingLabelTextContainer>
-          {/* Magazine Section */}
-          <ContactDetailsMailingLabelTextContainer>
-            <ContactDetailsMailingLabel variant="subtitle1">
-              {t('Magazine')}
-            </ContactDetailsMailingLabel>
-            <Typography variant="subtitle1">Not Implemented</Typography>
-          </ContactDetailsMailingLabelTextContainer>
-        </ContactDetailsMailingTextContainer>
-      </ContactDetailsMailingMainContainer>
-      <Box m={2}>
-        <Grid container alignItems="center">
-          <AddressAddIcon />
+                    <Typography variant="subtitle1">
+                      {address.country}
+                    </Typography>
+                    <Typography variant="subtitle1">
+                      {t(`Source: ${address.source}`)}
+                    </Typography>
+                  </ContactDetailsMailingTextContainer>
+                ))
+              : null}
+            {/* Greeting Section */}
+            <ContactDetailsMailingLabelTextContainer>
+              <ContactDetailsMailingLabel variant="subtitle1">
+                {t('Greeting')}
+              </ContactDetailsMailingLabel>
+              <Typography variant="subtitle1">{greeting}</Typography>
+            </ContactDetailsMailingLabelTextContainer>
+            {/* Newsletter Section */}
+            <ContactDetailsMailingLabelTextContainer>
+              <ContactDetailsMailingLabel variant="subtitle1">
+                {t('Newsletter')}
+              </ContactDetailsMailingLabel>
+              <Typography variant="subtitle1">{sendNewsletter}</Typography>
+            </ContactDetailsMailingLabelTextContainer>
+            {/* Magazine Section */}
+            <ContactDetailsMailingLabelTextContainer>
+              <ContactDetailsMailingLabel variant="subtitle1">
+                {t('Magazine')}
+              </ContactDetailsMailingLabel>
+              <Typography variant="subtitle1">Not Implemented</Typography>
+            </ContactDetailsMailingLabelTextContainer>
+          </ContactDetailsMailingTextContainer>
+        </ContactDetailsMailingMainContainer>
+        <Box m={2}>
+          <Grid container alignItems="center">
+            <AddressAddIcon />
 
-          <AddressAddText variant="subtitle1">
-            {t('Add Address')}
-          </AddressAddText>
-        </Grid>
+            <AddressAddText variant="subtitle1">
+              {t('Add Address')}
+            </AddressAddText>
+          </Grid>
+        </Box>
       </Box>
-    </Box>
+      {selectedAddress ? (
+        <EditContactAddressModal
+          accountListId={accountListId}
+          address={selectedAddress}
+          handleClose={() => setEditingAddressId(undefined)}
+        />
+      ) : null}
+    </>
   );
 };

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactDetailsTabMailing.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactDetailsTabMailing.tsx
@@ -124,7 +124,13 @@ export const ContactDetailsTabMailing: React.FC<MailingProp> = ({
                   </AddressEditIconContainer>
                 </ContactAddressRowContainer>
 
-                <ContactAddressRowContainer>
+                <ContactAddressRowContainer
+                  style={{
+                    textDecoration: primaryAddress.historic
+                      ? 'line-through'
+                      : 'none',
+                  }}
+                >
                   <Typography variant="subtitle1">
                     {`${primaryAddress.city}, ${primaryAddress.state} ${primaryAddress.postalCode}`}
                   </Typography>
@@ -156,7 +162,14 @@ export const ContactDetailsTabMailing: React.FC<MailingProp> = ({
             ) : null}
             {showMoreOpen
               ? nonPrimaryAddresses.map((address) => (
-                  <ContactDetailsMailingTextContainer key={address.id}>
+                  <ContactDetailsMailingTextContainer
+                    key={address.id}
+                    style={{
+                      textDecoration: address.historic
+                        ? 'line-through'
+                        : 'none',
+                    }}
+                  >
                     <ContactAddressRowContainer>
                       <Typography variant="subtitle1">
                         <Box fontWeight="fontWeightBold">{address.street}</Box>

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactDetailsTabMailing.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactDetailsTabMailing.tsx
@@ -1,7 +1,16 @@
-import { Box, Link, styled, Typography } from '@material-ui/core';
-import { LocationOn } from '@material-ui/icons';
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import {
+  Box,
+  Grid,
+  IconButton,
+  Link,
+  styled,
+  Typography,
+} from '@material-ui/core';
+import LocationOn from '@material-ui/icons/LocationOn';
+import CreateIcon from '@material-ui/icons/Create';
+import AddIcon from '@material-ui/icons/Add';
 import { ContactMailingFragment } from './ContactMailing.generated';
 
 const ContactDetailsMailingMainContainer = styled(Box)(({ theme }) => ({
@@ -14,7 +23,7 @@ const ContactDetailsMailingIcon = styled(LocationOn)(({ theme }) => ({
   color: theme.palette.cruGrayMedium.main,
 }));
 
-const ContactDetailsMailingTexContainer = styled(Box)(({}) => ({
+const ContactDetailsMailingTextContainer = styled(Box)(({}) => ({
   flexGrow: 4,
 }));
 
@@ -28,7 +37,38 @@ const ContactDetailsMailingLabel = styled(Typography)(({ theme }) => ({
   marginRight: '5px',
 }));
 
-const ContactDetailsShowMoreLabel = styled(Typography)(() => ({
+const ContactMailingShowMoreLabel = styled(Typography)(() => ({
+  color: '#2196F3',
+}));
+
+const ContactAddressPrimaryText = styled(Typography)(({ theme }) => ({
+  margin: theme.spacing(0, 1),
+  color: theme.palette.text.hint,
+}));
+
+const ContactAddressRowContainer = styled(Box)(() => ({
+  display: 'flex',
+  alignItems: 'center',
+}));
+
+const AddressEditIcon = styled(CreateIcon)(({ theme }) => ({
+  width: '18px',
+  height: '18px',
+  margin: theme.spacing(0),
+  color: theme.palette.cruGrayMedium.main,
+}));
+
+const AddressAddText = styled(Typography)(() => ({
+  color: '#2196F3',
+  textTransform: 'uppercase',
+  fontWeight: 'bold',
+}));
+
+const AddressEditIconContainer = styled(IconButton)(({ theme }) => ({
+  margin: theme.spacing(0, 1),
+}));
+
+const AddressAddIcon = styled(AddIcon)(() => ({
   color: '#2196F3',
 }));
 
@@ -38,32 +78,94 @@ interface MailingProp {
 
 export const ContactDetailsTabMailing: React.FC<MailingProp> = ({ data }) => {
   const { t } = useTranslation();
-  const { name, primaryAddress, greeting, sendNewsletter } = data;
+  const { addresses, greeting, sendNewsletter } = data;
+  const primaryAddress = addresses.nodes.filter(
+    (address) => address.primaryMailingAddress === true,
+  )[0];
+  const nonPrimaryAddresses = addresses.nodes.filter(
+    (address) => address.primaryMailingAddress !== true,
+  );
+
+  const [showMoreOpen, setShowMoreOpen] = useState(false);
   return (
     <Box>
       <ContactDetailsMailingMainContainer>
         <ContactDetailsMailingIcon />
-        <ContactDetailsMailingTexContainer>
+        <ContactDetailsMailingTextContainer>
           {/* Address Section */}
-          <Typography variant="subtitle1">{name}</Typography>
           {primaryAddress && (
             <>
-              <Typography variant="subtitle1">
-                {primaryAddress.street}
-              </Typography>
-              <Typography variant="subtitle1">
-                {`${primaryAddress.city}, ${primaryAddress.state} ${primaryAddress.postalCode}`}
-              </Typography>
+              <ContactAddressRowContainer>
+                <Typography variant="subtitle1">
+                  <Box fontWeight="fontWeightBold">{primaryAddress.street}</Box>
+                </Typography>
+                <ContactAddressPrimaryText variant="subtitle1">
+                  {`- ${t('Primary')}`}
+                </ContactAddressPrimaryText>
+                <AddressEditIconContainer
+                  onClick={() => {
+                    console.log('hi');
+                  }}
+                >
+                  <AddressEditIcon titleAccess={t('Edit Icon')} />
+                </AddressEditIconContainer>
+              </ContactAddressRowContainer>
+
+              <ContactAddressRowContainer>
+                <Typography variant="subtitle1">
+                  {`${primaryAddress.city}, ${primaryAddress.state} ${primaryAddress.postalCode}`}
+                </Typography>
+              </ContactAddressRowContainer>
+              <ContactAddressRowContainer>
+                <Typography variant="subtitle1">
+                  {primaryAddress.country}
+                </Typography>
+              </ContactAddressRowContainer>
+              <ContactAddressRowContainer>
+                <Typography variant="subtitle1">
+                  {t(`Source: ${primaryAddress.source}`)}
+                </Typography>
+              </ContactAddressRowContainer>
             </>
           )}
           {/* Show More Section */}
-          <ContactDetailsMailingLabelTextContainer>
-            <Link href="#">
-              <ContactDetailsShowMoreLabel variant="subtitle1">
-                {t('Show More')}
-              </ContactDetailsShowMoreLabel>
-            </Link>
-          </ContactDetailsMailingLabelTextContainer>
+          {nonPrimaryAddresses.length > 0 ? (
+            <ContactDetailsMailingLabelTextContainer>
+              <Link href="#">
+                <ContactMailingShowMoreLabel
+                  variant="subtitle1"
+                  onClick={() => setShowMoreOpen(!showMoreOpen)}
+                >
+                  {showMoreOpen ? t('Show Less') : t('Show More')}
+                </ContactMailingShowMoreLabel>
+              </Link>
+            </ContactDetailsMailingLabelTextContainer>
+          ) : null}
+          {showMoreOpen
+            ? nonPrimaryAddresses.map((address) => (
+                <ContactDetailsMailingTextContainer key={address.id}>
+                  <ContactAddressRowContainer>
+                    <Typography variant="subtitle1">
+                      <Box fontWeight="fontWeightBold">{address.street}</Box>
+                    </Typography>
+                    <AddressEditIconContainer
+                      onClick={() => {
+                        console.log('hi');
+                      }}
+                    >
+                      <AddressEditIcon titleAccess={t('Edit Icon')} />
+                    </AddressEditIconContainer>
+                  </ContactAddressRowContainer>
+                  <Typography variant="subtitle1">
+                    {`${address.city}, ${address.state} ${address.postalCode}`}
+                  </Typography>
+                  <Typography variant="subtitle1">{address.country}</Typography>
+                  <Typography variant="subtitle1">
+                    {t(`Source: ${address.source}`)}
+                  </Typography>
+                </ContactDetailsMailingTextContainer>
+              ))
+            : null}
           {/* Greeting Section */}
           <ContactDetailsMailingLabelTextContainer>
             <ContactDetailsMailingLabel variant="subtitle1">
@@ -85,8 +187,17 @@ export const ContactDetailsTabMailing: React.FC<MailingProp> = ({ data }) => {
             </ContactDetailsMailingLabel>
             <Typography variant="subtitle1">Not Implemented</Typography>
           </ContactDetailsMailingLabelTextContainer>
-        </ContactDetailsMailingTexContainer>
+        </ContactDetailsMailingTextContainer>
       </ContactDetailsMailingMainContainer>
+      <Box m={2}>
+        <Grid container alignItems="center">
+          <AddressAddIcon />
+
+          <AddressAddText variant="subtitle1">
+            {t('Add Address')}
+          </AddressAddText>
+        </Grid>
+      </Box>
     </Box>
   );
 };

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactMailing.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactMailing.graphql
@@ -1,10 +1,20 @@
 fragment ContactMailing on Contact {
   name
-  primaryAddress {
-    street
-    city
-    state
-    postalCode
+  addresses {
+    nodes {
+      city
+      country
+      historic
+      id
+      location
+      metroArea
+      postalCode
+      primaryMailingAddress
+      region
+      source
+      state
+      street
+    }
   }
   greeting
   sendNewsletter

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddress.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddress.graphql
@@ -1,0 +1,22 @@
+mutation UpdateContactAddress(
+  $accountListId: ID!
+  $attributes: AddressUpdateInput!
+) {
+  updateAddress(
+    input: { accountListId: $accountListId, attributes: $attributes }
+  ) {
+    address {
+      city
+      country
+      historic
+      id
+      location
+      metroArea
+      postalCode
+      primaryMailingAddress
+      region
+      state
+      street
+    }
+  }
+}

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.test.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+import { ThemeProvider } from '@material-ui/core';
+import { SnackbarProvider } from 'notistack';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GraphQLError } from 'graphql';
+import {
+  gqlMock,
+  GqlMockedProvider,
+} from '../../../../../../../__tests__/util/graphqlMocking';
+import theme from '../../../../../../theme';
+import {
+  ContactMailingFragment,
+  ContactMailingFragmentDoc,
+} from '../ContactMailing.generated';
+import { EditContactAddressModal } from './EditContactAddressModal';
+import { UpdateContactAddressMutation } from './EditContactAddress.generated';
+
+const handleClose = jest.fn();
+const mock = gqlMock<ContactMailingFragment>(ContactMailingFragmentDoc);
+const accountListId = 'abc';
+
+const mockEnqueue = jest.fn();
+
+jest.mock('notistack', () => ({
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  ...jest.requireActual('notistack'),
+  useSnackbar: () => {
+    return {
+      enqueueSnackbar: mockEnqueue,
+    };
+  },
+}));
+
+const mockContact: ContactMailingFragment = {
+  name: mock.name,
+  addresses: {
+    nodes: [
+      {
+        ...mock.addresses.nodes[0],
+        location: 'Home',
+        historic: true,
+        street: '123 Cool Street',
+      },
+    ],
+  },
+};
+
+describe('EditContactAddressModal', () => {
+  it('should render edit contact address modal', async () => {
+    const { getByText } = render(
+      <SnackbarProvider>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider<UpdateContactAddressMutation>>
+            <EditContactAddressModal
+              accountListId={accountListId}
+              handleClose={handleClose}
+              address={mockContact.addresses.nodes[0]}
+            />
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </SnackbarProvider>,
+    );
+
+    expect(getByText('Edit Address')).toBeInTheDocument();
+  });
+
+  it('should close edit contact other modal', () => {
+    const { getByText, getByRole } = render(
+      <SnackbarProvider>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider<UpdateContactAddressMutation>>
+            <EditContactAddressModal
+              accountListId={accountListId}
+              handleClose={handleClose}
+              address={mockContact.addresses.nodes[0]}
+            />
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </SnackbarProvider>,
+    );
+
+    expect(getByText('Edit Address')).toBeInTheDocument();
+    userEvent.click(getByRole('button', { name: 'Close' }));
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('should handle cancel click', () => {
+    const { getByText } = render(
+      <SnackbarProvider>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider<UpdateContactAddressMutation>>
+            <EditContactAddressModal
+              accountListId={accountListId}
+              handleClose={handleClose}
+              address={mockContact.addresses.nodes[0]}
+            />
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </SnackbarProvider>,
+    );
+
+    expect(getByText('Edit Address')).toBeInTheDocument();
+    userEvent.click(getByText('Cancel'));
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('should edit contact address', async () => {
+    const mutationSpy = jest.fn();
+    const newStreet = '4321 Neat Street';
+    const newCity = 'Orlando';
+    const newState = 'FL';
+    const newPostalCode = '55555';
+    const newCountry = 'United States';
+    const newRegion = 'New Region';
+    const newMetroArea = 'New Metro';
+    const { getByText, getByRole } = render(
+      <SnackbarProvider>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider<UpdateContactAddressMutation> onCall={mutationSpy}>
+            <EditContactAddressModal
+              accountListId={accountListId}
+              handleClose={handleClose}
+              address={mockContact.addresses.nodes[0]}
+            />
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </SnackbarProvider>,
+    );
+
+    userEvent.clear(getByRole('textbox', { name: 'Street' }));
+    userEvent.clear(getByRole('textbox', { name: 'City' }));
+    userEvent.clear(getByRole('textbox', { name: 'State' }));
+    userEvent.clear(getByRole('textbox', { name: 'Zip' }));
+    userEvent.clear(getByRole('textbox', { name: 'Country' }));
+    userEvent.clear(getByRole('textbox', { name: 'Region' }));
+    userEvent.clear(getByRole('textbox', { name: 'Metro' }));
+    userEvent.click(getByRole('button', { name: 'Location' }));
+    userEvent.click(getByRole('option', { name: 'Mailing' }));
+    userEvent.type(getByRole('textbox', { name: 'Street' }), newStreet);
+    userEvent.type(getByRole('textbox', { name: 'City' }), newCity);
+    userEvent.type(getByRole('textbox', { name: 'State' }), newState);
+    userEvent.type(getByRole('textbox', { name: 'Zip' }), newPostalCode);
+    userEvent.type(getByRole('textbox', { name: 'Country' }), newCountry);
+    userEvent.type(getByRole('textbox', { name: 'Region' }), newRegion);
+    userEvent.type(getByRole('textbox', { name: 'Metro' }), newMetroArea);
+    userEvent.click(getByRole('checkbox', { name: 'Address no longer valid' }));
+    userEvent.click(getByText('Save'));
+    await waitFor(() =>
+      expect(mockEnqueue).toHaveBeenCalledWith('Address updated successfully', {
+        variant: 'success',
+      }),
+    );
+
+    const { operation } = mutationSpy.mock.calls[0][0];
+
+    expect(operation.variables.accountListId).toEqual(accountListId);
+    expect(operation.variables.attributes.street).toEqual(newStreet);
+    expect(operation.variables.attributes.location).toEqual('Mailing');
+    expect(operation.variables.attributes.city).toEqual(newCity);
+    expect(operation.variables.attributes.state).toEqual(newState);
+    expect(operation.variables.attributes.postalCode).toEqual(newPostalCode);
+    expect(operation.variables.attributes.country).toEqual(newCountry);
+    expect(operation.variables.attributes.region).toEqual(newRegion);
+    expect(operation.variables.attributes.metroArea).toEqual(newMetroArea);
+    expect(operation.variables.attributes.historic).toEqual(false);
+  });
+
+  it('should handle errors with editing contact other details', async () => {
+    const newStreet = '4321 New Street';
+    const { getByText, getByRole } = render(
+      <SnackbarProvider>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider<UpdateContactAddressMutation>
+            mocks={{
+              UpdateContactAddress: {
+                updateAddress: {
+                  address: new GraphQLError(
+                    'GraphQL Error #42: Error updating contact.',
+                  ),
+                },
+              },
+            }}
+          >
+            <EditContactAddressModal
+              accountListId={accountListId}
+              handleClose={handleClose}
+              address={mockContact.addresses.nodes[0]}
+            />
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </SnackbarProvider>,
+    );
+
+    userEvent.clear(getByRole('textbox', { name: 'Street' }));
+    userEvent.type(getByRole('textbox', { name: 'Street' }), newStreet);
+    userEvent.click(getByText('Save'));
+    await waitFor(() =>
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        'GraphQL Error #42: Error updating contact.',
+        {
+          variant: 'error',
+        },
+      ),
+    );
+  });
+});

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.tsx
@@ -1,0 +1,276 @@
+import React, { ReactElement } from 'react';
+import { Formik } from 'formik';
+import { useTranslation } from 'react-i18next';
+import * as yup from 'yup';
+import { useSnackbar } from 'notistack';
+import {
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  DialogActions,
+  DialogContent,
+  FormControl,
+  FormControlLabel,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  styled,
+  TextField,
+} from '@material-ui/core';
+import { ContactMailingFragment } from '../ContactMailing.generated';
+import { AddressUpdateInput } from '../../../../../../../graphql/types.generated';
+import Modal from '../../../../../common/Modal/Modal';
+import { useUpdateContactAddressMutation } from './EditContactAddress.generated';
+
+const ContactEditContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  width: '100%',
+  flexDirection: 'column',
+  margin: theme.spacing(4, 0),
+}));
+
+const ContactInputWrapper = styled(Box)(({ theme }) => ({
+  position: 'relative',
+  padding: theme.spacing(0, 6),
+  margin: theme.spacing(2, 0),
+}));
+
+const LoadingIndicator = styled(CircularProgress)(({ theme }) => ({
+  margin: theme.spacing(0, 1, 0, 0),
+}));
+
+interface EditContactAddressModalProps {
+  accountListId: string;
+  address: ContactMailingFragment['addresses']['nodes'][0];
+  handleClose: () => void;
+}
+
+enum AddressLocationEnum {
+  Home = 'Home',
+  Business = 'Business',
+  Mailing = 'Mailing',
+  Seasonal = 'Seasonal',
+  Other = 'Other',
+  Temporary = 'Temporary',
+  RepAddress = 'Rep Address',
+}
+
+export const EditContactAddressModal: React.FC<EditContactAddressModalProps> = ({
+  accountListId,
+  address,
+  handleClose,
+}): ReactElement<EditContactAddressModalProps> => {
+  const { t } = useTranslation();
+  const { enqueueSnackbar } = useSnackbar();
+  const [
+    updateContactAddress,
+    { loading: updating },
+  ] = useUpdateContactAddressMutation();
+
+  // TODO Let Spencer know of contactId bug
+  const contactAddressSchema: yup.SchemaOf<
+    Omit<AddressUpdateInput, 'contactId'>
+  > = yup.object({
+    city: yup.string().nullable(),
+    country: yup.string().nullable(),
+    historic: yup.boolean().nullable(),
+    id: yup.string().required(),
+    location: yup.string().nullable(),
+    metroArea: yup.string().nullable(),
+    postalCode: yup.string().nullable(),
+    region: yup.string().nullable(),
+    state: yup.string().nullable(),
+    street: yup.string().nullable(),
+  });
+
+  const onSubmit = async (
+    attributes: Omit<AddressUpdateInput, 'contactId'>,
+  ) => {
+    try {
+      await updateContactAddress({
+        variables: {
+          accountListId,
+          attributes,
+        },
+      });
+      enqueueSnackbar(t('Address updated successfully'), {
+        variant: 'success',
+      });
+    } catch (error) {
+      enqueueSnackbar(error.message, { variant: 'error' });
+      throw error;
+    }
+  };
+
+  return (
+    <Modal isOpen={true} title={t('Edit Address')} handleClose={handleClose}>
+      <Formik
+        initialValues={{
+          id: address.id,
+          city: address.city ?? '',
+          country: address.country ?? '',
+          historic: address.historic,
+          location: address.location ?? '',
+          metroArea: address.metroArea ?? '',
+          postalCode: address.postalCode ?? '',
+          region: address.region ?? '',
+          state: address.state ?? '',
+          street: address.street ?? '',
+        }}
+        validationSchema={contactAddressSchema}
+        onSubmit={onSubmit}
+      >
+        {({
+          values: {
+            city,
+            country,
+            historic,
+            location,
+            metroArea,
+            postalCode,
+            region,
+            state,
+            street,
+          },
+          handleChange,
+          handleSubmit,
+          setFieldValue,
+          isSubmitting,
+          isValid,
+        }): ReactElement => (
+          <form onSubmit={handleSubmit} noValidate>
+            <DialogContent dividers>
+              <ContactEditContainer>
+                <ContactInputWrapper>
+                  <Grid container spacing={1}>
+                    <Grid item xs={9}>
+                      <TextField
+                        label={t('Street')}
+                        value={street}
+                        onChange={handleChange('street')}
+                        inputProps={{ 'aria-label': t('Street') }}
+                        fullWidth
+                      />
+                    </Grid>
+                    <Grid item xs={3}>
+                      <FormControl fullWidth>
+                        <InputLabel id="location-select-label">
+                          {t('Location')}
+                        </InputLabel>
+                        <Select
+                          labelId="location-select-label"
+                          value={location}
+                          onChange={handleChange('location')}
+                          fullWidth
+                        >
+                          {Object.values(AddressLocationEnum).map((value) => (
+                            <MenuItem key={value} value={value}>
+                              {t(value)}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    </Grid>
+                  </Grid>
+                </ContactInputWrapper>
+                <ContactInputWrapper>
+                  <Grid container spacing={1}>
+                    <Grid item xs={6}>
+                      <TextField
+                        label={t('City')}
+                        value={city}
+                        onChange={handleChange('city')}
+                        inputProps={{ 'aria-label': t('City') }}
+                        fullWidth
+                      />
+                    </Grid>
+                    <Grid item xs={3}>
+                      <TextField
+                        label={t('State')}
+                        value={state}
+                        onChange={handleChange('state')}
+                        inputProps={{ 'aria-label': t('State') }}
+                        fullWidth
+                      />
+                    </Grid>
+                    <Grid item xs={3}>
+                      <TextField
+                        label={t('Zip')}
+                        value={postalCode}
+                        onChange={handleChange('postalCode')}
+                        inputProps={{ 'aria-label': t('Zip') }}
+                        fullWidth
+                      />
+                    </Grid>
+                  </Grid>
+                </ContactInputWrapper>
+                <ContactInputWrapper>
+                  <Grid container spacing={1}>
+                    <Grid item xs={6}>
+                      <TextField
+                        label={t('Country')}
+                        value={country}
+                        onChange={handleChange('country')}
+                        inputProps={{ 'aria-label': t('Country') }}
+                        fullWidth
+                      />
+                    </Grid>
+                    <Grid item xs={3}>
+                      <TextField
+                        label={t('Region')}
+                        value={region}
+                        onChange={handleChange('region')}
+                        inputProps={{ 'aria-label': t('Region') }}
+                        fullWidth
+                      />
+                    </Grid>
+                    <Grid item xs={3}>
+                      <TextField
+                        label={t('Metro')}
+                        value={metroArea}
+                        onChange={handleChange('metroArea')}
+                        inputProps={{ 'aria-label': t('Metro') }}
+                        fullWidth
+                      />
+                    </Grid>
+                  </Grid>
+                </ContactInputWrapper>
+                <ContactInputWrapper>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={historic}
+                        onChange={() => setFieldValue('historic', !historic)}
+                      />
+                    }
+                    label={t('Address no longer valid')}
+                  />
+                </ContactInputWrapper>
+              </ContactEditContainer>
+            </DialogContent>
+            <DialogActions>
+              <Button
+                onClick={handleClose}
+                disabled={isSubmitting}
+                variant="text"
+              >
+                {t('Cancel')}
+              </Button>
+              <Button
+                color="primary"
+                type="submit"
+                variant="contained"
+                disabled={!isValid || isSubmitting}
+              >
+                {updating && <LoadingIndicator color="primary" size={20} />}
+                {t('Save')}
+              </Button>
+            </DialogActions>
+          </form>
+        )}
+      </Formik>
+    </Modal>
+  );
+};

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.tsx
@@ -69,7 +69,7 @@ export const EditContactAddressModal: React.FC<EditContactAddressModalProps> = (
     { loading: updating },
   ] = useUpdateContactAddressMutation();
 
-  // TODO Let Spencer know of contactId bug
+  // TODO Remove Omit once https://jira.cru.org/browse/MPDX-7090 is complete
   const contactAddressSchema: yup.SchemaOf<
     Omit<AddressUpdateInput, 'contactId'>
   > = yup.object({

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/ContactOther.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/ContactOther.graphql
@@ -1,4 +1,5 @@
 fragment ContactOther on Contact {
+  id
   name
   preferredContactMethod
   locale

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.test.tsx
@@ -10,16 +10,15 @@ import {
   GqlMockedProvider,
 } from '../../../../../../../__tests__/util/graphqlMocking';
 import theme from '../../../../../../theme';
-import { ContactDetailsTabQuery } from '../../ContactDetailsTab.generated';
 import {
-  ContactPeopleFragment,
-  ContactPeopleFragmentDoc,
-} from '../../People/ContactPeople.generated';
+  ContactOtherFragment,
+  ContactOtherFragmentDoc,
+} from '../ContactOther.generated';
 import { UpdateContactOtherMutation } from './EditContactOther.generated';
 import { EditContactOtherModal } from './EditContactOtherModal';
 
 const handleClose = jest.fn();
-const mock = gqlMock<ContactPeopleFragment>(ContactPeopleFragmentDoc);
+const mock = gqlMock<ContactOtherFragment>(ContactOtherFragmentDoc);
 const contactId = '123';
 const accountListId = 'abc';
 
@@ -41,27 +40,14 @@ jest.mock('i18next', () => ({
   t: (str: string) => str,
 }));
 
-const mockContact: ContactDetailsTabQuery['contact'] = {
-  name: 'test person',
+const mockContact: ContactOtherFragment = {
+  name: mock.name,
   id: contactId,
-  tagList: [],
   timezone: '(GMT-05:00) Eastern Time (US & Canada)',
   locale: 'English',
   preferredContactMethod: PreferredContactMethodEnum.PhoneCall,
-  churchName: 'A Great Church',
-  website: 'coolwebsite.com',
-  people: {
-    nodes: [
-      {
-        ...mock.people.nodes[0],
-        firstName: 'test',
-        lastName: 'guy',
-        id: mock.primaryPerson?.id ?? '',
-      },
-      ...mock.people.nodes,
-    ],
-  },
-  primaryPerson: mock.primaryPerson,
+  churchName: mock.churchName,
+  website: mock.website,
 };
 
 describe('EditContactOtherModal', () => {

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.tsx
@@ -22,10 +22,10 @@ import {
   PreferredContactMethodEnum,
 } from '../../../../../../../graphql/types.generated';
 import Modal from '../../../../../common/Modal/Modal';
-import { ContactDetailsTabQuery } from '../../ContactDetailsTab.generated';
 import { useApiConstants } from '../../../../../Constants/UseApiConstants';
 import { useGetTimezones } from '../../../../../../hooks/useGetTimezones';
 import { localizedContactMethod } from '../ContactDetailsOther';
+import { ContactOtherFragment } from '../ContactOther.generated';
 import { useUpdateContactOtherMutation } from './EditContactOther.generated';
 
 const ContactEditContainer = styled(Box)(({ theme }) => ({
@@ -46,7 +46,7 @@ const LoadingIndicator = styled(CircularProgress)(({ theme }) => ({
 }));
 
 interface EditContactOtherModalProps {
-  contact: ContactDetailsTabQuery['contact'];
+  contact: ContactOtherFragment;
   accountListId: string;
   isOpen: boolean;
   handleClose: () => void;

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/ContactPeople.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/ContactPeople.graphql
@@ -1,5 +1,6 @@
 fragment ContactPeople on Contact {
   id
+  name
   primaryPerson {
     ...ContactPerson
   }

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/EditContactDetailsModal/EditContactDetailsModal.stories.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/EditContactDetailsModal/EditContactDetailsModal.stories.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import { Box, Button, MuiThemeProvider } from '@material-ui/core';
 import { gqlMock } from '../../../../../../../../__tests__/util/graphqlMocking';
-import { ContactDetailsTabQuery } from '../../../ContactDetailsTab.generated';
 import {
   ContactPeopleFragment,
   ContactPeopleFragmentDoc,
@@ -21,10 +20,9 @@ export const Default = (): ReactElement => {
   const contactId = '123';
   const accountListId = 'abc';
 
-  const mockContact: ContactDetailsTabQuery['contact'] = {
+  const mockContact: ContactPeopleFragment = {
     name: 'test person',
     id: contactId,
-    tagList: [],
     people: mock.people,
     primaryPerson: mock.primaryPerson,
   };

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/EditContactDetailsModal/EditContactDetailsModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/EditContactDetailsModal/EditContactDetailsModal.test.tsx
@@ -10,7 +10,6 @@ import {
   ContactPeopleFragment,
   ContactPeopleFragmentDoc,
 } from '../../ContactPeople.generated';
-import { ContactDetailsTabQuery } from '../../../ContactDetailsTab.generated';
 import {
   gqlMock,
   GqlMockedProvider,
@@ -37,11 +36,9 @@ jest.mock('notistack', () => ({
   },
 }));
 
-const mockContact: ContactDetailsTabQuery['contact'] = {
+const mockContact: ContactPeopleFragment = {
   name: 'test person',
   id: contactId,
-  tagList: [],
-
   people: {
     nodes: [
       {

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/EditContactDetailsModal/EditContactDetailsModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/EditContactDetailsModal/EditContactDetailsModal.tsx
@@ -17,9 +17,9 @@ import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 import { useSnackbar } from 'notistack';
 import { Formik } from 'formik';
-import { ContactDetailsTabQuery } from '../../../ContactDetailsTab.generated';
 import Modal from '../../../../../../common/Modal/Modal';
 import { ContactUpdateInput } from '../../../../../../../../graphql/types.generated';
+import { ContactPeopleFragment } from '../../ContactPeople.generated';
 import { useUpdateContactDetailsMutation } from './EditContactDetails.generated';
 
 const ContactEditModalFooterButton = styled(Button)(() => ({
@@ -63,7 +63,7 @@ const LoadingIndicator = styled(CircularProgress)(({ theme }) => ({
 }));
 
 interface EditContactDetailsModalProps {
-  contact: ContactDetailsTabQuery['contact'];
+  contact: ContactPeopleFragment;
   accountListId: string;
   isOpen: boolean;
   handleClose: () => void;


### PR DESCRIPTION
I think I'm going to handle deleting and creating addresses in a separate pr. This PR focuses on rendering all contact addresses and allowing the editing of said addresses. There wasn't a design for this modal so I based it on the current design. Also made some adjustments to help make the separation of addresses clearer in the UI. The first commit is a little bit of a mess, sorry. It adds the rendering of all addresses instead of just the primary. While I was working on it, I realized I had not been using the fragment types for my other modal components so I updated them all to help simplify types.