### PR TITLE
Fix-Navbar-Visibility-Bug

### DIFF
--- a/src/components/Layouts/Primary/Primary.test.tsx
+++ b/src/components/Layouts/Primary/Primary.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { ThemeProvider } from '@material-ui/core';
+import * as nextRouter from 'next/router';
 import matchMediaMock from '../../../../__tests__/util/matchMediaMock';
 import TestWrapper from '../../../../__tests__/util/TestWrapper';
 import theme from '../../../theme';
@@ -10,9 +11,16 @@ import { getTopBarMock } from './TopBar/TopBar.mock';
 import Primary from '.';
 
 describe('Primary', () => {
+  const useRouter = jest.spyOn(nextRouter, 'useRouter');
   const mocks = [...getNotificationsMocks(), getTopBarMock()];
   beforeEach(() => {
     matchMediaMock({ width: '1024px' });
+    (useRouter as jest.SpyInstance<
+      Pick<nextRouter.NextRouter, 'query' | 'isReady'>
+    >).mockImplementation(() => ({
+      query: { accountListId: 'accountListId' },
+      isReady: true,
+    }));
   });
 
   it('has correct defaults', () => {

--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
@@ -1,13 +1,24 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import * as nextRouter from 'next/router';
 import { render } from '../../../../../../../__tests__/util/testingLibraryReactMock';
 import TestWrapper from '../../../../../../../__tests__/util/TestWrapper';
 import NavMenu from './NavMenu';
 
 describe('NavMenu', () => {
+  const useRouter = jest.spyOn(nextRouter, 'useRouter');
+
+  beforeEach(() => {
+    (useRouter as jest.SpyInstance<
+      Pick<nextRouter.NextRouter, 'query' | 'isReady'>
+    >).mockImplementation(() => ({
+      query: { accountListId: 'accountListId' },
+      isReady: true,
+    }));
+  });
   it('default', () => {
     const { getByRole, getByTestId } = render(
-      <TestWrapper initialState={{ accountListId: '1' }}>
+      <TestWrapper>
         <NavMenu />
       </TestWrapper>,
     );
@@ -40,8 +51,15 @@ describe('NavMenu', () => {
   });
 
   it('hidden', () => {
+    (useRouter as jest.SpyInstance<
+      Pick<nextRouter.NextRouter, 'query' | 'isReady'>
+    >).mockImplementation(() => ({
+      query: { accountListId: '' },
+      isReady: true,
+    }));
+
     const { queryByRole } = render(
-      <TestWrapper initialState={{}}>
+      <TestWrapper>
         <NavMenu />
       </TestWrapper>,
     );

--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.tsx
@@ -15,9 +15,9 @@ import clsx from 'clsx';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import NextLink from 'next/link';
 import { useTranslation } from 'react-i18next';
-import { useApp } from '../../../../../App';
 import HandoffLink from '../../../../../HandoffLink';
 import { ReportNavItems } from '../../../../../Reports/NavReportsList/ReportNavItems';
+import { useAccountListId } from '../../../../../../hooks/useAccountListId';
 
 const useStyles = makeStyles((theme: Theme) => ({
   navListItem: {
@@ -39,9 +39,9 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 const NavMenu = (): ReactElement => {
-  const classes = useStyles();
-  const { state } = useApp();
   const { t } = useTranslation();
+  const classes = useStyles();
+  const accountListId = useAccountListId();
 
   const [reportsMenuOpen, setReportsMenuOpen] = useState(false);
   const anchorRef = React.useRef<HTMLLIElement>(null);
@@ -60,12 +60,12 @@ const NavMenu = (): ReactElement => {
 
   return (
     <>
-      {state.accountListId ? (
+      {accountListId ? (
         <Grid container item alignItems="center" xs="auto" md={6}>
           <Grid item className={classes.navListItem}>
             <NextLink
               href="/accountLists/[accountListId]"
-              as={`/accountLists/${state.accountListId}`}
+              as={`/accountLists/${accountListId}`}
               scroll={false}
             >
               <MenuItem>
@@ -76,7 +76,7 @@ const NavMenu = (): ReactElement => {
           <Grid item className={classes.navListItem}>
             <NextLink
               href="/accountLists/[accountListId]/contacts"
-              as={`/accountLists/${state.accountListId}/contacts`}
+              as={`/accountLists/${accountListId}/contacts`}
               scroll={false}
             >
               <MenuItem>
@@ -87,7 +87,7 @@ const NavMenu = (): ReactElement => {
           <Grid item className={classes.navListItem}>
             <NextLink
               href="/accountLists/[accountListId]/tasks"
-              as={`/accountLists/${state.accountListId}/tasks`}
+              as={`/accountLists/${accountListId}/tasks`}
               scroll={false}
             >
               <MenuItem>
@@ -135,7 +135,7 @@ const NavMenu = (): ReactElement => {
                           <NextLink
                             key={reportItem.id}
                             href={`/accountLists/[accountListId]/reports/${reportItem.id}`}
-                            as={`/accountLists/${state.accountListId}/reports/${reportItem.id}`}
+                            as={`/accountLists/${accountListId}/reports/${reportItem.id}`}
                             scroll={false}
                           >
                             <MenuItem onClick={handleReportsMenuClose}>

--- a/src/components/Layouts/Primary/TopBar/TopBar.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/TopBar.test.tsx
@@ -3,28 +3,22 @@ import { render } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '@material-ui/core';
-import { AppState } from '../../../App/rootReducer';
-import { useApp } from '../../../App';
+import * as nextRouter from 'next/router';
 import theme from '../../../../theme';
 import { getNotificationsMocks } from './Items/NotificationMenu/NotificationMenu.mock';
 import { getTopBarMultipleMock } from './TopBar.mock';
 import TopBar from './TopBar';
 
-let state: AppState;
-const dispatch = jest.fn();
-
-jest.mock('../../../App', () => ({
-  useApp: jest.fn(),
-}));
-
 describe('TopBar', () => {
+  const useRouter = jest.spyOn(nextRouter, 'useRouter');
   const mocks = [getTopBarMultipleMock(), ...getNotificationsMocks()];
   beforeEach(() => {
-    state = { accountListId: 'accountListId-1', breadcrumb: '' };
-    (useApp as jest.Mock).mockReturnValue({
-      state,
-      dispatch,
-    });
+    (useRouter as jest.SpyInstance<
+      Pick<nextRouter.NextRouter, 'query' | 'isReady'>
+    >).mockImplementation(() => ({
+      query: { accountListId: 'accountListId' },
+      isReady: true,
+    }));
   });
 
   it('has correct defaults', () => {

--- a/src/components/Layouts/Primary/TopBar/TopBar.tsx
+++ b/src/components/Layouts/Primary/TopBar/TopBar.tsx
@@ -10,7 +10,7 @@ import {
   Hidden,
 } from '@material-ui/core';
 import logo from '../../../../images/logo.svg';
-import { useApp } from '../../../App';
+import { useAccountListId } from '../../../../hooks/useAccountListId';
 import NotificationMenu from './Items/NotificationMenu/NotificationMenu';
 import AddMenu from './Items/AddMenu/AddMenu';
 import SearchMenu from './Items/SearchMenu/SearchMenu';
@@ -59,7 +59,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 const TopBar = (): ReactElement => {
   const classes = useStyles();
-  const { state } = useApp();
+  const accountListId = useAccountListId();
   const trigger = useScrollTrigger({
     disableHysteresis: true,
     threshold: 0,
@@ -87,7 +87,7 @@ const TopBar = (): ReactElement => {
             <Grid
               item
               xs={12}
-              md={state.accountListId ? 5 : 11}
+              md={accountListId ? 5 : 11}
               container
               alignItems="center"
               justify="flex-end"


### PR DESCRIPTION
This bug was occurring because on certain pages, the state from ```useApp``` did not contain the ```accountListId```. We are moving away from putting stuff in this global state. I'm going to try to clean up other places that still use this in a separate pr but unfortunately, more components are using this than I thought...