### PR TITLE
solving non-nullable error

### DIFF
--- a/pages/api/Schema/reports/designationAccounts/datahandler.ts
+++ b/pages/api/Schema/reports/designationAccounts/datahandler.ts
@@ -9,7 +9,7 @@ export interface DesignationAccountsResponse {
   attributes: {
     active: true;
     balance: string;
-    balance_updated_at: string;
+    balance_updated_at: string | null;
     converted_balance: number;
     created_at: string;
     currency: string;


### PR DESCRIPTION
## Description
[MPDX-7652](https://jira.cru.org/browse/MPDX-7652) Designation accounts non-nullable field error. Page isn't working for everyone or most people.

## Changes
- If `balance_updated_at` is null, set it to an empty string.