### PR TITLE
Added the ability for non-CRU orgs to download their Onesky projects …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,4 +131,5 @@ jobs:
         env:
           ONESKY_API_KEY: ${{ secrets.ONESKY_API_KEY }}
           ONESKY_API_SECRET: ${{ secrets.ONESKY_API_SECRET }}
+          ONESKY_PROJECT_ID: ${{ secrets.ONESKY_PROJECT_ID }}
         run: yarn onesky:upload

--- a/onesky/download.js
+++ b/onesky/download.js
@@ -6,7 +6,7 @@ const onesky = require('@brainly/onesky-utils');
 const options = {
   secret: process.env.ONESKY_API_SECRET,
   apiKey: process.env.ONESKY_API_KEY,
-  projectId: '367075',
+  projectId: process.env.ONESKY_PROJECT_ID,
 };
 
 onesky
@@ -20,7 +20,7 @@ onesky
             language: lang.code,
             secret: process.env.ONESKY_API_SECRET,
             apiKey: process.env.ONESKY_API_KEY,
-            projectId: '367075',
+            projectId: process.env.ONESKY_PROJECT_ID,
             fileName: 'translation.json',
           })
           .then(function (langContent) {

--- a/onesky/upload.js
+++ b/onesky/upload.js
@@ -10,7 +10,7 @@ const options = {
   language: 'en',
   secret: process.env.ONESKY_API_SECRET,
   apiKey: process.env.ONESKY_API_KEY,
-  projectId: '367075',
+  projectId: process.env.ONESKY_PROJECT_ID,
   fileName: 'translation.json',
   format: 'HIERARCHICAL_JSON',
   content: JSON.stringify(translations),


### PR DESCRIPTION
## Description
Added the ability for non-CRU orgs to download their Onesky project's languages.
This will allow non-CRU orgs to use their Onesky account and project.
I will add the variable ONESKY_PROJECT_ID onto our Amplify server via Terraform.

- Updating the Onesky files to use ONESKY_PROJECT_ID var instead of hard-coded project id.