### PR TITLE
Fix-AccountListId-Graphql-Error-AccounLists-Page

### DIFF
--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.tsx
@@ -96,6 +96,7 @@ const NavMenu = (): ReactElement => {
   const currentToolId = useCurrentToolId();
   const { data, loading } = useGetToolNotificationsQuery({
     variables: { accountListId: accountListId ?? '' },
+    skip: !accountListId,
   });
 
   const toolData: { [key: string]: { totalCount: number } } = {


### PR DESCRIPTION
So I've been noticing this error recently so I decided to take a look and see what the cause was. This only shows up on the ```Accounts Lists``` page and based on the error message I figured somewhere a query was running that needed an ```accountListId```

<img width="312" alt="Screen Shot 2021-10-25 at 2 43 53 PM" src="https://user-images.githubusercontent.com/39680460/138752275-b3e181d8-e4ec-45b3-8775-e5eab598682b.png">

After looking in some console logs:

<img width="324" alt="Screen Shot 2021-10-25 at 2 41 00 PM" src="https://user-images.githubusercontent.com/39680460/138752451-75a782e9-ca82-4274-bd4b-38c67d835110.png">
I finally tracked down the query. So now we will skip it until they have selected an account.

