### PR TITLE
Fix email addresses basic UI

### DIFF
--- a/pages/accountLists/[accountListId]/tools/fixEmailAddresses.page.tsx
+++ b/pages/accountLists/[accountListId]/tools/fixEmailAddresses.page.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Head from 'next/head';
+import FixEmailAddresses from '../../../../src/components/Tool/FixEmailAddresses/FixEmailAddreses';
+
+const fixEmailAddresses: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Head>
+        <title>MPDX | {t('MPDX | Fix Email Addresses')}</title>
+      </Head>
+      <FixEmailAddresses />
+    </>
+  );
+};
+
+export default fixEmailAddresses;

--- a/src/components/Tool/FixEmailAddresses/Contact.test.tsx
+++ b/src/components/Tool/FixEmailAddresses/Contact.test.tsx
@@ -1,5 +1,6 @@
 import { ThemeProvider } from '@material-ui/core';
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render } from '../../../../__tests__/util/testingLibraryReactMock';
 import TestWrapper from '../../../../__tests__/util/TestWrapper';
 import theme from '../../../theme';
@@ -55,5 +56,37 @@ describe('FixEmailAddresses', () => {
     expect(getByText('MPDX (06/22/2021)')).toBeInTheDocument();
     expect(getByTestId('textfield-1')).toBeInTheDocument();
     expect(getByDisplayValue('test2@test1.com')).toBeInTheDocument();
+  });
+
+  it('input reset after adding an email address', () => {
+    const handleChangeMock = jest.fn();
+    const handleDeleteModalOpenMock = jest.fn();
+    const handleAddMock = jest.fn();
+    const handleChangePrimaryMock = jest.fn();
+
+    const { getByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <Contact
+            name={testData.name}
+            key={testData.name}
+            contactIndex={0}
+            emails={testData.emails}
+            handleChange={handleChangeMock}
+            handleDelete={handleDeleteModalOpenMock}
+            handleAdd={handleAddMock}
+            handleChangePrimary={handleChangePrimaryMock}
+          />
+        </TestWrapper>
+      </ThemeProvider>,
+    );
+
+    const addInput = getByTestId('addNewEmailInput') as HTMLInputElement;
+    const addButton = getByTestId('addButton');
+
+    userEvent.type(addInput, 'new@new.com');
+    expect(addInput.value).toBe('new@new.com');
+    userEvent.click(addButton);
+    expect(addInput.value).toBe('');
   });
 });

--- a/src/components/Tool/FixEmailAddresses/Contact.test.tsx
+++ b/src/components/Tool/FixEmailAddresses/Contact.test.tsx
@@ -51,10 +51,10 @@ describe('FixEmailAddresses', () => {
 
     expect(getByText(testData.name)).toBeInTheDocument();
     expect(getByText('DonorHub (06/21/2021)')).toBeInTheDocument();
-    expect(getByTestId('textfield-0')).toBeInTheDocument();
+    expect(getByTestId('textfield-0-0')).toBeInTheDocument();
     expect(getByDisplayValue('test1@test1.com')).toBeInTheDocument();
     expect(getByText('MPDX (06/22/2021)')).toBeInTheDocument();
-    expect(getByTestId('textfield-1')).toBeInTheDocument();
+    expect(getByTestId('textfield-0-1')).toBeInTheDocument();
     expect(getByDisplayValue('test2@test1.com')).toBeInTheDocument();
   });
 

--- a/src/components/Tool/FixEmailAddresses/Contact.test.tsx
+++ b/src/components/Tool/FixEmailAddresses/Contact.test.tsx
@@ -1,0 +1,59 @@
+import { ThemeProvider } from '@material-ui/core';
+import React from 'react';
+import { render } from '../../../../__tests__/util/testingLibraryReactMock';
+import TestWrapper from '../../../../__tests__/util/TestWrapper';
+import theme from '../../../theme';
+import Contact from './Contact';
+
+const testData = {
+  name: 'Test Contact',
+  id: 'testid',
+  emails: [
+    {
+      source: 'DonorHub',
+      date: '06/21/2021',
+      address: 'test1@test1.com',
+      primary: true,
+    },
+    {
+      source: 'MPDX',
+      date: '06/22/2021',
+      address: 'test2@test1.com',
+      primary: false,
+    },
+  ],
+};
+
+describe('FixEmailAddresses', () => {
+  it('default', () => {
+    const handleChangeMock = jest.fn();
+    const handleDeleteModalOpenMock = jest.fn();
+    const handleAddMock = jest.fn();
+    const handleChangePrimaryMock = jest.fn();
+
+    const { getByText, getByTestId, getByDisplayValue } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <Contact
+            name={testData.name}
+            key={testData.name}
+            contactIndex={0}
+            emails={testData.emails}
+            handleChange={handleChangeMock}
+            handleDelete={handleDeleteModalOpenMock}
+            handleAdd={handleAddMock}
+            handleChangePrimary={handleChangePrimaryMock}
+          />
+        </TestWrapper>
+      </ThemeProvider>,
+    );
+
+    expect(getByText(testData.name)).toBeInTheDocument();
+    expect(getByText('DonorHub (06/21/2021)')).toBeInTheDocument();
+    expect(getByTestId('textfield-0')).toBeInTheDocument();
+    expect(getByDisplayValue('test1@test1.com')).toBeInTheDocument();
+    expect(getByText('MPDX (06/22/2021)')).toBeInTheDocument();
+    expect(getByTestId('textfield-1')).toBeInTheDocument();
+    expect(getByDisplayValue('test2@test1.com')).toBeInTheDocument();
+  });
+});

--- a/src/components/Tool/FixEmailAddresses/Contact.test.tsx
+++ b/src/components/Tool/FixEmailAddresses/Contact.test.tsx
@@ -25,7 +25,7 @@ const testData = {
   ],
 };
 
