### PR TITLE
MPDX-7260-Apollo-Batch-HTTP-Link

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -4,6 +4,7 @@ import {
   InMemoryCache,
   NormalizedCacheObject,
 } from '@apollo/client';
+import { BatchHttpLink } from '@apollo/client/link/batch-http';
 import { onError } from '@apollo/client/link/error';
 import { persistCache, LocalStorageWrapper } from 'apollo3-cache-persist';
 import fetch from 'isomorphic-fetch';
@@ -33,8 +34,11 @@ export const cache = new InMemoryCache({
   },
 });
 
-const httpLink = createHttpLink({
+const httpLink = new BatchHttpLink({
   uri: `${process.env.SITE_URL}/api/graphql`,
+  batchMax: 25,
+  batchDebounce: true,
+  batchInterval: 20,
   fetch,
 });
 


### PR DESCRIPTION
This was actually way simpler to get up and running than I was anticipating! I tested it with the create multiple contacts modal, where at the moment we are firing one mutation per new contact. But with this new setup, all these requests get bundled into one graphql operation and therefore one request!
<img width="740" alt="Screen Shot 2022-03-04 at 10 41 47 AM" src="https://user-images.githubusercontent.com/39680460/156794054-e1025082-5cd3-4aa7-b949-ff63e0a64805.png">

as opposed to multiple requests
<img width="753" alt="Screen Shot 2022-03-04 at 10 38 23 AM" src="https://user-images.githubusercontent.com/39680460/156793519-79ee49cf-4183-4a7b-b988-8e541740129c.png">
