### PR TITLE
Enable Apollo assumeImmutableResults

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -55,6 +55,7 @@ if (process.browser && process.env.NODE_ENV === 'production') {
 const client = new ApolloClient({
   link: errorLink.concat(httpLink),
   cache,
+  assumeImmutableResults: true,
   defaultOptions: {
     watchQuery: {
       notifyOnNetworkStatusChange: true,
@@ -77,6 +78,7 @@ export const ssrClient = (
   return new ApolloClient({
     link: errorLink.concat(httpLink),
     ssrMode: true,
+    assumeImmutableResults: true,
     cache: new InMemoryCache({
       possibleTypes: generatedIntrospection.possibleTypes,
     }),


### PR DESCRIPTION
- `assumeImmutableResults` is still false by default but `freezeResults` has been defaulted to true by Apollo 3.0
- https://www.apollographql.com/blog/announcement/previewing-the-apollo-client-3-cache-565fadd6a01e/#additional-cache-improvements
- https://www.apollographql.com/blog/announcement/frontend/whats-new-in-apollo-client-2-6/#enforcing-immutability
- `assumeImmutableResults` is still `false` by default https://github.com/apollographql/apollo-client/blob/d3a74ec87cee2b9819a7bb5f2be605c14857aa28/src/core/ApolloClient.ts#L158