### PR TITLE
Improve-Contact-Deletion-Logic

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetails.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetails.tsx
@@ -119,6 +119,7 @@ export const ContactDetails: React.FC<Props> = ({
           <ContactDetailsTab
             accountListId={accountListId}
             contactId={contactId}
+            onClose={onClose}
           />
         </TabPanel>
         <TabPanel value={TabKey.Notes}>

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.stories.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.stories.tsx
@@ -25,6 +25,7 @@ export const Default = (): ReactElement => {
         <ContactDetailsTab
           accountListId={accountListId}
           contactId={contactId}
+          onClose={() => {}}
         />
       </GqlMockedProvider>
     </MuiThemeProvider>
@@ -48,7 +49,11 @@ export const Loading = (): ReactElement => {
         },
       ]}
     >
-      <ContactDetailsTab accountListId={accountListId} contactId={contactId} />
+      <ContactDetailsTab
+        accountListId={accountListId}
+        contactId={contactId}
+        onClose={() => {}}
+      />
     </MockedProvider>
   );
 };

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.test.tsx
@@ -22,6 +22,7 @@ const router = {
   query: { searchTerm: undefined, accountListId },
   push: jest.fn(),
 };
+const onClose = jest.fn();
 
 const mocks = {
   ContactDetailsTab: {
@@ -92,6 +93,7 @@ describe('ContactDetailTab', () => {
               <ContactDetailsTab
                 accountListId={accountListId}
                 contactId={contactId}
+                onClose={onClose}
               />
             </GqlMockedProvider>
           </ThemeProvider>
@@ -110,6 +112,7 @@ describe('ContactDetailTab', () => {
               <ContactDetailsTab
                 accountListId={accountListId}
                 contactId={contactId}
+                onClose={onClose}
               />
             </GqlMockedProvider>
           </ThemeProvider>
@@ -133,6 +136,7 @@ describe('ContactDetailTab', () => {
               <ContactDetailsTab
                 accountListId={accountListId}
                 contactId={contactId}
+                onClose={onClose}
               />
             </GqlMockedProvider>
           </ThemeProvider>
@@ -157,6 +161,7 @@ describe('ContactDetailTab', () => {
                 <ContactDetailsTab
                   accountListId={accountListId}
                   contactId={contactId}
+                  onClose={onClose}
                 />
               </GqlMockedProvider>
             </ThemeProvider>
@@ -181,6 +186,7 @@ describe('ContactDetailTab', () => {
                 <ContactDetailsTab
                   accountListId={accountListId}
                   contactId={contactId}
+                  onClose={onClose}
                 />
               </GqlMockedProvider>
             </ThemeProvider>
@@ -209,6 +215,7 @@ describe('ContactDetailTab', () => {
                 <ContactDetailsTab
                   accountListId={accountListId}
                   contactId={contactId}
+                  onClose={onClose}
                 />
               </GqlMockedProvider>
             </ThemeProvider>
@@ -233,6 +240,7 @@ describe('ContactDetailTab', () => {
                 <ContactDetailsTab
                   accountListId={accountListId}
                   contactId={contactId}
+                  onClose={onClose}
                 />
               </GqlMockedProvider>
             </ThemeProvider>
@@ -263,6 +271,7 @@ describe('ContactDetailTab', () => {
                 <ContactDetailsTab
                   accountListId={accountListId}
                   contactId={contactId}
+                  onClose={onClose}
                 />
               </GqlMockedProvider>
             </ThemeProvider>
@@ -287,6 +296,7 @@ describe('ContactDetailTab', () => {
                 <ContactDetailsTab
                   accountListId={accountListId}
                   contactId={contactId}
+                  onClose={onClose}
                 />
               </GqlMockedProvider>
             </ThemeProvider>
@@ -315,6 +325,7 @@ describe('ContactDetailTab', () => {
                 <ContactDetailsTab
                   accountListId={accountListId}
                   contactId={contactId}
+                  onClose={onClose}
                 />
               </GqlMockedProvider>
             </ThemeProvider>
@@ -339,6 +350,7 @@ describe('ContactDetailTab', () => {
                 <ContactDetailsTab
                   accountListId={accountListId}
                   contactId={contactId}
+                  onClose={onClose}
                 />
               </GqlMockedProvider>
             </ThemeProvider>
@@ -367,6 +379,7 @@ describe('ContactDetailTab', () => {
                 <ContactDetailsTab
                   accountListId={accountListId}
                   contactId={contactId}
+                  onClose={onClose}
                 />
               </GqlMockedProvider>
             </ThemeProvider>
@@ -395,6 +408,7 @@ describe('ContactDetailTab', () => {
                 <ContactDetailsTab
                   accountListId={accountListId}
                   contactId={contactId}
+                  onClose={onClose}
                 />
               </GqlMockedProvider>
             </ThemeProvider>
@@ -419,6 +433,7 @@ describe('ContactDetailTab', () => {
                 <ContactDetailsTab
                   accountListId={accountListId}
                   contactId={contactId}
+                  onClose={onClose}
                 />
               </GqlMockedProvider>
             </ThemeProvider>
@@ -516,6 +531,7 @@ describe('ContactDetailTab', () => {
               <ContactDetailsTab
                 accountListId={accountListId}
                 contactId={contactId}
+                onClose={onClose}
               />
             </GqlMockedProvider>
           </ThemeProvider>
@@ -542,6 +558,7 @@ describe('ContactDetailTab', () => {
         },
       }),
     );
+    expect(onClose).toHaveBeenCalled();
     await waitFor(() =>
       expect(router.push).toHaveBeenCalledWith({
         pathname: '/accountLists/[accountListId]/contacts',

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.tsx
@@ -89,11 +89,13 @@ const LoadingIndicator = styled(CircularProgress)(({ theme }) => ({
 interface ContactDetailTabProps {
   accountListId: string;
   contactId: string;
+  onClose: () => void;
 }
 
 export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
   accountListId,
   contactId,
+  onClose,
 }) => {
   const { data, loading } = useContactDetailsTabQuery({
     variables: { accountListId, contactId },
@@ -151,6 +153,8 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
           }
         },
       });
+      setDeleteModalOpen(false);
+      onClose();
     } catch (error) {
       enqueueSnackbar(error.message, { variant: 'error' });
       throw error;


### PR DESCRIPTION
Small random pr, sorry 🙂 I noticed a few issues with deleting a contact while working on removing ```useApp```. Those issues were:

1. the delete contact modal would not close after deleting the contact.
2. the contact details side panel would remain open even after deleting.

So I went ahead and quickly fixed that. Sorry for missing it initially!