### PR TITLE
MPDX-7214-Fix-Infinite-Scroll-on-Tasks-Page

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -26,6 +26,7 @@ export const cache = new InMemoryCache({
     Query: {
       fields: {
         contacts: paginationFieldPolicy,
+        tasks: paginationFieldPolicy,
         userNotifications: paginationFieldPolicy,
       },
     },


### PR DESCRIPTION
@CSimbulan noticed that infinite scroll wasn't working on the tasks page. After digging into it, I figured out that the cache wasn't properly getting updated once the first ```endReached``` was called, so it was never called again after. I remembered something about pagination, nodes, and the cache which led me to https://github.com/CruGlobal/mpdx-react/blob/b4cfffbdaca7db27ff6ca651345f2fd9d6a4947e/src/lib/client.ts#L23-L33 where I noticed ```tasks``` was missing. After adding it, everything works as expected.