### PR TITLE
Remove unused GOOGLE_GEOCODE_API_KEY env var from next config file.

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -53,7 +53,6 @@ module.exports = withPlugins([
       OKTA_CLIENT_SECRET: process.env.OKTA_CLIENT_SECRET,
       OKTA_ISSUER: process.env.OKTA_ISSUER ?? 'https://signon.okta.com',
       GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY,
-      GOOGLE_GEOCODE_API_KEY: process.env.GOOGLE_GEOCODE_API_KEY,
       ROLLBAR_ACCESS_TOKEN: process.env.ROLLBAR_ACCESS_TOKEN,
       ONESKY_API_SECRET: process.env.ONESKY_API_SECRET,
       ONESKY_API_KEY: process.env.ONESKY_API_KEY,


### PR DESCRIPTION
Remove unused GOOGLE_GEOCODE_API_KEY env var from the next config file.