### PR TITLE
[no-jira] Disallow console methods

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     'import/no-anonymous-default-export': 'error',
     'import/dynamic-import-chunkname': 'error',
     eqeqeq: 'error',
+    'no-console': 'error',
     '@typescript-eslint/no-loss-of-precision': 'warn',
     '@typescript-eslint/no-unused-vars': [
       'error',

--- a/onesky/download.js
+++ b/onesky/download.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const fs = require('fs');
 const onesky = require('@brainly/onesky-utils');
 

--- a/onesky/upload.js
+++ b/onesky/upload.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const fs = require('fs');
 const onesky = require('@brainly/onesky-utils');
 

--- a/pages/api/graphql.page.ts
+++ b/pages/api/graphql.page.ts
@@ -23,6 +23,7 @@ class AuthenticatedDataSource extends RemoteGraphQLDataSource {
         );
       }
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.error('Error adding Authorization header', e);
     }
   }

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/AddAddressModal/AddAddressModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/AddAddressModal/AddAddressModal.test.tsx
@@ -176,7 +176,6 @@ describe('AddAddressModal', () => {
     expect(operation.variables.attributes.street).toEqual(newStreet);
 
     const { operation: operation2 } = mutationSpy.mock.calls[1][0];
-    console.log(operation2);
     expect(operation2.variables.primaryAddressId).not.toBeNull();
   });
 

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonEmail/PersonEmailItem.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonEmail/PersonEmailItem.tsx
@@ -77,7 +77,6 @@ export const PersonEmailItem: React.FC<Props> = ({
 
   const handleChange = () => {
     handleChangePrimary(index);
-    console.log(index);
   };
 
   return (

--- a/src/components/Layouts/Primary/NavBar/NavTools/AddMenuPanel/AddMenuPanel.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/AddMenuPanel/AddMenuPanel.tsx
@@ -63,6 +63,7 @@ export const AddMenuPanel = (): ReactElement => {
     {
       text: 'Log Task',
       icon: EditIcon,
+      // eslint-disable-next-line no-console
       onClick: () => console.log('log task'),
     },
   ];

--- a/src/components/Tool/Appeal/AppealDrawer/AppealDrawerList.tsx
+++ b/src/components/Tool/Appeal/AppealDrawer/AppealDrawerList.tsx
@@ -46,6 +46,7 @@ const AppealDrawerList = ({ appeal }: Props): ReactElement => {
   const { appealState } = useAppealContext();
 
   const testFunc = (): void => {
+    // eslint-disable-next-line no-console
     console.log(appealState);
   };
 

--- a/src/components/Tool/MergeContacts/MergeContacts.tsx
+++ b/src/components/Tool/MergeContacts/MergeContacts.tsx
@@ -92,9 +92,11 @@ const MergeContacts: React.FC<Props> = ({ accountListId }: Props) => {
     for (const [id, action] of Object.entries(actions)) {
       switch (action.action) {
         case 'merge':
+          // eslint-disable-next-line no-console
           console.log(`Merging ${id} with ${action.mergeId}`);
           break;
         case 'delete':
+          // eslint-disable-next-line no-console
           console.log(`Deleting ${id}`);
           break;
         default:

--- a/src/components/Tool/MergePeople/MergePeople.tsx
+++ b/src/components/Tool/MergePeople/MergePeople.tsx
@@ -92,9 +92,11 @@ const MergePeople: React.FC<Props> = ({ accountListId }: Props) => {
     for (const [id, action] of Object.entries(actions)) {
       switch (action.action) {
         case 'merge':
+          // eslint-disable-next-line no-console
           console.log(`Merging ${id} with ${action.mergeId}`);
           break;
         case 'delete':
+          // eslint-disable-next-line no-console
           console.log(`Deleting ${id}`);
           break;
         default:


### PR DESCRIPTION
Add eslint rule to disallow the use of `console` methods because most `console.log` calls are accidentally left in from testing during development. If there's a legitimate use for `console.log`, like a placeholder for functionality that isn't implemented yet, just put `// eslint-disable-next-line no-console` on the previous line.