### PR TITLE
Mpdx 7614 mpdx 7615

### DIFF
--- a/pages/accountLists/[accountListId]/contacts/flows/setup.page.tsx
+++ b/pages/accountLists/[accountListId]/contacts/flows/setup.page.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
 import { DndProvider } from 'react-dnd';
@@ -7,6 +7,7 @@ import Box from '@mui/material/Box';
 import { v4 as uuidv4 } from 'uuid';
 import { useSnackbar } from 'notistack';
 import _ from 'lodash';
+import theme from 'src/theme';
 import useGetAppSettings from '../../../../../src/hooks/useGetAppSettings';
 import { ContactFlowSetupDragLayer } from '../../../../../src/components/Contacts/ContactFlow/ContactFlowSetup/DragLayer/ContactFlowSetupDragLayer';
 import { UnusedStatusesColumn } from '../../../../../src/components/Contacts/ContactFlow/ContactFlowSetup/Column/UnusedStatusesColumn';
@@ -26,23 +27,20 @@ import {
 } from '../../../../../src/components/Contacts/ContactFlow/ContactFlow';
 import { ContactFlowSetupColumn } from '../../../../../src/components/Contacts/ContactFlow/ContactFlowSetup/Column/ContactFlowSetupColumn';
 import { useUpdateUserOptionsMutation } from '../../../../../src/components/Contacts/ContactFlow/ContactFlowSetup/UpdateUserOptions.generated';
+import { styled } from '@mui/material/styles';
+
+const StickyBox = styled(Box)(() => ({
+  ['@media (min-width:900px)']: {
+    position: 'sticky',
+    right: 0,
+    background: '#ffffff',
+  },
+}));
 
 const ContactFlowSetupPage: React.FC = () => {
   const { t } = useTranslation();
   const accountListId = useAccountListId();
   const { enqueueSnackbar } = useSnackbar();
-  const { data: userOptions, loading } = useGetUserOptionsQuery({
-    onCompleted: () => {
-      setFlowOptions(
-        JSON.parse(
-          userOptions?.userOptions.find((option) => option.key === 'flows')
-            ?.value || '[]',
-        ),
-      );
-    },
-  });
-  const [updateUserOptions] = useUpdateUserOptionsMutation();
-  const { appName } = useGetAppSettings();
   const [flowOptions, setFlowOptions] = useState<
     {
       name: string;
@@ -51,6 +49,18 @@ const ContactFlowSetupPage: React.FC = () => {
       id: string;
     }[]
   >([]);
+  const { data: userOptions, loading } = useGetUserOptionsQuery();
+
+  useEffect(() => {
+    const newOptions = JSON.parse(
+      userOptions?.userOptions.find((option) => option.key === 'flows')
+        ?.value || '[]',
+    );
+    setFlowOptions(newOptions);
+  }, [userOptions]);
+
+  const [updateUserOptions] = useUpdateUserOptionsMutation();
+  const { appName } = useGetAppSettings();
 
   const allUsedStatuses = flowOptions
     ? flowOptions.flatMap((option) => option.statuses)
@@ -97,8 +107,8 @@ const ContactFlowSetupPage: React.FC = () => {
     });
   };
 
