### PR TITLE
Contact-Flow-Drag-Fix

### DIFF
--- a/src/components/Contacts/ContactFlow/ContactFlowColumn/ContactFlowColumn.tsx
+++ b/src/components/Contacts/ContactFlow/ContactFlowColumn/ContactFlowColumn.tsx
@@ -129,7 +129,6 @@ export const ContactFlowColumn: React.FC<Props> = ({
               height="100%"
               top={0}
               right={0}
-              zIndex={canDrop ? 1 : 0}
               display={canDrop ? 'grid' : 'none'}
               gridTemplateRows={`repeat(${statuses.length},auto)`}
             >

--- a/src/components/Contacts/ContactFlow/ContactFlowDropZone/ContactFlowDropZone.tsx
+++ b/src/components/Contacts/ContactFlow/ContactFlowDropZone/ContactFlowDropZone.tsx
@@ -48,6 +48,7 @@ export const ContactFlowDropZone: React.FC<Props> = ({
           : `3px solid ${theme.palette.cruGrayMedium.main}`,
         height: '100%',
         width: '100%',
+        zIndex: canDrop ? 1 : 0,
         color: canDrop
           ? theme.palette.common.white
           : theme.palette.cruGrayDark.main,
@@ -60,7 +61,7 @@ export const ContactFlowDropZone: React.FC<Props> = ({
       justifyContent="center"
       alignItems="center"
     >
-      <Typography variant="h5">
+      <Typography variant="h5" align="center">
         {t('{{status}}', { status: status.value })}
       </Typography>
     </Box>

--- a/src/components/Contacts/ContactFlow/ContactFlowRow/ContactFlowRow.tsx
+++ b/src/components/Contacts/ContactFlow/ContactFlowRow/ContactFlowRow.tsx
@@ -62,7 +62,7 @@ export const ContactFlowRow: React.FC<Props> = ({
   onContactSelected,
   columnWidth,
 }: Props) => {
-  const [, drag, preview] = useDrag(() => ({
+  const [{ isDragging }, drag, preview] = useDrag(() => ({
     type: 'contact',
     item: {
       id,
@@ -87,6 +87,8 @@ export const ContactFlowRow: React.FC<Props> = ({
       width="100%"
       style={{
         background: 'white',
+        zIndex: isDragging ? 3 : 0,
+        opacity: isDragging ? 0 : 1,
       }}
     >
       <DraggableBox>


### PR DESCRIPTION
Got a fix for this figured out. Moving the ```zIndex={canDrop ? 1 : 0}``` to the ```ContactFlowDropZone``` worked to a degree. But for columns that have multiple split-up drop zones, if a draggable element was currently occupying a drop zone for a different status, the same issue would occur(not being able to drag). So I just raised the z-index to be even higher than the dropzone, IF that element is currently being dragged. And this worked but had a minor issue.
<img width="1680" alt="Screen Shot 2022-02-16 at 10 00 50 AM" src="https://user-images.githubusercontent.com/39680460/154293847-9d43cea4-cd56-4677-ae22-b9f072f81fa8.png">

The element would visually cover the draggable zone it was currently in since it was technically a higher zindex. To fix this, I just made it have an opacity of ```0``` if it's being dragged because we have the preview item that we are dragging around. It feels a bit hacky but works well.

<img width="1319" alt="Screen Shot 2022-02-16 at 10 01 10 AM" src="https://user-images.githubusercontent.com/39680460/154294841-b1f6b18b-b922-41d0-baa5-bf82ca137a5f.png">

Let me know what you guys think of this and if there's anything I may have missed with the changes I made 🙂 