### PR TITLE
Tools notificattion limit

### DIFF
--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
@@ -298,13 +298,5 @@ describe('NavMenu', () => {
       expect(getByTestId('notificationTotal')).toBeInTheDocument(),
     );
     expect(getByTestId('notificationTotalText')).toHaveTextContent('9+');
-    userEvent.click(getByTestId('ToolsMenuToggle'));
-    expect(getByTestId('fixCommitmentInfo-false').firstChild).toHaveStyle(
-      'color: #383F43;',
-    );
-    expect(getByTestId('fixCommitmentInfo-false').children[1]).toHaveStyle(
-      'color: #383F43;',
-    );
-    expect(getByTestId('fixCommitmentInfo-notifications')).toBeInTheDocument();
   });
 });

--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
@@ -265,4 +265,46 @@ describe('NavMenu', () => {
     );
     expect(getByTestId('fixCommitmentInfo-notifications')).toBeInTheDocument();
   });
+
+  it('test notifications > 10', async () => {
+    const { getByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<GetToolNotificationsQuery>
+            mocks={{
+              GetToolNotifications: {
+                contacts: {
+                  totalCount: 3,
+                },
+                people: {
+                  totalCount: 3,
+                },
+                contactDuplicates: {
+                  totalCount: 3,
+                },
+                personDuplicates: {
+                  totalCount: 3,
+                },
+              },
+            }}
+          >
+            <NavMenu />
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(getByTestId('notificationTotal')).toBeInTheDocument(),
+    );
+    expect(getByTestId('notificationTotalText')).toHaveTextContent('9+');
+    userEvent.click(getByTestId('ToolsMenuToggle'));
+    expect(getByTestId('fixCommitmentInfo-false').firstChild).toHaveStyle(
+      'color: #383F43;',
+    );
+    expect(getByTestId('fixCommitmentInfo-false').children[1]).toHaveStyle(
+      'color: #383F43;',
+    );
+    expect(getByTestId('fixCommitmentInfo-notifications')).toBeInTheDocument();
+  });
 });

--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.tsx
@@ -267,7 +267,7 @@ const NavMenu = (): ReactElement => {
                   data-testid="notificationTotal"
                 >
                   <Typography data-testid="notificationTotalText">
-                    {sum}
+                    {sum < 10 ? sum : '9+'}
                   </Typography>
                 </Box>
               )}
@@ -349,7 +349,9 @@ const NavMenu = (): ReactElement => {
                                         data-testid={`${tool.id}-notifications`}
                                       >
                                         <Typography>
-                                          {toolData[tool.id].totalCount}
+                                          {toolData[tool.id].totalCount < 10
+                                            ? toolData[tool.id].totalCount
+                                            : '9+'}
                                         </Typography>
                                       </Box>
                                     )}


### PR DESCRIPTION
Added limit to the notifications to 9. If there is more than 9 it will show 9+ (like in the original app)