### PR TITLE
[HS-902502] Paginate donations

### DIFF
--- a/src/components/Reports/DonationsReport/GetDonationsTable.graphql
+++ b/src/components/Reports/DonationsReport/GetDonationsTable.graphql
@@ -1,15 +1,24 @@
 query GetDonationsTable(
   $accountListId: ID!
+  $pageSize: Int!
+  $cursor: String
   $startDate: ISO8601Date
   $endDate: ISO8601Date
 ) {
   donations(
     accountListId: $accountListId
     donationDate: { max: $endDate, min: $startDate }
+    first: $pageSize
+    after: $cursor
   ) {
     nodes {
       ...ExpectedDonationData
     }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    totalCount
   }
 }
 

--- a/src/components/Reports/DonationsReport/Table/Modal/EditDonationModal.test.tsx
+++ b/src/components/Reports/DonationsReport/Table/Modal/EditDonationModal.test.tsx
@@ -86,8 +86,6 @@ describe('DonationsReportTable', () => {
                   donation={donation}
                   open={true}
                   handleClose={handleClose}
-                  startDate={time.toString()}
-                  endDate={time.toString()}
                 />
               </GqlMockedProvider>
             </TestRouter>
@@ -98,41 +96,6 @@ describe('DonationsReportTable', () => {
     await waitFor(() => expect(getByText('Edit Donation')).toBeInTheDocument());
     expect(getByRole('button', { name: 'Save' })).toBeInTheDocument();
     expect(getByRole('textbox', { name: 'Amount' })).toHaveValue('100');
-  });
-
-  it('renders with no donation', async () => {
-    const mutationSpy = jest.fn();
-    const { getByText, getByRole, queryByText } = render(
-      <SnackbarProvider>
-        <LocalizationProvider dateAdapter={AdapterLuxon}>
-          <ThemeProvider theme={theme}>
-            <TestRouter router={router}>
-              <GqlMockedProvider<UpdateDonationMutation> onCall={mutationSpy}>
-                <EditDonationModal
-                  open={true}
-                  handleClose={handleClose}
-                  startDate={time.toString()}
-                  endDate={time.toString()}
-                />
-              </GqlMockedProvider>
-            </TestRouter>
-          </ThemeProvider>
-        </LocalizationProvider>
-      </SnackbarProvider>,
-    );
-    await waitFor(() => expect(getByText('Edit Donation')).toBeInTheDocument());
-    expect(getByRole('textbox', { name: 'Amount' })).toHaveValue('');
-    expect(queryByText('Field is required')).not.toBeInTheDocument();
-    userEvent.click(getByRole('button', { name: 'Save' }));
-    await waitFor(() =>
-      expect(getByText('Field is required')).toBeInTheDocument(),
-    );
-    userEvent.type(getByRole('textbox', { name: 'Amount' }), '123');
-    expect(getByRole('textbox', { name: 'Amount' })).toHaveValue('123');
-    userEvent.click(getByRole('button', { name: 'Save' }));
-    await waitFor(() =>
-      expect(queryByText('Field is required')).not.toBeInTheDocument(),
-    );
   });
 
   it('renders with appeal', async () => {
@@ -150,8 +113,6 @@ describe('DonationsReportTable', () => {
                   donation={donationWithAppeal}
                   open={true}
                   handleClose={handleClose}
-                  startDate={time.toString()}
-                  endDate={time.toString()}
                 />
               </GqlMockedProvider>
             </TestRouter>
@@ -184,8 +145,6 @@ describe('DonationsReportTable', () => {
                   donation={donation}
                   open={true}
                   handleClose={handleClose}
-                  startDate={time.toString()}
-                  endDate={time.toString()}
                 />
               </GqlMockedProvider>
             </TestRouter>
@@ -212,6 +171,53 @@ describe('DonationsReportTable', () => {
     expect(dateButton).toHaveValue('Mar 27, 2021');
   });
 
+  it('saves edits', async () => {
+    const mutationSpy = jest.fn();
+    const { getByText, getByRole } = render(
+      <SnackbarProvider>
+        <LocalizationProvider dateAdapter={AdapterLuxon}>
+          <ThemeProvider theme={theme}>
+            <TestRouter router={router}>
+              <GqlMockedProvider<UpdateDonationMutation>
+                mocks={mocks}
+                onCall={mutationSpy}
+              >
+                <EditDonationModal
+                  donation={donation}
+                  open={true}
+                  handleClose={handleClose}
+                />
+              </GqlMockedProvider>
+            </TestRouter>
+          </ThemeProvider>
+        </LocalizationProvider>
+      </SnackbarProvider>,
+    );
+    await waitFor(() => expect(getByText('Edit Donation')).toBeInTheDocument());
+    const amountTextbox = getByRole('textbox', { name: 'Amount' });
+    userEvent.type(amountTextbox, '0');
+    mutationSpy.mockReset();
+    userEvent.click(getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(handleClose).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockEnqueue).toHaveBeenCalledWith('Donation updated!', {
+        variant: 'success',
+      }),
+    );
+    expect(mutationSpy).toHaveBeenCalledTimes(1);
+    expect(mutationSpy.mock.calls[0][0]).toMatchObject({
+      operation: {
+        operationName: 'UpdateDonation',
+        variables: {
+          attributes: {
+            amount: 1000,
+          },
+        },
+      },
+    });
+  });
+
   it('clicks close button', async () => {
     const mutationSpy = jest.fn();
     const { getByText, getByRole } = render(
@@ -224,8 +230,6 @@ describe('DonationsReportTable', () => {
                   donation={donation}
                   open={true}
                   handleClose={handleClose}
-                  startDate={time.toString()}
-                  endDate={time.toString()}
                 />
               </GqlMockedProvider>
             </TestRouter>
@@ -252,8 +256,6 @@ describe('DonationsReportTable', () => {
                   donation={donation}
                   open={true}
                   handleClose={handleClose}
-                  startDate={time.toString()}
-                  endDate={time.toString()}
                 />
               </GqlMockedProvider>
             </TestRouter>
@@ -290,8 +292,6 @@ describe('DonationsReportTable', () => {
                     donation={donation}
                     open={true}
                     handleClose={handleClose}
-                    startDate={time.toString()}
-                    endDate={time.toString()}
                   />
                 </GqlMockedProvider>
               </TestRouter>

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -30,6 +30,7 @@ export const cache = new InMemoryCache({
     Query: {
       fields: {
         contacts: paginationFieldPolicy,
+        donations: paginationFieldPolicy,
         tasks: paginationFieldPolicy,
         userNotifications: paginationFieldPolicy,
       },


### PR DESCRIPTION
The donations table was only loading the first 25 donations for each month. This PR adds pagination support to the donations table. Because we need all donations loaded to calculate the total donations amount, the UI loads the rest of the donations in the background and only shows the total amount once they have all loaded.

This PR also fixes an issue where donations made on March 1st, for example, would appear in the list for both February and March.

Reported in HelpScout [#902502](https://secure.helpscout.net/conversation/2170654812/902502) and [#903045](https://secure.helpscout.net/conversation/2171642940/903045)
