### PR TITLE
Mpdx 7438 contact details missing on first click

### DIFF
--- a/pages/accountLists/[accountListId]/contacts/ContactsContext.test.tsx
+++ b/pages/accountLists/[accountListId]/contacts/ContactsContext.test.tsx
@@ -12,12 +12,12 @@ import {
   TableViewModeEnum,
 } from '../../../../src/components/Shared/Header/ListHeader';
 import {
-  ContactsPageContext,
-  ContactsPageProvider,
-  ContactsPageType,
+  ContactsContext,
+  ContactsType,
   getRedirectPathname,
-} from './ContactsPageContext';
+} from './ContactsContext';
 import { GetUserOptionsQuery } from 'src/components/Contacts/ContactFlow/GetUserOptions.generated';
+import { ContactsPage } from './ContactsPage';
 
 const accountListId = 'account-list-1';
 const push = jest.fn();
@@ -47,8 +47,8 @@ jest.mock('notistack', () => ({
 
 const TestRender: React.FC = () => {
   const { viewMode, handleViewModeChange, userOptionsLoading } = useContext(
-    ContactsPageContext,
-  ) as ContactsPageType;
+    ContactsContext,
+  ) as ContactsType;
   return (
     <Box>
       {!userOptionsLoading ? (
@@ -107,9 +107,9 @@ describe('ContactsPageContext', () => {
               },
             }}
           >
-            <ContactsPageProvider>
+            <ContactsPage>
               <TestRender />
-            </ContactsPageProvider>
+            </ContactsPage>
           </GqlMockedProvider>
         </TestRouter>
       </ThemeProvider>,
@@ -149,9 +149,9 @@ describe('ContactsPageContext', () => {
               },
             }}
           >
-            <ContactsPageProvider>
+            <ContactsPage>
               <TestRender />
-            </ContactsPageProvider>
+            </ContactsPage>
           </GqlMockedProvider>
         </TestRouter>
       </ThemeProvider>,
@@ -199,9 +199,9 @@ describe('ContactsPageContext', () => {
               },
             }}
           >
-            <ContactsPageProvider>
+            <ContactsPage>
               <TestRender />
-            </ContactsPageProvider>
+            </ContactsPage>
           </GqlMockedProvider>
         </TestRouter>
       </ThemeProvider>,

--- a/pages/accountLists/[accountListId]/contacts/ContactsPage.test.tsx
+++ b/pages/accountLists/[accountListId]/contacts/ContactsPage.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { render, waitFor, within } from '@testing-library/react';
+import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
+import userEvent from '@testing-library/user-event';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { ThemeProvider } from '@mui/material/styles';
+import {
+  gqlMock,
+  GqlMockedProvider,
+} from '../../../../__tests__/util/graphqlMocking';
+import {
+  mockDateRangeFilter,
+  mockMultiselectFilter,
+  mockTextFilter,
+} from 'src/components/Shared/Filters/FilterPanel.mocks';
+import { FilterPanel } from 'src/components/Shared/Filters/FilterPanel';
+import {
+  FilterPanelGroupFragment,
+  FilterPanelGroupFragmentDoc,
+  UserOptionFragment,
+  UserOptionFragmentDoc,
+} from 'src/components/Shared/Filters/FilterPanel.generated';
+import { SaveFilterMutation } from 'src/components/Shared/Filters/SaveFilterModal/SaveFilterModal.generated';
+import theme from 'src/theme';
+import { ContactsPage } from './ContactsPage';
+import { ContactFilterStatusEnum } from '../../../../graphql/types.generated';
+
+const onSelectedFiltersChanged = jest.fn();
+const onClose = jest.fn();
+
+const filterPanelDefaultMock = gqlMock<FilterPanelGroupFragment>(
+  FilterPanelGroupFragmentDoc,
+  {
+    mocks: {
+      name: 'Group 1',
+      featured: false,
+      filters: [mockTextFilter, mockMultiselectFilter],
+    },
+  },
+);
+const filterPanelFeaturedMock = gqlMock<FilterPanelGroupFragment>(
+  FilterPanelGroupFragmentDoc,
+  {
+    mocks: {
+      name: 'Group 2',
+      featured: true,
+      filters: [mockMultiselectFilter, mockDateRangeFilter],
+    },
+  },
+);
+
+const savedFiltersMock = gqlMock<UserOptionFragment>(UserOptionFragmentDoc, {
+  mocks: {
+    id: '123',
+    key: 'saved_contacts_filter_My_Cool_Filter',
+    value:
+      '{"any_tags":false,"account_list_id":"08bb09d1-3b62-4690-9596-b625b8af4750","params":{"status":"active,hidden,null,Never Contacted,Ask in Future,Cultivate Relationship,Contact for Appointment,Appointment Scheduled,Call for Decision,Partner - Financial,Partner - Special,Partner - Pray,Not Interested,Unresponsive,Never Ask,Research Abandoned,Expired Referral","pledge_received":"true","pledge_amount":"35.0,40.0","pledge_currency":"USD","pledge_frequency":"0.46153846153846,1.0","pledge_late_by":"30_60","newsletter":"no_value","referrer":"d5b1dab5-e3ae-417d-8f49-2abdd915515b","city":"Evansville","state":"FL","country":"United States","metro_area":"Cool","region":"Orange County","contact_info_email":"Yes","contact_info_phone":"No","contact_info_mobile":"No","contact_info_work_phone":"No","contact_info_addr":"Yes","contact_info_facebook":"No","opt_out":"No","church":"Cool Church II","appeal":"851769ba-b55d-45f3-b784-c4eca7ae99fd,77491693-df83-46ec-b40b-39d07333f47e","timezone":"America/Vancouver","locale":"English","donation":"first","donation_date":"2021-12-23..2021-12-23","next_ask":"2021-11-30..2021-12-22","user_ids":"787f286e-fe38-4055-b9fc-0177a0f55947","reverse_appeal":true, "contact_types": "person"},"tags":null,"exclude_tags":null,"wildcard_search":""}',
+  },
+});
+
+const mockEnqueue = jest.fn();
+
+jest.mock('notistack', () => ({
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  ...jest.requireActual('notistack'),
+  useSnackbar: () => {
+    return {
+      enqueueSnackbar: mockEnqueue,
+    };
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const useRouter = jest.spyOn(require('next/router'), 'useRouter');
+
+describe('Contacts', () => {
+  it('opens and selects a saved filter X2', async () => {
+    const routeReplace = jest.fn();
+    const routePush = jest.fn();
+    useRouter.mockReturnValue({
+      route: '/contacts',
+      query: {
+        accountListI: 'account-list-1',
+        filters: '%7B%22status%22:%5B%22ASK_IN_FUTURE%22%5D%7D',
+      },
+      replace: routeReplace,
+      push: routePush,
+    });
+
+    const {
+      getByTestId,
+      getByText,
+      queryByTestId,
+      queryAllByTestId,
+      getByRole,
+    } = render(
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider<SaveFilterMutation>>
+            <ContactsPage>
+              <FilterPanel
+                filters={[filterPanelDefaultMock, filterPanelFeaturedMock]}
+                savedFilters={[savedFiltersMock]}
+                selectedFilters={{}}
+                onClose={onClose}
+                onSelectedFiltersChanged={onSelectedFiltersChanged}
+              />
+            </ContactsPage>
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </LocalizationProvider>,
+    );
+
+    await waitFor(() => expect(queryByTestId('LoadingState')).toBeNull());
+    expect(queryByTestId('LoadingState')).toBeNull();
+    expect(queryByTestId('ErrorState')).toBeNull();
+
+    expect(queryAllByTestId('FilterGroup').length).toEqual(2);
+    expect(getByTestId('FilterListItemShowAll')).toBeVisible();
+    userEvent.click(getByTestId('FilterListItemShowAll'));
+    userEvent.click(getByText(filterPanelDefaultMock.name));
+
+    userEvent.click(
+      getByRole('button', {
+        hidden: true,
+        name: 'Group 1',
+      }),
+    );
+
+    const statusSelect = getByRole('combobox', {
+      hidden: true,
+      name: 'Status',
+    });
+    userEvent.click(statusSelect);
+
+    await waitFor(() =>
+      expect(getByText('Contact for Appointment')).toBeInTheDocument(),
+    );
+    userEvent.click(
+      await within(getByRole('presentation')).findByText(
+        'Contact for Appointment',
+      ),
+    );
+    expect(getByTestId('multiSelectFilter')).toBeInTheDocument();
+    expect(onSelectedFiltersChanged).toHaveBeenCalledWith({
+      status: [ContactFilterStatusEnum.ContactForAppointment],
+    });
+    userEvent.click(getByText('Saved Filters'));
+    expect(routeReplace).toHaveBeenCalled();
+  });
+});

--- a/pages/accountLists/[accountListId]/contacts/ContactsPage.tsx
+++ b/pages/accountLists/[accountListId]/contacts/ContactsPage.tsx
@@ -1,0 +1,53 @@
+import React, { useState, useEffect } from 'react';
+import _ from 'lodash';
+import { useRouter } from 'next/router';
+import { ContactsProvider } from './ContactsContext';
+import { ContactFilterSetInput } from '../../../../graphql/types.generated';
+
+interface Props {
+  children?: React.ReactNode;
+}
+export const ContactsPage: React.FC<Props> = ({ children }) => {
+  const router = useRouter();
+  const { query, replace, pathname } = router;
+
+  const urlFilters =
+    query?.filters && JSON.parse(decodeURI(query.filters as string));
+
+  const [activeFilters, setActiveFilters] = useState<ContactFilterSetInput>(
+    urlFilters ?? {},
+  );
+  const [starredFilter, setStarredFilter] = useState<ContactFilterSetInput>({});
+  const [filterPanelOpen, setFilterPanelOpen] = useState<boolean>(false);
+
+  const { contactId, searchTerm } = query;
+
+  useEffect(() => {
+    const { filters: _, ...oldQuery } = query;
+    replace({
+      pathname,
+      query: {
+        ...oldQuery,
+        ...(Object.keys(activeFilters).length > 0
+          ? { filters: encodeURI(JSON.stringify(activeFilters)) }
+          : undefined),
+      },
+    });
+  }, [activeFilters]);
+
+  return (
+    <ContactsProvider
+      urlFilters={urlFilters}
+      activeFilters={activeFilters}
+      setActiveFilters={setActiveFilters}
+      starredFilter={starredFilter}
+      setStarredFilter={setStarredFilter}
+      filterPanelOpen={filterPanelOpen}
+      setFilterPanelOpen={setFilterPanelOpen}
+      contactId={contactId}
+      searchTerm={searchTerm}
+    >
+      {children}
+    </ContactsProvider>
+  );
+};

--- a/pages/accountLists/[accountListId]/contacts/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/contacts/[[...contactId]].page.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import _ from 'lodash';
-import { ContactsPageProvider } from './ContactsPageContext';
 import { ContactsContainer } from 'src/components/Contacts/ContactsContainer';
+import { ContactsPage } from './ContactsPage';
 
-const ContactsPage: React.FC = () => {
+const Contacts: React.FC = () => {
   return (
-    <ContactsPageProvider>
+    <ContactsPage>
       <ContactsContainer />
-    </ContactsPageProvider>
+    </ContactsPage>
   );
 };
 
-export default ContactsPage;
+export default Contacts;

--- a/pages/accountLists/[accountListId]/contacts/map/map.tsx
+++ b/pages/accountLists/[accountListId]/contacts/map/map.tsx
@@ -10,7 +10,7 @@ import { Box, CircularProgress, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { StatusEnum } from '../../../../../graphql/types.generated';
-import { ContactsPageContext, ContactsPageType } from '../ContactsPageContext';
+import { ContactsContext, ContactsType } from '../ContactsContext';
 import theme from 'src/theme';
 import { sourceToStr } from 'src/utils/sourceToStr';
 
@@ -94,7 +94,7 @@ export const ContactsMap: React.FC = ({}) => {
     selected,
     setSelected,
     setContactFocus: onContactSelected,
-  } = React.useContext(ContactsPageContext) as ContactsPageType;
+  } = React.useContext(ContactsContext) as ContactsType;
 
   const onMapLoad = useCallback((map) => {
     mapRef.current = map;

--- a/pages/accountLists/[accountListId]/reports/donations/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/donations/[[...contactId]].page.tsx
@@ -10,7 +10,7 @@ import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { NavReportsList } from 'src/components/Reports/NavReportsList/NavReportsList';
 import { getQueryParam } from 'src/utils/queryParam';
-import { ContactsPageProvider } from '../../contacts/ContactsPageContext';
+import { ContactsPage } from '../../contacts/ContactsPage';
 import { ContactsRightPanel } from 'src/components/Contacts/ContactsRightPanel/ContactsRightPanel';
 
 const DonationsReportPageWrapper = styled(Box)(({ theme }) => ({
@@ -66,9 +66,9 @@ const DonationsReportPage: React.FC = () => {
             }
             rightPanel={
               selectedContactId ? (
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactsRightPanel onClose={() => handleSelectContact('')} />
-                </ContactsPageProvider>
+                </ContactsPage>
               ) : undefined
             }
             rightOpen={typeof selectedContactId !== 'undefined'}

--- a/pages/accountLists/[accountListId]/reports/partnerGivingAnalysis/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/partnerGivingAnalysis/[[...contactId]].page.tsx
@@ -14,7 +14,7 @@ import { FilterPanel } from 'src/components/Shared/Filters/FilterPanel';
 import { ReportContactFilterSetInput } from 'pages/api/graphql-rest.page.generated';
 import { useContactFiltersQuery } from '../../contacts/Contacts.generated';
 import { useDebounce } from 'use-debounce';
-import { ContactsPageProvider } from '../../contacts/ContactsPageContext';
+import { ContactsPage } from '../../contacts/ContactsPage';
 import { ContactsRightPanel } from 'src/components/Contacts/ContactsRightPanel/ContactsRightPanel';
 import { useRouter } from 'next/router';
 import { getQueryParam } from 'src/utils/queryParam';
@@ -119,9 +119,9 @@ const PartnerGivingAnalysisReportPage: React.FC = () => {
             }
             rightPanel={
               selectedContactId ? (
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactsRightPanel onClose={() => handleSelectContact('')} />
-                </ContactsPageProvider>
+                </ContactsPage>
               ) : undefined
             }
             rightOpen={typeof selectedContactId !== 'undefined'}

--- a/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
@@ -23,7 +23,7 @@ import NullState from '../../../../src/components/Shared/Filters/NullState/NullS
 import { FilterPanel } from '../../../../src/components/Shared/Filters/FilterPanel';
 import { useMassSelection } from '../../../../src/hooks/useMassSelection';
 import { UserOptionFragment } from '../../../../src/components/Shared/Filters/FilterPanel.generated';
-import { ContactsPageProvider } from '../contacts/ContactsPageContext';
+import { ContactsProvider } from '../contacts/ContactsContext';
 import {
   TasksDocument,
   useTaskFiltersQuery,
@@ -501,11 +501,21 @@ const TasksPage: React.FC = () => {
             }
             rightPanel={
               contactDetailsId ? (
-                <ContactsPageProvider>
+                <ContactsProvider
+                  urlFilters={urlFilters}
+                  activeFilters={activeFilters}
+                  setActiveFilters={setActiveFilters}
+                  starredFilter={starredFilter}
+                  setStarredFilter={setStarredFilter}
+                  filterPanelOpen={filterPanelOpen}
+                  setFilterPanelOpen={setFilterPanelOpen}
+                  contactId={contactId}
+                  searchTerm={searchTerm}
+                >
                   <ContactsRightPanel
                     onClose={() => setContactFocus(undefined)}
                   />
-                </ContactsPageProvider>
+                </ContactsProvider>
               ) : (
                 <></>
               )

--- a/src/components/Contacts/ContactDetails/ContactDetails.stories.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetails.stories.tsx
@@ -9,7 +9,7 @@ import {
   GetContactDetailsHeaderQuery,
 } from './ContactDetailsHeader/ContactDetailsHeader.generated';
 import TestRouter from '__tests__/util/TestRouter';
-import { ContactsPageProvider } from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 const accountListId = 'abc';
 const contactId = 'contact-1';
@@ -27,11 +27,11 @@ export const Default = (): ReactElement => {
   return (
     <TestRouter router={router}>
       <GqlMockedProvider<GetContactDetailsHeaderQuery>>
-        <ContactsPageProvider>
+        <ContactsPage>
           <ContactDetailProvider>
             <ContactDetails onClose={() => {}} />
           </ContactDetailProvider>
-        </ContactsPageProvider>
+        </ContactsPage>
       </GqlMockedProvider>
     </TestRouter>
   );
@@ -55,11 +55,11 @@ export const Loading = (): ReactElement => {
           },
         ]}
       >
-        <ContactsPageProvider>
+        <ContactsPage>
           <ContactDetailProvider>
             <ContactDetails onClose={() => {}} />
           </ContactDetailProvider>
-        </ContactsPageProvider>
+        </ContactsPage>
       </MockedProvider>
     </TestRouter>
   );

--- a/src/components/Contacts/ContactDetails/ContactDetails.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetails.test.tsx
@@ -8,7 +8,7 @@ import theme from '../../../theme';
 import { ContactDetails } from './ContactDetails';
 import { ContactDetailProvider } from './ContactDetailContext';
 import TestRouter from '__tests__/util/TestRouter';
-import { ContactsPageProvider } from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
@@ -24,11 +24,11 @@ describe('ContactDetails', () => {
         <TestRouter router={router}>
           <GqlMockedProvider>
             <ThemeProvider theme={theme}>
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <ContactDetails onClose={() => {}} />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </ThemeProvider>
           </GqlMockedProvider>
         </TestRouter>

--- a/src/components/Contacts/ContactDetails/ContactDetails.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetails.tsx
@@ -7,9 +7,9 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import theme from '../../../theme';
 import {
-  ContactsPageContext,
-  ContactsPageType,
-} from '../../../../pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+  ContactsContext,
+  ContactsType,
+} from '../../../../pages/accountLists/[accountListId]/contacts/ContactsContext';
 import { ContactDetailsHeader } from './ContactDetailsHeader/ContactDetailsHeader';
 import { ContactTasksTab } from './ContactTasksTab/ContactTasksTab';
 import { ContactDetailsTab } from './ContactDetailsTab/ContactDetailsTab';
@@ -74,7 +74,7 @@ export const ContactDetails: React.FC<Props> = ({ onClose }) => {
     accountListId,
     contactDetailsId: contactId,
     setContactFocus,
-  } = React.useContext(ContactsPageContext) as ContactsPageType;
+  } = React.useContext(ContactsContext) as ContactsType;
 
   const { selectedTabKey, handleTabChange: handleChange } = React.useContext(
     ContactDetailContext,

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsHeader.stories.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsHeader.stories.tsx
@@ -9,7 +9,7 @@ import {
   GetContactDetailsHeaderDocument,
   GetContactDetailsHeaderQuery,
 } from './ContactDetailsHeader.generated';
-import { ContactsPageProvider } from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 const accountListId = 'accountList-1';
 const contactId = 'contact-1';
@@ -21,7 +21,7 @@ export default {
 
 export const Default = (): ReactElement => {
   return (
-    <ContactsPageProvider>
+    <ContactsPage>
       <ContactDetailProvider>
         <GqlMockedProvider<GetContactDetailsHeaderQuery>>
           <ContactDetailsHeader
@@ -31,13 +31,13 @@ export const Default = (): ReactElement => {
           />
         </GqlMockedProvider>
       </ContactDetailProvider>
-    </ContactsPageProvider>
+    </ContactsPage>
   );
 };
 
 export const Loading = (): ReactElement => {
   return (
-    <ContactsPageProvider>
+    <ContactsPage>
       <ContactDetailProvider>
         <MockedProvider
           mocks={[
@@ -61,6 +61,6 @@ export const Loading = (): ReactElement => {
           />
         </MockedProvider>
       </ContactDetailProvider>
-    </ContactsPageProvider>
+    </ContactsPage>
   );
 };

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsHeader.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsHeader.test.tsx
@@ -9,7 +9,7 @@ import { ContactDetailsHeader } from './ContactDetailsHeader';
 import { GetContactDetailsHeaderQuery } from './ContactDetailsHeader.generated';
 import TestRouter from '__tests__/util/TestRouter';
 import theme from 'src/theme';
-import { ContactsPageProvider } from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 const accountListId = 'abc';
 const contactId = 'contact-1';
@@ -25,7 +25,7 @@ describe('ContactDetails', () => {
         <TestRouter router={router}>
           <ThemeProvider theme={theme}>
             <GqlMockedProvider<GetContactDetailsHeaderQuery>>
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <ContactDetailsHeader
                     accountListId={accountListId}
@@ -33,7 +33,7 @@ describe('ContactDetails', () => {
                     onClose={() => {}}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -59,7 +59,7 @@ describe('ContactDetails', () => {
                 },
               }}
             >
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <ContactDetailsHeader
                     accountListId={accountListId}
@@ -67,7 +67,7 @@ describe('ContactDetails', () => {
                     onClose={() => {}}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -96,7 +96,7 @@ describe('ContactDetails', () => {
                 },
               }}
             >
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <ContactDetailsHeader
                     accountListId={accountListId}
@@ -104,7 +104,7 @@ describe('ContactDetails', () => {
                     onClose={() => {}}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -133,7 +133,7 @@ describe('ContactDetails', () => {
                 },
               }}
             >
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <ContactDetailsHeader
                     accountListId={accountListId}
@@ -141,7 +141,7 @@ describe('ContactDetails', () => {
                     onClose={() => {}}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -173,7 +173,7 @@ describe('ContactDetails', () => {
                 },
               }}
             >
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <ContactDetailsHeader
                     accountListId={accountListId}
@@ -181,7 +181,7 @@ describe('ContactDetails', () => {
                     onClose={() => {}}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.test.tsx
@@ -12,7 +12,7 @@ import useTaskModal from '../../../../../hooks/useTaskModal';
 import { UpdateContactOtherMutation } from '../../ContactDetailsTab/Other/EditContactOtherModal/EditContactOther.generated';
 import { ContactDetailProvider } from '../../ContactDetailContext';
 import { ContactDetailsMoreAcitions } from './ContactDetailsMoreActions';
-import { ContactsPageProvider } from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 const accountListId = '111';
 const contactId = 'contact-1';
@@ -52,7 +52,7 @@ describe('ContactDetailsMoreActions', () => {
         <TestRouter router={router}>
           <ThemeProvider theme={theme}>
             <GqlMockedProvider>
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <ContactDetailsMoreAcitions
                     status={StatusEnum.AskInFuture}
@@ -60,7 +60,7 @@ describe('ContactDetailsMoreActions', () => {
                     onClose={onClose}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -82,7 +82,7 @@ describe('ContactDetailsMoreActions', () => {
         <TestRouter router={router}>
           <ThemeProvider theme={theme}>
             <GqlMockedProvider>
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <ContactDetailsMoreAcitions
                     status={StatusEnum.AskInFuture}
@@ -90,7 +90,7 @@ describe('ContactDetailsMoreActions', () => {
                     onClose={onClose}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -114,7 +114,7 @@ describe('ContactDetailsMoreActions', () => {
         <TestRouter router={router}>
           <ThemeProvider theme={theme}>
             <GqlMockedProvider>
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <ContactDetailsMoreAcitions
                     status={StatusEnum.AskInFuture}
@@ -122,7 +122,7 @@ describe('ContactDetailsMoreActions', () => {
                     onClose={onClose}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -157,7 +157,7 @@ describe('ContactDetailsMoreActions', () => {
                 },
               }}
             >
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <ContactDetailsMoreAcitions
                     status={StatusEnum.AskInFuture}
@@ -165,7 +165,7 @@ describe('ContactDetailsMoreActions', () => {
                     onClose={onClose}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -198,7 +198,7 @@ describe('ContactDetailsMoreActions', () => {
         <TestRouter router={router}>
           <ThemeProvider theme={theme}>
             <GqlMockedProvider<DeleteContactMutation>>
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <ContactDetailsMoreAcitions
                     status={StatusEnum.AskInFuture}
@@ -206,7 +206,7 @@ describe('ContactDetailsMoreActions', () => {
                     onClose={onClose}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -236,7 +236,7 @@ describe('ContactDetailsMoreActions', () => {
         <TestRouter router={router}>
           <ThemeProvider theme={theme}>
             <GqlMockedProvider<DeleteContactMutation>>
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <ContactDetailsMoreAcitions
                     status={StatusEnum.AskInFuture}
@@ -244,7 +244,7 @@ describe('ContactDetailsMoreActions', () => {
                     onClose={onClose}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -268,7 +268,7 @@ describe('ContactDetailsMoreActions', () => {
         <TestRouter router={router}>
           <ThemeProvider theme={theme}>
             <GqlMockedProvider<DeleteContactMutation>>
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <ContactDetailsMoreAcitions
                     status={StatusEnum.AskInFuture}
@@ -276,7 +276,7 @@ describe('ContactDetailsMoreActions', () => {
                     onClose={onClose}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
@@ -25,9 +25,9 @@ import {
   ContactsQuery,
 } from 'pages/accountLists/[accountListId]/contacts/Contacts.generated';
 import {
-  ContactsPageContext,
-  ContactsPageType,
-} from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+  ContactsContext,
+  ContactsType,
+} from 'pages/accountLists/[accountListId]/contacts/ContactsContext';
 import { MoreActionHideContactModal } from './MoreActionHideContactModal';
 
 type AddMenuItem = {
@@ -114,8 +114,8 @@ export const ContactDetailsMoreAcitions: React.FC<
   const { openTaskModal } = useTaskModal();
   const { t } = useTranslation();
   const { accountListId, searchTerm, router } = React.useContext(
-    ContactsPageContext,
-  ) as ContactsPageType;
+    ContactsContext,
+  ) as ContactsType;
   const { query, push } = router;
   const { ...queryWithoutContactId } = query;
 

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.test.tsx
@@ -11,7 +11,7 @@ import { GqlMockedProvider } from '../../../../../__tests__/util/graphqlMocking'
 import { ContactDetailProvider } from '../ContactDetailContext';
 import { ContactDetailsTab } from './ContactDetailsTab';
 import { ContactDetailsTabQuery } from './ContactDetailsTab.generated';
-import { ContactsPageProvider } from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 const accountListId = '111';
 const contactId = 'contact-1';
@@ -88,7 +88,7 @@ describe('ContactDetailTab', () => {
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <ThemeProvider theme={theme}>
               <GqlMockedProvider<ContactDetailsTabQuery>>
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <ContactDetailsTab
                       accountListId={accountListId}
@@ -96,7 +96,7 @@ describe('ContactDetailTab', () => {
                       onContactSelected={onContactSelected}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </LocalizationProvider>
@@ -113,7 +113,7 @@ describe('ContactDetailTab', () => {
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <ThemeProvider theme={theme}>
               <GqlMockedProvider<ContactDetailsTabQuery>>
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <ContactDetailsTab
                       accountListId={accountListId}
@@ -121,7 +121,7 @@ describe('ContactDetailTab', () => {
                       onContactSelected={onContactSelected}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </LocalizationProvider>
@@ -141,7 +141,7 @@ describe('ContactDetailTab', () => {
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <ThemeProvider theme={theme}>
               <GqlMockedProvider<ContactDetailsTabQuery>>
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <ContactDetailsTab
                       accountListId={accountListId}
@@ -149,7 +149,7 @@ describe('ContactDetailTab', () => {
                       onContactSelected={onContactSelected}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </LocalizationProvider>
@@ -166,7 +166,7 @@ describe('ContactDetailTab', () => {
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <ThemeProvider theme={theme}>
               <GqlMockedProvider<ContactDetailsTabQuery>>
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <ContactDetailsTab
                       accountListId={accountListId}
@@ -174,7 +174,7 @@ describe('ContactDetailTab', () => {
                       onContactSelected={onContactSelected}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </LocalizationProvider>
@@ -194,7 +194,7 @@ describe('ContactDetailTab', () => {
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <ThemeProvider theme={theme}>
               <GqlMockedProvider<ContactDetailsTabQuery>>
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <ContactDetailsTab
                       accountListId={accountListId}
@@ -202,7 +202,7 @@ describe('ContactDetailTab', () => {
                       onContactSelected={onContactSelected}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </LocalizationProvider>
@@ -222,7 +222,7 @@ describe('ContactDetailTab', () => {
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <ThemeProvider theme={theme}>
               <GqlMockedProvider<ContactDetailsTabQuery>>
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <ContactDetailsTab
                       accountListId={accountListId}
@@ -230,7 +230,7 @@ describe('ContactDetailTab', () => {
                       onContactSelected={onContactSelected}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </LocalizationProvider>
@@ -248,7 +248,7 @@ describe('ContactDetailTab', () => {
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <ThemeProvider theme={theme}>
               <GqlMockedProvider<ContactDetailsTabQuery> mocks={mocks}>
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <ContactDetailsTab
                       accountListId={accountListId}
@@ -256,7 +256,7 @@ describe('ContactDetailTab', () => {
                       onContactSelected={onContactSelected}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </LocalizationProvider>
@@ -273,7 +273,7 @@ describe('ContactDetailTab', () => {
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <ThemeProvider theme={theme}>
               <GqlMockedProvider<ContactDetailsTabQuery> mocks={mocks}>
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <ContactDetailsTab
                       accountListId={accountListId}
@@ -281,7 +281,7 @@ describe('ContactDetailTab', () => {
                       onContactSelected={onContactSelected}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </LocalizationProvider>
@@ -301,7 +301,7 @@ describe('ContactDetailTab', () => {
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <ThemeProvider theme={theme}>
               <GqlMockedProvider<ContactDetailsTabQuery> mocks={mocks}>
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <ContactDetailsTab
                       accountListId={accountListId}
@@ -309,7 +309,7 @@ describe('ContactDetailTab', () => {
                       onContactSelected={onContactSelected}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </LocalizationProvider>
@@ -326,7 +326,7 @@ describe('ContactDetailTab', () => {
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <ThemeProvider theme={theme}>
               <GqlMockedProvider<ContactDetailsTabQuery> mocks={mocks}>
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <ContactDetailsTab
                       accountListId={accountListId}
@@ -334,7 +334,7 @@ describe('ContactDetailTab', () => {
                       onContactSelected={onContactSelected}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </LocalizationProvider>
@@ -354,7 +354,7 @@ describe('ContactDetailTab', () => {
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <ThemeProvider theme={theme}>
               <GqlMockedProvider<ContactDetailsTabQuery> mocks={mocks}>
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <ContactDetailsTab
                       accountListId={accountListId}
@@ -362,7 +362,7 @@ describe('ContactDetailTab', () => {
                       onContactSelected={onContactSelected}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </LocalizationProvider>
@@ -379,7 +379,7 @@ describe('ContactDetailTab', () => {
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <ThemeProvider theme={theme}>
               <GqlMockedProvider<ContactDetailsTabQuery> mocks={mocks}>
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <ContactDetailsTab
                       accountListId={accountListId}
@@ -387,7 +387,7 @@ describe('ContactDetailTab', () => {
                       onContactSelected={onContactSelected}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </LocalizationProvider>
@@ -404,7 +404,7 @@ describe('ContactDetailTab', () => {
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <ThemeProvider theme={theme}>
               <GqlMockedProvider<ContactDetailsTabQuery> mocks={mocks}>
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <ContactDetailsTab
                       accountListId={accountListId}
@@ -412,7 +412,7 @@ describe('ContactDetailTab', () => {
                       onContactSelected={onContactSelected}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </LocalizationProvider>

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.test.tsx
@@ -17,8 +17,8 @@ import { ContactDetailProvider } from '../../../ContactDetailContext';
 import { UpdateContactOtherMutation } from './EditContactOther.generated';
 import { EditContactOtherModal } from './EditContactOtherModal';
 import { GetTaskModalContactsFilteredQuery } from 'src/components/Task/Modal/Form/TaskModal.generated';
-import { ContactsPageProvider } from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
 import TestRouter from '__tests__/util/TestRouter';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 const handleClose = jest.fn();
 const mock = gqlMock<ContactOtherFragment>(ContactOtherFragmentDoc);
@@ -72,7 +72,7 @@ describe('EditContactOtherModal', () => {
         <TestRouter router={router}>
           <ThemeProvider theme={theme}>
             <GqlMockedProvider<UpdateContactOtherMutation>>
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <EditContactOtherModal
                     accountListId={accountListId}
@@ -82,7 +82,7 @@ describe('EditContactOtherModal', () => {
                     referral={referral}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -115,7 +115,7 @@ describe('EditContactOtherModal', () => {
                 },
               }}
             >
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <EditContactOtherModal
                     accountListId={accountListId}
@@ -125,7 +125,7 @@ describe('EditContactOtherModal', () => {
                     referral={referral}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -150,7 +150,7 @@ describe('EditContactOtherModal', () => {
         <TestRouter router={router}>
           <ThemeProvider theme={theme}>
             <GqlMockedProvider<UpdateContactOtherMutation>>
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <EditContactOtherModal
                     accountListId={accountListId}
@@ -160,7 +160,7 @@ describe('EditContactOtherModal', () => {
                     referral={referral}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -178,7 +178,7 @@ describe('EditContactOtherModal', () => {
         <TestRouter router={router}>
           <ThemeProvider theme={theme}>
             <GqlMockedProvider<UpdateContactOtherMutation>>
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <EditContactOtherModal
                     accountListId={accountListId}
@@ -188,7 +188,7 @@ describe('EditContactOtherModal', () => {
                     referral={referral}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -210,7 +210,7 @@ describe('EditContactOtherModal', () => {
               <GqlMockedProvider<UpdateContactOtherMutation>
                 onCall={mutationSpy}
               >
-                <ContactsPageProvider>
+                <ContactsPage>
                   <ContactDetailProvider>
                     <EditContactOtherModal
                       accountListId={accountListId}
@@ -220,7 +220,7 @@ describe('EditContactOtherModal', () => {
                       referral={undefined}
                     />
                   </ContactDetailProvider>
-                </ContactsPageProvider>
+                </ContactsPage>
               </GqlMockedProvider>
             </ThemeProvider>
           </TestRouter>
@@ -248,7 +248,7 @@ describe('EditContactOtherModal', () => {
         <TestRouter router={router}>
           <ThemeProvider theme={theme}>
             <GqlMockedProvider<UpdateContactOtherMutation> onCall={mutationSpy}>
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <EditContactOtherModal
                     accountListId={accountListId}
@@ -258,7 +258,7 @@ describe('EditContactOtherModal', () => {
                     referral={undefined}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>
@@ -319,7 +319,7 @@ describe('EditContactOtherModal', () => {
                 },
               }}
             >
-              <ContactsPageProvider>
+              <ContactsPage>
                 <ContactDetailProvider>
                   <EditContactOtherModal
                     accountListId={accountListId}
@@ -329,7 +329,7 @@ describe('EditContactOtherModal', () => {
                     referral={referral}
                   />
                 </ContactDetailProvider>
-              </ContactsPageProvider>
+              </ContactsPage>
             </GqlMockedProvider>
           </ThemeProvider>
         </TestRouter>

--- a/src/components/Contacts/ContactRow/ContactRow.stories.tsx
+++ b/src/components/Contacts/ContactRow/ContactRow.stories.tsx
@@ -9,7 +9,7 @@ import {
   ContactRowFragment,
   ContactRowFragmentDoc,
 } from './ContactRow.generated';
-import { ContactsPageProvider } from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 export default {
   title: 'Contacts/ContactRow',
@@ -26,9 +26,9 @@ export const Default: Story = () => {
   });
 
   return (
-    <ContactsPageProvider>
+    <ContactsPage>
       <ContactRow contact={contact} />
-    </ContactsPageProvider>
+    </ContactsPage>
   );
 };
 

--- a/src/components/Contacts/ContactRow/ContactRow.test.tsx
+++ b/src/components/Contacts/ContactRow/ContactRow.test.tsx
@@ -6,7 +6,6 @@ import {
   gqlMock,
   GqlMockedProvider,
 } from '../../../../__tests__/util/graphqlMocking';
-import { ContactsPageProvider } from '../../../../pages/accountLists/[accountListId]/contacts/ContactsPageContext';
 import TestRouter from '../../../../__tests__/util/TestRouter';
 import { GetUserOptionsQuery } from '../ContactFlow/GetUserOptions.generated';
 import useTaskModal from '../../../hooks/useTaskModal';
@@ -16,6 +15,7 @@ import {
   ContactRowFragmentDoc,
 } from './ContactRow.generated';
 import theme from 'src/theme';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 const accountListId = 'account-list-1';
 
@@ -74,9 +74,9 @@ describe('ContactsRow', () => {
       <TestRouter router={router}>
         <GqlMockedProvider<GetUserOptionsQuery>>
           <ThemeProvider theme={theme}>
-            <ContactsPageProvider>
+            <ContactsPage>
               <ContactRow contact={contact} />
-            </ContactsPageProvider>
+            </ContactsPage>
           </ThemeProvider>
         </GqlMockedProvider>
       </TestRouter>,
@@ -99,9 +99,9 @@ describe('ContactsRow', () => {
       <TestRouter router={router}>
         <GqlMockedProvider<GetUserOptionsQuery>>
           <ThemeProvider theme={theme}>
-            <ContactsPageProvider>
+            <ContactsPage>
               <ContactRow contact={contact} />
-            </ContactsPageProvider>
+            </ContactsPage>
           </ThemeProvider>
         </GqlMockedProvider>
       </TestRouter>,
@@ -118,9 +118,9 @@ describe('ContactsRow', () => {
       <TestRouter router={router}>
         <GqlMockedProvider<GetUserOptionsQuery>>
           <ThemeProvider theme={theme}>
-            <ContactsPageProvider>
+            <ContactsPage>
               <ContactRow contact={contact} />
-            </ContactsPageProvider>
+            </ContactsPage>
           </ThemeProvider>
         </GqlMockedProvider>
       </TestRouter>,
@@ -142,9 +142,9 @@ describe('ContactsRow', () => {
       <TestRouter router={router}>
         <GqlMockedProvider<GetUserOptionsQuery>>
           <ThemeProvider theme={theme}>
-            <ContactsPageProvider>
+            <ContactsPage>
               <ContactRow contact={contact} />
-            </ContactsPageProvider>
+            </ContactsPage>
           </ThemeProvider>
         </GqlMockedProvider>
       </TestRouter>,

--- a/src/components/Contacts/ContactRow/ContactRow.tsx
+++ b/src/components/Contacts/ContactRow/ContactRow.tsx
@@ -17,9 +17,9 @@ import { StarContactIconButton } from '../StarContactIconButton/StarContactIconB
 import { ContactUncompletedTasksCount } from '../ContactUncompletedTasksCount/ContactUncompletedTasksCount';
 import { ContactRowFragment } from './ContactRow.generated';
 import {
-  ContactsPageContext,
-  ContactsPageType,
-} from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+  ContactsContext,
+  ContactsType,
+} from 'pages/accountLists/[accountListId]/contacts/ContactsContext';
 
 interface Props {
   contact: ContactRowFragment;
@@ -33,7 +33,7 @@ export const ContactRow: React.FC<Props> = ({ contact, useTopMargin }) => {
     contactDetailsOpen,
     setContactFocus: onContactSelected,
     toggleSelectionById: onContactCheckToggle,
-  } = React.useContext(ContactsPageContext) as ContactsPageType;
+  } = React.useContext(ContactsContext) as ContactsType;
 
   const ListItemButton = styled(ButtonBase)(({ theme }) => ({
     flex: '1 1 auto',

--- a/src/components/Contacts/ContactsContainer.stories.tsx
+++ b/src/components/Contacts/ContactsContainer.stories.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from 'react';
-import { ContactsPageProvider } from '../../../pages/accountLists/[accountListId]/contacts/ContactsPageContext';
 import { ContactsQuery } from '../../../pages/accountLists/[accountListId]/contacts/Contacts.generated';
 import { GqlMockedProvider } from '../../../__tests__/util/graphqlMocking';
 import { ContactsContainer } from './ContactsContainer';
+import { ContactsPage } from '../../../pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 export default {
   title: 'Contacts/Container',
@@ -11,9 +11,9 @@ export default {
 export const Default = (): ReactElement => {
   return (
     <GqlMockedProvider<ContactsQuery>>
-      <ContactsPageProvider>
+      <ContactsPage>
         <ContactsContainer />
-      </ContactsPageProvider>
+      </ContactsPage>
     </GqlMockedProvider>
   );
 };

--- a/src/components/Contacts/ContactsContainer.tsx
+++ b/src/components/Contacts/ContactsContainer.tsx
@@ -8,9 +8,9 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 import _ from 'lodash';
 import { SidePanelsLayout } from '../Layouts/SidePanelsLayout';
 import {
-  ContactsPageContext,
-  ContactsPageType,
-} from '../../../pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+  ContactsContext,
+  ContactsType,
+} from '../../../pages/accountLists/[accountListId]/contacts/ContactsContext';
 import { TableViewModeEnum } from '../Shared/Header/ListHeader';
 import Loading from '../Loading';
 import { ContactsMainPanel } from './ContactsMainPanel/ContactsMainPanel';
@@ -30,7 +30,7 @@ export const ContactsContainer: React.FC = ({}) => {
     contactDetailsOpen,
     viewMode,
     setContactFocus,
-  } = useContext(ContactsPageContext) as ContactsPageType;
+  } = useContext(ContactsContext) as ContactsType;
 
   return (
     <>

--- a/src/components/Contacts/ContactsLeftPanel/ContactsLeftPanel.stories.tsx
+++ b/src/components/Contacts/ContactsLeftPanel/ContactsLeftPanel.stories.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from 'react';
 import { ContactsLeftPanel } from './ContactsLeftPanel';
 import { ContactsQuery } from 'pages/accountLists/[accountListId]/contacts/Contacts.generated';
-import { ContactsPageProvider } from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 export default {
   title: 'Contacts/LeftPanel',
@@ -11,9 +11,9 @@ export default {
 export const Default = (): ReactElement => {
   return (
     <GqlMockedProvider<ContactsQuery>>
-      <ContactsPageProvider>
+      <ContactsPage>
         <ContactsLeftPanel />
-      </ContactsPageProvider>
+      </ContactsPage>
     </GqlMockedProvider>
   );
 };

--- a/src/components/Contacts/ContactsLeftPanel/ContactsLeftPanel.tsx
+++ b/src/components/Contacts/ContactsLeftPanel/ContactsLeftPanel.tsx
@@ -2,9 +2,9 @@ import _ from 'lodash';
 import React from 'react';
 import { ContactsMapPanel } from '../ContactsMap/ContactsMapPanel';
 import {
-  ContactsPageContext,
-  ContactsPageType,
-} from '../../../../pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+  ContactsContext,
+  ContactsType,
+} from '../../../../pages/accountLists/[accountListId]/contacts/ContactsContext';
 import { FilterPanel } from '../../../../src/components/Shared/Filters/FilterPanel';
 import { TableViewModeEnum } from '../../../../src/components/Shared/Header/ListHeader';
 
@@ -21,14 +21,14 @@ export const ContactsLeftPanel: React.FC = () => {
     selected,
     setSelected,
     viewMode,
-  } = React.useContext(ContactsPageContext) as ContactsPageType;
+  } = React.useContext(ContactsContext) as ContactsType;
 
   return (
     <>
       {viewMode !== TableViewModeEnum.Map ? (
         filterData && !filtersLoading ? (
           <FilterPanel
-            filters={filterData?.accountList.contactFilterGroups}
+            filters={filterData?.accountList?.contactFilterGroups}
             savedFilters={savedFilters}
             selectedFilters={activeFilters}
             onClose={toggleFilterPanel}

--- a/src/components/Contacts/ContactsList/ContactsList.stories.tsx
+++ b/src/components/Contacts/ContactsList/ContactsList.stories.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { ContactsQuery } from '../../../../pages/accountLists/[accountListId]/contacts/Contacts.generated';
 import { GqlMockedProvider } from '../../../../__tests__/util/graphqlMocking';
 import { ContactsList } from './ContactsList';
-import { ContactsPageProvider } from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 export default {
   title: 'Contacts/List',
@@ -11,9 +11,9 @@ export default {
 export const Default = (): ReactElement => {
   return (
     <GqlMockedProvider<ContactsQuery>>
-      <ContactsPageProvider>
+      <ContactsPage>
         <ContactsList />
-      </ContactsPageProvider>
+      </ContactsPage>
     </GqlMockedProvider>
   );
 };

--- a/src/components/Contacts/ContactsList/ContactsList.tsx
+++ b/src/components/Contacts/ContactsList/ContactsList.tsx
@@ -5,9 +5,9 @@ import { useContactsQuery } from '../../../../pages/accountLists/[accountListId]
 import { InfiniteList } from 'src/components/InfiniteList/InfiniteList';
 import NullState from 'src/components/Shared/Filters/NullState/NullState';
 import {
-  ContactsPageContext,
-  ContactsPageType,
-} from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+  ContactsContext,
+  ContactsType,
+} from 'pages/accountLists/[accountListId]/contacts/ContactsContext';
 import { TableViewModeEnum } from 'src/components/Shared/Header/ListHeader';
 
 export const ContactsList: React.FC = () => {
@@ -21,7 +21,7 @@ export const ContactsList: React.FC = () => {
     urlFilters,
     isFiltered,
     setActiveFilters,
-  } = React.useContext(ContactsPageContext) as ContactsPageType;
+  } = React.useContext(ContactsContext) as ContactsType;
 
   const { data, loading, fetchMore } = useContactsQuery({
     variables: {

--- a/src/components/Contacts/ContactsMainPanel/ContactsMainPanel.stories.tsx
+++ b/src/components/Contacts/ContactsMainPanel/ContactsMainPanel.stories.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from 'react';
 import { ContactsMainPanel } from './ContactsMainPanel';
 import { ContactsQuery } from 'pages/accountLists/[accountListId]/contacts/Contacts.generated';
-import { ContactsPageProvider } from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 export default {
   title: 'Contacts/MainPanel',
@@ -11,9 +11,9 @@ export default {
 export const Default = (): ReactElement => {
   return (
     <GqlMockedProvider<ContactsQuery>>
-      <ContactsPageProvider>
+      <ContactsPage>
         <ContactsMainPanel />
-      </ContactsPageProvider>
+      </ContactsPage>
     </GqlMockedProvider>
   );
 };

--- a/src/components/Contacts/ContactsMainPanel/ContactsMainPanel.tsx
+++ b/src/components/Contacts/ContactsMainPanel/ContactsMainPanel.tsx
@@ -4,9 +4,9 @@ import { ContactFlow } from '../ContactFlow/ContactFlow';
 import { ContactsList } from '../ContactsList/ContactsList';
 import { ContactsMap } from '../../../../pages/accountLists/[accountListId]/contacts/map/map';
 import {
-  ContactsPageContext,
-  ContactsPageType,
-} from '../../../../pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+  ContactsContext,
+  ContactsType,
+} from '../../../../pages/accountLists/[accountListId]/contacts/ContactsContext';
 import { ContactsMainPanelHeader } from './ContactsMainPanelHeader';
 import { TableViewModeEnum } from 'src/components/Shared/Header/ListHeader';
 
@@ -19,7 +19,7 @@ export const ContactsMainPanel: React.FC = () => {
     setContactFocus,
     viewMode,
     userOptionsLoading,
-  } = React.useContext(ContactsPageContext) as ContactsPageType;
+  } = React.useContext(ContactsContext) as ContactsType;
 
   return (
     <>

--- a/src/components/Contacts/ContactsMainPanel/ContactsMainPanelHeader.tsx
+++ b/src/components/Contacts/ContactsMainPanel/ContactsMainPanelHeader.tsx
@@ -15,9 +15,9 @@ import _ from 'lodash';
 import { useSnackbar } from 'notistack';
 import { StatusEnum } from '../../../../graphql/types.generated';
 import {
-  ContactsPageContext,
-  ContactsPageType,
-} from '../../../../pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+  ContactsContext,
+  ContactsType,
+} from '../../../../pages/accountLists/[accountListId]/contacts/ContactsContext';
 import { MassActionsRemoveTagsModal } from '../MassActions/RemoveTags/MassActionsRemoveTagsModal';
 import { MassActionsAddTagsModal } from '../MassActions/AddTags/MassActionsAddTagsModal';
 import { MassActionsAddToAppealModal } from '../MassActions/AddToAppeal/MassActionsAddToAppealModal';
@@ -76,7 +76,7 @@ export const ContactsMainPanelHeader: React.FC = () => {
     urlFilters,
     handleViewModeChange,
     selectedIds,
-  } = React.useContext(ContactsPageContext) as ContactsPageType;
+  } = React.useContext(ContactsContext) as ContactsType;
 
   const [openRemoveTagsModal, setOpenRemoveTagsModal] = useState(false);
   const [openAddTagsModal, setOpenAddTagsModal] = useState(false);

--- a/src/components/Contacts/ContactsMap/ContactsMapPanel.test.tsx
+++ b/src/components/Contacts/ContactsMap/ContactsMapPanel.test.tsx
@@ -4,10 +4,10 @@ import { ThemeProvider } from '@mui/material/styles';
 import { StatusEnum } from '../../../../graphql/types.generated';
 import TestRouter from '../../../../__tests__/util/TestRouter';
 import theme from '../../../../src/theme';
-import { ContactsPageProvider } from '../../../../pages/accountLists/[accountListId]/contacts/ContactsPageContext';
 import { ContactsMapPanel } from './ContactsMapPanel';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { ContactsQuery } from 'pages/accountLists/[accountListId]/contacts/Contacts.generated';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 const accountListId = 'account-list-1';
 
@@ -50,7 +50,7 @@ describe('ContactsMapPanel', () => {
       <ThemeProvider theme={theme}>
         <TestRouter router={router}>
           <GqlMockedProvider<ContactsQuery>>
-            <ContactsPageProvider>
+            <ContactsPage>
               <ContactsMapPanel
                 data={data}
                 selected={selected}
@@ -58,7 +58,7 @@ describe('ContactsMapPanel', () => {
                 panTo={panTo}
                 onClose={onClose}
               />
-            </ContactsPageProvider>
+            </ContactsPage>
           </GqlMockedProvider>
         </TestRouter>
       </ThemeProvider>,

--- a/src/components/Contacts/ContactsRightPanel/ContactsRightPanel.stories.tsx
+++ b/src/components/Contacts/ContactsRightPanel/ContactsRightPanel.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ContactDetailProvider } from '../ContactDetails/ContactDetailContext';
 import { ContactsRightPanel } from './ContactsRightPanel';
-import { ContactsPageProvider } from 'pages/accountLists/[accountListId]/contacts/ContactsPageContext';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
 
 export default {
   title: 'Contacts/RightPanel',
@@ -9,10 +9,10 @@ export default {
 
 export const Default = (): React.ReactElement => {
   return (
-    <ContactsPageProvider>
+    <ContactsPage>
       <ContactDetailProvider>
         <ContactsRightPanel onClose={() => {}} />
       </ContactDetailProvider>
-    </ContactsPageProvider>
+    </ContactsPage>
   );
 };

--- a/src/components/Shared/Filters/FilterPanel.tsx
+++ b/src/components/Shared/Filters/FilterPanel.tsx
@@ -434,7 +434,7 @@ export const FilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
 
   const tagsFilters =
     (
-      filters.find((filter) => filter.name === 'Tags')
+      filters?.find((filter) => filter.name === 'Tags')
         ?.filters[0] as MultiselectFilter
     )?.options ?? [];
 


### PR DESCRIPTION
Both the `Tasks` page and `ContactsContextProvider` were performing a router replace for the same reason, but on the tasks page, it was happening twice as it calls in the `ContactsContextProvider` onto the page.

To fix this, I moved some of `ContactsContextProvider` state and functionality up to a new parent, which is only included on the contacts page. Now tasks can import `ContactsContextProvider` and not have a duplicate router replace.

I also had to update all the tests with the new provider structure.

Then lastly, I renamed `ContactsPageContent` to just `ContactsContext` as it's used on contacts and tasks pages