### PR TITLE
removed sidebar, decreased content width and centered it

### DIFF
--- a/pages/accountLists/[accountListId]/tools/appeals.page.tsx
+++ b/pages/accountLists/[accountListId]/tools/appeals.page.tsx
@@ -1,17 +1,15 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import Head from 'next/head';
 import {
   makeStyles,
   Theme,
   Grid,
-  Container,
   Box,
   Typography,
   Divider,
 } from '@material-ui/core';
 import { motion } from 'framer-motion';
-import NavToolDrawer from '../../../../src/components/Tool/NavToolList/NavToolDrawer';
 import Appeals from '../../../../src/components/Tool/Appeal/Appeals';
 
 import AddAppealForm from '../../../../src/components/Tool/Appeal/AddAppealForm';
@@ -19,24 +17,23 @@ import AddAppealForm from '../../../../src/components/Tool/Appeal/AddAppealForm'
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
     padding: theme.spacing(3),
-    marginRight: theme.spacing(2),
+    width: '70%',
     display: 'flex',
     [theme.breakpoints.down('lg')]: {
-      paddingLeft: theme.spacing(4),
-      marginRight: theme.spacing(3),
+      width: '90%',
     },
     [theme.breakpoints.down('md')]: {
-      paddingLeft: theme.spacing(5),
-      marginRight: theme.spacing(2),
+      width: '70%',
     },
     [theme.breakpoints.down('sm')]: {
-      paddingLeft: theme.spacing(6),
+      width: '100%',
     },
   },
   outer: {
     display: 'flex',
     flexDirection: 'row',
-    minWidth: '100vw',
+    justifyContent: 'center',
+    width: '100%',
   },
   loadingIndicator: {
     margin: theme.spacing(0, 1, 0, 0),
@@ -45,12 +42,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 const AppealsPage = (): ReactElement => {
   const { t } = useTranslation();
-  const [isNavListOpen, setNavListOpen] = useState<boolean>(true);
   const classes = useStyles();
-
-  const handleNavListToggle = () => {
-    setNavListOpen(!isNavListOpen);
-  };
 
   const variants = {
     animate: {
@@ -77,47 +69,34 @@ const AppealsPage = (): ReactElement => {
         variants={variants}
       >
         <Box className={classes.outer}>
-          <NavToolDrawer
-            open={isNavListOpen}
-            toggle={handleNavListToggle}
-            selectedId={'appeals'}
-          />
-          <Container
-            className={classes.container}
-            style={{
-              minWidth: isNavListOpen ? 'calc(97.5vw - 290px)' : '97.5vw',
-              transition: 'min-width 0.15s linear',
-            }}
-          >
-            <Grid container spacing={3}>
-              <Grid item xs={12}>
-                <Box m={1}>
-                  <Typography variant="h4">{t('Appeals')}</Typography>
-                </Box>
-                <Divider />
-                <Box m={1}>
-                  <Typography variant="body2">
-                    {t(
-                      'You can track recurring support goals or special need ' +
-                        'support goals through our appeals wizard. Track the ' +
-                        'recurring support you raise for an increase ask for example, ' +
-                        'or special gifts you raise for a summer mission trip or your ' +
-                        'new staff special gift goal.',
-                    )}
-                  </Typography>
-                </Box>
-              </Grid>
-
-              <Grid item xs={12} sm={12} md={6}>
-                <Appeals />
-              </Grid>
-              <Grid item xs={12} sm={12} md={6}>
-                <Box>
-                  <AddAppealForm />
-                </Box>
-              </Grid>
+          <Grid container spacing={3} className={classes.container}>
+            <Grid item xs={12}>
+              <Box m={1}>
+                <Typography variant="h4">{t('Appeals')}</Typography>
+              </Box>
+              <Divider />
+              <Box m={1}>
+                <Typography variant="body2">
+                  {t(
+                    'You can track recurring support goals or special need ' +
+                      'support goals through our appeals wizard. Track the ' +
+                      'recurring support you raise for an increase ask for example, ' +
+                      'or special gifts you raise for a summer mission trip or your ' +
+                      'new staff special gift goal.',
+                  )}
+                </Typography>
+              </Box>
             </Grid>
-          </Container>
+
+            <Grid item xs={12} sm={12} lg={6}>
+              <Appeals />
+            </Grid>
+            <Grid item xs={12} sm={12} lg={6}>
+              <Box>
+                <AddAppealForm />
+              </Box>
+            </Grid>
+          </Grid>
         </Box>
       </motion.div>
     </>

--- a/src/components/Tool/Appeal/AddAppealForm.tsx
+++ b/src/components/Tool/Appeal/AddAppealForm.tsx
@@ -66,12 +66,8 @@ const AddAppealForm = (): ReactElement => {
               <Typography variant="h6">Name</Typography>
               <TextField
                 variant="outlined"
+                size="small"
                 className={classes.input}
-                inputProps={{
-                  style: {
-                    padding: 10,
-                  },
-                }}
               />
             </Box>
             <Box mt={1} mb={1}>
@@ -82,8 +78,9 @@ const AddAppealForm = (): ReactElement => {
                     flexDirection="column"
                     justifyContent="start"
                   >
-                    <Typography variant="h6">Initial Goal</Typography>
+                    <Typography>Initial Goal</Typography>
                     <TextField
+                      size="small"
                       variant="outlined"
                       className={classes.input}
                       inputProps={{
@@ -112,8 +109,9 @@ const AddAppealForm = (): ReactElement => {
                     flexDirection="column"
                     justifyContent="start"
                   >
-                    <Typography variant="h6">Letter Cost</Typography>
+                    <Typography>Letter Cost</Typography>
                     <TextField
+                      size="small"
                       variant="outlined"
                       className={classes.input}
                       inputProps={{
@@ -142,9 +140,10 @@ const AddAppealForm = (): ReactElement => {
                     flexDirection="column"
                     justifyContent="start"
                   >
-                    <Typography variant="h6">Admin %</Typography>
+                    <Typography>Admin %</Typography>
                     <TextField
                       variant="outlined"
+                      size="small"
                       className={classes.input}
                       inputProps={{
                         style: {
@@ -172,10 +171,11 @@ const AddAppealForm = (): ReactElement => {
                     flexDirection="column"
                     justifyContent="start"
                   >
-                    <Typography variant="h6">Goal</Typography>
+                    <Typography>Goal</Typography>
                     <TextField
                       variant="outlined"
                       className={classes.input}
+                      size="small"
                       inputProps={{
                         style: {
                           padding: 10,

--- a/src/components/Tool/FixCommitmentInfo/FixCommitmentInfo.tsx
+++ b/src/components/Tool/FixCommitmentInfo/FixCommitmentInfo.tsx
@@ -1,33 +1,23 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   makeStyles,
   Theme,
-  Container,
   Box,
   Typography,
   Grid,
   Divider,
 } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
-import NavToolDrawer from '../NavToolList/NavToolDrawer';
 import Contact from './Contact';
 import NoContacts from './NoContacts';
 
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
     padding: theme.spacing(3),
-    marginRight: theme.spacing(2),
+    width: '70%',
     display: 'flex',
-    [theme.breakpoints.down('lg')]: {
-      paddingLeft: theme.spacing(5),
-      marginRight: theme.spacing(2),
-    },
-    [theme.breakpoints.down('md')]: {
-      paddingLeft: theme.spacing(5),
-      marginRight: theme.spacing(2),
-    },
     [theme.breakpoints.down('sm')]: {
-      paddingLeft: theme.spacing(6),
+      width: '100%',
     },
   },
   toolIcon: {
@@ -38,7 +28,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   outer: {
     display: 'flex',
     flexDirection: 'row',
-    minWidth: '100vw',
+    justifyContent: 'center',
+    width: '100%',
   },
   divider: {
     marginTop: theme.spacing(2),
@@ -57,11 +48,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 const FixCommitmentInfo: React.FC = () => {
   const classes = useStyles();
-  const [isNavListOpen, setNavListOpen] = useState<boolean>(true);
   const { t } = useTranslation();
-  const handleNavListToggle = () => {
-    setNavListOpen(!isNavListOpen);
-  };
 
   const testData = [
     {
@@ -80,71 +67,58 @@ const FixCommitmentInfo: React.FC = () => {
   return (
     <>
       <Box className={classes.outer} data-testid="Home">
-        <NavToolDrawer
-          open={isNavListOpen}
-          toggle={handleNavListToggle}
-          selectedId="fixCommitmentInfo"
-        />
-        <Container
-          className={classes.container}
-          style={{
-            minWidth: isNavListOpen ? 'calc(97.5vw - 290px)' : '97.5vw',
-            transition: 'min-width 0.15s linear',
-          }}
-        >
-          <Grid container>
-            <Grid item xs={12}>
-              <Typography variant="h4">{t('Fix Commitment Info')}</Typography>
-              <Divider className={classes.divider} />
-              <Box className={classes.descriptionBox}>
-                <Typography>
-                  <strong>
-                    {t('You have {{amount}} partner statuses to confirm.', {
-                      amount: testData.length,
-                    })}
-                  </strong>
-                </Typography>
-                <Typography>
-                  {t(
-                    'MPDX has assigned partnership statuses and giving frequencies ' +
-                      'based on your partner’s giving history. MPDX has made its best ' +
-                      'attempt at matching the appropriate statuses for you. However, ' +
-                      'you will need to confirm them to be sure MPDX’s matching was ' +
-                      'accurate.',
-                  )}
-                </Typography>
-              </Box>
-            </Grid>
-            {testData.length > 0 ? (
-              <>
-                <Grid item xs={12}>
-                  {testData.map((contact) => (
-                    <Contact
-                      name={contact.name}
-                      key={contact.name}
-                      tagTitle={contact.tagTitle}
-                      tagValue={contact.tagValue}
-                      amount={contact.amount}
-                      amountCurrency={contact.amountCurrency}
-                      frequencyTitle={contact.frequencyTitle}
-                      frequencyValue={contact.frequencyValue}
-                    />
-                  ))}
-                </Grid>
-                <Grid item xs={12}>
-                  <Box className={classes.footer}>
-                    <Typography>
-                      Showing <strong>{testData.length}</strong> of{' '}
-                      <strong>{testData.length}</strong>
-                    </Typography>
-                  </Box>
-                </Grid>
-              </>
-            ) : (
-              <NoContacts />
-            )}
+        <Grid container className={classes.container}>
+          <Grid item xs={12}>
+            <Typography variant="h4">{t('Fix Commitment Info')}</Typography>
+            <Divider className={classes.divider} />
+            <Box className={classes.descriptionBox}>
+              <Typography>
+                <strong>
+                  {t('You have {{amount}} partner statuses to confirm.', {
+                    amount: testData.length,
+                  })}
+                </strong>
+              </Typography>
+              <Typography>
+                {t(
+                  'MPDX has assigned partnership statuses and giving frequencies ' +
+                    'based on your partner’s giving history. MPDX has made its best ' +
+                    'attempt at matching the appropriate statuses for you. However, ' +
+                    'you will need to confirm them to be sure MPDX’s matching was ' +
+                    'accurate.',
+                )}
+              </Typography>
+            </Box>
           </Grid>
-        </Container>
+          {testData.length > 0 ? (
+            <>
+              <Grid item xs={12}>
+                {testData.map((contact) => (
+                  <Contact
+                    name={contact.name}
+                    key={contact.name}
+                    tagTitle={contact.tagTitle}
+                    tagValue={contact.tagValue}
+                    amount={contact.amount}
+                    amountCurrency={contact.amountCurrency}
+                    frequencyTitle={contact.frequencyTitle}
+                    frequencyValue={contact.frequencyValue}
+                  />
+                ))}
+              </Grid>
+              <Grid item xs={12}>
+                <Box className={classes.footer}>
+                  <Typography>
+                    Showing <strong>{testData.length}</strong> of{' '}
+                    <strong>{testData.length}</strong>
+                  </Typography>
+                </Box>
+              </Grid>
+            </>
+          ) : (
+            <NoContacts />
+          )}
+        </Grid>
       </Box>
     </>
   );

--- a/src/components/Tool/FixMailingAddresses/Contact.tsx
+++ b/src/components/Tool/FixMailingAddresses/Contact.tsx
@@ -19,7 +19,7 @@ import { emptyAddress } from './FixMailingAddresses';
 
 const useStyles = makeStyles(() => ({
   left: {
-    [theme.breakpoints.up('md')]: {
+    [theme.breakpoints.up('lg')]: {
       border: `1px solid ${theme.palette.cruGrayMedium.main}`,
     },
   },
@@ -27,27 +27,34 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     alignItems: 'center',
     marginBottom: theme.spacing(2),
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('md')]: {
       border: `1px solid ${theme.palette.cruGrayMedium.main}`,
     },
   },
   boxBottom: {
     backgroundColor: theme.palette.cruGrayLight.main,
     width: '100%',
-    [theme.breakpoints.down('xs')]: {
+    [theme.breakpoints.down('sm')]: {
       paddingTop: theme.spacing(2),
     },
   },
   buttonTop: {
-    margin: theme.spacing(1),
-    [theme.breakpoints.down('sm')]: {
-      marginRight: theme.spacing(2),
-      marginTop: theme.spacing(2),
-      marginBottom: theme.spacing(2),
+    padding: theme.spacing(1),
+    [theme.breakpoints.down('md')]: {
+      display: 'flex',
+      justifyContent: 'center',
+      padding: theme.spacing(2),
     },
     '& .MuiButton-root': {
       backgroundColor: theme.palette.mpdxBlue.main,
+      width: '100%',
       color: 'white',
+      [theme.breakpoints.down('md')]: {
+        width: '50%',
+      },
+      [theme.breakpoints.down('xs')]: {
+        width: '100%',
+      },
     },
   },
   buttonIcon: {
@@ -55,7 +62,7 @@ const useStyles = makeStyles(() => ({
   },
   rowChangeResponsive: {
     flexDirection: 'column',
-    [theme.breakpoints.down('xs')]: {
+    [theme.breakpoints.down('sm')]: {
       marginTop: -20,
       flexDirection: 'row',
       justifyContent: 'space-between',
@@ -63,7 +70,7 @@ const useStyles = makeStyles(() => ({
     },
   },
   responsiveBorder: {
-    [theme.breakpoints.down('xs')]: {
+    [theme.breakpoints.down('sm')]: {
       paddingBottom: theme.spacing(2),
       borderBottom: `1px solid ${theme.palette.cruGrayMedium.main}`,
     },
@@ -127,7 +134,7 @@ const Contact: React.FC<Props> = ({ title, tag, addresses, openFunction }) => {
   return (
     <Grid container className={classes.container}>
       <Grid container>
-        <Grid item md={10} xs={12}>
+        <Grid item lg={10} xs={12}>
           <Box display="flex" alignItems="center" className={classes.left}>
             <Grid container>
               <Grid item xs={12}>
@@ -147,8 +154,8 @@ const Contact: React.FC<Props> = ({ title, tag, addresses, openFunction }) => {
 
               <Grid item xs={12} className={classes.boxBottom}>
                 <Grid container>
-                  <Hidden xsDown>
-                    <Grid item xs={12} sm={6} className={classes.paddingY}>
+                  <Hidden smDown>
+                    <Grid item xs={12} md={6} className={classes.paddingY}>
                       <Box
                         display="flex"
                         justifyContent="space-between"
@@ -162,7 +169,7 @@ const Contact: React.FC<Props> = ({ title, tag, addresses, openFunction }) => {
                         </Typography>
                       </Box>
                     </Grid>
-                    <Grid item xs={12} sm={6} className={classes.paddingY}>
+                    <Grid item xs={12} md={6} className={classes.paddingY}>
                       <Box
                         display="flex"
                         justifyContent="flex-start"
@@ -176,14 +183,14 @@ const Contact: React.FC<Props> = ({ title, tag, addresses, openFunction }) => {
                   </Hidden>
                   {addresses.map((address) => (
                     <Fragment key={address.street}>
-                      <Grid item xs={12} sm={6} className={classes.paddingB2}>
+                      <Grid item xs={12} md={6} className={classes.paddingB2}>
                         <Box
                           display="flex"
                           justifyContent="space-between"
                           className={classes.paddingX}
                         >
                           <Box>
-                            <Hidden smUp>
+                            <Hidden mdUp>
                               <Typography display="inline">
                                 <strong>{t('Source')}: </strong>
                               </Typography>
@@ -203,7 +210,7 @@ const Contact: React.FC<Props> = ({ title, tag, addresses, openFunction }) => {
                           </Typography>
                         </Box>
                       </Grid>
-                      <Grid item xs={12} sm={6} className={classes.paddingB2}>
+                      <Grid item xs={12} md={6} className={classes.paddingB2}>
                         <Box
                           display="flex"
                           justifyContent="flex-start"
@@ -234,14 +241,14 @@ const Contact: React.FC<Props> = ({ title, tag, addresses, openFunction }) => {
                       </Grid>
                     </Fragment>
                   ))}
-                  <Grid item xs={12} sm={6} className={classes.paddingB2}>
+                  <Grid item xs={12} md={6} className={classes.paddingB2}>
                     <Box
                       display="flex"
                       justifyContent="space-between"
                       className={classes.paddingX}
                     >
                       <Box>
-                        <Hidden smUp>
+                        <Hidden mdUp>
                           <Typography display="inline">
                             <strong>{t('Source')}: </strong>
                           </Typography>
@@ -250,7 +257,7 @@ const Contact: React.FC<Props> = ({ title, tag, addresses, openFunction }) => {
                       </Box>
                     </Box>
                   </Grid>
-                  <Grid item xs={12} sm={6} className={classes.paddingB2}>
+                  <Grid item xs={12} md={6} className={classes.paddingB2}>
                     <Box
                       display="flex"
                       justifyContent="flex-start"
@@ -272,14 +279,14 @@ const Contact: React.FC<Props> = ({ title, tag, addresses, openFunction }) => {
             </Grid>
           </Box>
         </Grid>
-        <Grid item xs={12} md={2}>
+        <Grid item xs={12} lg={2}>
           <Box
             display="flex"
             flexDirection="column"
             style={{ paddingLeft: theme.spacing(1) }}
           >
             <Box className={classes.buttonTop}>
-              <Button variant="contained" style={{ width: '100%' }}>
+              <Button variant="contained">
                 <Icon
                   path={mdiCheckboxMarkedCircle}
                   size={0.8}

--- a/src/components/Tool/FixMailingAddresses/FixMailingAddresses.tsx
+++ b/src/components/Tool/FixMailingAddresses/FixMailingAddresses.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import {
   makeStyles,
-  Container,
   Box,
   Typography,
   Grid,
@@ -11,7 +10,6 @@ import {
 
 import { Trans, useTranslation } from 'react-i18next';
 
-import NavToolDrawer from '../NavToolList/NavToolDrawer';
 import theme from '../../../theme';
 import Contact, { address } from './Contact';
 import NoContacts from './NoContacts';
@@ -21,24 +19,17 @@ import AddressModal from './AddressModal';
 const useStyles = makeStyles(() => ({
   container: {
     padding: theme.spacing(3),
-    marginRight: theme.spacing(1),
+    width: '70%',
     display: 'flex',
-    [theme.breakpoints.down('lg')]: {
-      paddingLeft: theme.spacing(5),
-      marginRight: theme.spacing(2),
-    },
-    [theme.breakpoints.down('md')]: {
-      paddingLeft: theme.spacing(5),
-      marginRight: theme.spacing(2),
-    },
     [theme.breakpoints.down('sm')]: {
-      paddingLeft: theme.spacing(6),
+      width: '100%',
     },
   },
   outer: {
     display: 'flex',
     flexDirection: 'row',
-    minWidth: '100vw',
+    justifyContent: 'center',
+    width: '100%',
   },
   divider: {
     marginTop: theme.spacing(2),
@@ -113,16 +104,12 @@ export const emptyAddress: address = {
 
 const FixSendNewsletter: React.FC = () => {
   const classes = useStyles();
-  const [isNavListOpen, setNavListOpen] = useState<boolean>(true);
   const [modalState, setModalState] = useState({
     open: false,
     address: emptyAddress,
   });
   const [test, setTest] = useState(testData);
   const { t } = useTranslation();
-  const handleNavListToggle = () => {
-    setNavListOpen(!isNavListOpen);
-  };
 
   const toggleData = (): void => {
     test.length > 0 ? setTest([]) : setTest(testData);
@@ -160,80 +147,70 @@ const FixSendNewsletter: React.FC = () => {
   return (
     <>
       <Box className={classes.outer} data-testid="Home">
-        <NavToolDrawer
-          open={isNavListOpen}
-          toggle={handleNavListToggle}
-          selectedId="fixMailingAddresses"
-        />
-        <Container
-          className={classes.container}
-          style={{
-            minWidth: isNavListOpen ? 'calc(97.5vw - 290px)' : '97.5vw',
-            transition: 'min-width 0.15s linear',
-          }}
-        >
-          <Grid container>
-            <Grid item xs={12}>
-              <Typography variant="h4">{t('Fix Mailing Addresses')}</Typography>
-              <Divider className={classes.divider} />
-              <Box className={classes.descriptionBox}>
-                {test.length > 0 && (
-                  <>
-                    <Typography>
-                      <strong>
-                        {t(
-                          'You have {{amount}} mailing addresses to confirm.',
-                          { amount: test.length },
-                        )}
-                      </strong>
-                    </Typography>
-                    <Typography>
-                      {t(
-                        'Choose below which mailing address will be set as primary. Primary mailing addresses will be used for Newsletter exports.',
-                      )}
-                    </Typography>
-                  </>
-                )}
-                <Button size="small" variant="outlined" onClick={toggleData}>
-                  Change Test
-                </Button>
-              </Box>
-            </Grid>
-            {test.length > 0 ? (
-              <>
-                <Grid item xs={12}>
-                  {test.map((contact) => (
-                    <Contact
-                      title={contact.title}
-                      tag={contact.tag}
-                      key={contact.title}
-                      addresses={contact.addresses}
-                      openFunction={handleOpen}
-                    />
-                  ))}
-                </Grid>
-                <Grid item xs={12}>
-                  <Box className={classes.footer}>
-                    <Typography>
-                      <Trans
-                        defaults="Showing <bold>{{value}}</bold> of <bold>{{value}}</bold>"
-                        values={{ value: test.length }}
-                        components={{ bold: <strong /> }}
-                      />
-                    </Typography>
-                  </Box>
-                </Grid>
-              </>
-            ) : (
-              <NoContacts />
-            )}
+        <Grid container className={classes.container}>
+          <Grid item xs={12}>
+            <Typography variant="h4">{t('Fix Mailing Addresses')}</Typography>
+            <Divider className={classes.divider} />
+            <Box className={classes.descriptionBox}>
+              {test.length > 0 && (
+                <>
+                  <Typography>
+                    <strong>
+                      {t('You have {{amount}} mailing addresses to confirm.', {
+                        amount: test.length,
+                      })}
+                    </strong>
+                  </Typography>
+                  <Typography>
+                    {t(
+                      'Choose below which mailing address will be set as primary. Primary mailing addresses will be used for Newsletter exports.',
+                    )}
+                  </Typography>
+                </>
+              )}
+              <Button size="small" variant="outlined" onClick={toggleData}>
+                Change Test
+              </Button>
+              <Typography>
+                * Below is test data used for testing the UI. It is not linked
+                to any account ID
+              </Typography>
+            </Box>
           </Grid>
-          <AddressModal
-            modalState={modalState}
-            handleClose={handleClose}
-            handleChange={handleChange}
-          />
-        </Container>
+          {test.length > 0 ? (
+            <>
+              <Grid item xs={12}>
+                {test.map((contact) => (
+                  <Contact
+                    title={contact.title}
+                    tag={contact.tag}
+                    key={contact.title}
+                    addresses={contact.addresses}
+                    openFunction={handleOpen}
+                  />
+                ))}
+              </Grid>
+              <Grid item xs={12}>
+                <Box className={classes.footer}>
+                  <Typography>
+                    <Trans
+                      defaults="Showing <bold>{{value}}</bold> of <bold>{{value}}</bold>"
+                      values={{ value: test.length }}
+                      components={{ bold: <strong /> }}
+                    />
+                  </Typography>
+                </Box>
+              </Grid>
+            </>
+          ) : (
+            <NoContacts />
+          )}
+        </Grid>
+        <AddressModal
+          modalState={modalState}
+          handleClose={handleClose}
+          handleChange={handleChange}
+        />
       </Box>
     </>
   );

--- a/src/components/Tool/FixMailingAddresses/FixMailingAddresses.tsx
+++ b/src/components/Tool/FixMailingAddresses/FixMailingAddresses.tsx
@@ -169,11 +169,12 @@ const FixSendNewsletter: React.FC = () => {
                 </>
               )}
               <Button size="small" variant="outlined" onClick={toggleData}>
-                Change Test
+                {t('Change Test')}
               </Button>
               <Typography>
-                * Below is test data used for testing the UI. It is not linked
-                to any account ID
+                {t(
+                  '* Below is test data used for testing the UI. It is not linked to any account ID',
+                )}
               </Typography>
             </Box>
           </Grid>

--- a/src/components/Tool/FixSendNewsletter/Contact.tsx
+++ b/src/components/Tool/FixSendNewsletter/Contact.tsx
@@ -16,7 +16,7 @@ import { StyledInput } from './StyledInput';
 
 const useStyles = makeStyles(() => ({
   left: {
-    [theme.breakpoints.up('md')]: {
+    [theme.breakpoints.up('lg')]: {
       border: `1px solid ${theme.palette.cruGrayMedium.main}`,
     },
   },
@@ -24,7 +24,7 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     alignItems: 'center',
     marginBottom: theme.spacing(2),
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('md')]: {
       border: `1px solid ${theme.palette.cruGrayMedium.main}`,
     },
   },
@@ -33,15 +33,22 @@ const useStyles = makeStyles(() => ({
     width: '100%',
   },
   buttonTop: {
-    margin: theme.spacing(1),
-    [theme.breakpoints.down('sm')]: {
-      marginRight: theme.spacing(2),
-      marginTop: theme.spacing(2),
-      marginBottom: theme.spacing(2),
+    padding: theme.spacing(1),
+    [theme.breakpoints.down('md')]: {
+      display: 'flex',
+      justifyContent: 'center',
+      padding: theme.spacing(2),
     },
     '& .MuiButton-root': {
       backgroundColor: theme.palette.mpdxBlue.main,
+      width: '100%',
       color: 'white',
+      [theme.breakpoints.down('md')]: {
+        width: '50%',
+      },
+      [theme.breakpoints.down('xs')]: {
+        width: '100%',
+      },
     },
   },
   buttonIcon: {
@@ -57,7 +64,7 @@ const useStyles = makeStyles(() => ({
     },
   },
   newsletterInput: {
-    width: '75%',
+    width: '100%',
     [theme.breakpoints.down('xs')]: {
       width: '50%',
     },
@@ -104,7 +111,7 @@ const Contact = ({
   return (
     <Grid container className={classes.container}>
       <Grid container>
-        <Grid item md={10} xs={12}>
+        <Grid item lg={10} xs={12}>
           <Box display="flex" alignItems="center" className={classes.left}>
             <Grid container>
               <Grid item xs={12} sm={8} md={9}>
@@ -204,14 +211,14 @@ const Contact = ({
             </Grid>
           </Box>
         </Grid>
-        <Grid item xs={12} md={2}>
+        <Grid item xs={12} lg={2}>
           <Box
             display="flex"
             flexDirection="column"
             style={{ paddingLeft: theme.spacing(1) }}
           >
             <Box className={classes.buttonTop}>
-              <Button variant="contained" style={{ width: '100%' }}>
+              <Button variant="contained">
                 <Icon
                   path={mdiCheckboxMarkedCircle}
                   size={0.8}

--- a/src/components/Tool/FixSendNewsletter/FixSendNewsletter.tsx
+++ b/src/components/Tool/FixSendNewsletter/FixSendNewsletter.tsx
@@ -7,7 +7,7 @@ import {
   Divider,
   Button,
 } from '@material-ui/core';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import theme from '../../../theme';
 import Contact from './Contact';
 import NoContacts from './NoContacts';
@@ -83,7 +83,12 @@ const FixSendNewsletter = (): ReactElement => {
                 <>
                   <Typography>
                     <strong>
-                      You have {testData.length} newsletter status to confirm.
+                      {t(
+                        'You have {{amount}} newsletter statuses to confirm.',
+                        {
+                          amount: test.length,
+                        },
+                      )}
                     </strong>
                   </Typography>
                   <Typography>
@@ -94,7 +99,7 @@ const FixSendNewsletter = (): ReactElement => {
                 </>
               )}
               <Button size="small" variant="outlined" onClick={toggleData}>
-                Change Test
+                {t('Change Test')}
               </Button>
             </Box>
           </Grid>
@@ -116,8 +121,11 @@ const FixSendNewsletter = (): ReactElement => {
               <Grid item xs={12}>
                 <Box className={classes.footer}>
                   <Typography>
-                    Showing <strong>{test.length}</strong> of{' '}
-                    <strong>{test.length}</strong>
+                    <Trans
+                      defaults="Showing <bold>{{value}}</bold> of <bold>{{value}}</bold>"
+                      values={{ value: test.length }}
+                      components={{ bold: <strong /> }}
+                    />
                   </Typography>
                 </Box>
               </Grid>

--- a/src/components/Tool/FixSendNewsletter/FixSendNewsletter.tsx
+++ b/src/components/Tool/FixSendNewsletter/FixSendNewsletter.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 import {
   makeStyles,
-  Container,
   Box,
   Typography,
   Grid,
@@ -9,7 +8,6 @@ import {
   Button,
 } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
-import NavToolDrawer from '../NavToolList/NavToolDrawer';
 import theme from '../../../theme';
 import Contact from './Contact';
 import NoContacts from './NoContacts';
@@ -17,24 +15,17 @@ import NoContacts from './NoContacts';
 const useStyles = makeStyles(() => ({
   container: {
     padding: theme.spacing(3),
-    marginRight: theme.spacing(1),
+    width: '70%',
     display: 'flex',
-    [theme.breakpoints.down('lg')]: {
-      paddingLeft: theme.spacing(5),
-      marginRight: theme.spacing(2),
-    },
-    [theme.breakpoints.down('md')]: {
-      paddingLeft: theme.spacing(5),
-      marginRight: theme.spacing(2),
-    },
     [theme.breakpoints.down('sm')]: {
-      paddingLeft: theme.spacing(6),
+      width: '100%',
     },
   },
   outer: {
     display: 'flex',
     flexDirection: 'row',
-    minWidth: '100vw',
+    width: '100%',
+    justifyContent: 'center',
   },
   divider: {
     marginTop: theme.spacing(2),
@@ -71,12 +62,8 @@ const testData = [
 
 const FixSendNewsletter = (): ReactElement => {
   const classes = useStyles();
-  const [isNavListOpen, setNavListOpen] = useState<boolean>(true);
   const [test, setTest] = useState(testData);
   const { t } = useTranslation();
-  const handleNavListToggle = () => {
-    setNavListOpen(!isNavListOpen);
-  };
 
   const toggleData = (): void => {
     test.length > 0 ? setTest([]) : setTest(testData);
@@ -87,71 +74,58 @@ const FixSendNewsletter = (): ReactElement => {
   return (
     <>
       <Box className={classes.outer} data-testid="Home">
-        <NavToolDrawer
-          open={isNavListOpen}
-          toggle={handleNavListToggle}
-          selectedId="fixSendNewsletter"
-        />
-        <Container
-          className={classes.container}
-          style={{
-            minWidth: isNavListOpen ? 'calc(97.5vw - 290px)' : '97.5vw',
-            transition: 'min-width 0.15s linear',
-          }}
-        >
-          <Grid container>
-            <Grid item xs={12}>
-              <Typography variant="h4">{t('Fix Send Newsletter')}</Typography>
-              <Divider className={classes.divider} />
-              <Box className={classes.descriptionBox}>
-                {test.length > 0 && (
-                  <>
-                    <Typography>
-                      <strong>
-                        You have {testData.length} newsletter status to confirm.
-                      </strong>
-                    </Typography>
-                    <Typography>
-                      {t(
-                        'Contacts that appear here have an empty Newsletter Status and Partner Status set to Financial, Special, or Pray. Choose a newsletter status for contacts below.',
-                      )}
-                    </Typography>
-                  </>
-                )}
-                <Button size="small" variant="outlined" onClick={toggleData}>
-                  Change Test
-                </Button>
-              </Box>
-            </Grid>
-            {test.length > 0 ? (
-              <>
-                <Grid item xs={12}>
-                  {test.map((contact) => (
-                    <Contact
-                      title={contact.title}
-                      tag={contact.tag}
-                      name={contact.name || ''}
-                      key={contact.title}
-                      address={contact.address || { street: '', city: '' }}
-                      email={contact.email || ''}
-                      newsletterType={contact.newsletterType}
-                    />
-                  ))}
-                </Grid>
-                <Grid item xs={12}>
-                  <Box className={classes.footer}>
-                    <Typography>
-                      Showing <strong>{test.length}</strong> of{' '}
-                      <strong>{test.length}</strong>
-                    </Typography>
-                  </Box>
-                </Grid>
-              </>
-            ) : (
-              <NoContacts />
-            )}
+        <Grid container className={classes.container}>
+          <Grid item xs={12}>
+            <Typography variant="h4">{t('Fix Send Newsletter')}</Typography>
+            <Divider className={classes.divider} />
+            <Box className={classes.descriptionBox}>
+              {test.length > 0 && (
+                <>
+                  <Typography>
+                    <strong>
+                      You have {testData.length} newsletter status to confirm.
+                    </strong>
+                  </Typography>
+                  <Typography>
+                    {t(
+                      'Contacts that appear here have an empty Newsletter Status and Partner Status set to Financial, Special, or Pray. Choose a newsletter status for contacts below.',
+                    )}
+                  </Typography>
+                </>
+              )}
+              <Button size="small" variant="outlined" onClick={toggleData}>
+                Change Test
+              </Button>
+            </Box>
           </Grid>
-        </Container>
+          {test.length > 0 ? (
+            <>
+              <Grid item xs={12}>
+                {test.map((contact) => (
+                  <Contact
+                    title={contact.title}
+                    tag={contact.tag}
+                    name={contact.name || ''}
+                    key={contact.title}
+                    address={contact.address || { street: '', city: '' }}
+                    email={contact.email || ''}
+                    newsletterType={contact.newsletterType}
+                  />
+                ))}
+              </Grid>
+              <Grid item xs={12}>
+                <Box className={classes.footer}>
+                  <Typography>
+                    Showing <strong>{test.length}</strong> of{' '}
+                    <strong>{test.length}</strong>
+                  </Typography>
+                </Box>
+              </Grid>
+            </>
+          ) : (
+            <NoContacts />
+          )}
+        </Grid>
       </Box>
     </>
   );

--- a/src/components/Tool/Home/Home.tsx
+++ b/src/components/Tool/Home/Home.tsx
@@ -1,26 +1,17 @@
-import React, { ReactElement, useState } from 'react';
-import { makeStyles, Theme, Grid, Container, Box } from '@material-ui/core';
+import React, { ReactElement } from 'react';
+import { makeStyles, Theme, Grid, Box } from '@material-ui/core';
 import { motion } from 'framer-motion';
 
-import NavToolDrawer from '../NavToolList/NavToolDrawer';
 import Tool from './Tool';
 import { ToolsList } from './ToolList';
 
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
     padding: theme.spacing(3),
-    marginRight: theme.spacing(2),
+    width: '70%',
     display: 'flex',
-    [theme.breakpoints.down('lg')]: {
-      paddingLeft: theme.spacing(5),
-      marginRight: theme.spacing(2),
-    },
-    [theme.breakpoints.down('md')]: {
-      paddingLeft: theme.spacing(5),
-      marginRight: theme.spacing(2),
-    },
     [theme.breakpoints.down('sm')]: {
-      paddingLeft: theme.spacing(6),
+      width: '100%',
     },
   },
   toolIcon: {
@@ -31,7 +22,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   outer: {
     display: 'flex',
     flexDirection: 'row',
-    minWidth: '100vw',
+    width: '100%',
+    justifyContent: 'center',
   },
 }));
 
@@ -50,12 +42,7 @@ const variants = {
 
 const ToolHome = (): ReactElement => {
   const classes = useStyles();
-  const [isNavListOpen, setNavListOpen] = useState<boolean>(false);
   const toolsListFlattened = ToolsList.flatMap((tool) => tool.items);
-
-  const handleNavListToggle = () => {
-    setNavListOpen(!isNavListOpen);
-  };
 
   return (
     <motion.div
@@ -65,29 +52,20 @@ const ToolHome = (): ReactElement => {
       variants={variants}
     >
       <Box className={classes.outer} data-testid="Home">
-        <NavToolDrawer open={isNavListOpen} toggle={handleNavListToggle} />
-        <Container
-          className={classes.container}
-          style={{
-            minWidth: isNavListOpen ? 'calc(97.5vw - 290px)' : '97.5vw',
-            transition: 'min-width 0.15s linear',
-          }}
-        >
-          <Grid container spacing={3}>
-            {toolsListFlattened.map((tool) => {
-              return (
-                <Grid item xs={12} sm={6} md={4} lg={4} key={tool.tool}>
-                  <Tool
-                    tool={tool.tool}
-                    desc={tool.desc}
-                    icon={tool.icon}
-                    id={tool.id}
-                  />
-                </Grid>
-              );
-            })}
-          </Grid>
-        </Container>
+        <Grid container spacing={3} className={classes.container}>
+          {toolsListFlattened.map((tool) => {
+            return (
+              <Grid item xs={12} sm={6} lg={4} key={tool.tool}>
+                <Tool
+                  tool={tool.tool}
+                  desc={tool.desc}
+                  icon={tool.icon}
+                  id={tool.id}
+                />
+              </Grid>
+            );
+          })}
+        </Grid>
       </Box>
     </motion.div>
   );

--- a/src/components/Tool/Home/Tool.tsx
+++ b/src/components/Tool/Home/Tool.tsx
@@ -36,10 +36,10 @@ const useStyles = makeStyles(() => ({
     height: '200px',
   },
   iconBG: {
-    padding: '10px',
+    padding: theme.spacing(2),
     borderRadius: '50%',
-    height: '80px',
-    width: '80px',
+    height: theme.spacing(8),
+    width: theme.spacing(8),
     backgroundColor: 'white',
   },
 }));
@@ -69,7 +69,7 @@ const Tool = ({ tool, desc, icon, id }: Props): ReactElement => {
               justifyContent="center"
               alignItems="center"
             >
-              <Icon path={icon} size={1.5} />
+              <Icon path={icon} size={3} />
             </Box>
             <Typography variant="h6">{tool}</Typography>
             <Typography variant="body2">{desc}</Typography>


### PR DESCRIPTION
Removed the sidebar for the tools pages, except the appeal details page, I think we should discuss more for this page because it feels nice being able to toggle between the views without having to click on the top bar.

Also fixed some of the responsiveness for some of the tools pages

![image](https://user-images.githubusercontent.com/16872059/132055263-c3fdf1e8-bdf2-448d-811c-ba4d39f09011.png)
![image](https://user-images.githubusercontent.com/16872059/132055275-51a1409b-6de4-461a-b215-fe94669b2452.png)
![image](https://user-images.githubusercontent.com/16872059/132055283-5d0a6b2d-df35-4912-9fd2-e647061e963b.png)
