### PR TITLE
MPDX-7556: Change label on edit Greeting/Envelope Name modal

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditMailingInfoModal/EditMailingInfoModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditMailingInfoModal/EditMailingInfoModal.test.tsx
@@ -114,12 +114,12 @@ describe('EditMailingInfoModal', () => {
     userEvent.clear(greetingInput);
     userEvent.type(greetingInput, newGreeting);
 
-    const envelopeGreetingInput = getByLabelText('Envelope Greeting');
+    const envelopeGreetingInput = getByLabelText('Envelope Name Line');
     expect(envelopeGreetingInput).toHaveValue(contact.envelopeGreeting);
     userEvent.clear(envelopeGreetingInput);
     userEvent.type(envelopeGreetingInput, newEnvelopeGreeting);
 
-    const sendNewsletterInput = getByLabelText('Send Newsletter');
+    const sendNewsletterInput = getByLabelText('Newsletter');
     expect(sendNewsletterInput.textContent).toEqual(contact.sendNewsletter);
     userEvent.click(sendNewsletterInput);
     userEvent.click(getByText(newSendNewsletter));

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditMailingInfoModal/EditMailingInfoModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditMailingInfoModal/EditMailingInfoModal.tsx
@@ -133,20 +133,20 @@ export const EditMailingInfoModal: React.FC<EditMailingInfoModalProps> = ({
                 </ContactInputWrapper>
                 <ContactInputWrapper>
                   <TextField
-                    label={t('Envelope Greeting')}
+                    label={t('Envelope Name Line')}
                     value={envelopeGreeting}
                     onChange={handleChange('envelopeGreeting')}
-                    inputProps={{ 'aria-label': t('Envelope Greeting') }}
+                    inputProps={{ 'aria-label': t('Envelope Name Line') }}
                     fullWidth
                   />
                 </ContactInputWrapper>
                 <ContactInputWrapper>
                   <FormControl fullWidth>
                     <InputLabel id="send-newsletter-select-label">
-                      {t('Send Newsletter')}
+                      {t('Newsletter')}
                     </InputLabel>
                     <Select
-                      label={t('Send Newsletter')}
+                      label={t('Newsletter')}
                       labelId="send-newsletter-select-label"
                       value={sendNewsletter}
                       onChange={(e) =>


### PR DESCRIPTION
[Jira ticket](https://jira.cru.org/browse/MPDX-7556)

Jira description: When you click the pencil by the Greeting info on a Contact Card, the labels on the modal that comes up should be Envelope Name Line (NOT Envelope Greeting) and Newsletter (NOT Send Newsletter) so they can be translated properly.