-  const addColumn = (): void => {
-    updateOptions([
+  const addColumn = (): Promise<void> => {
+    return updateOptions([
       ...flowOptions,
       {
         name: 'Untitled',
@@ -190,19 +200,17 @@ const ContactFlowSetupPage: React.FC = () => {
               <Box
                 display="grid"
                 minWidth="100%"
-                gridTemplateColumns={`repeat(${flowOptions.length + 1}, 1fr`}
+                gridTemplateColumns={`repeat(${
+                  flowOptions.length + 1
+                }, minmax(300px, 1fr)); minmax(300px, 1fr)`}
                 gridAutoFlow="column"
+                gap={theme.spacing(1)}
+                overflow="auto"
                 style={{ overflowX: 'auto' }}
+                gridAutoColumns="300px"
               >
                 {flowOptions.map((column, index) => (
-                  <Box
-                    width={'100%'}
-                    // If there are more than five columns give them a fixed width
-                    // otherwise fit them equally into the screen
-                    minWidth={flowOptions.length > 5 ? 360 : '100%'}
-                    p={2}
-                    key={index}
-                  >
+                  <Box width={'100%'} minWidth={300} p={2} key={index}>
                     <ContactFlowSetupColumn
                       index={index}
                       loading={loading}
@@ -221,16 +229,11 @@ const ContactFlowSetupPage: React.FC = () => {
                         id: statusMap[status] as ContactFilterStatusEnum,
                         value: status,
                       }))}
+                      flowOptions={flowOptions}
                     />
                   </Box>
                 ))}
-                <Box
-                  width={'100%'}
-                  // If there are more than five columns give them a fixed width
-                  // otherwise fit them equally into the screen
-                  minWidth={flowOptions.length > 5 ? 360 : '100%'}
-                  p={2}
-                >
+                <StickyBox width={'100%'} minWidth={250} p={2}>
                   <UnusedStatusesColumn
                     accountListId={accountListId}
                     columnWidth={columnWidth}
@@ -241,7 +244,7 @@ const ContactFlowSetupPage: React.FC = () => {
                       value: status,
                     }))}
                   />
-                </Box>
+                </StickyBox>
               </Box>
             )}
           </Box>

