### PR TITLE
Change Apollo fetchPolicy to cache-and-network

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -58,6 +58,7 @@ const client = new ApolloClient({
   assumeImmutableResults: true,
   defaultOptions: {
     watchQuery: {
+      fetchPolicy: 'cache-and-network',
       notifyOnNetworkStatusChange: true,
     },
   },


### PR DESCRIPTION
https://www.apollographql.com/docs/react/data/queries/#supported-fetch-policies

Chris ran into an issue where a query for the tools nav menu was stored in the cache. When the actual tools page loaded, no query was sent. I'm a little confused why it still went to the cache even though there were fields missing and should have sent a network request for the missing fields.

I think this will be a better default in general, especially with a persisted cache on production and is what we had in missionhub-react-native. Guess I assumed this was already setup.