-describe('FixEmailAddresses', () => {
+describe('FixEmailAddresses-Contact', () => {
   it('default', () => {
     const handleChangeMock = jest.fn();
     const handleDeleteModalOpenMock = jest.fn();
@@ -81,8 +81,8 @@ describe('FixEmailAddresses', () => {
       </ThemeProvider>,
     );
 
-    const addInput = getByTestId('addNewEmailInput') as HTMLInputElement;
-    const addButton = getByTestId('addButton');
+    const addInput = getByTestId('addNewEmailInput-0') as HTMLInputElement;
+    const addButton = getByTestId('addButton-0');
 
     userEvent.type(addInput, 'new@new.com');
     expect(addInput.value).toBe('new@new.com');

--- a/src/components/Tool/FixEmailAddresses/Contact.tsx
+++ b/src/components/Tool/FixEmailAddresses/Contact.tsx
@@ -1,0 +1,348 @@
+import React, { Fragment, useState } from 'react';
+import {
+  Box,
+  Grid,
+  Button,
+  Typography,
+  Avatar,
+  makeStyles,
+  Hidden,
+  TextField,
+  Theme,
+} from '@material-ui/core';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { Icon } from '@mdi/react';
+import { mdiCheckboxMarkedCircle, mdiLock, mdiPlus, mdiDelete } from '@mdi/js';
+import StarIcon from '@material-ui/icons/Star';
+import StarOutlineIcon from '@material-ui/icons/StarOutline';
+import theme from '../../../theme';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  left: {
+    [theme.breakpoints.up('md')]: {
+      border: `1px solid ${theme.palette.cruGrayMedium.main}`,
+    },
+  },
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    marginBottom: theme.spacing(2),
+    [theme.breakpoints.down('sm')]: {
+      border: `1px solid ${theme.palette.cruGrayMedium.main}`,
+    },
+  },
+  boxBottom: {
+    backgroundColor: theme.palette.cruGrayLight.main,
+    width: '100%',
+    [theme.breakpoints.down('xs')]: {
+      paddingTop: theme.spacing(2),
+    },
+  },
+  buttonTop: {
+    marginLeft: theme.spacing(2),
+    [theme.breakpoints.down('sm')]: {
+      marginLeft: theme.spacing(1),
+      marginRight: theme.spacing(2),
+      marginTop: theme.spacing(2),
+      marginBottom: theme.spacing(2),
+    },
+    '& .MuiButton-root': {
+      backgroundColor: theme.palette.mpdxBlue.main,
+      color: 'white',
+    },
+  },
+  buttonIcon: {
+    marginRight: theme.spacing(1),
+  },
+  rowChangeResponsive: {
+    flexDirection: 'column',
+    [theme.breakpoints.down('xs')]: {
+      marginTop: -20,
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    },
+  },
+  responsiveBorder: {
+    [theme.breakpoints.down('xs')]: {
+      paddingBottom: theme.spacing(2),
+      borderBottom: `1px solid ${theme.palette.cruGrayMedium.main}`,
+    },
+  },
+  paddingX: {
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+  },
+  paddingY: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+  },
+  paddingB2: {
+    paddingBottom: theme.spacing(2),
+  },
+  address: {
+    borderBottom: '1px solid gray',
+    width: '100%',
+    cursor: 'text',
+  },
+  hoverHighlight: {
+    '&:hover': {
+      color: theme.palette.mpdxBlue.main,
+      cursor: 'pointer',
+    },
+  },
+  avatar: {
+    width: theme.spacing(7),
+    height: theme.spacing(7),
+  },
+}));
+
+export interface email {
+  source: string;
+  date: string;
+  address: string;
+  primary: boolean;
+}
+
+interface Props {
+  name: string;
+  emails: email[];
+  contactIndex: number;
+  handleChange: (
+    contactIndex: number,
+    emailIndex: number,
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => void;
+  handleDelete: (contactIndex: number, emailIndex: number) => void;
+  handleAdd: (contactIndex: number, address: string) => void;
+  handleChangePrimary: (contactIndex: number, emailIndex: number) => void;
+}
+
+const Contact: React.FC<Props> = ({
+  name,
+  emails,
+  contactIndex,
+  handleChange,
+  handleDelete,
+  handleAdd,
+  handleChangePrimary,
+}) => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+  const [newEmailAddress, setNewEmailAddress] = useState<string>('');
+  //TODO: Add button functionality
+  //TODO: Make name pop up a modal to edit the person info
+
+  const updateNewEmailAddress = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    setNewEmailAddress(event.target.value);
+  };
+
+  const addNewEmailAddress = (): void => {
+    if (newEmailAddress) {
+      handleAdd(contactIndex, newEmailAddress);
+      setNewEmailAddress('');
+    }
+  };
+
+  return (
+    <Grid container className={classes.container}>
+      <Grid container>
+        <Grid item md={10} xs={12}>
+          <Box display="flex" alignItems="center" className={classes.left}>
+            <Grid container>
+              <Grid item xs={12}>
+                <Box
+                  display="flex"
+                  alignItems="center"
+                  style={{ height: '100%' }}
+                  p={2}
+                >
+                  <Avatar src="" className={classes.avatar} />
+                  <Box display="flex" flexDirection="column" ml={2}>
+                    <Typography variant="h6">{name}</Typography>
+                  </Box>
+                </Box>
+              </Grid>
+
+              <Grid item xs={12} className={classes.boxBottom}>
+                <Grid container>
+                  <Hidden xsDown>
+                    <Grid item xs={12} sm={6} className={classes.paddingY}>
+                      <Box
+                        display="flex"
+                        justifyContent="space-between"
+                        className={classes.paddingX}
+                      >
+                        <Typography>
+                          <strong>{t('Source')}</strong>
+                        </Typography>
+                        <Typography>
+                          <strong>{t('Primary')}</strong>
+                        </Typography>
+                      </Box>
+                    </Grid>
+                    <Grid item xs={12} sm={6} className={classes.paddingY}>
+                      <Box
+                        display="flex"
+                        justifyContent="flex-start"
+                        className={classes.paddingX}
+                      >
+                        <Typography>
+                          <strong>{t('Address')}</strong>
+                        </Typography>
+                      </Box>
+                    </Grid>
+                  </Hidden>
+                  {emails.map((email, index) => (
+                    <Fragment key={index}>
+                      <Grid item xs={12} sm={6} className={classes.paddingB2}>
+                        <Box
+                          display="flex"
+                          justifyContent="space-between"
+                          className={classes.paddingX}
+                        >
+                          <Box>
+                            <Hidden smUp>
+                              <Typography display="inline">
+                                <strong>{t('Source')}: </strong>
+                              </Typography>
+                            </Hidden>
+                            <Typography display="inline">
+                              {`${email.source} (${email.date})`}
+                            </Typography>
+                          </Box>
+                          <Typography>
+                            {email.primary ? (
+                              <StarIcon className={classes.hoverHighlight} />
+                            ) : (
+                              <StarOutlineIcon
+                                className={classes.hoverHighlight}
+                                onClick={() =>
+                                  handleChangePrimary(contactIndex, index)
+                                }
+                              />
+                            )}
+                          </Typography>
+                        </Box>
+                      </Grid>
+                      <Grid item xs={12} sm={6} className={classes.paddingB2}>
+                        <Box
+                          display="flex"
+                          justifyContent="flex-start"
+                          className={clsx(
+                            classes.responsiveBorder,
+                            classes.paddingX,
+                          )}
+                        >
+                          <TextField
+                            style={{ width: '100%' }}
+                            inputProps={{
+                              'data-testid': `textfield-${index}`,
+                            }}
+                            onChange={(
+                              event: React.ChangeEvent<HTMLInputElement>,
+                            ) => handleChange(contactIndex, index, event)}
+                            value={email.address}
+                            disabled={email.source !== 'MPDX'}
+                          />
+
+                          {email.source === 'MPDX' ? (
+                            <Box
+                              onClick={() => handleDelete(contactIndex, index)}
+                            >
+                              <Icon
+                                path={mdiDelete}
+                                size={1}
+                                className={classes.hoverHighlight}
+                              />
+                            </Box>
+                          ) : (
+                            <Icon
+                              path={mdiLock}
+                              size={1}
+                              style={{
+                                color: theme.palette.cruGrayMedium.main,
+                              }}
+                            />
+                          )}
+                        </Box>
+                      </Grid>
+                    </Fragment>
+                  ))}
+                  <Grid item xs={12} sm={6} className={classes.paddingB2}>
+                    <Box
+                      display="flex"
+                      justifyContent="space-between"
+                      className={classes.paddingX}
+                    >
+                      <Box>
+                        <Hidden smUp>
+                          <Typography display="inline">
+                            <strong>{t('Source')}: </strong>
+                          </Typography>
+                        </Hidden>
+                        <Typography display="inline">MPDX</Typography>
+                      </Box>
+                    </Box>
+                  </Grid>
+                  <Grid item xs={12} sm={6} className={classes.paddingB2}>
+                    <Box
+                      display="flex"
+                      justifyContent="flex-start"
+                      className={clsx(
+                        classes.responsiveBorder,
+                        classes.paddingX,
+                      )}
+                    >
+                      <TextField
+                        style={{ width: '100%' }}
+                        onChange={(
+                          event: React.ChangeEvent<HTMLInputElement>,
+                        ) => updateNewEmailAddress(event)}
+                        value={newEmailAddress}
+                      />
+                      <Box onClick={() => addNewEmailAddress()}>
+                        <Icon
+                          path={mdiPlus}
+                          size={1}
+                          className={classes.hoverHighlight}
+                        />
+                      </Box>
+                    </Box>
+                  </Grid>
+                </Grid>
+              </Grid>
+            </Grid>
+          </Box>
+        </Grid>
+        <Grid item xs={12} md={2}>
+          <Box
+            display="flex"
+            flexDirection="column"
+            style={{ paddingLeft: theme.spacing(1) }}
+          >
+            <Box className={classes.buttonTop}>
+              <Button
+                variant="contained"
+                style={{ width: '100%' }}
+                onClick={() => console.log(emails)}
+              >
+                <Icon
+                  path={mdiCheckboxMarkedCircle}
+                  size={0.8}
+                  className={classes.buttonIcon}
+                />
+                {t('Confirm')}
+              </Button>
+            </Box>
+          </Box>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default Contact;

--- a/src/components/Tool/FixEmailAddresses/Contact.tsx
+++ b/src/components/Tool/FixEmailAddresses/Contact.tsx
@@ -216,9 +216,13 @@ const Contact: React.FC<Props> = ({
                           </Box>
                           <Typography>
                             {email.primary ? (
-                              <StarIcon className={classes.hoverHighlight} />
+                              <StarIcon
+                                data-testid={`starIcon-${contactIndex}-${index}`}
+                                className={classes.hoverHighlight}
+                              />
                             ) : (
                               <StarOutlineIcon
+                                data-testid={`starOutlineIcon-${contactIndex}-${index}`}
                                 className={classes.hoverHighlight}
                                 onClick={() =>
                                   handleChangePrimary(contactIndex, index)
@@ -240,7 +244,7 @@ const Contact: React.FC<Props> = ({
                           <TextField
                             style={{ width: '100%' }}
                             inputProps={{
-                              'data-testid': `textfield-${index}`,
+                              'data-testid': `textfield-${contactIndex}-${index}`,
                             }}
                             onChange={(
                               event: React.ChangeEvent<HTMLInputElement>,
@@ -251,6 +255,7 @@ const Contact: React.FC<Props> = ({
 
                           {email.source === 'MPDX' ? (
                             <Box
+                              data-testid={`delete-${contactIndex}-${index}`}
                               onClick={() => handleDelete(contactIndex, index)}
                             >
                               <Icon
@@ -331,11 +336,7 @@ const Contact: React.FC<Props> = ({
             style={{ paddingLeft: theme.spacing(1) }}
           >
             <Box className={classes.buttonTop}>
-              <Button
-                variant="contained"
-                style={{ width: '100%' }}
-                onClick={() => console.log(emails)}
-              >
+              <Button variant="contained" style={{ width: '100%' }}>
                 <Icon
                   path={mdiCheckboxMarkedCircle}
                   size={0.8}

--- a/src/components/Tool/FixEmailAddresses/Contact.tsx
+++ b/src/components/Tool/FixEmailAddresses/Contact.tsx
@@ -243,9 +243,7 @@ const Contact: React.FC<Props> = ({
                         >
                           <TextField
                             style={{ width: '100%' }}
-                            inputProps={{
-                              'data-testid': `textfield-${contactIndex}-${index}`,
-                            }}
+                            data-testid={`textfield-${contactIndex}-${index}`}
                             onChange={(
                               event: React.ChangeEvent<HTMLInputElement>,
                             ) => handleChange(contactIndex, index, event)}

--- a/src/components/Tool/FixEmailAddresses/Contact.tsx
+++ b/src/components/Tool/FixEmailAddresses/Contact.tsx
@@ -306,13 +306,13 @@ const Contact: React.FC<Props> = ({
                           event: React.ChangeEvent<HTMLInputElement>,
                         ) => updateNewEmailAddress(event)}
                         inputProps={{
-                          'data-testid': 'addNewEmailInput',
+                          'data-testid': `addNewEmailInput-${contactIndex}`,
                         }}
                         value={newEmailAddress}
                       />
                       <Box
                         onClick={() => addNewEmailAddress()}
-                        data-testid="addButton"
+                        data-testid={`addButton-${contactIndex}`}
                       >
                         <Icon
                           path={mdiPlus}

--- a/src/components/Tool/FixEmailAddresses/Contact.tsx
+++ b/src/components/Tool/FixEmailAddresses/Contact.tsx
@@ -302,9 +302,15 @@ const Contact: React.FC<Props> = ({
                         onChange={(
                           event: React.ChangeEvent<HTMLInputElement>,
                         ) => updateNewEmailAddress(event)}
+                        inputProps={{
+                          'data-testid': 'addNewEmailInput',
+                        }}
                         value={newEmailAddress}
                       />
-                      <Box onClick={() => addNewEmailAddress()}>
+                      <Box
+                        onClick={() => addNewEmailAddress()}
+                        data-testid="addButton"
+                      >
                         <Icon
                           path={mdiPlus}
                           size={1}

--- a/src/components/Tool/FixEmailAddresses/DeleteModal.test.tsx
+++ b/src/components/Tool/FixEmailAddresses/DeleteModal.test.tsx
@@ -1,0 +1,40 @@
+import { ThemeProvider } from '@material-ui/core';
+import React from 'react';
+import { render } from '../../../../__tests__/util/testingLibraryReactMock';
+import TestWrapper from '../../../../__tests__/util/TestWrapper';
+import theme from '../../../theme';
+import DeleteModal from './DeleteModal';
+
+const testState = {
+  open: true,
+  contactIndex: 0,
+  emailIndex: 0,
+  emailAddress: 'test@test.com',
+};
+
+describe('FixEmailAddresses-DeleteModal', () => {
+  it('default', () => {
+    const handleClose = jest.fn();
+    const handleDelete = jest.fn();
+
+    const { getByText } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <DeleteModal
+            modalState={testState}
+            handleClose={handleClose}
+            handleDelete={handleDelete}
+          />
+        </TestWrapper>
+      </ThemeProvider>,
+    );
+
+    expect(getByText('Confirm')).toBeInTheDocument();
+    expect(
+      getByText('Are you sure you wish to delete this email address:'),
+    ).toBeInTheDocument();
+    expect(getByText('"test@test.com"')).toBeInTheDocument();
+    expect(getByText('Cancel')).toBeInTheDocument();
+    expect(getByText('Delete')).toBeInTheDocument();
+  });
+});

--- a/src/components/Tool/FixEmailAddresses/DeleteModal.tsx
+++ b/src/components/Tool/FixEmailAddresses/DeleteModal.tsx
@@ -111,6 +111,7 @@ const DeleteModal: React.FC<Props> = ({
             variant="contained"
             size="small"
             className={clsx(classes.blue, classes.actionButtons)}
+            data-testid="emailAddressDeleteButton"
             onClick={handleDelete}
           >
             {/*TODO: make "newAddress" field in address false so it says "edit" instead of "add" */}

--- a/src/components/Tool/FixEmailAddresses/DeleteModal.tsx
+++ b/src/components/Tool/FixEmailAddresses/DeleteModal.tsx
@@ -1,0 +1,125 @@
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  Modal,
+  Typography,
+  makeStyles,
+  Theme,
+  IconButton,
+  Box,
+} from '@material-ui/core';
+import Icon from '@mdi/react';
+import clsx from 'clsx';
+import React from 'react';
+import { mdiCloseThick } from '@mdi/js';
+import { useTranslation } from 'react-i18next';
+import theme from '../../../theme';
+import { ModalState } from './FixEmailAddreses';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  modal: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'auto',
+  },
+  actionButtons: {
+    textTransform: 'none',
+  },
+  blue: {
+    color: 'white',
+    backgroundColor: theme.palette.mpdxBlue.main,
+  },
+  iconButton: {
+    position: 'absolute',
+    top: -theme.spacing(2),
+    right: -theme.spacing(2),
+    '&:hover': {
+      color: 'red',
+    },
+  },
+  headerBox: {
+    padding: 0,
+    marginBottom: -theme.spacing(1),
+    position: 'relative',
+  },
+}));
+
+interface Props {
+  modalState: ModalState;
+  handleClose: () => void;
+  handleDelete: () => void;
+}
+
+const DeleteModal: React.FC<Props> = ({
+  modalState,
+  handleClose,
+  handleDelete,
+}) => {
+  const classes = useStyles();
+  const { t } = useTranslation();
+  return (
+    <Modal
+      open={modalState.open}
+      onClose={handleClose}
+      className={classes.modal}
+    >
+      <Card>
+        <CardHeader
+          title={
+            <Box
+              display="flex"
+              flexDirection="column"
+              alignItems="center"
+              className={classes.headerBox}
+            >
+              <Typography variant="h5" style={{ marginTop: -theme.spacing(1) }}>
+                {t('Confirm')}
+              </Typography>
+              <IconButton onClick={handleClose} className={classes.iconButton}>
+                <Icon path={mdiCloseThick} size={1} />
+              </IconButton>
+            </Box>
+          }
+        />
+        <CardContent>
+          <Box
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Typography>
+              {t('Are you sure you wish to delete this email address:')}
+            </Typography>
+            <Typography>{`"${modalState.emailAddress}"`}</Typography>
+          </Box>
+        </CardContent>
+        <CardActions>
+          <Button
+            variant="contained"
+            size="small"
+            className={classes.actionButtons}
+            onClick={handleClose}
+          >
+            {t('Cancel')}
+          </Button>
+          <Button
+            variant="contained"
+            size="small"
+            className={clsx(classes.blue, classes.actionButtons)}
+            onClick={handleDelete}
+          >
+            {/*TODO: make "newAddress" field in address false so it says "edit" instead of "add" */}
+            {t('Delete')}
+          </Button>
+        </CardActions>
+      </Card>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/src/components/Tool/FixEmailAddresses/FixEmailAddreses.tsx
+++ b/src/components/Tool/FixEmailAddresses/FixEmailAddreses.tsx
@@ -279,7 +279,12 @@ const FixEmailAddresses: React.FC = () => {
                   </Box>
                 </>
               )}
-              <Button size="small" variant="outlined" onClick={toggleData}>
+              <Button
+                size="small"
+                variant="outlined"
+                data-testid="changeTestData"
+                onClick={toggleData}
+              >
                 Change Test
               </Button>
               <Typography>

--- a/src/components/Tool/FixEmailAddresses/FixEmailAddreses.tsx
+++ b/src/components/Tool/FixEmailAddresses/FixEmailAddreses.tsx
@@ -1,0 +1,260 @@
+import React, { useState } from 'react';
+import {
+  makeStyles,
+  Box,
+  Typography,
+  Grid,
+  Divider,
+  Button,
+} from '@material-ui/core';
+
+import { Trans, useTranslation } from 'react-i18next';
+
+import theme from '../../../theme';
+import Contact from './Contact';
+import NoContacts from './NoContacts';
+import DeleteModal from './DeleteModal';
+
+const useStyles = makeStyles(() => ({
+  container: {
+    padding: theme.spacing(3),
+    overflow: 'auto',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  outter: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'end',
+    width: '70%',
+    [theme.breakpoints.down('sm')]: {
+      width: '100%',
+    },
+  },
+  divider: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+  },
+  descriptionBox: {
+    marginBottom: theme.spacing(2),
+  },
+  footer: {
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+  },
+}));
+
+// Temporary date for desting, structure most likely isn't accurate
+// but making adjustments should be easy in the future
+const testData = [
+  {
+    name: 'Test Contact',
+    id: 'testid',
+    emails: [
+      {
+        source: 'DonorHub',
+        date: '06/21/2021',
+        address: 'test1@test1.com',
+        primary: true,
+      },
+      {
+        source: 'DonorHub',
+        date: '06/21/2021',
+        address: 'test.email@gmail.com',
+        primary: false,
+      },
+      {
+        source: 'MPDX',
+        date: '06/21/2021',
+        address: 'test1@test1.com',
+        primary: false,
+      },
+    ],
+  },
+  {
+    name: 'Simba Lion',
+    id: 'testid2',
+    emails: [
+      {
+        source: 'DonorHub',
+        date: '06/21/2021',
+        address: 'test1@test1.com',
+        primary: true,
+      },
+      {
+        source: 'MPDX',
+        date: '06/22/2021',
+        address: 'test2@test1.com',
+        primary: false,
+      },
+    ],
+  },
+];
+
+export interface ModalState {
+  open: boolean;
+  contactIndex: number;
+  emailIndex: number;
+  emailAddress: string;
+}
+
+const defaultDeleteModalState = {
+  open: false,
+  contactIndex: 0,
+  emailIndex: 0,
+  emailAddress: '',
+};
+
+const FixEmailAddresses: React.FC = () => {
+  const classes = useStyles();
+  const [test, setTest] = useState(testData);
+  const [deleteModalState, setDeleteModalState] = useState<ModalState>(
+    defaultDeleteModalState,
+  );
+  const { t } = useTranslation();
+
+  const toggleData = (): void => {
+    test.length > 0 ? setTest([]) : setTest(testData);
+  };
+
+  const handleDeleteModalOpen = (
+    contactIndex: number,
+    emailIndex: number,
+  ): void => {
+    setDeleteModalState({
+      open: true,
+      contactIndex: contactIndex,
+      emailIndex: emailIndex,
+      emailAddress: test[contactIndex].emails[emailIndex].address,
+    });
+  };
+
+  const handleDeleteModalClose = (): void => {
+    setDeleteModalState(defaultDeleteModalState);
+  };
+
+  const handleChange = (
+    contactIndex: number,
+    emailIndex: number,
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    const temp = [...test];
+    test[contactIndex].emails[emailIndex].address = event.target.value;
+    setTest(temp);
+  };
+
+  const handleDelete = (): void => {
+    const temp = [...test];
+    const wasPrimary = temp[deleteModalState.contactIndex].emails.splice(
+      deleteModalState.emailIndex,
+      1,
+    );
+    wasPrimary[0].primary &&
+      (temp[deleteModalState.contactIndex].emails[0]['primary'] = true); // If the deleted email was primary, set the new first index to primary
+    setTest(temp);
+    handleDeleteModalClose();
+  };
+
+  const handleAdd = (contactIndex: number, address: string): void => {
+    const temp = [...test];
+    temp[contactIndex].emails.push({
+      source: 'MPDX',
+      date: new Date().toLocaleDateString('en-US'),
+      address: address,
+      primary: false,
+    });
+    setTest(temp);
+  };
+
+  const handleChangePrimary = (
+    contactIndex: number,
+    emailIndex: number,
+  ): void => {
+    const temp = [...test];
+    temp[contactIndex].emails = temp[contactIndex].emails.map(
+      (email, index) => ({
+        ...email,
+        primary: index === emailIndex ? true : false,
+      }),
+    );
+    setTest(temp);
+  };
+
+  return (
+    <>
+      <Box className={classes.container}>
+        <Grid container className={classes.outter}>
+          <Grid item xs={12}>
+            <Typography variant="h4">{t('Fix Email Addresses')}</Typography>
+            <Divider className={classes.divider} />
+            <Box className={classes.descriptionBox}>
+              {test.length > 0 && (
+                <>
+                  <Typography>
+                    <strong>
+                      {t('You have {{amount}} email addresses to confirm.', {
+                        amount: test.length,
+                      })}
+                    </strong>
+                  </Typography>
+                  <Typography>
+                    {t(
+                      'Choose below which email address will be set as primary.',
+                    )}
+                  </Typography>
+                </>
+              )}
+              <Button size="small" variant="outlined" onClick={toggleData}>
+                Change Test
+              </Button>
+              <Typography>
+                * Below is test data used for testing the UI. It is not linked
+                to any account ID
+              </Typography>
+            </Box>
+          </Grid>
+          {test.length > 0 ? (
+            <>
+              <Grid item xs={12}>
+                {test.map((contact, index) => (
+                  <Contact
+                    name={contact.name}
+                    key={contact.name}
+                    contactIndex={index}
+                    emails={contact.emails}
+                    handleChange={handleChange}
+                    handleDelete={handleDeleteModalOpen}
+                    handleAdd={handleAdd}
+                    handleChangePrimary={handleChangePrimary}
+                  />
+                ))}
+              </Grid>
+              <Grid item xs={12}>
+                <Box className={classes.footer}>
+                  <Typography>
+                    <Trans
+                      defaults="Showing <bold>{{value}}</bold> of <bold>{{value}}</bold>"
+                      values={{ value: test.length }}
+                      components={{ bold: <strong /> }}
+                    />
+                  </Typography>
+                </Box>
+              </Grid>
+            </>
+          ) : (
+            <NoContacts />
+          )}
+        </Grid>
+        <DeleteModal
+          modalState={deleteModalState}
+          handleClose={handleDeleteModalClose}
+          handleDelete={handleDelete}
+        />
+      </Box>
+    </>
+  );
+};
+
+export default FixEmailAddresses;

--- a/src/components/Tool/FixEmailAddresses/FixEmailAddreses.tsx
+++ b/src/components/Tool/FixEmailAddresses/FixEmailAddreses.tsx
@@ -6,11 +6,15 @@ import {
   Grid,
   Divider,
   Button,
+  NativeSelect,
 } from '@material-ui/core';
 
 import { Trans, useTranslation } from 'react-i18next';
 
+import Icon from '@mdi/react';
+import { mdiCheckboxMarkedCircle } from '@mdi/js';
 import theme from '../../../theme';
+import { StyledInput } from '../FixCommitmentInfo/StyledInput';
 import Contact from './Contact';
 import NoContacts from './NoContacts';
 import DeleteModal from './DeleteModal';
@@ -43,6 +47,41 @@ const useStyles = makeStyles(() => ({
     width: '100%',
     display: 'flex',
     justifyContent: 'center',
+  },
+  buttonBlue: {
+    backgroundColor: theme.palette.mpdxBlue.main,
+    paddingRight: theme.spacing(1.5),
+    color: 'white',
+    [theme.breakpoints.down('xs')]: {
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(2),
+    },
+  },
+  buttonIcon: {
+    marginRight: theme.spacing(1),
+  },
+  defaultBox: {
+    display: 'flex',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    marginTop: theme.spacing(1),
+    [theme.breakpoints.down('xs')]: {
+      flexDirection: 'column',
+      alignItems: 'start',
+    },
+  },
+  nativeSelect: {
+    minWidth: theme.spacing(20),
+    width: '10%',
+    marginLeft: theme.spacing(2),
+    marginRight: theme.spacing(2),
+    [theme.breakpoints.down('xs')]: {
+      marginLeft: theme.spacing(0),
+      marginRight: theme.spacing(0),
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+    },
   },
 }));
 
@@ -110,6 +149,7 @@ const defaultDeleteModalState = {
 const FixEmailAddresses: React.FC = () => {
   const classes = useStyles();
   const [test, setTest] = useState(testData);
+  const [defaultSource, setDefaultSource] = useState('MPDX');
   const [deleteModalState, setDeleteModalState] = useState<ModalState>(
     defaultDeleteModalState,
   );
@@ -159,6 +199,7 @@ const FixEmailAddresses: React.FC = () => {
 
   const handleAdd = (contactIndex: number, address: string): void => {
     const temp = [...test];
+
     temp[contactIndex].emails.push({
       source: 'MPDX',
       date: new Date().toLocaleDateString('en-US'),
@@ -180,6 +221,12 @@ const FixEmailAddresses: React.FC = () => {
       }),
     );
     setTest(temp);
+  };
+
+  const handleSourceChange = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ): void => {
+    setDefaultSource(event.target.value);
   };
 
   return (
@@ -204,6 +251,32 @@ const FixEmailAddresses: React.FC = () => {
                       'Choose below which email address will be set as primary.',
                     )}
                   </Typography>
+                  <Box className={classes.defaultBox}>
+                    <Typography>{t('Default Primary Source:')}</Typography>
+
+                    <NativeSelect
+                      input={<StyledInput />}
+                      className={classes.nativeSelect}
+                      value={defaultSource}
+                      onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+                        handleSourceChange(event)
+                      }
+                    >
+                      <option value="MPDX">MPDX</option>
+                      <option value="DataServer">DataServer</option>
+                    </NativeSelect>
+                    <Button className={classes.buttonBlue}>
+                      <Icon
+                        path={mdiCheckboxMarkedCircle}
+                        size={0.8}
+                        className={classes.buttonIcon}
+                      />
+                      {t('Confirm {{amount}} as {{source}}', {
+                        amount: test.length,
+                        source: defaultSource,
+                      })}
+                    </Button>
+                  </Box>
                 </>
               )}
               <Button size="small" variant="outlined" onClick={toggleData}>

--- a/src/components/Tool/FixEmailAddresses/FixEmailAddresses.test.tsx
+++ b/src/components/Tool/FixEmailAddresses/FixEmailAddresses.test.tsx
@@ -8,7 +8,7 @@ import FixEmailAddresses from './FixEmailAddreses';
 
 describe('FixEmailAddresses-Home', () => {
   it('default with test data', () => {
-    const { getByText } = render(
+    const { getByText, getByTestId } = render(
       <ThemeProvider theme={theme}>
         <TestWrapper>
           <FixEmailAddresses />
@@ -23,6 +23,8 @@ describe('FixEmailAddresses-Home', () => {
     expect(getByText('Confirm 2 as MPDX')).toBeInTheDocument();
     expect(getByText('Test Contact')).toBeInTheDocument();
     expect(getByText('Simba Lion')).toBeInTheDocument();
+    expect(getByTestId('textfield-0-0')).toBeInTheDocument();
+    expect(getByTestId('starIcon-0-0')).toBeInTheDocument();
   });
 
   it('change test data', () => {
@@ -45,5 +47,40 @@ describe('FixEmailAddresses-Home', () => {
         'People with new email addresses or multiple primary email addresses will appear here.',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('change primary of first email', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <FixEmailAddresses />
+        </TestWrapper>
+      </ThemeProvider>,
+    );
+
+    const star1 = getByTestId('starOutlineIcon-0-1');
+    userEvent.click(star1);
+
+    expect(queryByTestId('starIcon-0-0')).not.toBeInTheDocument();
+    expect(getByTestId('starIcon-0-1')).toBeInTheDocument();
+    expect(getByTestId('starOutlineIcon-0-0')).toBeInTheDocument();
+  });
+
+  it('delete third email from first person', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <FixEmailAddresses />
+        </TestWrapper>
+      </ThemeProvider>,
+    );
+
+    const delete02 = getByTestId('delete-0-2');
+    userEvent.click(delete02);
+
+    const deleteButton = getByTestId('emailAddressDeleteButton');
+    userEvent.click(deleteButton);
+
+    expect(queryByTestId('textfield-0-2')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Tool/FixEmailAddresses/FixEmailAddresses.test.tsx
+++ b/src/components/Tool/FixEmailAddresses/FixEmailAddresses.test.tsx
@@ -1,0 +1,49 @@
+import { ThemeProvider } from '@material-ui/core';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../../__tests__/util/testingLibraryReactMock';
+import TestWrapper from '../../../../__tests__/util/TestWrapper';
+import theme from '../../../theme';
+import FixEmailAddresses from './FixEmailAddreses';
+
+describe('FixEmailAddresses-Home', () => {
+  it('default with test data', () => {
+    const { getByText } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <FixEmailAddresses />
+        </TestWrapper>
+      </ThemeProvider>,
+    );
+
+    expect(getByText('Fix Email Addresses')).toBeInTheDocument();
+    expect(
+      getByText('You have 2 email addresses to confirm.'),
+    ).toBeInTheDocument();
+    expect(getByText('Confirm 2 as MPDX')).toBeInTheDocument();
+    expect(getByText('Test Contact')).toBeInTheDocument();
+    expect(getByText('Simba Lion')).toBeInTheDocument();
+  });
+
+  it('change test data', () => {
+    const { getByText, getByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <FixEmailAddresses />
+        </TestWrapper>
+      </ThemeProvider>,
+    );
+
+    const button = getByTestId('changeTestData');
+    userEvent.click(button);
+
+    expect(
+      getByText('No people with email addresses need attention'),
+    ).toBeInTheDocument();
+    expect(
+      getByText(
+        'People with new email addresses or multiple primary email addresses will appear here.',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Tool/FixEmailAddresses/FixEmailAddresses.test.tsx
+++ b/src/components/Tool/FixEmailAddresses/FixEmailAddresses.test.tsx
@@ -123,4 +123,25 @@ describe('FixEmailAddresses-Home', () => {
     expect(queryByTestId('starIcon-1-1')).not.toBeInTheDocument();
     expect(getByTestId('starIcon-1-0')).toBeInTheDocument();
   });
+
+  it('add an email address to first person', () => {
+    const { getByTestId, getByDisplayValue } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <FixEmailAddresses />
+        </TestWrapper>
+      </ThemeProvider>,
+    );
+    expect(getByTestId('starIcon-1-0')).toBeInTheDocument();
+    expect(getByTestId('textfield-1-0')).toBeInTheDocument();
+
+    const textfieldNew1 = getByTestId('addNewEmailInput-1') as HTMLInputElement;
+    userEvent.type(textfieldNew1, 'a@a.com');
+    const addButton1 = getByTestId('addButton-1');
+    userEvent.click(addButton1);
+
+    expect(textfieldNew1.value).toBe('');
+    expect(getByTestId('textfield-1-1')).toBeInTheDocument();
+    expect(getByDisplayValue('a@a.com')).toBeInTheDocument();
+  });
 });

--- a/src/components/Tool/FixEmailAddresses/FixEmailAddresses.test.tsx
+++ b/src/components/Tool/FixEmailAddresses/FixEmailAddresses.test.tsx
@@ -83,4 +83,44 @@ describe('FixEmailAddresses-Home', () => {
 
     expect(queryByTestId('textfield-0-2')).not.toBeInTheDocument();
   });
+
+  it('change third email from first person', () => {
+    const { getByDisplayValue } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <FixEmailAddresses />
+        </TestWrapper>
+      </ThemeProvider>,
+    );
+
+    expect(getByDisplayValue('test2@test1.com')).toBeInTheDocument();
+    const textfield11 = getByDisplayValue(
+      'test2@test1.com',
+    ) as HTMLInputElement;
+    userEvent.type(textfield11, 'a');
+
+    expect(textfield11.value).toBe('test2@test1.coma');
+  });
+
+  it('change second email for second person to primary then delete it', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <FixEmailAddresses />
+        </TestWrapper>
+      </ThemeProvider>,
+    );
+
+    const star11 = getByTestId('starOutlineIcon-1-1');
+    userEvent.click(star11);
+
+    const delete11 = getByTestId('delete-1-1');
+    userEvent.click(delete11);
+
+    const deleteButton = getByTestId('emailAddressDeleteButton');
+    userEvent.click(deleteButton);
+
+    expect(queryByTestId('starIcon-1-1')).not.toBeInTheDocument();
+    expect(getByTestId('starIcon-1-0')).toBeInTheDocument();
+  });
 });

--- a/src/components/Tool/FixEmailAddresses/NoContacts.test.tsx
+++ b/src/components/Tool/FixEmailAddresses/NoContacts.test.tsx
@@ -1,0 +1,27 @@
+import { ThemeProvider } from '@material-ui/core';
+import React from 'react';
+import { render } from '../../../../__tests__/util/testingLibraryReactMock';
+import TestWrapper from '../../../../__tests__/util/TestWrapper';
+import theme from '../../../theme';
+import NoContacts from './NoContacts';
+
+describe('FixEmailAddresses-NoContacts', () => {
+  it('default', () => {
+    const { getByText } = render(
+      <ThemeProvider theme={theme}>
+        <TestWrapper>
+          <NoContacts />
+        </TestWrapper>
+      </ThemeProvider>,
+    );
+
+    expect(
+      getByText('No people with email addresses need attention'),
+    ).toBeInTheDocument();
+    expect(
+      getByText(
+        'People with new email addresses or multiple primary email addresses will appear here.',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Tool/FixEmailAddresses/NoContacts.tsx
+++ b/src/components/Tool/FixEmailAddresses/NoContacts.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Box, Typography, styled } from '@material-ui/core';
+import { mdiEmailOutline } from '@mdi/js';
+import { useTranslation } from 'react-i18next';
+import Icon from '@mdi/react';
+
+const StyledBox = styled(Box)(({ theme }) => ({
+  width: '100%',
+  border: '1px solid',
+  borderColor: theme.palette.cruGrayMedium.main,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  flexDirection: 'column',
+  backgroundColor: theme.palette.cruGrayLight.main,
+  paddingTop: theme.spacing(7),
+  paddingBottom: theme.spacing(7),
+  paddingLeft: theme.spacing(3),
+  paddingRight: theme.spacing(3),
+  textAlign: 'center',
+  boxShadow: `0px 0px 5px ${theme.palette.cruGrayMedium.main} inset`,
+}));
+
+const NoContacts: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <StyledBox>
+      <Icon path={mdiEmailOutline} size={1.5} />
+      <Typography variant="h5">
+        {t('No people with email addresses need attention')}
+      </Typography>
+      <Typography>
+        {t(
+          'People with new email addresses or multiple primary email addresses will appear here.',
+        )}
+      </Typography>
+    </StyledBox>
+  );
+};
+
+export default NoContacts;


### PR DESCRIPTION
- Removed side bar
- Looks similar to fixing mailing addresses but there is some functionality, adding an new email, deleting one and changing primary, the incoming data is stored in the component state, then mutations update the state. When the user clicks confirm, a gql mutation will be made so it should work in the future without too much tweaking.
- Very similar to the fix phone numbers so will wait for this one to get approved first

![image](https://user-images.githubusercontent.com/16872059/131945801-8e20b52c-e700-42b2-a2f9-e686f85d689a.png)
![image](https://user-images.githubusercontent.com/16872059/131943461-5d7dab7b-578c-4ca6-abdf-1c63284a57cb.png)
![image](https://user-images.githubusercontent.com/16872059/131945810-e93efb72-f630-4440-b7d2-9a41ba371473.png)

Adding emails and changing primary:
![image](https://user-images.githubusercontent.com/16872059/131943503-8e41d5ef-6ad1-45ab-8986-c78e76911937.png)

Mobile View:
![image](https://user-images.githubusercontent.com/16872059/131943571-3881c79b-69d2-414d-8742-d3d24e92b75b.png)

