### PR TITLE
Mpdx 7628 contact notes chartacters deleting

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailContext.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailContext.tsx
@@ -34,8 +34,6 @@ export type ContactDetailsType = {
   setSelectedDonationTabKey: React.Dispatch<
     React.SetStateAction<DonationTabKey>
   >;
-  notes: string;
-  setNotes: React.Dispatch<React.SetStateAction<string>>;
   referralsModalOpen: boolean;
   setReferralsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
   deleteModalOpen: boolean;
@@ -81,8 +79,6 @@ export const ContactDetailProvider: React.FC<Props> = ({ children }) => {
   const [selectedDonationTabKey, setSelectedDonationTabKey] = React.useState(
     DonationTabKey.Donations,
   );
-  const [notes, setNotes] = useState('');
-
   const [referralsModalOpen, setReferralsModalOpen] = useState(false);
 
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
@@ -115,8 +111,6 @@ export const ContactDetailProvider: React.FC<Props> = ({ children }) => {
         setCreatePersonModalOpen: setCreatePersonModalOpen,
         selectedDonationTabKey: selectedDonationTabKey,
         setSelectedDonationTabKey: setSelectedDonationTabKey,
-        notes: notes,
-        setNotes: setNotes,
         referralsModalOpen: referralsModalOpen,
         setReferralsModalOpen: setReferralsModalOpen,
         deleteModalOpen: deleteModalOpen,

--- a/src/components/Contacts/ContactDetails/ContactNotesTab/ContactNotesTab.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactNotesTab/ContactNotesTab.test.tsx
@@ -50,12 +50,12 @@ describe('ContactNotesTab', () => {
     expect(input).toBeVisible();
     input && userEvent.type(input, note);
     await waitFor(() => expect(getByText(note)).toBeVisible());
+    await new Promise((resolve) => setTimeout(resolve, 1200));
     const { operation } = mutationSpy.mock.calls[0][0];
-
     await waitFor(() =>
       expect(operation.variables.accountListId).toEqual('123'),
     );
-
+    await waitFor(() => expect(operation.variables.notes).toEqual(note));
     await waitFor(() =>
       expect(mockEnqueue).toHaveBeenCalledWith('Notes successfully saved.', {
         variant: 'success',


### PR DESCRIPTION
## Description
When you type in the contact notes field, it randomly deletes some of what you're typing and the "notes successfully saved" ticker message is constantly sliding out from the bottom left of the screen

## Changes
- Created a local version of notes, which doesn't skip/remove characters that the user types in while it's being saved.
- Added a property to the snack bar to prevent duplicates
- Increased the time of the debounce.