### PR TITLE
Mpdx 7651 create primary record on contact creation

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
@@ -116,8 +116,6 @@ export const ContactDetailsMoreAcitions: React.FC<
   const { accountListId, searchTerm, router } = React.useContext(
     ContactsContext,
   ) as ContactsType;
-  const { query, push } = router;
-  const { ...queryWithoutContactId } = query;
 
   const {
     referralsModalOpen,
@@ -134,6 +132,8 @@ export const ContactDetailsMoreAcitions: React.FC<
 
   const [openHideModal, setOpenHideModal] = useState(false);
   const [updateHiding, setUpdateHiding] = useState(false);
+  const { query, push } = router;
+  const { contactId: _, ...queryWithoutContactId } = query;
   const hideContact = async (): Promise<void> => {
     setUpdateHiding(true);
     const attributes = {

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateContact/CreateContact.graphql
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateContact/CreateContact.graphql
@@ -7,3 +7,13 @@ mutation CreateContact($accountListId: ID!, $attributes: ContactCreateInput!) {
     }
   }
 }
+
+mutation CreatePerson($accountListId: ID!, $attributes: PersonCreateInput!) {
+  createPerson(
+    input: { accountListId: $accountListId, attributes: $attributes }
+  ) {
+    person {
+      ...ContactPerson
+    }
+  }
+}


### PR DESCRIPTION
## Description
[MPDX-7651](https://jira.cru.org/browse/MPDX-7651) When creating a new contact or multiple contacts, auto create the primary person record as well.

## Changes
- Updated create contact modal to create a primary person
- Updated create multiple contacts modal to create a primary person for each contact
- Fixed create multiple contacts modal height.
- Fixed the error that happens when you delete a contact by removing the contact Id from the URL.