### PR TITLE
Fix contact filter select label

### DIFF
--- a/src/components/Shared/Filters/FilterListItemSelect.tsx
+++ b/src/components/Shared/Filters/FilterListItemSelect.tsx
@@ -24,6 +24,7 @@ export const FilterListItemSelect: React.FC<Props> = ({
       <FormControl style={{ flex: 'auto' }}>
         <InputLabel>{filter.title}</InputLabel>
         <Select
+          label={filter.title}
           value={value}
           onChange={(e) => onUpdate(e.target.value as string)}
         >


### PR DESCRIPTION
When `label` is missing on `Select`, the outline will go through the label instead of going around it. Selects need to have the same label in the `InputLabel` and the `<Select label={} />` prop.