### PR TITLE
MPDX-7375 - Make Save & Clear All options in the Filter pane more prominent

### DIFF
--- a/src/components/Shared/Filters/FilterListItemShowAll.tsx
+++ b/src/components/Shared/Filters/FilterListItemShowAll.tsx
@@ -1,4 +1,4 @@
-import { ListItem, ListItemText } from '@material-ui/core';
+import { ListItem, ListItemText, useTheme } from '@material-ui/core';
 import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +13,7 @@ export const FilterListItemShowAll: React.FC<Props> = ({
   onToggle,
 }: Props) => {
   const { t } = useTranslation();
+  const theme = useTheme();
 
   return (
     <ListItem button onClick={onToggle} data-testid="FilterListItemShowAll">
@@ -21,12 +22,12 @@ export const FilterListItemShowAll: React.FC<Props> = ({
         primaryTypographyProps={{
           variant: 'subtitle1',
         }}
-        style={{ color: '#2196F3' }}
+        style={{ color: theme.palette.info.main }}
       />
       {showAll ? (
-        <ExpandLess style={{ color: '#2196F3' }} />
+        <ExpandLess style={{ color: theme.palette.info.main }} />
       ) : (
-        <ExpandMore style={{ color: '#2196F3' }} />
+        <ExpandMore style={{ color: theme.palette.info.main }} />
       )}
     </ListItem>
   );

--- a/src/components/Shared/Filters/FilterPanel.tsx
+++ b/src/components/Shared/Filters/FilterPanel.tsx
@@ -65,11 +65,11 @@ const FilterList = styled(List)(({ theme }) => ({
   },
 }));
 
-const LinkButton = styled(Button)(() => ({
+const LinkButton = styled(Button)(({ theme }) => ({
   minWidth: 0,
   textTransform: 'none',
   fontSize: 16,
-  color: '#2196F3',
+  color: theme.palette.info.main,
   fontWeight: 'bold',
 }));
 


### PR DESCRIPTION
https://jira.cru.org/browse/MPDX-7375

The buttons were grayed out when there wasn't an active filter which makes sense for an inactive state. When they were active, they turned to the darker, primary blue color set by the theme. Per Scott's request, using the Figma design for reference, I increased the font-size from 14px to 16px, made them bold, and changed the active blue color to #2196F3 from the designs.

I also changed the color of the "See More/Less Filters" button to the same brighter blue as shown in Figma to match the buttons above.