### PR TITLE
MPDX-7152-Contact-and-Tasks-Show-Featured-Filters

### DIFF
--- a/src/components/Contacts/ContactFilters/ContactFilters.mocks.ts
+++ b/src/components/Contacts/ContactFilters/ContactFilters.mocks.ts
@@ -1,8 +1,8 @@
 import { GraphQLError } from 'graphql';
 import {
-  CheckboxFilter,
   DaterangeFilter,
   MultiselectFilter,
+  TextFilter,
 } from '../../../../graphql/types.generated';
 
 const mockDateRangeFilter: DaterangeFilter = {
@@ -12,26 +12,44 @@ const mockDateRangeFilter: DaterangeFilter = {
   title: 'Date Range',
   options: [],
 };
-const mockMultiselectFilter: MultiselectFilter = {
+const mockMultiselectFilterNonFeatured: MultiselectFilter = {
+  __typename: 'MultiselectFilter',
+  featured: false,
+  filterKey: 'multiselect',
+  title: 'MultiSelect',
+  options: [
+    { name: 'Option3', value: 'option3' },
+    { name: 'Option4', value: 'option4' },
+  ],
+};
+const mockMultiselectFilterFeatured: MultiselectFilter = {
   __typename: 'MultiselectFilter',
   featured: true,
   filterKey: 'multiselect',
   title: 'MultiSelect',
+  options: [
+    { name: 'Option1', value: 'option1' },
+    { name: 'Option2', value: 'option2' },
+  ],
 };
-const mockCheckboxFilter: CheckboxFilter = {
-  __typename: 'CheckboxFilter',
+const mockTextilter: TextFilter = {
+  __typename: 'TextFilter',
   featured: false,
-  filterKey: 'checkbox',
-  title: 'Checkbox',
+  filterKey: 'text',
+  title: 'Text',
+  options: [],
 };
 
 export const ContactFiltersDefaultMock = {
   accountList: {
     contactFilterGroups: [
-      { name: 'Group 1', filters: [mockCheckboxFilter] },
+      {
+        name: 'Group 1',
+        filters: [mockTextilter, mockMultiselectFilterNonFeatured],
+      },
       {
         name: 'Group 2',
-        filters: [mockMultiselectFilter, mockDateRangeFilter],
+        filters: [mockMultiselectFilterFeatured, mockDateRangeFilter],
       },
     ],
   },

--- a/src/components/Contacts/ContactFilters/ContactFilters.mocks.ts
+++ b/src/components/Contacts/ContactFilters/ContactFilters.mocks.ts
@@ -14,15 +14,15 @@ const mockDateRangeFilter: DaterangeFilter = {
 };
 const mockMultiselectFilter: MultiselectFilter = {
   __typename: 'MultiselectFilter',
-  featured: false,
-  filterKey: 'daterange',
-  title: 'Date Range',
+  featured: true,
+  filterKey: 'multiselect',
+  title: 'MultiSelect',
 };
 const mockCheckboxFilter: CheckboxFilter = {
   __typename: 'CheckboxFilter',
   featured: false,
-  filterKey: 'daterange',
-  title: 'Date Range',
+  filterKey: 'checkbox',
+  title: 'Checkbox',
 };
 
 export const ContactFiltersDefaultMock = {

--- a/src/components/Contacts/ContactFilters/ContactFilters.test.tsx
+++ b/src/components/Contacts/ContactFilters/ContactFilters.test.tsx
@@ -32,6 +32,12 @@ describe('ContactFilters', () => {
     expect(queryAllByTestId('FilterGroup').length).toEqual(2);
     expect(getByTestId('FilterListItemShowAll')).toBeVisible();
 
+    expect(
+      getByText(
+        ContactFiltersDefaultMock.accountList.contactFilterGroups[1].name,
+      ),
+    ).toBeVisible();
+
     expect(getByText('See More Filters')).toBeVisible();
 
     userEvent.click(getByTestId('FilterListItemShowAll'));
@@ -42,6 +48,24 @@ describe('ContactFilters', () => {
         ContactFiltersDefaultMock.accountList.contactFilterGroups[0].name,
       ),
     ).toBeVisible();
+    expect(
+      getByText(
+        ContactFiltersDefaultMock.accountList.contactFilterGroups[1].name,
+      ),
+    ).toBeVisible();
+
+    userEvent.click(getByTestId('FilterListItemShowAll'));
+
+    expect(getByText('See More Filters')).toBeVisible();
+
+    await waitFor(() =>
+      expect(
+        getByText(
+          ContactFiltersDefaultMock.accountList.contactFilterGroups[0].name,
+        ),
+      ).not.toBeVisible(),
+    );
+
     expect(
       getByText(
         ContactFiltersDefaultMock.accountList.contactFilterGroups[1].name,

--- a/src/components/Contacts/ContactFilters/ContactFilters.test.tsx
+++ b/src/components/Contacts/ContactFilters/ContactFilters.test.tsx
@@ -129,6 +129,45 @@ describe('ContactFilters', () => {
     expect(getByText('Group 1 (1)')).toBeVisible();
   });
 
+  it('clears filters', async () => {
+    const { getByTestId, getByText, queryByTestId, queryAllByTestId } = render(
+      <MuiPickersUtilsProvider utils={LuxonUtils}>
+        <GqlMockedProvider<ContactFiltersQuery>
+          mocks={{ ContactFilters: ContactFiltersDefaultMock }}
+        >
+          <ContactFilters
+            accountListId={accountListId}
+            onClose={() => {}}
+            onSelectedFiltersChanged={() => {}}
+          />
+        </GqlMockedProvider>
+      </MuiPickersUtilsProvider>,
+    );
+
+    await waitFor(() => expect(queryByTestId('LoadingState')).toBeNull());
+    expect(queryByTestId('LoadingState')).toBeNull();
+    expect(queryByTestId('ErrorState')).toBeNull();
+
+    expect(queryAllByTestId('FilterGroup').length).toEqual(2);
+    expect(getByTestId('FilterListItemShowAll')).toBeVisible();
+    userEvent.click(getByTestId('FilterListItemShowAll'));
+    userEvent.click(
+      getByText(
+        ContactFiltersDefaultMock.accountList.contactFilterGroups[0].name,
+      ),
+    );
+
+    userEvent.click(queryAllByTestId('CheckboxIcon')[0]);
+
+    await waitFor(() => userEvent.click(getByTestId('CloseFilterGroupButton')));
+
+    expect(getByText('Group 1 (1)')).toBeVisible();
+
+    userEvent.click(getByText('Clear All'));
+    expect(getByText('Group 1')).toBeVisible();
+    expect(getByText('Filter')).toBeVisible();
+  });
+
   it('no filters', async () => {
     const { queryByTestId, queryAllByTestId } = render(
       <GqlMockedProvider<ContactFiltersQuery>

--- a/src/components/Contacts/ContactFilters/ContactFilters.tsx
+++ b/src/components/Contacts/ContactFilters/ContactFilters.tsx
@@ -237,6 +237,7 @@ export const ContactFilters: React.FC<Props & BoxProps> = ({
           <div>
             <FilterHeader>
               <IconButton
+                data-testid="CloseFilterGroupButton"
                 size="small"
                 edge="start"
                 onClick={() => setSelectedGroup(undefined)}


### PR DESCRIPTION
I did a couple of different things in this pr:

1. Add logic to show featured filters and hide the rest in the "See more filters" section.
<img width="290" alt="Screen Shot 2021-10-01 at 11 31 01 AM" src="https://user-images.githubusercontent.com/39680460/135647227-fa4c0d8b-3192-431e-aef6-b2a1e317431e.png">

2. Fixed some logic that was causing selected filters not to show up outside of the "See more filters" section.
<img width="287" alt="Screen Shot 2021-10-01 at 11 32 48 AM" src="https://user-images.githubusercontent.com/39680460/135647479-5afa5d81-61e1-4001-939e-074fa7ab74bc.png">

3. Added logic to show the number of selected options per filter.
<img width="311" alt="Screen Shot 2021-10-01 at 11 30 30 AM" src="https://user-images.githubusercontent.com/39680460/135647341-5716c4b9-a2dc-46a1-9ae1-f2c270b8c4e3.png">

4. Fixed the clear all logic as it wasn't updating the filters and results correctly.

I'm not sure if the currently featured filters are the ones that are actually wanted. I didn't see those specified in Figma, but maybe I missed it 🤷‍♂️