### PR TITLE
Remove-openTaskDrawer

### DIFF
--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -17,6 +17,7 @@ import PrimaryLayout from '../src/components/Layouts/Primary';
 import Loading from '../src/components/Loading';
 import i18n from '../src/lib/i18n';
 import { AppProvider } from '../src/components/App';
+import TaskDrawerProvider from '../src/components/Task/Drawer/TaskDrawerProvider';
 
 const handleExitComplete = (): void => {
   if (typeof window !== 'undefined') {
@@ -91,9 +92,11 @@ const App = ({ Component, pageProps, router }: AppProps): ReactElement => {
                     onExitComplete={handleExitComplete}
                   >
                     <AppProvider>
-                      <Layout>
-                        <Component {...pageProps} key={router.route} />
-                      </Layout>
+                      <TaskDrawerProvider>
+                        <Layout>
+                          <Component {...pageProps} key={router.route} />
+                        </Layout>
+                      </TaskDrawerProvider>
                     </AppProvider>
                   </AnimatePresence>
                   <Loading />

--- a/src/components/App/Context.ts
+++ b/src/components/App/Context.ts
@@ -2,7 +2,6 @@ import { createContext } from 'react';
 import { AppProviderContext } from './Provider';
 
 const AppContext = createContext<AppProviderContext>({
-  openTaskDrawer: () => undefined,
   state: {},
   dispatch: () => undefined,
 });

--- a/src/components/App/Provider.tsx
+++ b/src/components/App/Provider.tsx
@@ -1,18 +1,8 @@
-import React, {
-  ReactNode,
-  ReactElement,
-  useState,
-  useReducer,
-  Dispatch,
-} from 'react';
-import { v4 as uuidv4 } from 'uuid';
-import TaskDrawer, { TaskDrawerProps } from '../Task/Drawer/Drawer';
-import theme from '../../theme';
+import React, { ReactNode, ReactElement, useReducer, Dispatch } from 'react';
 import rootReducer, { Action, AppState } from './rootReducer';
 import { AppContext } from '.';
 
 export interface AppProviderContext {
-  openTaskDrawer: (props: TaskDrawerProps) => void;
   state: AppState;
   dispatch: Dispatch<Action>;
 }
@@ -22,64 +12,19 @@ interface Props {
   initialState?: Partial<AppState>;
 }
 
-interface TaskDrawerPropsWithId extends TaskDrawerProps {
-  id: string;
-}
-
 const AppProvider = ({ initialState, children }: Props): ReactElement => {
-  const [taskDrawers, setTaskDrawers] = useState<TaskDrawerPropsWithId[]>([]);
   const [state, dispatch] = useReducer<typeof rootReducer>(rootReducer, {
     accountListId: undefined,
     breadcrumb: undefined,
     ...initialState,
   });
 
-  const openTaskDrawer = (taskDrawerProps: TaskDrawerProps): void => {
-    const id = uuidv4();
-    if (
-      !taskDrawerProps.taskId ||
-      !taskDrawers.find(
-        ({ taskId, showCompleteForm }) =>
-          taskId === taskDrawerProps.taskId &&
-          showCompleteForm === taskDrawerProps.showCompleteForm,
-      )
-    ) {
-      setTaskDrawers([
-        ...taskDrawers,
-        {
-          id,
-          ...taskDrawerProps,
-          onClose: (): void => {
-            taskDrawerProps.onClose && taskDrawerProps.onClose();
-            setTimeout(
-              () =>
-                setTaskDrawers((taskDrawers) =>
-                  taskDrawers.filter(({ id: taskId }) => taskId !== id),
-                ),
-              theme.transitions.duration.leavingScreen,
-            );
-          },
-        },
-      ]);
-    }
-  };
-
   const value: AppProviderContext = {
-    openTaskDrawer,
     state,
     dispatch,
   };
 
-  return (
-    <AppContext.Provider value={value}>
-      {children}
-      {taskDrawers.map((props: TaskDrawerPropsWithId) => {
-        const { id, ...taskDrawerProps } = props;
-
-        return <TaskDrawer key={id} {...taskDrawerProps} />;
-      })}
-    </AppContext.Provider>
-  );
+  return <AppContext.Provider value={value}>{children}</AppContext.Provider>;
 };
 
 export default AppProvider;

--- a/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/ContactTaskRow.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/ContactTaskRow.test.tsx
@@ -10,8 +10,8 @@ import {
   gqlMock,
   GqlMockedProvider,
 } from '../../../../../../__tests__/util/graphqlMocking';
+import useTaskDrawer from '../../../../../hooks/useTaskDrawer';
 import theme from '../../../../../theme';
-import { useApp } from '../../../../App';
 import { TaskDrawerTabsEnum } from '../../../../Task/Drawer/Drawer';
 import { ContactTaskRow } from './ContactTaskRow';
 import {
@@ -22,14 +22,12 @@ import {
 const accountListId = 'abc';
 const startAt = '2021-04-12';
 
-jest.mock('../../../../App', () => ({
-  useApp: jest.fn(),
-}));
+jest.mock('../../../../../hooks/useTaskDrawer');
 
 const openTaskDrawer = jest.fn();
 
 beforeEach(() => {
-  (useApp as jest.Mock).mockReturnValue({
+  (useTaskDrawer as jest.Mock).mockReturnValue({
     openTaskDrawer,
   });
 });

--- a/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/ContactTaskRow.tsx
+++ b/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/ContactTaskRow.tsx
@@ -8,8 +8,8 @@ import {
   ActivityTypeEnum,
   ResultEnum,
 } from '../../../../../../graphql/types.generated';
+import useTaskDrawer from '../../../../../hooks/useTaskDrawer';
 import theme from '../../../../../theme';
-import { useApp } from '../../../../App';
 import { StarredItemIcon } from '../../../../common/StarredItemIcon/StarredItemIcon';
 import { TaskDrawerTabsEnum } from '../../../../Task/Drawer/Drawer';
 import { ContactCheckBox } from '../../../ContactCheckBox/ContactCheckBox';
@@ -135,7 +135,7 @@ export const ContactTaskRow: React.FC<ContactTaskRowProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const { openTaskDrawer } = useApp();
+  const { openTaskDrawer } = useTaskDrawer();
 
   const handleContactCheckPressed = () => {
     //select contact for actions

--- a/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTasksTab.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTasksTab.test.tsx
@@ -3,19 +3,17 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DateTime } from 'luxon';
 import { GqlMockedProvider } from '../../../../../__tests__/util/graphqlMocking';
+import useTaskDrawer from '../../../../hooks/useTaskDrawer';
 import theme from '../../../../theme';
-import { useApp } from '../../../App';
 import { ContactTasksTab } from './ContactTasksTab';
 import { ContactTasksTabQuery } from './ContactTasksTab.generated';
 
-jest.mock('../../../App', () => ({
-  useApp: jest.fn(),
-}));
+jest.mock('../../../../hooks/useTaskDrawer');
 
 const openTaskDrawer = jest.fn();
 
 beforeEach(() => {
-  (useApp as jest.Mock).mockReturnValue({
+  (useTaskDrawer as jest.Mock).mockReturnValue({
     openTaskDrawer,
   });
 });

--- a/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTasksTab.tsx
+++ b/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTasksTab.tsx
@@ -6,7 +6,7 @@ import { DateTime } from 'luxon';
 import { StarredItemIcon } from '../../../common/StarredItemIcon/StarredItemIcon';
 import { SearchBox } from '../../../common/SearchBox/SearchBox';
 import { ContactCheckBox } from '../../ContactCheckBox/ContactCheckBox';
-import { useApp } from '../../../App';
+import useTaskDrawer from '../../../../hooks/useTaskDrawer';
 import { ContactTaskRow } from './ContactTaskRow/ContactTaskRow';
 import { useContactTasksTabQuery } from './ContactTasksTab.generated';
 
@@ -94,7 +94,7 @@ export const ContactTasksTab: React.FC<ContactTasksTabProps> = ({
     variables: { accountListId, contactId, searchTerm },
   });
 
-  const { openTaskDrawer } = useApp();
+  const { openTaskDrawer } = useTaskDrawer();
 
   const { t } = useTranslation();
 

--- a/src/components/Dashboard/Dashboard.test.tsx
+++ b/src/components/Dashboard/Dashboard.test.tsx
@@ -4,17 +4,19 @@ import { MockedProvider } from '@apollo/client/testing';
 import { SnackbarProvider } from 'notistack';
 import { ThemeProvider } from '@material-ui/core';
 import matchMediaMock from '../../../__tests__/util/matchMediaMock';
-import { AppProviderContext } from '../App/Provider';
 import { GetDashboardQuery } from '../../../pages/accountLists/GetDashboard.generated';
 import theme from '../../theme';
+import useTaskDrawer from '../../hooks/useTaskDrawer';
 import { GetThisWeekDefaultMocks } from './ThisWeek/ThisWeek.mock';
 import Dashboard from '.';
 
-jest.mock('../App', () => ({
-  useApp: (): Partial<AppProviderContext> => ({
+jest.mock('../../hooks/useTaskDrawer');
+
+beforeEach(() => {
+  (useTaskDrawer as jest.Mock).mockReturnValue({
     openTaskDrawer: jest.fn(),
-  }),
-}));
+  });
+});
 
 const data: GetDashboardQuery = {
   user: {

--- a/src/components/Dashboard/ThisWeek/PartnerCare/PartnerCare.test.tsx
+++ b/src/components/Dashboard/ThisWeek/PartnerCare/PartnerCare.test.tsx
@@ -5,20 +5,18 @@ import {
   render,
   fireEvent,
 } from '../../../../../__tests__/util/testingLibraryReactMock';
-import { useApp } from '../../../App';
 import { GetThisWeekQuery } from '../GetThisWeek.generated';
 import { ActivityTypeEnum } from '../../../../../graphql/types.generated';
 import theme from '../../../../theme';
+import useTaskDrawer from '../../../../hooks/useTaskDrawer';
 import PartnerCare from './PartnerCare';
 
-jest.mock('../../../App', () => ({
-  useApp: jest.fn(),
-}));
+jest.mock('../../../../hooks/useTaskDrawer');
 
 const openTaskDrawer = jest.fn();
 
 beforeEach(() => {
-  (useApp as jest.Mock).mockReturnValue({
+  (useTaskDrawer as jest.Mock).mockReturnValue({
     openTaskDrawer,
   });
 });

--- a/src/components/Dashboard/ThisWeek/PartnerCare/PartnerCare.tsx
+++ b/src/components/Dashboard/ThisWeek/PartnerCare/PartnerCare.tsx
@@ -28,10 +28,10 @@ import DoneIcon from '@material-ui/icons/Done';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 import { dayMonthFormat } from '../../../../lib/intlFormat';
 import AnimatedCard from '../../../AnimatedCard';
-import { useApp } from '../../../App';
 import illustration4 from '../../../../images/drawkit/grape/drawkit-grape-pack-illustration-4.svg';
 import illustration7 from '../../../../images/drawkit/grape/drawkit-grape-pack-illustration-7.svg';
 import { GetThisWeekQuery } from '../GetThisWeek.generated';
+import useTaskDrawer from '../../../../hooks/useTaskDrawer';
 
 const CardContainer = styled(AnimatedCard)(({ theme }) => ({
   flex: 'flex',
@@ -139,7 +139,7 @@ const PartnerCare = ({
 }: Props): ReactElement => {
   const { t } = useTranslation();
   const [value, setValue] = useState(0);
-  const { openTaskDrawer } = useApp();
+  const { openTaskDrawer } = useTaskDrawer();
 
   const handleClick = ({
     id: taskId,

--- a/src/components/Dashboard/ThisWeek/TasksDueThisWeek/TasksDueThisWeek.test.tsx
+++ b/src/components/Dashboard/ThisWeek/TasksDueThisWeek/TasksDueThisWeek.test.tsx
@@ -2,20 +2,18 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '@material-ui/core';
 import { render } from '../../../../../__tests__/util/testingLibraryReactMock';
-import { useApp } from '../../../App';
 import { GetThisWeekQuery } from '../GetThisWeek.generated';
 import { ActivityTypeEnum } from '../../../../../graphql/types.generated';
 import theme from '../../../../theme';
+import useTaskDrawer from '../../../../hooks/useTaskDrawer';
 import TasksDueThisWeek from '.';
 
-jest.mock('../../../App', () => ({
-  useApp: jest.fn(),
-}));
+jest.mock('../../../../hooks/useTaskDrawer');
 
 const openTaskDrawer = jest.fn();
 
 beforeEach(() => {
-  (useApp as jest.Mock).mockReturnValue({
+  (useTaskDrawer as jest.Mock).mockReturnValue({
     openTaskDrawer,
   });
 });

--- a/src/components/Dashboard/ThisWeek/TasksDueThisWeek/TasksDueThisWeek.tsx
+++ b/src/components/Dashboard/ThisWeek/TasksDueThisWeek/TasksDueThisWeek.tsx
@@ -19,10 +19,10 @@ import { useTranslation } from 'react-i18next';
 import Link from 'next/link';
 import { DateTime } from 'luxon';
 import AnimatedCard from '../../../AnimatedCard';
-import { useApp } from '../../../App';
 import TaskStatus from '../../../Task/Status';
 import illustration8 from '../../../../images/drawkit/grape/drawkit-grape-pack-illustration-8.svg';
 import { GetThisWeekQuery } from '../GetThisWeek.generated';
+import useTaskDrawer from '../../../../hooks/useTaskDrawer';
 
 const useStyles = makeStyles((theme: Theme) => ({
   div: {
@@ -71,7 +71,7 @@ const TasksDueThisWeek = ({
 }: Props): ReactElement => {
   const classes = useStyles();
   const { t } = useTranslation();
-  const { openTaskDrawer } = useApp();
+  const { openTaskDrawer } = useTaskDrawer();
 
   const handleClick = ({
     id: taskId,

--- a/src/components/Dashboard/ThisWeek/ThisWeek.test.tsx
+++ b/src/components/Dashboard/ThisWeek/ThisWeek.test.tsx
@@ -3,8 +3,8 @@ import { render, waitFor } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
 import { SnackbarProvider } from 'notistack';
 import { ThemeProvider } from '@material-ui/core';
-import { AppProviderContext } from '../../App/Provider';
 import theme from '../../../theme';
+import useTaskDrawer from '../../../hooks/useTaskDrawer';
 import {
   GetThisWeekEmptyMocks,
   GetThisWeekLoadingMocks,
@@ -12,11 +12,13 @@ import {
 } from './ThisWeek.mock';
 import ThisWeek from '.';
 
-jest.mock('../../App', () => ({
-  useApp: (): Partial<AppProviderContext> => ({
+jest.mock('../../../hooks/useTaskDrawer');
+
+beforeEach(() => {
+  (useTaskDrawer as jest.Mock).mockReturnValue({
     openTaskDrawer: jest.fn(),
-  }),
-}));
+  });
+});
 
 describe('ThisWeek', () => {
   it('default', async () => {

--- a/src/components/Layouts/Primary/AddFab/AddFab.test.tsx
+++ b/src/components/Layouts/Primary/AddFab/AddFab.test.tsx
@@ -9,17 +9,15 @@ import {
   getDataForTaskDrawerMock,
   createTaskMutationMock,
 } from '../../../Task/Drawer/Form/Form.mock';
-import { useApp } from '../../../App';
+import useTaskDrawer from '../../../../hooks/useTaskDrawer';
 import AddFab from '.';
 
-jest.mock('../../../App', () => ({
-  useApp: jest.fn(),
-}));
+jest.mock('../../../../hooks/useTaskDrawer');
 
 const openTaskDrawer = jest.fn();
 
 beforeEach(() => {
-  (useApp as jest.Mock).mockReturnValue({
+  (useTaskDrawer as jest.Mock).mockReturnValue({
     openTaskDrawer,
   });
 });

--- a/src/components/Layouts/Primary/AddFab/AddFab.tsx
+++ b/src/components/Layouts/Primary/AddFab/AddFab.tsx
@@ -3,7 +3,7 @@ import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import { SpeedDial, SpeedDialIcon, SpeedDialAction } from '@material-ui/lab';
 import AssignmentIcon from '@material-ui/icons/Assignment';
 import { useTranslation } from 'react-i18next';
-import { useApp } from '../../../App';
+import useTaskDrawer from '../../../../hooks/useTaskDrawer';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -19,7 +19,7 @@ const AddFab = (): ReactElement => {
   const classes = useStyles();
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
-  const { openTaskDrawer } = useApp();
+  const { openTaskDrawer } = useTaskDrawer();
 
   const handleClose = (): void => {
     setOpen(false);

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/AddMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/AddMenu.test.tsx
@@ -8,6 +8,7 @@ import { AppState } from '../../../../../App/rootReducer';
 import { useApp } from '../../../../../App';
 import TestRouter from '../../../../../../../__tests__/util/TestRouter';
 import { GqlMockedProvider } from '../../../../../../../__tests__/util/graphqlMocking';
+import useTaskDrawer from '../../../../../../hooks/useTaskDrawer';
 import AddMenu from './AddMenu';
 
 const openTaskDrawer = jest.fn();
@@ -18,6 +19,7 @@ const dispatch = jest.fn();
 jest.mock('../../../../../App', () => ({
   useApp: jest.fn(),
 }));
+jest.mock('../../../../../../hooks/useTaskDrawer');
 
 const router = {
   push: jest.fn(),
@@ -29,6 +31,8 @@ describe('AddMenu', () => {
     (useApp as jest.Mock).mockReturnValue({
       state,
       dispatch,
+    });
+    (useTaskDrawer as jest.Mock).mockReturnValue({
       openTaskDrawer,
     });
   });

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/AddMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/AddMenu.tsx
@@ -15,6 +15,7 @@ import ListIcon from '@material-ui/icons/FormatListBulleted';
 import EditIcon from '@material-ui/icons/Edit';
 import { useTranslation } from 'react-i18next';
 import { useApp } from '../../../../../App';
+import useTaskDrawer from '../../../../../../hooks/useTaskDrawer';
 import CreateContact from './Items/CreateContact/CreateContact';
 
 const HoverAddIcon = styled(AddIcon)(({ theme }) => ({
@@ -60,7 +61,8 @@ const MenuItemText = styled(ListItemText)(({ theme }) => ({
 
 const AddMenu = (): ReactElement => {
   const { t } = useTranslation();
-  const { state, openTaskDrawer } = useApp();
+  const { state } = useApp();
+  const { openTaskDrawer } = useTaskDrawer();
   const { accountListId } = state;
   const [selectedMenuItem, changeSelectedMenuItem] = useState(-1);
   const [dialogOpen, changeDialogOpen] = useState(false);

--- a/src/components/Task/Drawer/CompleteForm/CompleteForm.test.tsx
+++ b/src/components/Task/Drawer/CompleteForm/CompleteForm.test.tsx
@@ -5,7 +5,6 @@ import { DateTime } from 'luxon';
 import { getDataForTaskDrawerMock } from '../Form/Form.mock';
 import TestWrapper from '../../../../../__tests__/util/TestWrapper';
 import { dateFormat } from '../../../../lib/intlFormat/intlFormat';
-import { useApp } from '../../../App';
 import {
   ActivityTypeEnum,
   NotificationTimeUnitEnum,
@@ -13,20 +12,19 @@ import {
   ResultEnum,
 } from '../../../../../graphql/types.generated';
 import { GetThisWeekDefaultMocks } from '../../../Dashboard/ThisWeek/ThisWeek.mock';
+import useTaskDrawer from '../../../../hooks/useTaskDrawer';
 import {
   completeTaskMutationMock,
   completeSimpleTaskMutationMock,
 } from './CompleteForm.mock';
 import TaskDrawerCompleteForm from '.';
 
-jest.mock('../../../App', () => ({
-  useApp: jest.fn(),
-}));
+jest.mock('../../../../hooks/useTaskDrawer');
 
 const openTaskDrawer = jest.fn();
 
 beforeEach(() => {
-  (useApp as jest.Mock).mockReturnValue({
+  (useTaskDrawer as jest.Mock).mockReturnValue({
     openTaskDrawer,
   });
 });

--- a/src/components/Task/Drawer/CompleteForm/CompleteForm.tsx
+++ b/src/components/Task/Drawer/CompleteForm/CompleteForm.tsx
@@ -22,7 +22,6 @@ import * as yup from 'yup';
 import { DateTime } from 'luxon';
 import { useSnackbar } from 'notistack';
 import { dateFormat } from '../../../../lib/intlFormat/intlFormat';
-import { useApp } from '../../../App';
 import {
   ActivityTypeEnum,
   ContactConnection,
@@ -33,6 +32,7 @@ import {
 import { GetTaskForTaskDrawerQuery } from '../TaskDrawerTask.generated';
 import { useGetDataForTaskDrawerQuery } from '../Form/TaskDrawer.generated';
 import { GetThisWeekDocument } from '../../../Dashboard/ThisWeek/GetThisWeek.generated';
+import useTaskDrawer from '../../../../hooks/useTaskDrawer';
 import { useCompleteTaskMutation } from './CompleteTask.generated';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -88,7 +88,7 @@ const TaskDrawerCompleteForm = ({
   const classes = useStyles();
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
-  const { openTaskDrawer } = useApp();
+  const { openTaskDrawer } = useTaskDrawer();
   const { data } = useGetDataForTaskDrawerQuery({
     variables: { accountListId },
   });

--- a/src/components/Task/Drawer/TaskDrawerContext.ts
+++ b/src/components/Task/Drawer/TaskDrawerContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+import { TaskDrawerProviderContext } from './TaskDrawerProvider';
+
+const TaskDrawerContext = createContext<TaskDrawerProviderContext>({
+  openTaskDrawer: () => undefined,
+  taskDrawers: [],
+});
+
+export default TaskDrawerContext;

--- a/src/components/Task/Drawer/TaskDrawerProvider.tsx
+++ b/src/components/Task/Drawer/TaskDrawerProvider.tsx
@@ -1,0 +1,68 @@
+import { ReactElement, ReactNode, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import theme from '../../../theme';
+import TaskDrawer, { TaskDrawerProps } from './Drawer';
+import TaskDrawerContext from './TaskDrawerContext';
+
+interface Props {
+  children: ReactNode;
+}
+
+export interface TaskDrawerProviderContext {
+  openTaskDrawer: (props: TaskDrawerProps) => void;
+  taskDrawers: TaskDrawerPropsWithId[];
+}
+
+interface TaskDrawerPropsWithId extends TaskDrawerProps {
+  id: string;
+}
+
+const TaskDrawerProvider = ({ children }: Props): ReactElement => {
+  const [taskDrawers, setTaskDrawers] = useState<TaskDrawerPropsWithId[]>([]);
+  const openTaskDrawer = (taskDrawerProps: TaskDrawerProps): void => {
+    const id = uuidv4();
+    if (
+      !taskDrawerProps.taskId ||
+      !taskDrawers.find(
+        ({ taskId, showCompleteForm }) =>
+          taskId === taskDrawerProps.taskId &&
+          showCompleteForm === taskDrawerProps.showCompleteForm,
+      )
+    ) {
+      setTaskDrawers([
+        ...taskDrawers,
+        {
+          id,
+          ...taskDrawerProps,
+          onClose: (): void => {
+            taskDrawerProps.onClose && taskDrawerProps.onClose();
+            setTimeout(
+              () =>
+                setTaskDrawers((taskDrawers) =>
+                  taskDrawers.filter(({ id: taskId }) => taskId !== id),
+                ),
+              theme.transitions.duration.leavingScreen,
+            );
+          },
+        },
+      ]);
+    }
+  };
+  const value: TaskDrawerProviderContext = {
+    openTaskDrawer,
+    taskDrawers,
+  };
+
+  return (
+    <TaskDrawerContext.Provider value={value}>
+      {children}
+      {taskDrawers.map((props: TaskDrawerPropsWithId) => {
+        const { id, ...taskDrawerProps } = props;
+
+        return <TaskDrawer key={id} {...taskDrawerProps} />;
+      })}
+    </TaskDrawerContext.Provider>
+  );
+};
+
+export default TaskDrawerProvider;

--- a/src/components/Task/List/List.test.tsx
+++ b/src/components/Task/List/List.test.tsx
@@ -10,6 +10,7 @@ import {
 import { useApp } from '../../App';
 import { ActivityTypeEnum } from '../../../../graphql/types.generated';
 import theme from '../../../theme';
+import useTaskDrawer from '../../../hooks/useTaskDrawer';
 import {
   getTasksForTaskListMock,
   getFilteredTasksForTaskListMock,
@@ -35,14 +36,17 @@ jest.mock('notistack', () => ({
   },
 }));
 
+jest.mock('../../../hooks/useTaskDrawer');
 jest.mock('../../App', () => ({
   useApp: jest.fn(),
 }));
 
 beforeEach(() => {
   (useApp as jest.Mock).mockReturnValue({
-    openTaskDrawer,
     state: { accountListId, breadcrumb: 'Tasks' },
+  });
+  (useTaskDrawer as jest.Mock).mockReturnValue({
+    openTaskDrawer,
   });
 });
 

--- a/src/components/Task/List/List.tsx
+++ b/src/components/Task/List/List.tsx
@@ -28,6 +28,7 @@ import TaskStatus from '../Status';
 import illustration15 from '../../../images/drawkit/grape/drawkit-grape-pack-illustration-15.svg';
 import { ActivityTypeEnum } from '../../../../graphql/types.generated';
 import { useGetDataForTaskDrawerQuery } from '../Drawer/Form/TaskDrawer.generated';
+import useTaskDrawer from '../../../hooks/useTaskDrawer';
 import {
   useGetTasksForTaskListQuery,
   GetTasksForTaskListQueryVariables,
@@ -87,8 +88,9 @@ const TaskList = ({ initialFilter }: Props): ReactElement => {
 
   const {
     state: { accountListId },
-    openTaskDrawer,
   } = useApp();
+
+  const { openTaskDrawer } = useTaskDrawer();
 
   const { data: filterData } = useGetDataForTaskDrawerQuery({
     variables: { accountListId: accountListId ?? '' },

--- a/src/components/Task/Status/Status.test.tsx
+++ b/src/components/Task/Status/Status.test.tsx
@@ -2,18 +2,16 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '@material-ui/core';
-import { useApp } from '../../App';
 import theme from '../../../theme';
+import useTaskDrawer from '../../../hooks/useTaskDrawer';
 import TaskStatus from '.';
 
-jest.mock('../../App', () => ({
-  useApp: jest.fn(),
-}));
+jest.mock('../../../hooks/useTaskDrawer');
 
 const openTaskDrawer = jest.fn();
 
 beforeEach(() => {
-  (useApp as jest.Mock).mockReturnValue({
+  (useTaskDrawer as jest.Mock).mockReturnValue({
     openTaskDrawer,
   });
 });

--- a/src/components/Task/Status/Status.tsx
+++ b/src/components/Task/Status/Status.tsx
@@ -6,7 +6,7 @@ import AssignmentIcon from '@material-ui/icons/Assignment';
 import AssignmentTurnedInIcon from '@material-ui/icons/AssignmentTurnedIn';
 import { useTranslation } from 'react-i18next';
 import DoneIcon from '@material-ui/icons/Done';
-import { useApp } from '../../App';
+import useTaskDrawer from '../../../hooks/useTaskDrawer';
 
 const useStyles = makeStyles((theme: Theme) => ({
   buttonGreen: {
@@ -94,7 +94,8 @@ const TaskStatus = ({
 }: Props): ReactElement => {
   const classes = useStyles();
   const { t } = useTranslation();
-  const { openTaskDrawer } = useApp();
+  const { openTaskDrawer } = useTaskDrawer();
+
   const handleClick = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   ): void => {

--- a/src/hooks/useTaskDrawer.tsx
+++ b/src/hooks/useTaskDrawer.tsx
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import TaskDrawerContext from '../components/Task/Drawer/TaskDrawerContext';
+import { TaskDrawerProviderContext } from '../components/Task/Drawer/TaskDrawerProvider';
+
+const useTaskDrawer = (): TaskDrawerProviderContext =>
+  useContext(TaskDrawerContext);
+
+export default useTaskDrawer;


### PR DESCRIPTION
Slowly getting rid of ```useApp```, piece by piece 🙂 We determined that the task drawer state/logic still has to exist in a context that is accessible, so now it's in its own context instead of a global one.