--- a/src/components/Contacts/ContactFlow/ContactFlow.tsx
+++ b/src/components/Contacts/ContactFlow/ContactFlow.tsx
@@ -138,24 +138,21 @@ export const ContactFlow: React.FC<Props> = ({
             <Box
               display="grid"
               minWidth="100%"
-              gridTemplateColumns={`repeat(${flowOptions.length}, ${
-                flowOptions.length > 5
-                  ? '1fr'
-                  : 'minmax(0, 1fr)); minmax(0, 1fr)'
-              }`}
+              gridTemplateColumns={`repeat(${flowOptions.length}, minmax(300px, 1fr)); minmax(300px, 1fr)`}
               gridAutoFlow="column"
               gap={theme.spacing(1)}
               overflow="auto"
               style={{ overflowX: 'auto' }}
+              gridAutoColumns="300px"
+              data-testid="contactsFlow"
             >
               {flowOptions.map((column) => (
                 <Box
                   width={'100%'}
-                  // If there are more than five columns give them a fixed width
-                  // otherwise fit them equally into the screen
-                  minWidth={flowOptions.length > 5 ? 360 : '100%'}
+                  minWidth={300}
                   p={2}
                   key={column.name}
+                  data-testid={`contactsFlow${column.name}`}
                 >
                   <ContactFlowColumn
                     accountListId={accountListId}

--- a/src/components/Contacts/ContactFlow/ContactFlowSetup/Column/ContactFlowSetupColumn.test.tsx
+++ b/src/components/Contacts/ContactFlow/ContactFlowSetup/Column/ContactFlowSetupColumn.test.tsx
@@ -53,6 +53,7 @@ describe('ContactFlowSetupColumn', () => {
                 setColumnWidth={setColumnWidth}
                 statuses={status}
                 updateColumns={updateColumns}
+                flowOptions={[]}
               />
             </TestRouter>
           </ThemeProvider>
@@ -66,7 +67,16 @@ describe('ContactFlowSetupColumn', () => {
     );
     const columnTitle = getByTestId('column-title') as HTMLInputElement;
     expect(columnTitle.value).toBe(title);
-    userEvent.type(columnTitle, 'additional text');
+
+    userEvent.type(columnTitle, 'addi');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    userEvent.type(columnTitle, 'tional');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    userEvent.type(columnTitle, ' text');
+
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    expect(changeTitle).toHaveBeenCalledTimes(1);
+
     expect(columnTitle.value).toBe(title + 'additional text');
   });
 
@@ -91,6 +101,7 @@ describe('ContactFlowSetupColumn', () => {
                 moveColumns={moveColumns}
                 statuses={status}
                 updateColumns={updateColumns}
+                flowOptions={[]}
               />
             </TestRouter>
           </ThemeProvider>
@@ -138,6 +149,7 @@ describe('ContactFlowSetupColumn', () => {
                 moveColumns={moveColumns}
                 statuses={status}
                 updateColumns={updateColumns}
+                flowOptions={[]}
               />
             </TestRouter>
           </ThemeProvider>

--- a/src/components/Contacts/ContactFlow/ContactFlowSetup/Column/ContactFlowSetupColumn.tsx
+++ b/src/components/Contacts/ContactFlow/ContactFlowSetup/Column/ContactFlowSetupColumn.tsx
@@ -43,8 +43,12 @@ const ColoredCircle = styled(FiberManualRecord)(
     height: size,
     width: size,
     '&:hover': {
-      height: !selected ? `calc(${size} + ${theme.spacing(1)})` : 'initial',
-      width: !selected ? `calc(${size} + ${theme.spacing(1)})` : 'initial',
+      height: !selected
+        ? `calc(${size} + ${theme.spacing(1)})`
+        : theme.spacing(4),
+      width: !selected
+        ? `calc(${size} + ${theme.spacing(1)})`
+        : theme.spacing(4),
     },
   }),
 );
@@ -75,6 +79,12 @@ interface Props {
   setColumnWidth: Dispatch<SetStateAction<number>>;
   moveColumns: (dragIndex: number, hoverIndex: number) => void;
   updateColumns: () => void;
+  flowOptions: {
+    name: string;
+    statuses: string[];
+    color: string;
+    id: string;
+  }[];
 }
 
 interface DragItem {
@@ -97,6 +107,7 @@ export const ContactFlowSetupColumn: React.FC<Props> = ({
   columnWidth,
   setColumnWidth,
   updateColumns,
+  flowOptions,
 }: Props) => {
   const CardContentRef = useRef<HTMLDivElement>();
   const [localTitle, setLocalTitle] = useState(title);
@@ -105,12 +116,11 @@ export const ContactFlowSetupColumn: React.FC<Props> = ({
     setLocalTitle(event.target.value);
     onTitleChange(event, index);
   };
-
   const onTitleChange = useCallback(
     debounce(200, (event, index) => {
       changeTitle(event, index);
     }),
-    [],
+    [flowOptions],
   );
 
   useLayoutEffect(() => {
@@ -283,6 +293,7 @@ export const ContactFlowSetupColumn: React.FC<Props> = ({
               <ContactFlowSetupDropZone
                 columnIndex={index}
                 moveStatus={moveStatus}
+                flowOptions={flowOptions}
               />
             )}
           </Box>

--- a/src/components/Contacts/ContactFlow/ContactFlowSetup/DropZone/ContactFlowSetupDropZone.test.tsx
+++ b/src/components/Contacts/ContactFlow/ContactFlowSetup/DropZone/ContactFlowSetupDropZone.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { ThemeProvider } from '@mui/material/styles';
+import { SnackbarProvider } from 'notistack';
+import TestRouter from '../../../../../../__tests__/util/TestRouter';
+import theme from '../../../../../../src/theme';
+import { ContactFilterStatusEnum } from '../../../../../../graphql/types.generated';
+import { ContactFlowSetupColumn } from '../Column/ContactFlowSetupColumn';
+
+const accountListId = 'abc';
+const title = 'Test Column';
+const status = [
+  {
+    id: 'APPOINTMENT_SCHEDULED' as ContactFilterStatusEnum,
+    value: 'Appointment Scheduled',
+  },
+  {
+    id: 'PARTNER_FINANCIAL' as ContactFilterStatusEnum,
+    value: 'Partner - Financial',
+  },
+];
+
+const statusTwo = [
+  {
+    id: 'NOT_INTERESTED' as ContactFilterStatusEnum,
+    value: 'Not Interested',
+  },
+];
+const router = {
+  query: { accountListId },
+  isReady: true,
+};
+
+const changeColor = jest.fn();
+const changeTitle = jest.fn();
+const deleteColumn = jest.fn();
+const moveStatus = jest.fn();
+const setColumnWidth = jest.fn();
+const moveColumns = jest.fn();
+const updateColumns = jest.fn();
+
+interface flowOptionsArray {
+  name: string;
+  statuses: string[];
+  color: string;
+  id: string;
+}
+[];
+
+const flowOptions: flowOptionsArray[] = [
+  {
+    name: 'Untitled Two',
+    id: '6ced166a-d570-4086-af56-e3eeed8a1f98',
+    statuses: [
+      'Appointment Scheduled',
+      'Not Interested',
+      'Partner - Financial',
+    ],
+    color: 'color-text',
+  },
+  {
+    name: 'Untitled',
+    id: '8a6bc2ed-820e-437b-81b8-36fbbe91f5e3',
+    statuses: ['Partner - Pray', 'Never Ask'],
+    color: 'color-info',
+  },
+];
+
+describe('ContactFlowSetupDropZone', () => {
+  it('Test Drag and Drop of status', async () => {
+    const { getByTestId } = render(
+      <SnackbarProvider>
+        <DndProvider backend={HTML5Backend}>
+          <ThemeProvider theme={theme}>
+            <TestRouter router={router}>
+              <ContactFlowSetupColumn
+                index={0}
+                accountListId={accountListId}
+                color={theme.palette.mpdxBlue.main}
+                title={title}
+                changeColor={changeColor}
+                changeTitle={changeTitle}
+                deleteColumn={deleteColumn}
+                moveStatus={moveStatus}
+                moveColumns={moveColumns}
+                loading={false}
+                columnWidth={100}
+                setColumnWidth={setColumnWidth}
+                statuses={status}
+                updateColumns={updateColumns}
+                flowOptions={flowOptions}
+              />
+              <ContactFlowSetupColumn
+                index={1}
+                accountListId={accountListId}
+                color={theme.palette.mpdxBlue.main}
+                title={title}
+                changeColor={changeColor}
+                changeTitle={changeTitle}
+                deleteColumn={deleteColumn}
+                moveStatus={moveStatus}
+                moveColumns={moveColumns}
+                loading={false}
+                columnWidth={100}
+                setColumnWidth={setColumnWidth}
+                statuses={statusTwo}
+                updateColumns={updateColumns}
+                flowOptions={flowOptions}
+              />
+            </TestRouter>
+          </ThemeProvider>
+        </DndProvider>
+      </SnackbarProvider>,
+    );
+
+    const statusBox = getByTestId('APPOINTMENT_SCHEDULED');
+    const statusDropZone = getByTestId('ContactFlowSetupDropZone-1');
+
+    await waitFor(() => expect(statusBox).toBeInTheDocument());
+    await waitFor(() =>
+      expect(getByTestId('NOT_INTERESTED')).toBeInTheDocument(),
+    );
+
+    await waitFor(() => expect(statusDropZone).toBeInTheDocument());
+
+    fireEvent.dragStart(statusBox);
+    fireEvent.dragEnter(statusDropZone);
+    fireEvent.dragOver(statusDropZone);
+    fireEvent.drop(statusDropZone);
+    await waitFor(() => expect(moveStatus).toHaveBeenCalled());
+  });
+});

--- a/src/components/Contacts/ContactFlow/ContactFlowSetup/DropZone/ContactFlowSetupDropZone.tsx
+++ b/src/components/Contacts/ContactFlow/ContactFlowSetup/DropZone/ContactFlowSetupDropZone.tsx
@@ -11,22 +11,32 @@ interface Props {
     destinationIndex: number,
     status: string,
   ) => void;
+  flowOptions?: {
+    name: string;
+    statuses: string[];
+    color: string;
+    id: string;
+  }[];
 }
 
 export const ContactFlowSetupDropZone: React.FC<Props> = ({
   columnIndex,
   moveStatus,
+  flowOptions,
 }: Props) => {
-  const [{ isOver, canDrop }, drop] = useDrop(() => ({
-    accept: 'status',
-    canDrop: (item: ContactFlowSetupItemDrag) =>
-      item.originIndex !== columnIndex,
-    drop: (item) => moveStatus(item.originIndex, columnIndex, item.status),
-    collect: (monitor) => ({
-      isOver: !!monitor.isOver(),
-      canDrop: !!monitor.canDrop(),
+  const [{ isOver, canDrop }, drop] = useDrop(
+    () => ({
+      accept: 'status',
+      canDrop: (item: ContactFlowSetupItemDrag) =>
+        item.originIndex !== columnIndex,
+      drop: (item) => moveStatus(item.originIndex, columnIndex, item.status),
+      collect: (monitor) => ({
+        isOver: !!monitor.isOver(),
+        canDrop: !!monitor.canDrop(),
+      }),
     }),
-  }));
+    [flowOptions],
+  );
 
   return (
     <Box
@@ -37,6 +47,7 @@ export const ContactFlowSetupDropZone: React.FC<Props> = ({
       alignItems="start"
       width="100%"
       height="100%"
+      data-testid={`ContactFlowSetupDropZone-${columnIndex}`}
     >
       <Box
         height={48}

--- a/src/components/Contacts/ContactFlow/ContactFlowSetup/Header/ContactFlowSetupHeader.tsx
+++ b/src/components/Contacts/ContactFlow/ContactFlowSetup/Header/ContactFlowSetupHeader.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Box, Button } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import Add from '@mui/icons-material/Add';
 import ChevronLeft from '@mui/icons-material/ChevronLeft';
 import NextLink from 'next/link';
+import LoadingButton from '@mui/lab/LoadingButton';
 import { useTranslation } from 'react-i18next';
 import { useAccountListId } from '../../../../../../src/hooks/useAccountListId';
 
@@ -22,13 +23,16 @@ const BackButton = styled(Button)(({ theme }) => ({
   textTransform: 'none',
 }));
 
-const AddColumnButton = styled(Button)(({ theme }) => ({
+const AddColumnLoadingButton = styled(LoadingButton)(({ theme }) => ({
   backgroundColor: theme.palette.mpdxBlue.main,
   color: theme.palette.common.white,
   textTransform: 'none',
   paddingRight: theme.spacing(1.5),
   '&:hover': {
     backgroundColor: theme.palette.info.dark,
+  },
+  '&.Mui-disabled': {
+    color: theme.palette.common.white,
   },
 }));
 
@@ -41,6 +45,14 @@ export const ContactFlowSetupHeader: React.FC<Props> = ({
 }: Props) => {
   const { t } = useTranslation();
   const accountListId = useAccountListId();
+  const [addingColumn, setAddingColumn] = useState(false);
+
+  const handleAddColumnButtonClick = async () => {
+    setAddingColumn(true);
+    await addColumn();
+    setAddingColumn(false);
+  };
+
   return (
     <HeaderWrap>
       <NextLink href={`/accountLists/${accountListId}/contacts`}>
@@ -49,10 +61,14 @@ export const ContactFlowSetupHeader: React.FC<Props> = ({
           {t('Contacts')}
         </BackButton>
       </NextLink>
-      <AddColumnButton onClick={addColumn}>
-        <Add />
+      <AddColumnLoadingButton
+        loading={addingColumn}
+        loadingPosition="start"
+        startIcon={<Add />}
+        onClick={handleAddColumnButtonClick}
+      >
         {t('Add Column')}
-      </AddColumnButton>
+      </AddColumnLoadingButton>
     </HeaderWrap>
   );
 };

--- a/src/components/Contacts/ContactFlow/ContactFlowSetup/Row/ContactFlowSetupStatusRow.tsx
+++ b/src/components/Contacts/ContactFlow/ContactFlowSetup/Row/ContactFlowSetupStatusRow.tsx
@@ -57,7 +57,7 @@ export const ContactFlowSetupStatusRow: React.FC<Props> = ({
     preview(getEmptyImage(), { captureDraggingState: true });
   }, []);
   return (
-    <StatusRow {...{ ref: drag }}>
+    <StatusRow {...{ ref: drag }} data-testid={status.id}>
       <Typography>{t(status.value)}</Typography>
     </StatusRow>
   );

--- a/src/components/Contacts/ContactFlow/ContactsFlow.test.tsx
+++ b/src/components/Contacts/ContactFlow/ContactsFlow.test.tsx
@@ -1,0 +1,95 @@
+import { ThemeProvider } from '@mui/material/styles';
+import { render, waitFor } from '@testing-library/react';
+import { SnackbarProvider } from 'notistack';
+import React from 'react';
+import { GqlMockedProvider } from '../../../../__tests__/util/graphqlMocking';
+import theme from '../../../theme';
+import { ContactFlow } from './ContactFlow';
+import TestRouter from '__tests__/util/TestRouter';
+import { ContactsPage } from 'pages/accountLists/[accountListId]/contacts/ContactsPage';
+import { GetUserOptionsQuery } from './GetUserOptions.generated';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+
+const accountListId = 'account-list-1';
+const contactId = 'contact-1';
+
+const router = {
+  query: { accountListId, contactId: [contactId] },
+};
+
+const mocks = {
+  GetUserOptions: {
+    userOptions: [
+      {
+        id: 'test-id',
+        key: 'contacts_view',
+        value: 'flows',
+      },
+      {
+        id: '551d0a2c-4c90-444c-97dc-11f4ca858e3c',
+        key: 'flows',
+        value:
+          '[{"name":"UntitledOne","id":"6ced166a-d570-4086-af56-e3eeed8a1f98","statuses":["Appointment Scheduled","Not Interested"],"color":"color-text"},{"name":"UntitledTwo","id":"8a6bc2ed-820e-437b-81b8-36fbbe91f5e3","statuses":["Partner - Pray","Never Ask","Partner - Financial"],"color":"color-info"}]',
+      },
+    ],
+  },
+};
+
+describe('ContactFlow', () => {
+  it('Should show loading', async () => {
+    const { getByTestId } = render(
+      <SnackbarProvider>
+        <TestRouter router={router}>
+          <GqlMockedProvider<GetUserOptionsQuery>>
+            <ThemeProvider theme={theme}>
+              <ContactsPage>
+                <DndProvider backend={HTML5Backend}>
+                  <ContactFlow
+                    accountListId={accountListId}
+                    onContactSelected={jest.fn()}
+                    selectedFilters={{}}
+                  />
+                </DndProvider>
+              </ContactsPage>
+            </ThemeProvider>
+          </GqlMockedProvider>
+        </TestRouter>
+      </SnackbarProvider>,
+    );
+
+    await waitFor(() => expect(getByTestId('Loading')).toBeInTheDocument());
+  });
+
+  it('Should show flow options', async () => {
+    const { getByTestId } = render(
+      <SnackbarProvider>
+        <TestRouter router={router}>
+          <GqlMockedProvider<GetUserOptionsQuery> mocks={mocks}>
+            <ThemeProvider theme={theme}>
+              <ContactsPage>
+                <DndProvider backend={HTML5Backend}>
+                  <ContactFlow
+                    accountListId={accountListId}
+                    onContactSelected={jest.fn()}
+                    selectedFilters={{}}
+                  />
+                </DndProvider>
+              </ContactsPage>
+            </ThemeProvider>
+          </GqlMockedProvider>
+        </TestRouter>
+      </SnackbarProvider>,
+    );
+
+    await waitFor(() =>
+      expect(getByTestId('contactsFlow')).toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(getByTestId('contactsFlowUntitledOne')).toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(getByTestId('contactsFlowUntitledTwo')).toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## Description
Contacts Flows adjustments
MPDX 7614, MPDX 7615, MPDX 7612

## Changes
- `/flows`
> - Column min-width is `300px`.
> - Columns scroll X if all can't fit onto the screen.
- `flows/setup` 
> - Column min-width is `300px`.
> - Columns scroll X if all can't fit onto the screen.
> - Adding/Removing columns now updates local as well as server.
> - `Unused Statuses` now sticks to the right-hand-side, to make it easier for users to move statuses around.
> - Fixed `:hover` of the coloured circles.
> - `useDrops` and `useCallbacks` to include `flowOptions` as a dependency.
> - `add column` button loading for UX as sometimes it would take a while to add a new column.