### PR TITLE
Mpdx 7659 impersonate

### DIFF
--- a/__tests__/pages/api/MpdxWebHandoff.test.ts
+++ b/__tests__/pages/api/MpdxWebHandoff.test.ts
@@ -2,11 +2,20 @@ import { createMocks } from 'node-mocks-http';
 import { getToken } from 'next-auth/jwt';
 import mpdxWebHandoff from '../../../pages/api/mpdx-web-handoff.page';
 import { taskFiltersTabs } from '../../../src/utils/tasks/taskFilterTabs';
+import { nextAuthSessionCookieName } from 'pages/api/utils/cookies';
 
 jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
 
 const siteUrl = `${process.env.SITE_URL}`;
 const accountListsUrl = `${process.env.SITE_URL}/accountLists`;
+// User one
+const userOneId = 'userId_1';
+const userOneToken = 'userOne.token';
+const userOneImpersonate = 'userOne.impersonate.token';
+// User two
+const userTwoId = 'userId_2';
+const userTwoToken = 'userTwo.token';
+const userTwoImpersonate = 'userTwo.impersonate.token';
 
 const convertCookieStringToObject = (cookieString) => {
   return cookieString.split('; ').reduce((prev, current) => {
@@ -14,6 +23,14 @@ const convertCookieStringToObject = (cookieString) => {
     prev[name] = value.join('=');
     return prev;
   }, {});
+};
+
+const grabCookies = (setCookieHeader: string[]): cookiesType[] => {
+  const cookies: cookiesType[] = [];
+  setCookieHeader.forEach((cookie) =>
+    cookies.push(convertCookieStringToObject(cookie)),
+  );
+  return cookies;
 };
 
 interface cookiesType {
@@ -27,11 +44,13 @@ describe('/api/mpdx-web-handoff', () => {
     expect(res._getRedirectUrl()).toBe(`${siteUrl}/`);
   });
 
-  describe('Inactive session', () => {
+  const redirectUrl = `${process.env.SITE_URL}/accountLists/accountListId/contacts`;
+
+  describe('No prev session', () => {
     beforeEach(() => {
       (getToken as jest.Mock).mockReturnValue(null);
     });
-    it('Redirect to login', async () => {
+    it('New user - Redirect to login with correct cookies', async () => {
       const { req, res } = createMocks({
         method: 'GET',
         query: {
@@ -40,59 +59,142 @@ describe('/api/mpdx-web-handoff', () => {
         },
       });
       await mpdxWebHandoff(req, res);
-
       expect(res._getRedirectUrl()).toBe(`${siteUrl}/login`);
-    });
-
-    it('Assigned the correct cookies', async () => {
-      const { req, res } = createMocks({
-        method: 'GET',
-        query: {
-          accountListId: 'accountListId',
-          path: '/contacts',
-        },
-      });
-      await mpdxWebHandoff(req, res);
-
-      expect(res._getRedirectUrl()).toBe(`${siteUrl}/login`);
-      const cookies: cookiesType[] = [];
-      res._getHeaders()['set-cookie'].forEach((cookie) => {
-        cookies.push(convertCookieStringToObject(cookie));
-      });
+      const cookies = grabCookies(res._getHeaders()['set-cookie']);
       expect(cookies.length).toBe(2);
-      expect(cookies[0]['mpdx-handoff.redirect-url']).toBe(
-        `${process.env.SITE_URL}/accountLists/accountListId/contacts`,
-      );
+      expect(cookies[0]['mpdx-handoff.redirect-url']).toBe(redirectUrl);
       expect(cookies[1]['mpdx-handoff.logged-in']).toBe(`true`);
     });
-    it('No accountListId or path defined. Redirect to home', async () => {
+
+    it('Impersonate user - Redirect to login with correct cookies', async () => {
+      const { req, res } = createMocks({
+        method: 'GET',
+        query: {
+          accountListId: 'accountListId',
+          path: '/contacts',
+          userId: userOneId,
+          token: userOneToken,
+          impersonate: userOneImpersonate,
+        },
+      });
+      await mpdxWebHandoff(req, res);
+      expect(res._getRedirectUrl()).toBe(`${siteUrl}/login`);
+      const cookies = grabCookies(res._getHeaders()['set-cookie']);
+
+      expect(cookies.length).toBe(4);
+      expect(cookies[0]['mpdx-handoff.impersonate']).toBe(userOneImpersonate);
+      expect(cookies[1]['mpdx-handoff.redirect-url']).toBe(redirectUrl);
+      expect(cookies[2]['mpdx-handoff.token']).toBe(userOneToken);
+      expect(cookies[3]['mpdx-handoff.logged-in']).toBe(`true`);
+    });
+
+    it('No user - Redirect to home', async () => {
       const { req, res } = createMocks({ method: 'GET' });
       await mpdxWebHandoff(req, res);
       expect(res._getRedirectUrl()).toBe(`${siteUrl}/`);
     });
   });
 
-  describe('Active session', () => {
+  describe('Has active session', () => {
     beforeEach(() => {
-      (getToken as jest.Mock).mockReturnValue({ apiToken: 'accessToken' });
+      (getToken as jest.Mock).mockReturnValue({
+        apiToken: userOneToken,
+        userID: userOneId,
+      });
     });
 
-    it('Redirects with contactId', async () => {
+    it('New user - Loggout prev user', async () => {
       const { req, res } = createMocks({
         method: 'GET',
         query: {
           accountListId: 'accountListId',
           path: '/contacts',
+          userId: userTwoId,
+          token: userTwoToken,
         },
       });
       await mpdxWebHandoff(req, res);
-
       expect(res._getRedirectUrl()).toBe(
-        `${accountListsUrl}/accountListId/contacts`,
+        `${siteUrl}/accountLists/accountListId/contacts`,
       );
+      const cookies = grabCookies(res._getHeaders()['set-cookie']);
+
+      expect(cookies.length).toBe(4);
+      expect(cookies[0][nextAuthSessionCookieName]).toBe('');
+      expect(cookies[0]['Max-Age']).toBe('0');
+      expect(cookies[1]['mpdx-handoff.accountConflictUserId']).toBe(userTwoId);
+      expect(cookies[2]['mpdx-handoff.redirect-url']).toBe(redirectUrl);
+      expect(cookies[3]['mpdx-handoff.token']).toBe(userTwoToken);
     });
 
-    it('Redirects with contactId and other url params', async () => {
+    it('New user - Same token - Shouldnt remove prev user', async () => {
+      const { req, res } = createMocks({
+        method: 'GET',
+        query: {
+          accountListId: 'accountListId',
+          path: '/contacts',
+          userId: userTwoId,
+          token: userOneToken,
+        },
+      });
+      await mpdxWebHandoff(req, res);
+      expect(res._getRedirectUrl()).toBe(
+        `${siteUrl}/accountLists/accountListId/contacts`,
+      );
+      const cookies = grabCookies(res._getHeaders()['set-cookie']);
+
+      expect(cookies.length).toBe(4);
+      expect(cookies[0][nextAuthSessionCookieName]).toBe('');
+      expect(cookies[0]['Max-Age']).toBe('0');
+      expect(cookies[1]['mpdx-handoff.accountConflictUserId']).toBe(userTwoId);
+      expect(cookies[2]['mpdx-handoff.redirect-url']).toBe(redirectUrl);
+      expect(cookies[3]['mpdx-handoff.token']).toBe(userOneToken);
+    });
+
+    it('Impersonate user - Loggout prev user', async () => {
+      const { req, res } = createMocks({
+        method: 'GET',
+        query: {
+          accountListId: 'accountListId',
+          path: '/contacts',
+          userId: userTwoId,
+          token: userTwoToken,
+          impersonate: userTwoImpersonate,
+        },
+      });
+      await mpdxWebHandoff(req, res);
+      expect(res._getRedirectUrl()).toBe(
+        `${siteUrl}/accountLists/accountListId/contacts`,
+      );
+      const cookies = grabCookies(res._getHeaders()['set-cookie']);
+
+      expect(cookies.length).toBe(5);
+      expect(cookies[0][nextAuthSessionCookieName]).toBe('');
+      expect(cookies[0]['Max-Age']).toBe('0');
+      expect(cookies[1]['mpdx-handoff.accountConflictUserId']).toBe(userTwoId);
+      expect(cookies[2]['mpdx-handoff.redirect-url']).toBe(redirectUrl);
+      expect(cookies[3]['mpdx-handoff.token']).toBe(userTwoToken);
+      expect(cookies[4]['mpdx-handoff.impersonate']).toBe(userTwoImpersonate);
+    });
+
+    it('New user - Same token - Should logout prev user', async () => {
+      const { req, res } = createMocks({
+        method: 'GET',
+        query: {
+          accountListId: 'accountListId',
+          path: '/contacts',
+          token: userOneToken,
+        },
+      });
+      await mpdxWebHandoff(req, res);
+      expect(res._getRedirectUrl()).toBe(
+        `${siteUrl}/accountLists/accountListId/contacts`,
+      );
+      const cookies = grabCookies(res._getHeaders()['set-cookie']);
+      expect(cookies.length).toBe(0);
+    });
+
+    it('Same user - Redirect to contact with url params', async () => {
       const { req, res } = createMocks({
         method: 'GET',
         query: {
@@ -107,8 +209,10 @@ describe('/api/mpdx-web-handoff', () => {
       expect(res._getRedirectUrl()).toBe(
         `${accountListsUrl}/accountListId/contacts?p1=p1&p2=p2&`,
       );
+      const cookies = grabCookies(res._getHeaders()['set-cookie']);
+      expect(cookies.length).toBe(0);
     });
-    it('Redirects with reports', async () => {
+    it('Same user - Redirects to reports', async () => {
       const { req, res } = createMocks({
         method: 'GET',
         query: {
@@ -121,9 +225,11 @@ describe('/api/mpdx-web-handoff', () => {
       expect(res._getRedirectUrl()).toBe(
         `${accountListsUrl}/accountListId/reports`,
       );
+      const cookies = grabCookies(res._getHeaders()['set-cookie']);
+      expect(cookies.length).toBe(0);
     });
 
-    it('Redirects with reports and other url params', async () => {
+    it('Same user - Redirects to reports with url params', async () => {
       const { req, res } = createMocks({
         method: 'GET',
         query: {
@@ -138,8 +244,10 @@ describe('/api/mpdx-web-handoff', () => {
       expect(res._getRedirectUrl()).toBe(
         `${accountListsUrl}/accountListId/reports?p1=p1&p2=p2&`,
       );
+      const cookies = grabCookies(res._getHeaders()['set-cookie']);
+      expect(cookies.length).toBe(0);
     });
-    it('Redirects with tasks', async () => {
+    it('Same user - Redirects with tasks', async () => {
       const { req, res } = createMocks({
         method: 'GET',
         query: {
@@ -152,9 +260,11 @@ describe('/api/mpdx-web-handoff', () => {
       expect(res._getRedirectUrl()).toBe(
         `${accountListsUrl}/accountListId/tasks`,
       );
+      const cookies = grabCookies(res._getHeaders()['set-cookie']);
+      expect(cookies.length).toBe(0);
     });
 
-    it('Redirects with tasks and group', async () => {
+    it('Same user - Redirects with tasks and group', async () => {
       const { req, res } = createMocks({
         method: 'GET',
         query: {
@@ -176,9 +286,11 @@ describe('/api/mpdx-web-handoff', () => {
       expect(res._getRedirectUrl()).toBe(
         `${accountListsUrl}/accountListId/tasks?${filters}`,
       );
+      const cookies = grabCookies(res._getHeaders()['set-cookie']);
+      expect(cookies.length).toBe(0);
     });
 
-    it('Redirects with none Contact/Report or Task path', async () => {
+    it('Same user - Redirects with none Contact/Report or Task path', async () => {
       const { req, res } = createMocks({
         method: 'GET',
         query: {
@@ -192,6 +304,8 @@ describe('/api/mpdx-web-handoff', () => {
       expect(res._getRedirectUrl()).toBe(
         `${accountListsUrl}/accountListId/?modal=AddContact&`,
       );
+      const cookies = grabCookies(res._getHeaders()['set-cookie']);
+      expect(cookies.length).toBe(0);
     });
   });
 });

--- a/__tests__/pages/api/NextAuth.test.ts
+++ b/__tests__/pages/api/NextAuth.test.ts
@@ -1,0 +1,114 @@
+import { setUserInfo } from 'pages/api/auth/setUserInfo';
+import {
+  nextAuthSessionCookieName,
+  expireCookieDefaultInfo,
+} from 'pages/api/utils/cookies';
+
+// User One
+const userOneId = 'userId_1';
+const userOneToken = 'userOne.token';
+const userOneImpersonate = 'userOne.impersonate.token';
+
+// User Two
+const userTwoId = 'userId_2';
+const userTwoToken = 'userTwo.token';
+const userTwoImpersonate = 'userTwo.impersonate.token';
+
+const cookieCreator = (name: string, value: string) => {
+  switch (name) {
+    case nextAuthSessionCookieName:
+      return `${nextAuthSessionCookieName}=${value}; Secure; HttpOnly; path=/; Max-Age=0`;
+    case 'mpdx-handoff.logged-in':
+      return `mpdx-handoff.logged-in=${value}; path=/; domain=${process.env.REWRITE_DOMAIN}`;
+    default:
+      return `${name}=${value}; ${expireCookieDefaultInfo}`;
+  }
+};
+
+describe('/api/auth/[...nextauth]', () => {
+  it('Standard login', async () => {
+    const userInfo = await setUserInfo(userOneToken, userOneId, '');
+    expect(userInfo.user?.apiToken).toBe(userOneToken);
+    expect(userInfo.user?.userID).toBe(userOneId);
+    expect(userInfo.user?.impersonatorApiToken).toBe('');
+    expect(userInfo.user?.impersonating).toBe(false);
+    expect(userInfo.cookies?.length).toBe(0);
+  });
+
+  it('Standard login with impersonatorApiToken', async () => {
+    const cookies = `
+      ${cookieCreator('mpdx-handoff.impersonate', userOneImpersonate)};
+    `;
+    const userInfo = await setUserInfo(userOneToken, userOneId, cookies);
+    expect(userInfo.user?.apiToken).toBe(userOneImpersonate);
+    expect(userInfo.user?.userID).toBe(userOneId);
+    expect(userInfo.user?.impersonatorApiToken).toBe(userOneToken);
+    expect(userInfo.user?.impersonating).toBe(true);
+    expect(userInfo.cookies?.length).toBe(1);
+    expect(userInfo?.cookies[0]).toBe(
+      `mpdx-handoff.impersonate=; HttpOnly; path=/; Max-Age=0`,
+    );
+  });
+
+  it('Log User Two in and ignore standard login details', async () => {
+    const cookies = `
+      ${cookieCreator('mpdx-handoff.accountConflictUserId', userTwoId)};
+      ${cookieCreator('mpdx-handoff.token', userTwoToken)};
+    `;
+    const userInfo = await setUserInfo(userOneToken, userOneId, cookies);
+    expect(userInfo.user?.apiToken).toBe(userTwoToken);
+    expect(userInfo.user?.userID).toBe(userTwoId);
+    expect(userInfo.user?.impersonatorApiToken).toBe('');
+    expect(userInfo.user?.impersonating).toBe(false);
+    expect(userInfo.cookies?.length).toBe(2);
+    expect(userInfo?.cookies[0]).toBe(
+      `mpdx-handoff.accountConflictUserId=; HttpOnly; path=/; Max-Age=0`,
+    );
+    expect(userInfo?.cookies[1]).toBe(
+      `mpdx-handoff.token=; HttpOnly; path=/; Max-Age=0`,
+    );
+  });
+
+  it('Log Impersonate user in, store ImpersonatorToken and ignore standard login details', async () => {
+    const cookies = `
+      ${cookieCreator('mpdx-handoff.token', userTwoToken)};
+      ${cookieCreator('mpdx-handoff.impersonate', userTwoImpersonate)};
+    `;
+
+    const userInfo = await setUserInfo(userOneToken, userOneId, cookies);
+    expect(userInfo.user?.apiToken).toBe(userTwoImpersonate);
+    expect(userInfo.user?.userID).toBe(userOneId);
+    expect(userInfo.user?.impersonatorApiToken).toBe(userTwoToken);
+    expect(userInfo.user?.impersonating).toBe(true);
+    expect(userInfo.cookies?.length).toBe(2);
+    expect(userInfo?.cookies[0]).toBe(
+      `mpdx-handoff.impersonate=; HttpOnly; path=/; Max-Age=0`,
+    );
+    expect(userInfo?.cookies[1]).toBe(
+      `mpdx-handoff.token=; HttpOnly; path=/; Max-Age=0`,
+    );
+  });
+
+  it('Log Impersonate user in and replace userID', async () => {
+    const cookies = `
+      ${cookieCreator('mpdx-handoff.accountConflictUserId', userTwoId)};
+      ${cookieCreator('mpdx-handoff.token', userTwoToken)};
+      ${cookieCreator('mpdx-handoff.impersonate', userTwoImpersonate)};
+    `;
+    const userInfo = await setUserInfo(userOneToken, userOneId, cookies);
+    expect(userInfo.user?.apiToken).toBe(userTwoImpersonate);
+    expect(userInfo.user?.userID).toBe(userTwoId);
+    expect(userInfo.user?.impersonatorApiToken).toBe(userTwoToken);
+    expect(userInfo.user?.impersonating).toBe(true);
+    expect(userInfo.cookies?.length).toBe(3);
+    expect(userInfo?.cookies[0]).toBe(
+      `mpdx-handoff.impersonate=; HttpOnly; path=/; Max-Age=0`,
+    );
+    expect(userInfo?.cookies[1]).toBe(
+      `mpdx-handoff.accountConflictUserId=; HttpOnly; path=/; Max-Age=0`,
+    );
+    expect(userInfo?.cookies[2]).toBe(
+      `mpdx-handoff.token=; HttpOnly; path=/; Max-Age=0`,
+    );
+  });
+});

--- a/__tests__/pages/api/stopImpersonating.test.ts
+++ b/__tests__/pages/api/stopImpersonating.test.ts
@@ -1,0 +1,43 @@
+import { createMocks } from 'node-mocks-http';
+import { getToken } from 'next-auth/jwt';
+import stopImpersonating from '../../../pages/api/stop-impersonating.page';
+import { nextAuthSessionCookieName } from 'pages/api/utils/cookies';
+
+jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
+const siteUrl = `${process.env.SITE_URL}`;
+// User one
+const userOneImpersonate = 'userOne.impersonate.token';
+
+const convertCookieStringToObject = (cookieString) => {
+  return cookieString.split('; ').reduce((prev, current) => {
+    const [name, ...value] = current.split('=');
+    prev[name] = value.join('=');
+    return prev;
+  }, {});
+};
+interface cookiesType {
+  [key: string]: string;
+}
+
+describe('/api/stop-impersonating', () => {
+  beforeEach(() => {
+    (getToken as jest.Mock).mockReturnValue({
+      impersonatorApiToken: userOneImpersonate,
+    });
+  });
+
+  it('Ensure Correct cookies are removed or added/edited', async () => {
+    const { req, res } = createMocks({ method: 'GET' });
+    await stopImpersonating(req, res);
+    expect(res._getRedirectUrl()).toBe(`${siteUrl}/login`);
+    const cookies: cookiesType[] = [];
+    res._getHeaders()['set-cookie'].forEach((cookie) => {
+      cookies.push(convertCookieStringToObject(cookie));
+    });
+    expect(cookies.length).toBe(3);
+    expect(cookies[0][nextAuthSessionCookieName]).toBe('');
+    expect(cookies[0]['Max-Age']).toBe('0');
+    expect(cookies[1]['mpdx-handoff.redirect-url']).toBe(`${siteUrl}/`);
+    expect(cookies[2]['mpdx-handoff.token']).toBe(userOneImpersonate);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "storybook": "start-storybook -p 6006 -c .storybook -s ./public",
     "build-storybook": "build-storybook -c .storybook -s ./public",
     "test": "cross-env NODE_ICU_DATA=$(yarn bin node-full-icu-path) jest --silent",
+    "test:log": "yarn test --silent=false",
     "test:watch": "cross-env NODE_ICU_DATA=$(yarn bin node-full-icu-path) jest --watch",
     "localtest": "yarn test --runInBand --verbose",
     "localtest:watch": "yarn test:watch --runInBand",

--- a/pages/accountLists/[accountListId].page.tsx
+++ b/pages/accountLists/[accountListId].page.tsx
@@ -88,35 +88,46 @@ export const getServerSideProps: GetServerSideProps = async ({
     };
   }
 
-  const client = await ssrClient(session?.user.apiToken);
-  const response = await client.query<
-    GetDashboardQuery,
-    GetDashboardQueryVariables
-  >({
-    query: GetDashboardDocument,
-    variables: {
-      accountListId: query?.accountListId
-        ? Array.isArray(query.accountListId)
-          ? query.accountListId[0]
-          : query.accountListId
-        : '',
-      // TODO: implement these variables in query
-      // endOfDay: DateTime.local().endOf('day').toISO(),
-      // today: DateTime.local().endOf('day').toISODate(),
-      // twoWeeksFromNow: DateTime.local()
-      //   .endOf('day')
-      //   .plus({ weeks: 2 })
-      //   .toISODate(),
-    },
-  });
+  try {
+    const client = await ssrClient(session?.user.apiToken);
+    const response = await client.query<
+      GetDashboardQuery,
+      GetDashboardQueryVariables
+    >({
+      query: GetDashboardDocument,
+      variables: {
+        accountListId: query?.accountListId
+          ? Array.isArray(query.accountListId)
+            ? query.accountListId[0]
+            : query.accountListId
+          : '',
+        // TODO: implement these variables in query
+        // endOfDay: DateTime.local().endOf('day').toISO(),
+        // today: DateTime.local().endOf('day').toISODate(),
+        // twoWeeksFromNow: DateTime.local()
+        //   .endOf('day')
+        //   .plus({ weeks: 2 })
+        //   .toISODate(),
+      },
+    });
 
-  return {
-    props: {
-      data: response.data,
-      accountListId: query?.accountListId?.toString(),
-      modal: query?.modal?.toString() ?? '',
-    },
-  };
+    if (!response) throw new Error('Undefined response');
+
+    return {
+      props: {
+        data: response?.data,
+        accountListId: query?.accountListId?.toString(),
+        modal: query?.modal?.toString() ?? '',
+      },
+    };
+  } catch {
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    };
+  }
 };
 
 export default AccountListIdPage;

--- a/pages/api/auth/setUserInfo.ts
+++ b/pages/api/auth/setUserInfo.ts
@@ -1,0 +1,49 @@
+import { expireCookieDefaultInfo } from '../utils/cookies';
+
+interface User {
+  apiToken?: string;
+  userID?: string;
+  impersonating?: boolean;
+  impersonatorApiToken?: string;
+}
+interface SetUserInfoReturn {
+  user: User;
+  cookies: string[];
+}
+
+export const setUserInfo = (
+  access_token: string,
+  userId: string,
+  reqCookies: string | undefined,
+): SetUserInfoReturn => {
+  const getCookie = (name: string): string | undefined =>
+    reqCookies?.split(`${name}=`)[1]?.split(';')[0];
+
+  const impersonateJWT = getCookie('mpdx-handoff.impersonate');
+  const impersonateUserId = getCookie('mpdx-handoff.accountConflictUserId');
+  const token = getCookie('mpdx-handoff.token');
+
+  const user: User = {};
+
+  user.apiToken = impersonateJWT || token || access_token;
+  user.userID = impersonateUserId || userId;
+  user.impersonating = !!impersonateJWT;
+  user.impersonatorApiToken = impersonateJWT ? token || access_token : '';
+
+  const cookies: string[] = [];
+  if (impersonateJWT) {
+    cookies.push(`mpdx-handoff.impersonate=; ${expireCookieDefaultInfo}`);
+  }
+  if (impersonateUserId) {
+    cookies.push(
+      `mpdx-handoff.accountConflictUserId=; ${expireCookieDefaultInfo}`,
+    );
+  }
+  if (token) {
+    cookies.push(`mpdx-handoff.token=; ${expireCookieDefaultInfo}`);
+  }
+  return {
+    user,
+    cookies,
+  };
+};

--- a/pages/api/mpdx-web-handoff.page.ts
+++ b/pages/api/mpdx-web-handoff.page.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getToken } from 'next-auth/jwt';
 import { taskFiltersTabs } from '../../src/utils/tasks/taskFilterTabs';
+import { cookieDefaultInfo, nextAuthSessionCookie } from './utils/cookies';
 
 interface defineRedirectUrlProps {
   accountListId: string;
@@ -54,28 +55,59 @@ const mpdxWebHandoff = async (
     const jwtToken = (await getToken({
       req,
       secret: process.env.JWT_SECRET as string,
-    })) as { apiToken: string } | null;
+    })) as { apiToken: string; userID: string } | null;
 
-    const { path = '', accountListId = '', ...rest } = req.query;
+    const {
+      path = '',
+      accountListId = '',
+      userId = '',
+      token = '',
+      impersonate = '',
+      ...rest
+    } = req.query;
     if (!path || !accountListId) {
       throw new Error('Path and accountListId are not defined.');
     }
+
+    const isAccountConflict = !!(
+      userId &&
+      jwtToken &&
+      userId !== jwtToken?.userID
+    );
+
     const redirectUrl = defineRedirectUrl({
       accountListId: accountListId.toString(),
       path: path.toString(),
       rest,
     });
-    if (!jwtToken) {
-      const expireDate = new Date();
-      expireDate.setTime(expireDate.getTime() + 5 * 60 * 1000);
-      res.setHeader('Set-Cookie', [
-        `mpdx-handoff.redirect-url=${redirectUrl}; HttpOnly; path=/; Expires=${expireDate.toUTCString()}`,
-        `mpdx-handoff.logged-in=true; path=/; domain=${process.env.REWRITE_DOMAIN}`,
-      ]);
-      res.redirect(`${process.env.SITE_URL}/login`);
-      return;
+
+    const cookies: string[] = [];
+    if (isAccountConflict) {
+      // We can force the user to logout, but OKTA caches and will auto log the previous user in.
+      // To solve this problem we store the JWT as a HTTP cookie which we use on login in [...nextauth].page.ts
+      cookies.push(
+        nextAuthSessionCookie,
+        `mpdx-handoff.accountConflictUserId=${userId}; ${cookieDefaultInfo}`,
+        `mpdx-handoff.redirect-url=${redirectUrl}; ${cookieDefaultInfo}`,
+        `mpdx-handoff.token=${token}; ${cookieDefaultInfo}`,
+      );
     }
-    res.redirect(redirectUrl);
+    if (impersonate) {
+      cookies.push(
+        `mpdx-handoff.impersonate=${impersonate}; ${cookieDefaultInfo}`,
+        `mpdx-handoff.redirect-url=${redirectUrl}; ${cookieDefaultInfo}`,
+        `mpdx-handoff.token=${token}; ${cookieDefaultInfo}`,
+      );
+    }
+    if (!jwtToken) {
+      cookies.push(
+        `mpdx-handoff.redirect-url=${redirectUrl}; ${cookieDefaultInfo}`,
+        `mpdx-handoff.logged-in=true; path=/; domain=${process.env.REWRITE_DOMAIN}`,
+      );
+    }
+    // Removes duplicates and set cookies
+    if (cookies) res.setHeader('Set-Cookie', [...new Set(cookies)]);
+    res.redirect(jwtToken ? redirectUrl : `${process.env.SITE_URL}/login`);
   } catch (err) {
     res.redirect(`${process.env.SITE_URL}/`);
   }

--- a/pages/api/stop-impersonating.page.ts
+++ b/pages/api/stop-impersonating.page.ts
@@ -1,0 +1,26 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getToken } from 'next-auth/jwt';
+import { cookieDefaultInfo, nextAuthSessionCookie } from './utils/cookies';
+
+const redirectUrl = `${process.env.SITE_URL}/`;
+const mpdxWebHandoff = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> => {
+  try {
+    const jwtToken = (await getToken({
+      req,
+      secret: process.env.JWT_SECRET as string,
+    })) as { impersonatorApiToken: string } | null;
+    res.setHeader('Set-Cookie', [
+      nextAuthSessionCookie,
+      `mpdx-handoff.redirect-url=${redirectUrl}; ${cookieDefaultInfo}`,
+      `mpdx-handoff.token=${jwtToken?.impersonatorApiToken}; ${cookieDefaultInfo}`,
+    ]);
+    res.redirect(`${process.env.SITE_URL}/login`);
+  } catch (err) {
+    res.redirect(redirectUrl);
+  }
+};
+
+export default mpdxWebHandoff;

--- a/pages/api/utils/cookies.ts
+++ b/pages/api/utils/cookies.ts
@@ -1,0 +1,10 @@
+export const cookieDefaultInfo = `HttpOnly; path=/; Max-Age=${5 * 60}`;
+export const expireCookieDefaultInfo = `HttpOnly; path=/; Max-Age=0`;
+
+const isProd = process.env.NODE_ENV === 'production';
+export const nextAuthSessionCookieName = isProd
+  ? '__Secure-next-auth.session-token'
+  : 'next-auth.session-token';
+export const nextAuthSessionCookie = `${nextAuthSessionCookieName}=; ${
+  isProd ? 'Secure; ' : ''
+}${expireCookieDefaultInfo}`;

--- a/pages/login.page.tsx
+++ b/pages/login.page.tsx
@@ -90,7 +90,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   if (immediateSignIn) {
     context.res.setHeader(
       'Set-Cookie',
-      `mpdx-handoff.redirect-url=; HttpOnly; path=/; Expires=${new Date().toUTCString()}`,
+      `mpdx-handoff.redirect-url=; HttpOnly; path=/; Max-Age=0`,
     );
   }
   if (context.res && session) {

--- a/pages/logout.page.tsx
+++ b/pages/logout.page.tsx
@@ -52,9 +52,7 @@ const LogoutPage = ({}): ReactElement => {
 export const getServerSideProps: GetServerSideProps = async (context) => {
   context.res.setHeader(
     'Set-Cookie',
-    `mpdx-handoff.logged-in=; path=/; Expires=${new Date().toUTCString()}; domain=${
-      process.env.REWRITE_DOMAIN
-    }`,
+    `mpdx-handoff.logged-in=; path=/; Max-Age=0; domain=${process.env.REWRITE_DOMAIN}`,
   );
   return {
     props: {},

--- a/src/components/Layouts/Primary/Primary.test.tsx
+++ b/src/components/Layouts/Primary/Primary.test.tsx
@@ -10,6 +10,22 @@ import { getNotificationsMocks } from './TopBar/Items/NotificationMenu/Notificat
 import { getTopBarMock } from './TopBar/TopBar.mock';
 import Primary from '.';
 
+const session = {
+  expires: '2021-10-28T14:48:20.897Z',
+  user: {
+    email: 'Chair Library Bed',
+    image: null,
+    name: 'Dung Tapestry',
+    token: 'superLongJwtString',
+  },
+};
+
+jest.mock('next-auth/react', () => {
+  return {
+    useSession: jest.fn().mockImplementation(() => Promise.resolve(session)),
+  };
+});
+
 describe('Primary', () => {
   const useRouter = jest.spyOn(nextRouter, 'useRouter');
   const mocks = [...getNotificationsMocks(), getTopBarMock()];

--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.test.tsx
@@ -29,6 +29,7 @@ jest.mock('next-auth/react', () => {
   return {
     signOut: jest.fn().mockImplementation(() => Promise.resolve()),
     getSession: jest.fn().mockImplementation(() => Promise.resolve(session)),
+    useSession: jest.fn().mockImplementation(() => Promise.resolve(session)),
   };
 });
 

--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
@@ -2,7 +2,6 @@ import React, { useState, ReactElement } from 'react';
 import {
   Avatar,
   Box,
-  IconButton,
   ListItemText,
   Menu,
   Divider,
@@ -18,23 +17,19 @@ import {
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/router';
-import { signOut } from 'next-auth/react';
-import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import { signOut, useSession } from 'next-auth/react';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useAccountListId } from '../../../../../../hooks/useAccountListId';
 import { clearDataDogUser } from 'src/hooks/useDataDog';
 import HandoffLink from '../../../../../HandoffLink';
 import { useGetTopBarQuery } from '../../GetTopBar.generated';
 import theme from '../../../../../../theme';
+import ProfileName from './ProfileName';
 
 const AccountName = styled(Typography)(({ theme }) => ({
   color: theme.palette.common.white,
   margin: 0,
   padding: '0px 8px',
-}));
-
-const StyledAvatar = styled(AccountCircleIcon)(({ theme }) => ({
-  color: theme.palette.cruGrayMedium.main,
 }));
 
 const MenuItemAccount = styled(MenuItem)(() => ({
@@ -101,9 +96,21 @@ const MenuWrapper = styled(Menu)(({ theme }) => ({
   },
 }));
 
+const ImpersonatingMenuButton = styled(Button)(({ theme }) => ({
+  width: '100%',
+  marginTop: theme.spacing(1),
+  borderColor: '#f6921e',
+  color: '#f6921e',
+  '&:hover': {
+    backgroundColor: '#f6921e',
+    color: '#ffffff',
+  },
+}));
+
 const ProfileMenu = (): ReactElement => {
   const { t } = useTranslation();
   const router = useRouter();
+  const { data: session } = useSession();
   const { contactId: _, ...queryWithoutContactId } = router.query;
   const accountListId = useAccountListId();
   const { data } = useGetTopBarQuery();
@@ -119,39 +126,41 @@ const ProfileMenu = (): ReactElement => {
   const handleProfileMenuClose = () => {
     setProfileMenuAnchorEl(undefined);
   };
+  const hasSelectedAccount = data?.accountLists?.nodes
+    ? !!(accountListId && data.accountLists.nodes.length > 1)
+    : false;
 
   return (
     <>
-      <IconButton
-        onClick={handleProfileMenuOpen}
-        data-testid="profileMenuButton"
+      <ProfileName
+        impersonating={!!session?.user?.impersonating}
+        onProfileMenuOpen={handleProfileMenuOpen}
+        showSubAccount={hasSelectedAccount}
       >
-        <Box display="flex" alignItems="center" m={-1}>
-          <StyledAvatar />
-          {data && (
-            <Box display="block" textAlign="left">
-              <AccountName>
-                {[data.user.firstName, data.user.lastName]
-                  .filter(Boolean)
-                  .join(' ')}
+        {data && (
+          <Box display="block" textAlign="left">
+            <AccountName>
+              {session?.user?.impersonating ? `Impersonating ` : ``}
+              {[data.user.firstName, data.user.lastName]
+                .filter(Boolean)
+                .join(' ')}
+            </AccountName>
+            {hasSelectedAccount && (
+              <AccountName
+                display="block"
+                variant="body2"
+                data-testid="accountListName"
+              >
+                {
+                  data?.accountLists.nodes.find(
+                    (accountList) => accountList.id === accountListId,
+                  )?.name
+                }
               </AccountName>
-              {accountListId && data.accountLists.nodes.length > 1 && (
-                <AccountName
-                  display="block"
-                  variant="body2"
-                  data-testid="accountListName"
-                >
-                  {
-                    data?.accountLists.nodes.find(
-                      (accountList) => accountList.id === accountListId,
-                    )?.name
-                  }
-                </AccountName>
-              )}
-            </Box>
-          )}
-        </Box>
-      </IconButton>
+            )}
+          </Box>
+        )}
+      </ProfileName>
       <MenuWrapper
         data-testid="profileMenu"
         anchorEl={profileMenuAnchorEl}
@@ -268,17 +277,28 @@ const ProfileMenu = (): ReactElement => {
           </HandoffLink>
         )}
         <MenuItem>
-          <MenuButton
-            variant="outlined"
-            color="inherit"
-            onClick={() => {
-              signOut({ callbackUrl: 'signOut' }).then(() => {
-                clearDataDogUser();
-              });
-            }}
-          >
-            {t('Sign Out')}
-          </MenuButton>
+          {session?.user?.impersonating && (
+            <ImpersonatingMenuButton
+              variant="outlined"
+              color="inherit"
+              href="/api/stop-impersonating"
+            >
+              {t('Stop Impersonating')}
+            </ImpersonatingMenuButton>
+          )}
+          {!session?.user?.impersonating && (
+            <MenuButton
+              variant="outlined"
+              color="inherit"
+              onClick={() => {
+                signOut({ callbackUrl: 'signOut' }).then(() => {
+                  clearDataDogUser();
+                });
+              }}
+            >
+              {t('Sign Out')}
+            </MenuButton>
+          )}
         </MenuItem>
         <MenuItemFooter>
           <Link

--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileName.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileName.tsx
@@ -1,0 +1,71 @@
+import React, { ReactElement } from 'react';
+import { Box, IconButton } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+
+const StyledAvatar = styled(AccountCircleIcon)(({ theme }) => ({
+  color: theme.palette.cruGrayMedium.main,
+}));
+
+const ImpersonatingBox = styled(Box)(() => ({
+  paddingLeft: '6px',
+  paddingRight: '6px',
+}));
+const ImpersonatingAvatar = styled(AccountCircleIcon)(() => ({
+  color: '#ffffff',
+}));
+
+const ImpersonatingIconButton = styled(IconButton, {
+  shouldForwardProp: (prop) => prop !== 'showSubAccount',
+})<{ showSubAccount?: boolean }>(({ showSubAccount }) => ({
+  backgroundColor: '#f6921e',
+  paddingTop: showSubAccount ? '10px' : '20px',
+  paddingBottom: showSubAccount ? '10px' : '20px',
+  borderRadius: '4px',
+  '&:hover': {
+    backgroundColor: '#d87809',
+  },
+}));
+
+interface ProfileNameProps {
+  impersonating: boolean;
+  showSubAccount: boolean;
+  onProfileMenuOpen: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => void;
+  children: React.ReactNode;
+}
+
+const ProfileName = ({
+  impersonating,
+  showSubAccount,
+  onProfileMenuOpen,
+  children,
+}: ProfileNameProps): ReactElement => {
+  return (
+    <>
+      {impersonating && (
+        <ImpersonatingIconButton
+          onClick={onProfileMenuOpen}
+          data-testid="profileMenuButton"
+          showSubAccount={showSubAccount}
+        >
+          <ImpersonatingBox display="flex" alignItems="center" m={-1}>
+            <ImpersonatingAvatar />
+            {children}
+          </ImpersonatingBox>
+        </ImpersonatingIconButton>
+      )}
+      {!impersonating && (
+        <IconButton onClick={onProfileMenuOpen} data-testid="profileMenuButton">
+          <Box display="flex" alignItems="center" m={-1}>
+            <StyledAvatar />
+            {children}
+          </Box>
+        </IconButton>
+      )}
+    </>
+  );
+};
+
+export default ProfileName;

--- a/src/components/Layouts/Primary/TopBar/TopBar.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/TopBar.test.tsx
@@ -17,6 +17,21 @@ const router = {
   query: { accountListId },
   isReady: true,
 };
+const session = {
+  expires: '2021-10-28T14:48:20.897Z',
+  user: {
+    email: 'Chair Library Bed',
+    image: null,
+    name: 'Dung Tapestry',
+    token: 'superLongJwtString',
+  },
+};
+
+jest.mock('next-auth/react', () => {
+  return {
+    useSession: jest.fn().mockImplementation(() => Promise.resolve(session)),
+  };
+});
 
 const mockEnqueue = jest.fn();
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -59,6 +59,13 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
           clearDataDogUser();
         });
       }
+      // Redirect to homepage if user doesn't have access to view accountList,
+      if (
+        message.includes('AccountList with id=') &&
+        message.includes(' not found')
+      ) {
+        location.href = `${process.env.SITE_URL}/`;
+      }
       snackNotifications.error(message);
     });
   }


### PR DESCRIPTION
 ## Description
This solves a few issues.
1. MPDX React Impersonator functionality. [MPDX-7659](https://jira.cru.org/browse/MPDX-7659)
2. Solves a issue with conflicting accounts logged in. [MPDX-7625](https://jira.cru.org/browse/MPDX-7625)

**More info:**
1. Allows impersonators on the MPDX site to view the MPDX React with functionality to act as that user and signout and regain their access to their account on MPDX React.
3. Solved the issue of both MPDX sites having two different logged-in users. If React is logged in `accountA`, while Angluar is logged in `accountB`, if they navigate from Angluar to React, `accountA` will be logged out and `accountB` will be automatically logged in.


MPDX Angluar related PR https://github.com/CruGlobal/mpdx_web/pull/2272