### PR TITLE
Mpdx 7628 contact notes

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactNotesTab/ContactNotesTab.graphql
+++ b/src/components/Contacts/ContactDetails/ContactNotesTab/ContactNotesTab.graphql
@@ -19,7 +19,6 @@ mutation UpdateContactNotes(
   ) {
     contact {
       id
-      notes
       notesSavedAt
     }
   }

--- a/src/components/Contacts/ContactDetails/ContactNotesTab/ContactNotesTab.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactNotesTab/ContactNotesTab.test.tsx
@@ -59,6 +59,7 @@ describe('ContactNotesTab', () => {
     await waitFor(() =>
       expect(mockEnqueue).toHaveBeenCalledWith('Notes successfully saved.', {
         variant: 'success',
+        preventDuplicate: true,
       }),
     );
   });

--- a/src/components/Contacts/ContactDetails/ContactNotesTab/ContactNotesTab.tsx
+++ b/src/components/Contacts/ContactDetails/ContactNotesTab/ContactNotesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { TextField } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { DateTime } from 'luxon';
@@ -37,7 +37,7 @@ export const ContactNotesTab: React.FC<Props> = ({
     ContactDetailContext,
   ) as ContactDetailsType;
 
-  React.useEffect(() => {
+  useEffect(() => {
     setNotes(data?.contact.notes ?? '');
   }, [data?.contact.notes]);
 
@@ -52,9 +52,10 @@ export const ContactNotesTab: React.FC<Props> = ({
       });
       enqueueSnackbar(t('Notes successfully saved.'), {
         variant: 'success',
+        preventDuplicate: true,
       });
     }, 500),
-    [],
+    [contactId, accountListId],
   );
 
   const handleChange = (notes: string) => {


### PR DESCRIPTION
## Description
When you type in the contact notes field, it randomly deletes some of what you're typing and the "notes successfully saved" ticker message is constantly sliding out from the bottom left of the screen

## Changes
- Created a local version of notes, which doesn't skip/remove characters that the user types in while it's being saved.
- Added a property to the snack bar to prevent duplicates