### PR TITLE
Update codecov config to use GitHub Actions uploader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,6 @@ jobs:
         chunk: ${{ fromJson(needs.split-tests.outputs['test-chunk-ids']) }}
     steps:
       - uses: actions/checkout@v2
-        with:
-          # Help Codecov detect commit SHA
-          fetch-depth: 2
       - uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -60,7 +57,10 @@ jobs:
         env:
           CHUNKS: ${{ needs.split-tests.outputs['test-chunks'] }}
       - name: Codecov
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   eslint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Use private repo secret

Apparently due to pending licencing decisions from legal regarding providing MPDX to other organizations, this repo was made private. Apparently we might be able to make it public again later... Makes no sense to me but it broke Codecov. But it's a good excuse to upgrade to the new codecov uploader.