### PR TITLE
[no-jira] Add spacing between report buttons

### DIFF
--- a/src/components/Reports/DonationsReport/Table/DonationsReportTable.tsx
+++ b/src/components/Reports/DonationsReport/Table/DonationsReportTable.tsx
@@ -293,7 +293,13 @@ export const DonationsReportTable: React.FC<Props> = ({
 
   return (
     <>
-      <Box style={{ display: 'flex', margin: 8 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          margin: 1,
+          gap: 2,
+        }}
+      >
         <Typography variant="h6">{title}</Typography>
         <Button
           style={{ marginLeft: 'auto', maxHeight: 35 }}

--- a/src/components/Reports/EmptyReport/EmptyReport.tsx
+++ b/src/components/Reports/EmptyReport/EmptyReport.tsx
@@ -44,17 +44,12 @@ export const EmptyReport: React.FC<Props> = ({
       </Box>
       <Typography variant="h5">{title}</Typography>
       {subTitle && <Typography>{subTitle}</Typography>}
-      <Box style={{ padding: 4 }}>
+      <Box sx={{ padding: 1, display: 'flex', gap: 2 }}>
         <HandoffLink path="/preferences/integrations">
           <Button variant="contained">{t('Connect Services')}</Button>
         </HandoffLink>
         {hasAddNewDonation && (
-          <Button
-            variant="contained"
-            color="primary"
-            style={{ marginLeft: 2 }}
-            onClick={addNewDonation}
-          >
+          <Button variant="contained" color="primary" onClick={addNewDonation}>
             {t('Add New Donation')}
           </Button>
         )}

--- a/src/components/common/EmptyDonationsTable/EmptyDonationsTable.tsx
+++ b/src/components/common/EmptyDonationsTable/EmptyDonationsTable.tsx
@@ -45,7 +45,7 @@ export const EmptyDonationsTable: React.FC<Props> = ({ title }) => {
           'You can setup an organization account to import historic donations or add a new donation.',
         )}
       </Typography>
-      <Box style={{ padding: 4 }}>
+      <Box sx={{ padding: 1, display: 'flex', gap: 2 }}>
         <Button variant="contained" onClick={connectServices}>
           Connect Services
         </Button>


### PR DESCRIPTION
Use the flexbox gap CSS property to add consistent spacing between adjacent buttons. The margin/padding numbers are changing because `style` uses `px` units and `sx` uses `4px` units.