### PR TITLE
Rename DesignationAccount Rest GraphQL type due to conflict with API

### DIFF
--- a/pages/api/Schema/reports/designationAccounts/datahandler.ts
+++ b/pages/api/Schema/reports/designationAccounts/datahandler.ts
@@ -1,5 +1,5 @@
 import {
-  DesignationAccount,
+  DesignationAccountRest,
   DesignationAccountsGroup,
 } from '../../../graphql-rest.page.generated';
 
@@ -42,12 +42,12 @@ export interface DesignationAccountsResponse {
 }
 
 type PreDesignationAccountsGroup = {
-  [organizationName: string]: DesignationAccount[];
+  [organizationName: string]: DesignationAccountRest[];
 };
 
 const createDesignationAccount = (
   account: DesignationAccountsResponse,
-): DesignationAccount => ({
+): DesignationAccountRest => ({
   active: account.attributes.active,
   balanceUpdatedAt: account.attributes.balance_updated_at,
   currency: account.attributes.currency,
@@ -85,4 +85,4 @@ export const createDesignationAccountsGroup = (
 
 export const setActiveDesignationAccount = (
   data: DesignationAccountsResponse,
-): DesignationAccount => createDesignationAccount(data);
+): DesignationAccountRest => createDesignationAccount(data);

--- a/pages/api/Schema/reports/designationAccounts/designationAccounts.graphql
+++ b/pages/api/Schema/reports/designationAccounts/designationAccounts.graphql
@@ -5,10 +5,10 @@ extend type Query {
 extend type Mutation {
   setActiveDesignationAccount(
     input: SetActiveDesignationAccountInput!
-  ): DesignationAccount!
+  ): DesignationAccountRest!
 }
 
-type DesignationAccount {
+type DesignationAccountRest {
   active: Boolean!
   balanceUpdatedAt: ISO8601Date!
   convertedBalance: Float!
@@ -20,7 +20,7 @@ type DesignationAccount {
 
 type DesignationAccountsGroup {
   organizationName: String!
-  designationAccounts: [DesignationAccount!]!
+  designationAccounts: [DesignationAccountRest!]!
 }
 
 input SetActiveDesignationAccountInput {


### PR DESCRIPTION
Spencer added a DesignationAccount type to the Rails GraphQL schema. I'm just renaming this to get our server working again. We'll need to reconcile these eventually.