### PR TITLE
[no-jira] Stop waiting for clicks

### DIFF
--- a/pages/accountLists/[accountListId]/contacts/ContactsContext.test.tsx
+++ b/pages/accountLists/[accountListId]/contacts/ContactsContext.test.tsx
@@ -116,7 +116,7 @@ describe('ContactsPageContext', () => {
     );
     expect(getByText('Loading')).toBeInTheDocument();
     await waitFor(() => expect(getByText('Flows Button')).toBeInTheDocument());
-    await waitFor(() => userEvent.click(getByText('Flows Button')));
+    userEvent.click(getByText('Flows Button'));
     await waitFor(() => expect(getByText('flows')).toBeInTheDocument());
     await waitFor(() =>
       expect(push).toHaveBeenCalledWith({

--- a/pages/accountLists/[accountListId]/tasks/Tasks.test.tsx
+++ b/pages/accountLists/[accountListId]/tasks/Tasks.test.tsx
@@ -141,7 +141,7 @@ it.skip('should open add task panel', async () => {
   );
   await waitFor(() => expect(getByText('Test Person')).toBeInTheDocument());
   await waitFor(() => expect(getByText('Test Subject')).toBeInTheDocument());
-  await waitFor(() => userEvent.click(getByText('Add Task')));
+  userEvent.click(getByText('Add Task'));
   await waitFor(() => expect(openTaskModal).toHaveBeenCalled());
 });
 
@@ -167,8 +167,8 @@ it('should show Completed', async () => {
 
   await waitFor(() => expect(getByText('Historic')).toBeInTheDocument());
   await waitFor(() => expect(getByText('Current')).toBeInTheDocument());
-  await waitFor(() => userEvent.click(getByText('Historic')));
-  await waitFor(() => userEvent.click(getByText('Current')));
+  userEvent.click(getByText('Historic'));
+  userEvent.click(getByText('Current'));
   await waitFor(() =>
     expect(router).toMatchInlineSnapshot(`
       Object {

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsHeader.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsHeader.test.tsx
@@ -147,10 +147,10 @@ describe('ContactDetails', () => {
         </TestRouter>
       </SnackbarProvider>,
     );
-    await waitFor(() => {
-      expect(queryByText('Loading')).not.toBeInTheDocument();
-      userEvent.click(getAllByLabelText('Edit Icon')[0]);
-    });
+    await waitFor(() =>
+      expect(getAllByLabelText('Edit Icon')[0]).toBeInTheDocument(),
+    );
+    userEvent.click(getAllByLabelText('Edit Icon')[0]);
     await waitFor(() =>
       expect(queryByText('Edit Contact Details')).toBeInTheDocument(),
     );
@@ -187,10 +187,10 @@ describe('ContactDetails', () => {
         </TestRouter>
       </SnackbarProvider>,
     );
-    await waitFor(() => {
-      expect(queryByText('Loading')).not.toBeInTheDocument();
-      userEvent.click(getAllByLabelText('Edit Icon')[0]);
-    });
+    await waitFor(() =>
+      expect(getAllByLabelText('Edit Icon')[0]).toBeInTheDocument(),
+    );
+    userEvent.click(getAllByLabelText('Edit Icon')[0]);
     await waitFor(() =>
       expect(queryByText('Edit Contact Details')).toBeInTheDocument(),
     );

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.test.tsx
@@ -177,7 +177,7 @@ describe('ContactDetailsMoreActions', () => {
     );
     expect(getByText('Hide Contact')).toBeInTheDocument();
     userEvent.click(getByText('Hide Contact'));
-    await waitFor(() => userEvent.click(getByText('Hide')));
+    userEvent.click(getByText('Hide'));
     await waitFor(() =>
       expect(mockEnqueue).toHaveBeenCalledWith('Contact hidden successfully!', {
         variant: 'success',

--- a/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.test.tsx
@@ -119,7 +119,7 @@ describe('EditPartnershipInfoModal', () => {
     );
 
     expect(getByText('Edit Partnership')).toBeInTheDocument();
-    await waitFor(() => userEvent.click(getByLabelText('Close')));
+    userEvent.click(getByLabelText('Close'));
     expect(handleClose).toHaveBeenCalled();
   });
 
@@ -140,7 +140,7 @@ describe('EditPartnershipInfoModal', () => {
     );
 
     expect(getByText('Edit Partnership')).toBeInTheDocument();
-    await waitFor(() => userEvent.click(getByText('Cancel')));
+    userEvent.click(getByText('Cancel'));
     expect(handleClose).toHaveBeenCalled();
   });
 
@@ -342,7 +342,7 @@ describe('EditPartnershipInfoModal', () => {
     const currencyInput = getByLabelText('Currency');
 
     userEvent.click(currencyInput);
-    await waitFor(() => userEvent.click(getByText('CDF (CDF)')));
+    userEvent.click(getByText('CDF (CDF)'));
     userEvent.click(getByText('Save'));
     await waitFor(() =>
       expect(mockEnqueue).toHaveBeenCalledWith(

--- a/src/components/Contacts/ContactRow/ContactRow.test.tsx
+++ b/src/components/Contacts/ContactRow/ContactRow.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '@mui/material/styles';
 import {
@@ -109,7 +109,7 @@ describe('ContactsRow', () => {
 
     const checkbox = getByRole('checkbox');
     expect(checkbox).not.toBeChecked();
-    await waitFor(() => userEvent.click(checkbox));
+    userEvent.click(checkbox);
     // TODO: Find a way to check that click event was pressed.
   });
 
@@ -127,7 +127,7 @@ describe('ContactsRow', () => {
     );
 
     const taskButton = getByTitle('Log Task');
-    await waitFor(() => userEvent.click(taskButton));
+    userEvent.click(taskButton);
     // TODO: Find a way to check that click event was pressed.
     expect(openTaskModal).toHaveBeenCalledWith({
       view: 'log',

--- a/src/components/Shared/Filters/FilterPanel.test.tsx
+++ b/src/components/Shared/Filters/FilterPanel.test.tsx
@@ -396,7 +396,7 @@ describe('FilterPanel', () => {
       expect(queryAllByTestId('FilterGroup').length).toEqual(2);
       expect(getByText('Group 1 (1)')).toBeVisible();
 
-      await waitFor(() => userEvent.click(getByText('Clear All')));
+      userEvent.click(getByText('Clear All'));
       expect(onSelectedFiltersChanged).toHaveBeenCalledWith({});
     });
 


### PR DESCRIPTION
`userEvent.click()` can be called directly and should not be wrapped in `await waitFor(() => userEvent.click())`