### PR TITLE
Specify Node.js version from 16.x to 16.16.0 on README due to ERR_LOADER_CHAIN_INCOMPLETE error on v16.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MPDX
 
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/zeit/next.js/tree/canary/packages/create-next-app).
-The project uses node version 16.x.
+The project uses node version 16.16.0.
 
 ## Environments
 


### PR DESCRIPTION
Specify Node.js version from 16.x to 16.16.0 on README due to ERR_LOADER_CHAIN_INCOMPLETE error on v16.17.0