### PR TITLE
MPDX-7352 Flows Setup Duplicate Statuses

### DIFF
--- a/pages/accountLists/[accountListId]/contacts/flows/setup.page.tsx
+++ b/pages/accountLists/[accountListId]/contacts/flows/setup.page.tsx
@@ -134,6 +134,7 @@ const ContactFlowSetupPage: React.FC = () => {
       temp[destinationIndex].statuses.push(draggedStatus);
     }
     updateOptions(temp);
+    setFlowOptions(temp);
   };
 
   const changeTitle = (


### PR DESCRIPTION
[Jira](https://jira.cru.org/browse/MPDX-7352)

The columns were getting updated through the mutation and the cache was being rewritten, but the local state was not updated, causing buggy behavior such as duplicate statuses.