### PR TITLE
Fix VS Code Apollo tooling that was throwing errors with duplicate op…

### DIFF
--- a/apollo.config.js
+++ b/apollo.config.js
@@ -4,5 +4,7 @@ module.exports = {
       name: 'MPDX',
       url: 'https://api.stage.mpdx.org/graphql',
     },
+    // Added generated files to avoid duplicate operation name errors https://www.apollographql.com/docs/devtools/apollo-config/#clientexcludes
+    excludes: ['**/node_modules', '**/__tests__', '**/*.generated.ts'],
   },
 };


### PR DESCRIPTION
…eration names

Should make autocomplete in .graphql files work again.