### PR TITLE
No jira data dog user tracking

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -79,6 +79,11 @@ module.exports = withPlugins([
       REWRITE_DOMAIN: process.env.REWRITE_DOMAIN ?? 'mpdx.org',
       DATADOG_APP_ID: process.env.DATADOG_APP_ID,
       DATADOG_CLIENT_TOKEN: process.env.DATADOG_CLIENT_TOKEN,
+      DATADOG_CONFIGURED: !!(
+        process.env.NODE_ENV === 'production' &&
+        process.env.DATADOG_APP_ID &&
+        process.env.DATADOG_CLIENT_TOKEN
+      ),
     },
     experimental: {
       modularizeImports: {

--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -28,6 +28,7 @@ import { RouterGuard } from '../src/components/RouterGuard/RouterGuard';
 import HelpscoutBeacon from '../src/components/Helpscout/HelpscoutBeacon';
 import { UserPreferenceProvider } from 'src/components/User/Preferences/UserPreferenceProvider';
 import { AppSettingsProvider } from '../src/components/common/AppSettings/AppSettingsProvider';
+import DataDog from 'src/components/DataDog/DataDog';
 
 const handleExitComplete = (): void => {
   if (typeof window !== 'undefined') {
@@ -160,6 +161,7 @@ const App = ({
                     </StyledEngineProvider>
                   </I18nextProvider>
                 </UserPreferenceProvider>
+                <DataDog />
               </SessionProvider>
             </ApolloProvider>
           </AppSettingsProvider>

--- a/pages/_document.page.tsx
+++ b/pages/_document.page.tsx
@@ -22,13 +22,11 @@ class MyDocument extends Document {
             href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;700&display=swap"
             rel="stylesheet"
           />
-          {process.env.NODE_ENV === 'production' &&
-            process.env.DATADOG_APP_ID &&
-            process.env.DATADOG_CLIENT_TOKEN && (
-              <Script id="datadog-rum" strategy="afterInteractive">
-                {`!function(a,e,t,n,s){a=a[s]=a[s]||{q:[],onReady:function(e){a.q.push(e)}},(s=e.createElement(t)).async=1,s.src=n,(n=e.getElementsByTagName(t)[0]).parentNode.insertBefore(s,n)}(window,document,"script","https://www.datadoghq-browser-agent.com/datadog-rum-v4.js","DD_RUM"),DD_RUM.onReady(function(){DD_RUM.init({clientToken:"${process.env.DATADOG_CLIENT_TOKEN}",applicationId:"${process.env.DATADOG_APP_ID}",site:"datadoghq.com",service:"mpdx-web-react",sessionSampleRate:100,sessionReplaySampleRate:20,trackUserInteractions:!0,trackResources:!0,trackLongTasks:!0,defaultPrivacyLevel:"mask-user-input"}),DD_RUM.startSessionReplayRecording()});`}
-              </Script>
-            )}
+          {process.env.DATADOG_CONFIGURED && (
+            <Script id="datadog-rum" strategy="afterInteractive">
+              {`!function(a,e,t,n,s){a=a[s]=a[s]||{q:[],onReady:function(e){a.q.push(e)}},(s=e.createElement(t)).async=1,s.src=n,(n=e.getElementsByTagName(t)[0]).parentNode.insertBefore(s,n)}(window,document,"script","https://www.datadoghq-browser-agent.com/datadog-rum-v4.js","DD_RUM"),DD_RUM.onReady(function(){DD_RUM.init({clientToken:"${process.env.DATADOG_CLIENT_TOKEN}",applicationId:"${process.env.DATADOG_APP_ID}",site:"datadoghq.com",service:"mpdx-web-react",sessionSampleRate:100,sessionReplaySampleRate:20,trackUserInteractions:!0,trackResources:!0,trackLongTasks:!0,defaultPrivacyLevel:"mask-user-input"}),DD_RUM.startSessionReplayRecording()});`}
+            </Script>
+          )}
           {process.env.GOOGLE_TAG_MANAGER_CONTAINER_ID && (
             <Script id="google-analytics" strategy="afterInteractive">
               {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${process.env.GOOGLE_TAG_MANAGER_CONTAINER_ID}');`}

--- a/pages/logout.page.tsx
+++ b/pages/logout.page.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import { GetServerSideProps } from 'next';
 import { useTranslation } from 'react-i18next';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
+import { clearDataDogUser } from 'src/hooks/useDataDog';
 import { Box, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import ExitToAppRoundedIcon from '@mui/icons-material/ExitToAppRounded';
@@ -25,7 +26,9 @@ const LogoutPage = ({}): ReactElement => {
   const { appName } = useGetAppSettings();
 
   useEffect(() => {
-    signOut({ callbackUrl: 'signOut' });
+    signOut({ callbackUrl: 'signOut' }).then(() => {
+      clearDataDogUser();
+    });
   }, []);
 
   return (

--- a/src/components/DataDog/DataDog.tsx
+++ b/src/components/DataDog/DataDog.tsx
@@ -1,0 +1,32 @@
+import { ReactElement, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
+import { useGetUserInfoQuery } from './GetUserInfo.generated';
+import { setDataDogUser } from 'src/hooks/useDataDog';
+
+const DataDog = (): ReactElement => {
+  const { query } = useRouter();
+  const { data: session } = useSession();
+  const { data, loading } = useGetUserInfoQuery({ skip: !session });
+
+  useEffect(() => {
+    if (!loading && data) {
+      const accountListId = query?.accountListId
+        ? Array.isArray(query.accountListId)
+          ? query.accountListId[0]
+          : query.accountListId
+        : '';
+
+      const { user } = data;
+      setDataDogUser({
+        userId: user?.id,
+        accountListId,
+        name: `${user?.firstName ?? ''} ${user?.lastName ?? ''}`,
+        email: user?.keyAccounts[0]?.email ?? '',
+      });
+    }
+  }, [loading, data]);
+  return <></>;
+};
+
+export default DataDog;

--- a/src/components/DataDog/GetUserInfo.graphql
+++ b/src/components/DataDog/GetUserInfo.graphql
@@ -1,0 +1,10 @@
+query GetUserInfo {
+  user {
+    id
+    firstName
+    lastName
+    keyAccounts {
+      email
+    }
+  }
+}

--- a/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.test.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.test.tsx
@@ -11,7 +11,7 @@ import { ProfileMenuPanel } from './ProfileMenuPanel';
 
 jest.mock('next-auth/react', () => {
   return {
-    signOut: jest.fn(),
+    signOut: jest.fn().mockImplementation(() => Promise.resolve()),
   };
 });
 

--- a/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/router';
 import ChevronRight from '@mui/icons-material/ChevronRight';
 import theme from '../../../../../../theme';
 import { useAccountListId } from '../../../../../../hooks/useAccountListId';
+import { clearDataDogUser } from 'src/hooks/useDataDog';
 import { LeafButton, LeafListItem, Title } from '../../NavItem/NavItem';
 import HandoffLink from '../../../../../HandoffLink';
 import { useGetTopBarQuery } from '../../../TopBar/GetTopBar.generated';
@@ -197,7 +198,11 @@ export const ProfileMenuPanel: React.FC = () => {
           <Button
             variant="outlined"
             color="secondary"
-            onClick={() => signOut({ callbackUrl: 'signOut' })}
+            onClick={() =>
+              signOut({ callbackUrl: 'signOut' }).then(() => {
+                clearDataDogUser();
+              })
+            }
           >
             {t('Sign Out')}
           </Button>

--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.test.tsx
@@ -17,7 +17,7 @@ import ProfileMenu from './ProfileMenu';
 
 jest.mock('next-auth/react', () => {
   return {
-    signOut: jest.fn(),
+    signOut: jest.fn().mockImplementation(() => Promise.resolve()),
   };
 });
 

--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
@@ -22,6 +22,7 @@ import { signOut } from 'next-auth/react';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useAccountListId } from '../../../../../../hooks/useAccountListId';
+import { clearDataDogUser } from 'src/hooks/useDataDog';
 import HandoffLink from '../../../../../HandoffLink';
 import { useGetTopBarQuery } from '../../GetTopBar.generated';
 import theme from '../../../../../../theme';
@@ -270,7 +271,11 @@ const ProfileMenu = (): ReactElement => {
           <MenuButton
             variant="outlined"
             color="inherit"
-            onClick={() => signOut({ callbackUrl: 'signOut' })}
+            onClick={() => {
+              signOut({ callbackUrl: 'signOut' }).then(() => {
+                clearDataDogUser();
+              });
+            }}
           >
             {t('Sign Out')}
           </MenuButton>

--- a/src/hooks/__tests__/useDataDog.test.ts
+++ b/src/hooks/__tests__/useDataDog.test.ts
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react-hooks';
+import {
+  isDataDogConfigured,
+  clearDataDogUser,
+  setDataDogUser,
+} from '../useDataDog';
+
+const setDataDogUserMock = {
+  userId: '123456',
+  accountListId: '1234-4567-8910-1112-1314',
+  name: 'Roger',
+  email: 'roger@cru.org',
+};
+
+describe('useDataDog', () => {
+  beforeEach(() => {
+    window.DD_RUM = {
+      getUser: jest.fn(),
+      setUser: jest.fn(),
+      clearUser: jest.fn(),
+    };
+  });
+
+  describe('DataDog not configured', () => {
+    it('should return isDataDogConfigured as false', () => {
+      const { result } = renderHook(() => isDataDogConfigured(), {});
+      expect(result.current).toEqual(false);
+    });
+
+    it('should NOT run setDataDogUser', () => {
+      renderHook(() => setDataDogUser(setDataDogUserMock), {});
+      expect(window.DD_RUM.getUser).not.toHaveBeenCalled();
+      expect(window.DD_RUM.clearUser).not.toHaveBeenCalled();
+      expect(window.DD_RUM.setUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DataDog configured', () => {
+    beforeEach(() => {
+      process.env.DATADOG_CONFIGURED = 'true';
+    });
+
+    //#region Default Tests
+    it('should return isDataDogConfigured as true', () => {
+      const { result } = renderHook(() => isDataDogConfigured(), {});
+      expect(result.current).toEqual(true);
+    });
+
+    it('should run clearDataDogUser', () => {
+      renderHook(() => clearDataDogUser(), {});
+      expect(window.DD_RUM.clearUser).toHaveBeenCalled();
+    });
+
+    it('New User', () => {
+      renderHook(() => setDataDogUser(setDataDogUserMock), {});
+      expect(window.DD_RUM.getUser).toHaveBeenCalledTimes(2);
+      expect(window.DD_RUM.clearUser).toHaveBeenCalled();
+      expect(window.DD_RUM.setUser).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/useDataDog.ts
+++ b/src/hooks/useDataDog.ts
@@ -1,0 +1,46 @@
+declare global {
+  interface Window {
+    DD_RUM: any;
+  }
+}
+
+export const isDataDogConfigured = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  return !!(
+    process.env.DATADOG_CONFIGURED &&
+    Object.hasOwn(window?.DD_RUM ?? {}, 'getUser')
+  );
+};
+
+export interface setUserProps {
+  userId: string;
+  name: string;
+  email: string;
+  accountListId: string;
+}
+export const setDataDogUser = ({
+  userId,
+  name,
+  email,
+  accountListId,
+}: setUserProps): void => {
+  if (!isDataDogConfigured()) return;
+  if (
+    window.DD_RUM.getUser()?.accountListId &&
+    window.DD_RUM.getUser()?.accountListId === accountListId
+  )
+    return;
+  if (window.DD_RUM.getUser()?.accountListId !== accountListId)
+    clearDataDogUser();
+  window.DD_RUM.setUser({
+    id: accountListId,
+    name,
+    email,
+    userId: userId,
+  });
+};
+
+export const clearDataDogUser = (): void => {
+  if (!isDataDogConfigured()) return;
+  window.DD_RUM.clearUser();
+};

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -9,6 +9,7 @@ import { onError } from '@apollo/client/link/error';
 import { persistCache, LocalStorageWrapper } from 'apollo3-cache-persist';
 import fetch from 'isomorphic-fetch';
 import { signOut } from 'next-auth/react';
+import { clearDataDogUser } from 'src/hooks/useDataDog';
 import generatedIntrospection from '../../graphql/possibleTypes.generated';
 import snackNotifications from '../components/Snackbar/Snackbar';
 import { dispatch } from './analytics';
@@ -48,7 +49,9 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors) {
     graphQLErrors.map(({ message, extensions }) => {
       if (extensions?.code === 'AUTHENTICATION_ERROR') {
-        signOut({ redirect: true, callbackUrl: 'signOut' });
+        signOut({ redirect: true, callbackUrl: 'signOut' }).then(() => {
+          clearDataDogUser();
+        });
       }
       snackNotifications.error(message);
     });


### PR DESCRIPTION
## Description
Added DataDog user tracking.

## What I've done
- Create custom hooks to set and clear user.
- Made a new `next.config` variable to make it easier to understand if DataDog should be called in.
- On the Dashboard component, pulled in more useful info about the user.
- On the dashboard, I register the user with DataDog. This is where people land when they log in with one account or select one of their accounts. Plus we already had most of the data we needed on this page.
- Update Dashboard tests and stories with new GraphQL data.
- On logout, clear the Datadog user.
