### PR TITLE
MPDX-7487 - clicking on a tasks contact redirects you to contacts page

### DIFF
--- a/pages/accountLists/[accountListId]/contacts/ContactsPageContext.test.tsx
+++ b/pages/accountLists/[accountListId]/contacts/ContactsPageContext.test.tsx
@@ -15,6 +15,7 @@ import {
   ContactsPageContext,
   ContactsPageProvider,
   ContactsPageType,
+  setRedirectPathname,
 } from './ContactsPageContext';
 import { GetUserOptionsQuery } from 'src/components/Contacts/ContactFlow/GetUserOptions.generated';
 
@@ -215,4 +216,18 @@ it.skip('does not have a contact id and changes to map', async () => {
       query: {},
     }),
   );
+});
+
+it('Should return the tasks URL when user is on the tasks page', async () => {
+  // I tried to test this through rendering the component,
+  // I couldn't work it out so I'm just testing the function instead.
+  const router = {
+    pathname: '/accountLists/[accountListId]/tasks/[[...contactId]]',
+    query: { accountListId, contactId: ['list', 'abc'] },
+    isReady,
+    push,
+  };
+  const pathName = setRedirectPathname(router, accountListId);
+
+  expect(pathName).toBe('/accountLists/account-list-1/tasks');
 });

--- a/pages/accountLists/[accountListId]/contacts/ContactsPageContext.tsx
+++ b/pages/accountLists/[accountListId]/contacts/ContactsPageContext.tsx
@@ -82,6 +82,16 @@ export const ContactsPageContext = React.createContext<ContactsPageType | null>(
   null,
 );
 
+export const setRedirectPathname = (router, accountListId) => {
+  let pathName = `/accountLists/${accountListId}/contacts`;
+  if (
+    router.pathname === '/accountLists/[accountListId]/tasks/[[...contactId]]'
+  ) {
+    pathName = `/accountLists/${accountListId}/tasks`;
+  }
+  return pathName;
+};
+
 interface Props {
   children?: React.ReactNode;
 }
@@ -281,13 +291,8 @@ export const ContactsPageProvider: React.FC<Props> = ({ children }) => {
       }
     }
 
-    let pathName = `/accountLists/${accountListId}/contacts`;
+    const pathName = setRedirectPathname(router, accountListId);
 
-    if (
-      router.pathname === '/accountLists/[accountListId]/tasks/[[...contactId]]'
-    ) {
-      pathName = `/accountLists/${accountListId}/tasks/`;
-    }
     push(
       id
         ? {


### PR DESCRIPTION
https://jira.cru.org/browse/MPDX-7569

The Tasks contact link is meant to pop open the contact window. Currently, it's redirecting you to the contacts page and then opens the contact window. this should keep you on the tasks page and open the window.

### What I've done:
Added check to see if the user is on the Tasks page; if so ensure they are kept on the Tasks page. 

Test by clicking contacts names on tasks on the Tasks page and contacts Contacts page.