### PR TITLE
MPDX One Sky Upload Fix

### DIFF
--- a/onesky/upload.js
+++ b/onesky/upload.js
@@ -3,8 +3,9 @@
 const fs = require('fs');
 const onesky = require('@brainly/onesky-utils');
 
-const translations = JSON.parse(
-  fs.readFileSync('public/locales/en/translation.json', 'utf-8'),
+const translations = fs.readFileSync(
+  'public/locales/en/translation.json',
+  'utf-8',
 );
 const options = {
   language: 'en',
@@ -13,7 +14,7 @@ const options = {
   projectId: process.env.ONESKY_PROJECT_ID,
   fileName: 'translation.json',
   format: 'HIERARCHICAL_JSON',
-  content: JSON.stringify(translations),
+  content: translations,
   keepStrings: true,
 };
 


### PR DESCRIPTION
## Description
MPDX React upload has uploaded translation files to Onesky, but they weren't formatted correctly, meaning Onesky hasn't been updating. I've corrected the formatting. The translation file will now upload data in the correct format.

### What I've done
- Removed `.toString` as `readFileSync` already returns as a string since we pass `utf8` as the encoder.
- Added `JSON.parse()` around `readFileSync` to ensure `translations` is JSON before running stringify on line 16, Preventing it from being stringified twice.