### PR TITLE
MPDX-7121-Add-Ability-To-Edit-ReferredBy-In-Edit-Partnership-Modal

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDontationsTab/ContactDonationsTab.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDontationsTab/ContactDonationsTab.graphql
@@ -54,7 +54,9 @@ fragment ContactDonorAccounts on Contact {
   }
   contactReferralsToMe {
     nodes {
+      id
       referredBy {
+        id
         name
       }
     }

--- a/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.graphql
@@ -14,6 +14,27 @@ mutation UpdateContactPartnership(
       pledgeStartDate
       nextAsk
       noAppeals
+      contactReferralsToMe {
+        nodes {
+          id
+          referredBy {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+}
+
+query GetDataForPartnershipInfoModal(
+  $accountListId: ID!
+  $contactsFilter: ContactFilterSetInput
+) {
+  contacts(accountListId: $accountListId, contactsFilter: $contactsFilter) {
+    nodes {
+      id
+      name
     }
   }
 }

--- a/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.test.tsx
@@ -76,7 +76,6 @@ describe('EditPartnershipInfoModal', () => {
               <EditPartnershipInfoModal
                 contact={contactMock}
                 handleClose={handleClose}
-                isOpen={true}
               />
             </GqlMockedProvider>
           </ThemeProvider>
@@ -97,7 +96,6 @@ describe('EditPartnershipInfoModal', () => {
               <EditPartnershipInfoModal
                 contact={contactMock}
                 handleClose={handleClose}
-                isOpen={true}
               />
             </GqlMockedProvider>
           </ThemeProvider>
@@ -119,7 +117,6 @@ describe('EditPartnershipInfoModal', () => {
               <EditPartnershipInfoModal
                 contact={contactMock}
                 handleClose={handleClose}
-                isOpen={true}
               />
             </GqlMockedProvider>
           </ThemeProvider>
@@ -141,7 +138,6 @@ describe('EditPartnershipInfoModal', () => {
               <EditPartnershipInfoModal
                 contact={contactMock}
                 handleClose={handleClose}
-                isOpen={true}
               />
             </GqlMockedProvider>
           </ThemeProvider>
@@ -190,7 +186,6 @@ describe('EditPartnershipInfoModal', () => {
               <EditPartnershipInfoModal
                 contact={contactMock}
                 handleClose={handleClose}
-                isOpen={true}
               />
             </GqlMockedProvider>
           </ThemeProvider>
@@ -235,7 +230,6 @@ describe('EditPartnershipInfoModal', () => {
               <EditPartnershipInfoModal
                 contact={contactMock}
                 handleClose={handleClose}
-                isOpen={true}
               />
             </GqlMockedProvider>
           </ThemeProvider>
@@ -271,7 +265,6 @@ describe('EditPartnershipInfoModal', () => {
               <EditPartnershipInfoModal
                 contact={contactMock}
                 handleClose={handleClose}
-                isOpen={true}
               />
             </GqlMockedProvider>
           </ThemeProvider>
@@ -328,13 +321,13 @@ describe('EditPartnershipInfoModal', () => {
               <EditPartnershipInfoModal
                 contact={contactMock}
                 handleClose={handleClose}
-                isOpen={true}
               />
             </GqlMockedProvider>
           </ThemeProvider>
         </MuiPickersUtilsProvider>
       </SnackbarProvider>,
     );
+    await waitFor(() => expect(getByLabelText('Currency')).toBeInTheDocument());
     const currencyInput = getByLabelText('Currency');
 
     userEvent.click(currencyInput);
@@ -381,7 +374,6 @@ describe('EditPartnershipInfoModal', () => {
               <EditPartnershipInfoModal
                 contact={contactMock}
                 handleClose={handleClose}
-                isOpen={true}
               />
             </GqlMockedProvider>
           </ThemeProvider>
@@ -437,7 +429,6 @@ describe('EditPartnershipInfoModal', () => {
               <EditPartnershipInfoModal
                 contact={contactMock}
                 handleClose={handleClose}
-                isOpen={true}
               />
             </GqlMockedProvider>
           </ThemeProvider>

--- a/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.test.tsx
@@ -55,6 +55,10 @@ const contactMock = gqlMock<ContactDonorAccountsFragment>(
   },
 );
 
+const contactMockNoReferrals: ContactDonorAccountsFragment = {
+  ...contactMock,
+  contactReferralsToMe: { nodes: [] },
+};
 jest.mock('next/router', () => ({
   useRouter: () => {
     return {
@@ -498,6 +502,36 @@ describe('EditPartnershipInfoModal', () => {
       ),
     );
     expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('should handle editing the referred by | No Contacts or Referrals', async () => {
+    const { getByLabelText, getByText } = render(
+      <SnackbarProvider>
+        <MuiPickersUtilsProvider utils={LuxonUtils}>
+          <ThemeProvider theme={theme}>
+            <GqlMockedProvider<UpdateContactPartnershipMutation>
+              mocks={{
+                GetDataForPartnershipInfoModal: {
+                  contacts: {
+                    nodes: [],
+                  },
+                },
+              }}
+            >
+              <EditPartnershipInfoModal
+                contact={contactMockNoReferrals}
+                handleClose={handleClose}
+              />
+            </GqlMockedProvider>
+          </ThemeProvider>
+        </MuiPickersUtilsProvider>
+      </SnackbarProvider>,
+    );
+
+    const referredByInput = getByLabelText('Referred By');
+    await waitFor(() => expect(referredByInput).toBeInTheDocument());
+    userEvent.click(referredByInput);
+    expect(getByText('No options')).toBeInTheDocument();
   });
 
   it('should handle editing next ask date', async () => {

--- a/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
@@ -333,6 +333,23 @@ export const EditPartnershipInfoModal: React.FC<EditPartnershipInfoModalProps> =
                     onChange={(e) =>
                       updateStatus(e.target.value as StatusEnum, setFieldValue)
                     }
+                    MenuProps={{
+                      anchorOrigin: {
+                        vertical: 'bottom',
+                        horizontal: 'left',
+                      },
+                      transformOrigin: {
+                        vertical: 'top',
+                        horizontal: 'left',
+                      },
+                      getContentAnchorEl: null,
+                      PaperProps: {
+                        style: {
+                          maxHeight: '300px',
+                          overflow: 'auto',
+                        },
+                      },
+                    }}
                   >
                     {Object.values(StatusEnum).map((value) => (
                       <MenuItem key={value} value={value}>

--- a/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/PartnershipInfo.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/PartnershipInfo.tsx
@@ -222,9 +222,8 @@ export const PartnershipInfo: React.FC<PartnershipInfoProp> = ({ contact }) => {
           {t('Add Account')}
         </AddAccountButton>
       </IconAndTextContainerCenter>
-      {contact ? (
+      {contact && editPartnershipModalOpen ? (
         <EditPartnershipInfoModal
-          isOpen={editPartnershipModalOpen}
           handleClose={() => setEditPartnershipModalOpen(false)}
           contact={contact}
         />


### PR DESCRIPTION
This was a bit complicated to work on, more so than I initially thought lol. What's complicated is that you have to persist the data as the user searches for new contacts, as the data is continually changing because of the auto-complete component. And then if they decide to delete a contact referral that was already created, I had to figure out a way to remove it from the UI, but still persist it as it's not truly removed until ```destroyed``` is set to ```true``` and is sent to the api. There's just a lot of moving parts and pieces. Feel free to try it out and make sure it works. I tried to cover all the scenarios but maybe I missed something 🙂 I'll be adding tests in a separate commit as I wanted others to take an initial look at the logic for this.