### PR TITLE
[MPDX-7648] Add designation account filters to reports

### DIFF
--- a/pages/accountLists/[accountListId]/reports/GetExpectedMonthlyTotals.graphql
+++ b/pages/accountLists/[accountListId]/reports/GetExpectedMonthlyTotals.graphql
@@ -1,5 +1,11 @@
-query GetExpectedMonthlyTotals($accountListId: ID!) {
-  expectedMonthlyTotalReport(accountListId: $accountListId) {
+query GetExpectedMonthlyTotals(
+  $accountListId: ID!
+  $designationAccountIds: [ID!]
+) {
+  expectedMonthlyTotalReport(
+    accountListId: $accountListId
+    designationAccountId: $designationAccountIds
+  ) {
     received {
       donations {
         ...ExpectedDonationRow

--- a/pages/accountLists/[accountListId]/reports/designationAccounts.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/designationAccounts.page.tsx
@@ -20,6 +20,7 @@ const DesignationAccountsReportPage: React.FC = () => {
   const accountListId = useAccountListId();
   const { appName } = useGetAppSettings();
   const [isNavListOpen, setNavListOpen] = useState<boolean>(false);
+  const [designationAccounts, setDesignationAccounts] = useState<string[]>([]);
 
   useEffect(() => {
     suggestArticles('HS_REPORTS_SUGGESTIONS');
@@ -45,6 +46,8 @@ const DesignationAccountsReportPage: React.FC = () => {
                 isOpen={isNavListOpen}
                 selectedId="designationAccounts"
                 onClose={handleNavListToggle}
+                designationAccounts={designationAccounts}
+                setDesignationAccounts={setDesignationAccounts}
               />
             }
             leftOpen={isNavListOpen}

--- a/pages/accountLists/[accountListId]/reports/donations/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/donations/[[...contactId]].page.tsx
@@ -24,6 +24,7 @@ const DonationsReportPage: React.FC = () => {
   const router = useRouter();
   const accountListId = useAccountListId();
   const { appName } = useGetAppSettings();
+  const [designationAccounts, setDesignationAccounts] = useState<string[]>([]);
   const [isNavListOpen, setNavListOpen] = useState<boolean>(false);
 
   useEffect(() => {
@@ -58,6 +59,8 @@ const DonationsReportPage: React.FC = () => {
                 isOpen={isNavListOpen}
                 selectedId="donations"
                 onClose={handleNavListToggle}
+                designationAccounts={designationAccounts}
+                setDesignationAccounts={setDesignationAccounts}
               />
             }
             leftOpen={isNavListOpen}
@@ -65,6 +68,7 @@ const DonationsReportPage: React.FC = () => {
             mainContent={
               <DonationsReport
                 accountListId={accountListId}
+                designationAccounts={designationAccounts}
                 isNavListOpen={isNavListOpen}
                 onNavListToggle={handleNavListToggle}
                 onSelectContact={handleSelectContact}

--- a/pages/accountLists/[accountListId]/reports/expectedMonthlyTotal.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/expectedMonthlyTotal.page.tsx
@@ -1,22 +1,35 @@
-import React, { ReactElement, useEffect } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
 import { ExpectedMonthlyTotalReportHeader } from '../../../../src/components/Reports/ExpectedMonthlyTotalReport/Header/ExpectedMonthlyTotalReportHeader';
 import Loading from '../../../../src/components/Loading';
 import { useAccountListId } from '../../../../src/hooks/useAccountListId';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
 import { ExpectedMonthlyTotalReport } from '../../../../src/components/Reports/ExpectedMonthlyTotalReport/ExpectedMonthlyTotalReport';
 import { suggestArticles } from 'src/lib/helpScout';
+import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
+import { NavReportsList } from 'src/components/Reports/NavReportsList/NavReportsList';
+
+const ExpectedMonthlyTotalReportPageWrapper = styled(Box)(({ theme }) => ({
+  backgroundColor: theme.palette.common.white,
+}));
 
 const ExpectedMonthlyTotalReportPage = (): ReactElement => {
   const { t } = useTranslation();
   const accountListId = useAccountListId();
   const { appName } = useGetAppSettings();
+  const [isNavListOpen, setNavListOpen] = useState<boolean>(false);
+  const [designationAccounts, setDesignationAccounts] = useState<string[]>([]);
 
   useEffect(() => {
     suggestArticles('HS_REPORTS_SUGGESTIONS');
   }, []);
+
+  const handleNavListToggle = () => {
+    setNavListOpen(!isNavListOpen);
+  };
 
   return (
     <>
@@ -26,11 +39,33 @@ const ExpectedMonthlyTotalReportPage = (): ReactElement => {
         </title>
       </Head>
       {accountListId ? (
-        <ExpectedMonthlyTotalReport
-          accountListId={accountListId}
-        ></ExpectedMonthlyTotalReport>
+        <ExpectedMonthlyTotalReportPageWrapper>
+          <SidePanelsLayout
+            isScrollBox={false}
+            leftPanel={
+              <NavReportsList
+                isOpen={isNavListOpen}
+                selectedId="expectedMonthlyTotal"
+                onClose={handleNavListToggle}
+                designationAccounts={designationAccounts}
+                setDesignationAccounts={setDesignationAccounts}
+              />
+            }
+            leftOpen={isNavListOpen}
+            leftWidth="290px"
+            mainContent={
+              <ExpectedMonthlyTotalReport
+                accountListId={accountListId}
+                designationAccounts={designationAccounts}
+                isNavListOpen={isNavListOpen}
+                onNavListToggle={handleNavListToggle}
+                title={t('Expected Monthly Total')}
+              />
+            }
+          />
+        </ExpectedMonthlyTotalReportPageWrapper>
       ) : (
-        <Box>
+        <>
           <ExpectedMonthlyTotalReportHeader
             empty={true}
             totalDonations={0}
@@ -40,7 +75,7 @@ const ExpectedMonthlyTotalReportPage = (): ReactElement => {
             currency={''}
           />
           <Loading loading />
-        </Box>
+        </>
       )}
     </>
   );

--- a/pages/accountLists/[accountListId]/reports/partnerCurrency.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/partnerCurrency.page.tsx
@@ -21,6 +21,7 @@ const PartnerCurrencyReportPage: React.FC = () => {
   const accountListId = useAccountListId();
   const { appName } = useGetAppSettings();
   const [isNavListOpen, setNavListOpen] = useState<boolean>(false);
+  const [designationAccounts, setDesignationAccounts] = useState<string[]>([]);
 
   useEffect(() => {
     suggestArticles('HS_REPORTS_SUGGESTIONS');
@@ -46,6 +47,8 @@ const PartnerCurrencyReportPage: React.FC = () => {
                 isOpen={isNavListOpen}
                 selectedId="partnerCurrency"
                 onClose={handleNavListToggle}
+                designationAccounts={designationAccounts}
+                setDesignationAccounts={setDesignationAccounts}
               />
             }
             leftOpen={isNavListOpen}
@@ -53,6 +56,7 @@ const PartnerCurrencyReportPage: React.FC = () => {
             mainContent={
               <FourteenMonthReport
                 accountListId={accountListId}
+                designationAccounts={designationAccounts}
                 currencyType={FourteenMonthReportCurrencyType.Donor}
                 isNavListOpen={isNavListOpen}
                 onNavListToggle={handleNavListToggle}

--- a/pages/accountLists/[accountListId]/reports/responsibilityCenters.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/responsibilityCenters.page.tsx
@@ -20,6 +20,7 @@ const ResponsibilityCentersReportPage: React.FC = () => {
   const accountListId = useAccountListId();
   const { appName } = useGetAppSettings();
   const [isNavListOpen, setNavListOpen] = useState<boolean>(false);
+  const [designationAccounts, setDesignationAccounts] = useState<string[]>([]);
 
   useEffect(() => {
     suggestArticles('HS_REPORTS_SUGGESTIONS');
@@ -45,6 +46,8 @@ const ResponsibilityCentersReportPage: React.FC = () => {
                 isOpen={isNavListOpen}
                 selectedId="responsibilityCenters"
                 onClose={handleNavListToggle}
+                designationAccounts={designationAccounts}
+                setDesignationAccounts={setDesignationAccounts}
               />
             }
             leftOpen={isNavListOpen}
@@ -52,6 +55,7 @@ const ResponsibilityCentersReportPage: React.FC = () => {
             mainContent={
               <ResponsibilityCentersReport
                 accountListId={accountListId}
+                designationAccounts={designationAccounts}
                 isNavListOpen={isNavListOpen}
                 onNavListToggle={handleNavListToggle}
                 title={t('Responsibility Centers')}

--- a/pages/accountLists/[accountListId]/reports/salaryCurrency.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/salaryCurrency.page.tsx
@@ -21,6 +21,7 @@ const SalaryCurrencyReportPage: React.FC = () => {
   const accountListId = useAccountListId();
   const { appName } = useGetAppSettings();
   const [isNavListOpen, setNavListOpen] = useState<boolean>(false);
+  const [designationAccounts, setDesignationAccounts] = useState<string[]>([]);
 
   useEffect(() => {
     suggestArticles('HS_REPORTS_SUGGESTIONS');
@@ -46,6 +47,8 @@ const SalaryCurrencyReportPage: React.FC = () => {
                 isOpen={isNavListOpen}
                 selectedId="salaryCurrency"
                 onClose={handleNavListToggle}
+                designationAccounts={designationAccounts}
+                setDesignationAccounts={setDesignationAccounts}
               />
             }
             leftOpen={isNavListOpen}
@@ -53,6 +56,7 @@ const SalaryCurrencyReportPage: React.FC = () => {
             mainContent={
               <FourteenMonthReport
                 accountListId={accountListId}
+                designationAccounts={designationAccounts}
                 isNavListOpen={isNavListOpen}
                 onNavListToggle={handleNavListToggle}
                 title={t('Contributions by Salary Currency')}

--- a/pages/api/Schema/reports/designationAccounts/datahandler.ts
+++ b/pages/api/Schema/reports/designationAccounts/datahandler.ts
@@ -14,7 +14,7 @@ export interface DesignationAccountsResponse {
     created_at: string;
     currency: string;
     currency_symbol: string;
-    designation_number: string;
+    designation_number: string | null;
     display_name: string;
     exchange_rate: number;
     legacy_designation_number: null;

--- a/pages/api/Schema/reports/designationAccounts/designationAccounts.graphql
+++ b/pages/api/Schema/reports/designationAccounts/designationAccounts.graphql
@@ -13,7 +13,7 @@ type DesignationAccountRest {
   balanceUpdatedAt: ISO8601Date!
   convertedBalance: Float!
   currency: String!
-  designationNumber: String!
+  designationNumber: String
   id: ID!
   name: String!
 }

--- a/pages/api/Schema/reports/entryHistories/datahandler.ts
+++ b/pages/api/Schema/reports/entryHistories/datahandler.ts
@@ -33,7 +33,10 @@ export const createEntryHistoriesGroup = (
   financialAccountId: string,
 ): EntryHistoriesGroup => ({
   financialAccountId,
-  entryHistories: data.map((entryHistory) => createEntryHistory(entryHistory)),
+  entryHistories: data
+    // The last entry is the total for the whole year, so ignore it
+    .slice(0, -1)
+    .map((entryHistory) => createEntryHistory(entryHistory)),
 });
 
 const createEntryHistory = (

--- a/pages/api/Schema/reports/expectedMonthlyTotal/expectedMonthlyTotal.graphql
+++ b/pages/api/Schema/reports/expectedMonthlyTotal/expectedMonthlyTotal.graphql
@@ -1,5 +1,8 @@
 extend type Query {
-  expectedMonthlyTotalReport(accountListId: ID!): ExpectedMonthlyTotalReport!
+  expectedMonthlyTotalReport(
+    accountListId: ID!
+    designationAccountId: [ID!]
+  ): ExpectedMonthlyTotalReport!
 }
 
 type ExpectedMonthlyTotalReport {

--- a/pages/api/Schema/reports/expectedMonthlyTotal/resolvers.ts
+++ b/pages/api/Schema/reports/expectedMonthlyTotal/resolvers.ts
@@ -4,11 +4,12 @@ export const ExpectedMonthlyTotalReportResolvers: Resolvers = {
   Query: {
     expectedMonthlyTotalReport: (
       _source,
-      { accountListId },
+      { accountListId, designationAccountId },
       { dataSources },
     ) => {
       return dataSources.mpdxRestApi.getExpectedMonthlyTotalReport(
         accountListId,
+        designationAccountId,
       );
     },
   },

--- a/pages/api/Schema/reports/fourteenMonth/fourteenMonth.graphql
+++ b/pages/api/Schema/reports/fourteenMonth/fourteenMonth.graphql
@@ -1,6 +1,7 @@
 extend type Query {
   fourteenMonthReport(
     accountListId: ID!
+    designationAccountId: [ID!]
     currencyType: FourteenMonthReportCurrencyType!
   ): FourteenMonthReport!
 }

--- a/pages/api/Schema/reports/fourteenMonth/resolvers.ts
+++ b/pages/api/Schema/reports/fourteenMonth/resolvers.ts
@@ -4,11 +4,12 @@ const FourteenMonthReportResolvers: Resolvers = {
   Query: {
     fourteenMonthReport: (
       _source,
-      { accountListId, currencyType },
+      { accountListId, designationAccountId, currencyType },
       { dataSources },
     ) => {
       return dataSources.mpdxRestApi.getFourteenMonthReport(
         accountListId,
+        designationAccountId,
         currencyType,
       );
     },

--- a/pages/api/graphql-rest.page.ts
+++ b/pages/api/graphql-rest.page.ts
@@ -357,14 +357,19 @@ class MpdxRestApi extends RESTDataSource {
 
   async getFourteenMonthReport(
     accountListId: string,
+    designationAccountId: string[] | null | undefined,
     currencyType: FourteenMonthReportCurrencyType,
   ) {
+    const designationAccountFilter =
+      designationAccountId && designationAccountId.length > 0
+        ? `&filter[designation_account_id=${designationAccountId.join(',')}`
+        : '';
     const { data }: { data: FourteenMonthReportResponse } = await this.get(
       `reports/${
         currencyType === 'salary'
           ? 'salary_currency_donations'
           : 'donor_currency_donations'
-      }?filter[account_list_id]=${accountListId}&filter[month_range]=${Interval.before(
+      }?filter[account_list_id]=${accountListId}${designationAccountFilter}&filter[month_range]=${Interval.before(
         DateTime.now().endOf('month'),
         Duration.fromObject({ months: 14 }).minus({ day: 1 }),
       )
@@ -374,9 +379,16 @@ class MpdxRestApi extends RESTDataSource {
     return mapFourteenMonthReport(data, currencyType);
   }
 
-  async getExpectedMonthlyTotalReport(accountListId: string) {
+  async getExpectedMonthlyTotalReport(
+    accountListId: string,
+    designationAccountId: string[] | null | undefined,
+  ) {
+    const designationAccountFilter =
+      designationAccountId && designationAccountId.length > 0
+        ? `&filter[designation_account_id=${designationAccountId.join(',')}`
+        : '';
     const { data }: { data: ExpectedMonthlyTotalResponse } = await this.get(
-      `reports/expected_monthly_totals?filter[account_list_id]=${accountListId}`,
+      `reports/expected_monthly_totals?filter[account_list_id]=${accountListId}${designationAccountFilter}`,
     );
     return mapExpectedMonthlyTotalReport(data);
   }

--- a/src/components/Contacts/ContactDetails/ContactDontationsTab/DonationsGraph/DonationsGraph.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDontationsTab/DonationsGraph/DonationsGraph.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable eqeqeq */
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';

--- a/src/components/Reports/AccountsListLayout/Header/Header.test.tsx
+++ b/src/components/Reports/AccountsListLayout/Header/Header.test.tsx
@@ -17,30 +17,30 @@ describe('AccountsListHeader', () => {
           isNavListOpen={true}
           title={title}
           onNavListToggle={onNavListToggle}
-          totalBalance={totalBalance}
+          rightExtra={totalBalance}
         />
       </ThemeProvider>,
     );
 
     expect(getByText(title)).toBeInTheDocument();
-    expect(getByText(`Balance: ${totalBalance}`)).toBeInTheDocument();
+    expect(getByText('CA111')).toBeInTheDocument();
     userEvent.click(
       getByRole('button', { hidden: true, name: 'Toggle Filter Panel' }),
     );
   });
 
-  it('should not render total balance if undefined', async () => {
+  it('should not render rightExtra if undefined', async () => {
     const { queryByText } = render(
       <ThemeProvider theme={theme}>
         <Header
           isNavListOpen={true}
           title={title}
           onNavListToggle={onNavListToggle}
-          totalBalance={undefined}
+          rightExtra={undefined}
         />
       </ThemeProvider>,
     );
 
-    expect(queryByText(`Balance: ${totalBalance}`)).toBeNull();
+    expect(queryByText('CA111')).toBeNull();
   });
 });

--- a/src/components/Reports/AccountsListLayout/Header/Header.tsx
+++ b/src/components/Reports/AccountsListLayout/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box, IconButton, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
@@ -9,17 +9,13 @@ interface AccountsListHeaderProps {
   isNavListOpen: boolean;
   onNavListToggle: () => void;
   title: string;
-  totalBalance?: string | undefined;
+  rightExtra?: ReactNode;
 }
 
 const StickyHeader = styled(Box)(({}) => ({
   position: 'sticky',
   top: 0,
   height: 96,
-}));
-
-const HeaderTitle = styled(Typography)(({}) => ({
-  lineHeight: 1.1,
 }));
 
 const NavListButton = styled(IconButton, {
@@ -41,26 +37,27 @@ const NavListIcon = styled(FilterList)(({ theme }) => ({
 
 export const AccountsListHeader: FC<AccountsListHeaderProps> = ({
   title,
+  rightExtra,
   isNavListOpen,
   onNavListToggle,
-  totalBalance,
 }) => {
   const { t } = useTranslation();
 
   return (
     <StickyHeader p={2} test-dataid="AccountsListHeader">
-      <Box display="flex" justifyContent="space-between" alignItems="center">
-        <Box display="flex" alignItems="center">
-          <NavListButton panelOpen={isNavListOpen} onClick={onNavListToggle}>
-            <NavListIcon titleAccess={t('Toggle Filter Panel')} />
-          </NavListButton>
-          <HeaderTitle variant="h5">{title}</HeaderTitle>
-        </Box>
-        {totalBalance && (
-          <HeaderTitle variant="h6">{`${t(
-            'Balance',
-          )}: ${totalBalance}`}</HeaderTitle>
-        )}
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
+        sx={{ lineHeight: 1.1 }}
+      >
+        <NavListButton panelOpen={isNavListOpen} onClick={onNavListToggle}>
+          <NavListIcon titleAccess={t('Toggle Filter Panel')} />
+        </NavListButton>
+        <Typography variant="h5" sx={{ flex: 1 }}>
+          {title}
+        </Typography>
+        {rightExtra}
       </Box>
     </StickyHeader>
   );

--- a/src/components/Reports/AccountsListLayout/List/ListItem/ListItem.tsx
+++ b/src/components/Reports/AccountsListLayout/List/ListItem/ListItem.tsx
@@ -89,7 +89,7 @@ export const AccountListItem: FC<AccountListItemProps> = ({
                     <Typography variant="h6">{account.name}</Typography>
                     <Typography variant="body2" color="textSecondary">
                       {`${hasFinancial ? '' : t('Designation #')}${
-                        account.code
+                        account.code ?? ''
                       } · ${t('Last Synced')} ${
                         account.lastSyncDate
                           ? DateTime.fromISO(

--- a/src/components/Reports/DesignationAccountsReport/DesignationAccountsReport.test.tsx
+++ b/src/components/Reports/DesignationAccountsReport/DesignationAccountsReport.test.tsx
@@ -26,7 +26,7 @@ const mocks = {
         organizationName: 'test org 01',
         designationAccounts: [
           {
-            active: false,
+            active: true,
             id: 'test-id-111',
             balanceUpdatedAt: '2/2/2021',
             convertedBalance: 3500,

--- a/src/components/Reports/DesignationAccountsReport/DesignationAccountsReport.tsx
+++ b/src/components/Reports/DesignationAccountsReport/DesignationAccountsReport.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Box, CircularProgress, Divider } from '@mui/material';
+import { Box, CircularProgress, Divider, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { AccountsList as List } from '../AccountsListLayout/List/List';
 import { AccountsListHeader as Header } from '../AccountsListLayout/Header/Header';
@@ -72,20 +72,21 @@ export const DesignationAccountsReport: React.FC<Props> = ({
       );
   }, [data?.designationAccounts]);
 
+  const balanceNode =
+    totalBalance && totalBalance > 0 ? (
+      <Typography variant="h6">{`${t('Balance')}: ${currencyFormat(
+        totalBalance,
+        data?.designationAccounts[0].designationAccounts[0].currency,
+      )}`}</Typography>
+    ) : undefined;
+
   return (
     <Box>
       <Header
         isNavListOpen={isNavListOpen}
         onNavListToggle={onNavListToggle}
         title={title}
-        totalBalance={
-          totalBalance && totalBalance > 0
-            ? currencyFormat(
-                totalBalance,
-                data?.designationAccounts[0].designationAccounts[0].currency,
-              )
-            : undefined
-        }
+        rightExtra={balanceNode}
       />
       {loading ? (
         <Box
@@ -114,7 +115,7 @@ export const DesignationAccountsReport: React.FC<Props> = ({
               designationAccountGroup.designationAccounts.map((account) => ({
                 active: account.active,
                 balance: account.convertedBalance,
-                code: account.designationNumber,
+                code: account.designationNumber ?? undefined,
                 currency: account.currency,
                 id: account.id,
                 lastSyncDate: account.balanceUpdatedAt,

--- a/src/components/Reports/DonationsReport/DonationsReport.tsx
+++ b/src/components/Reports/DonationsReport/DonationsReport.tsx
@@ -7,16 +7,18 @@ import { AccountsListHeader as Header } from '../AccountsListLayout/Header/Heade
 import { MonthlyActivitySection } from './MonthlyActivity/MonthlyActivitySection';
 import { DonationsReportTable } from './Table/DonationsReportTable';
 
-interface Props {
+interface DonationReportsProps {
   accountListId: string;
+  designationAccounts?: string[];
   isNavListOpen: boolean;
   onNavListToggle: () => void;
   onSelectContact: (contactId: string) => void;
   title: string;
 }
 
-export const DonationsReport: React.FC<Props> = ({
+export const DonationsReport: React.FC<DonationReportsProps> = ({
   accountListId,
+  designationAccounts,
   isNavListOpen,
   onNavListToggle,
   onSelectContact,
@@ -47,10 +49,12 @@ export const DonationsReport: React.FC<Props> = ({
       <Container>
         <MonthlyActivitySection
           accountListId={accountListId}
+          designationAccounts={designationAccounts}
           setTime={setTime}
         />
         <DonationsReportTable
           accountListId={accountListId}
+          designationAccounts={designationAccounts}
           onSelectContact={onSelectContact}
           time={time}
           setTime={setTime}

--- a/src/components/Reports/DonationsReport/GetDonationGraph.graphql
+++ b/src/components/Reports/DonationsReport/GetDonationGraph.graphql
@@ -1,11 +1,14 @@
-query GetDonationGraph($accountListId: ID!) {
+query GetDonationGraph($accountListId: ID!, $designationAccountIds: [ID!]) {
   accountList(id: $accountListId) {
     id
     currency
     monthlyGoal
     totalPledges
   }
-  reportsDonationHistories(accountListId: $accountListId) {
+  reportsDonationHistories(
+    accountListId: $accountListId
+    designationAccountId: $designationAccountIds
+  ) {
     averageIgnoreCurrent
     periods {
       startDate

--- a/src/components/Reports/DonationsReport/GetDonationsTable.graphql
+++ b/src/components/Reports/DonationsReport/GetDonationsTable.graphql
@@ -4,10 +4,12 @@ query GetDonationsTable(
   $after: String
   $startDate: ISO8601Date
   $endDate: ISO8601Date
+  $designationAccountIds: [ID!]
 ) {
   donations(
     accountListId: $accountListId
     donationDate: { max: $endDate, min: $startDate }
+    designationAccountId: $designationAccountIds
     first: $pageSize
     after: $after
   ) {

--- a/src/components/Reports/DonationsReport/MonthlyActivity/MonthlyActivitySection.test.tsx
+++ b/src/components/Reports/DonationsReport/MonthlyActivity/MonthlyActivitySection.test.tsx
@@ -87,56 +87,113 @@ describe('Render Monthly Activity Section', () => {
       queryByTestId('DonationHistoriesGridLoading'),
     ).not.toBeInTheDocument();
   });
-});
-it('renders empty', async () => {
-  const mocks = {
-    GetDonationGraph: {
-      accountList: {
-        currency: 'CAD',
-        monthlyGoal: 0,
-        totalPledges: 0,
-      },
-      reportsDonationHistories: {
-        averageIgnoreCurrent: 0,
-        periods: [
-          {
-            startDate: DateTime.now().minus({ months: 12 }).toISO(),
-            convertedTotal: 0,
-            totals: [
-              {
-                currency: 'CAD',
-                convertedAmount: 0,
-              },
-            ],
-          },
-          {
-            startDate: DateTime.now().minus({ months: 11 }).toISO(),
-            convertedTotal: 0,
-            totals: [
-              {
-                currency: 'CAD',
-                convertedAmount: 0,
-              },
-            ],
-          },
-        ],
-      },
-    },
-  };
 
-  const { queryByText, queryByRole, getByTestId } = render(
-    <ThemeProvider theme={theme}>
-      <TestRouter router={router}>
-        <GqlMockedProvider<GetDonationGraphQuery> mocks={mocks}>
-          <MonthlyActivitySection accountListId={'abc'} setTime={setTime} />
-        </GqlMockedProvider>
-      </TestRouter>
-    </ThemeProvider>,
-  );
+  it('renders empty', async () => {
+    const mocks = {
+      GetDonationGraph: {
+        accountList: {
+          currency: 'CAD',
+          monthlyGoal: 0,
+          totalPledges: 0,
+        },
+        reportsDonationHistories: {
+          averageIgnoreCurrent: 0,
+          periods: [
+            {
+              startDate: DateTime.now().minus({ months: 12 }).toISO(),
+              convertedTotal: 0,
+              totals: [
+                {
+                  currency: 'CAD',
+                  convertedAmount: 0,
+                },
+              ],
+            },
+            {
+              startDate: DateTime.now().minus({ months: 11 }).toISO(),
+              convertedTotal: 0,
+              totals: [
+                {
+                  currency: 'CAD',
+                  convertedAmount: 0,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
 
-  await waitFor(() =>
-    expect(queryByRole('progressbar')).not.toBeInTheDocument(),
-  );
-  expect(getByTestId('DonationHistoriesBoxEmpty')).toBeInTheDocument();
-  expect(queryByText('Average')).not.toBeInTheDocument();
+    const { queryByText, queryByRole, getByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<GetDonationGraphQuery> mocks={mocks}>
+            <MonthlyActivitySection
+              accountListId={'abc'}
+              designationAccounts={[]}
+              setTime={setTime}
+            />
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(queryByRole('progressbar')).not.toBeInTheDocument(),
+    );
+    expect(getByTestId('DonationHistoriesBoxEmpty')).toBeInTheDocument();
+    expect(queryByText('Average')).not.toBeInTheDocument();
+  });
+
+  it('filters report by designation account', async () => {
+    const mutationSpy = jest.fn();
+    render(
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<GetDonationGraphQuery> onCall={mutationSpy}>
+            <MonthlyActivitySection
+              accountListId={'abc'}
+              designationAccounts={['account-1']}
+              setTime={setTime}
+            />
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mutationSpy.mock.calls[0][0]).toMatchObject({
+        operation: {
+          operationName: 'GetDonationGraph',
+          variables: {
+            designationAccountIds: ['account-1'],
+          },
+        },
+      }),
+    );
+  });
+
+  it('does not filter report by designation account', async () => {
+    const mutationSpy = jest.fn();
+    render(
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<GetDonationGraphQuery> onCall={mutationSpy}>
+            <MonthlyActivitySection accountListId={'abc'} setTime={setTime} />
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mutationSpy.mock.calls[0][0]).toMatchObject({
+        operation: {
+          operationName: 'GetDonationGraph',
+          variables: {
+            designationAccountIds: null,
+          },
+        },
+      }),
+    );
+  });
 });

--- a/src/components/Reports/DonationsReport/MonthlyActivity/MonthlyActivitySection.tsx
+++ b/src/components/Reports/DonationsReport/MonthlyActivity/MonthlyActivitySection.tsx
@@ -5,15 +5,22 @@ import { useGetDonationGraphQuery } from '../GetDonationGraph.generated';
 
 interface Props {
   accountListId: string;
+  designationAccounts?: string[];
   setTime?: (time: DateTime) => void;
 }
 
 export const MonthlyActivitySection: React.FC<Props> = ({
   accountListId,
+  designationAccounts,
   setTime,
 }) => {
   const { data } = useGetDonationGraphQuery({
-    variables: { accountListId },
+    variables: {
+      accountListId,
+      designationAccountIds: designationAccounts?.length
+        ? designationAccounts
+        : null,
+    },
   });
 
   return (

--- a/src/components/Reports/DonationsReport/Table/DonationsReportTable.test.tsx
+++ b/src/components/Reports/DonationsReport/Table/DonationsReportTable.test.tsx
@@ -215,6 +215,67 @@ describe('DonationsReportTable', () => {
     expect(onSelectContact).toHaveBeenCalledWith('contact1');
   });
 
+  it('filters report by designation account', async () => {
+    const mutationSpy = jest.fn();
+    render(
+      <ThemeProvider theme={theme}>
+        <GqlMockedProvider<GetDonationsTableQuery>
+          mocks={mocks}
+          onCall={mutationSpy}
+        >
+          <DonationsReportTable
+            accountListId={'abc'}
+            designationAccounts={['account-1']}
+            onSelectContact={onSelectContact}
+            time={time}
+            setTime={setTime}
+          />
+        </GqlMockedProvider>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mutationSpy.mock.calls[0][0]).toMatchObject({
+        operation: {
+          operationName: 'GetDonationsTable',
+          variables: {
+            designationAccountIds: ['account-1'],
+          },
+        },
+      }),
+    );
+  });
+
+  it('does not filter report by designation account', async () => {
+    const mutationSpy = jest.fn();
+    render(
+      <ThemeProvider theme={theme}>
+        <GqlMockedProvider<GetDonationsTableQuery>
+          mocks={mocks}
+          onCall={mutationSpy}
+        >
+          <DonationsReportTable
+            accountListId={'abc'}
+            onSelectContact={onSelectContact}
+            time={time}
+            setTime={setTime}
+          />
+        </GqlMockedProvider>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mutationSpy.mock.calls[0][0]).toMatchObject({
+        operation: {
+          operationName: 'GetDonationsTable',
+          variables: {
+            designationAccountIds: null,
+          },
+        },
+      }),
+    );
+  });
+
   it('is not clickable when contact is missing', async () => {
     const mocks = {
       GetDonationsTable: {

--- a/src/components/Reports/DonationsReport/Table/DonationsReportTable.tsx
+++ b/src/components/Reports/DonationsReport/Table/DonationsReportTable.tsx
@@ -31,12 +31,14 @@ import {
   useGetDonationsTableQuery,
   ExpectedDonationDataFragment,
   useGetAccountListCurrencyQuery,
+  GetDonationsTableQueryVariables,
 } from '../GetDonationsTable.generated';
 import { EditDonationModal } from './Modal/EditDonationModal';
 import { useFetchAllPages } from 'src/hooks/useFetchAllPages';
 
-interface Props {
+interface DonationReportTableProps {
   accountListId: string;
+  designationAccounts?: string[];
   onSelectContact: (contactId: string) => void;
   time: DateTime;
   setTime: (time: DateTime) => void;
@@ -101,8 +103,9 @@ export interface Donation {
   appealAmount: number | null;
 }
 
-export const DonationsReportTable: React.FC<Props> = ({
+export const DonationsReportTable: React.FC<DonationReportTableProps> = ({
   accountListId,
+  designationAccounts,
   onSelectContact,
   time,
   setTime,
@@ -128,9 +131,17 @@ export const DonationsReportTable: React.FC<Props> = ({
   // pageSize is intentionally omitted from the dependencies array so that the query isn't rerun when the page size changes
   // If all the pages have loaded and the user changes the page size, there's no reason to reload all the pages
   // TODO: sort donations on the server after https://jira.cru.org/browse/MPDX-7634 is implemented
-  const variables = useMemo(
-    () => ({ accountListId, pageSize, startDate, endDate }),
-    [accountListId, startDate, endDate],
+  const variables: GetDonationsTableQueryVariables = useMemo(
+    () => ({
+      accountListId,
+      pageSize,
+      startDate,
+      endDate,
+      designationAccountIds: designationAccounts?.length
+        ? designationAccounts
+        : null,
+    }),
+    [accountListId, startDate, endDate, designationAccounts],
   );
   const { data, loading, fetchMore } = useGetDonationsTableQuery({
     variables,

--- a/src/components/Reports/ExpectedMonthlyTotalReport/ExpectedMonthlyTotalReport.stories.tsx
+++ b/src/components/Reports/ExpectedMonthlyTotalReport/ExpectedMonthlyTotalReport.stories.tsx
@@ -7,10 +7,18 @@ export default {
   title: 'Reports/ExpectedMonthlyTotal',
 };
 
+const title = 'Expected Monthly Total';
+const onNavListToggle = jest.fn();
+
 export const Default = (): ReactElement => {
   return (
     <GqlMockedProvider<GetExpectedMonthlyTotalsQuery>>
-      <ExpectedMonthlyTotalReport accountListId={'abc'} />
+      <ExpectedMonthlyTotalReport
+        accountListId={'abc'}
+        isNavListOpen={true}
+        onNavListToggle={onNavListToggle}
+        title={title}
+      />
     </GqlMockedProvider>
   );
 };
@@ -34,7 +42,12 @@ export const Empty = (): ReactElement => {
 
   return (
     <GqlMockedProvider<GetExpectedMonthlyTotalsQuery> mocks={mocks}>
-      <ExpectedMonthlyTotalReport accountListId={'abc'} />
+      <ExpectedMonthlyTotalReport
+        accountListId={'abc'}
+        isNavListOpen={true}
+        onNavListToggle={onNavListToggle}
+        title={title}
+      />
     </GqlMockedProvider>
   );
 };

--- a/src/components/Reports/ExpectedMonthlyTotalReport/ExpectedMonthlyTotalReport.test.tsx
+++ b/src/components/Reports/ExpectedMonthlyTotalReport/ExpectedMonthlyTotalReport.test.tsx
@@ -7,61 +7,139 @@ import { GqlMockedProvider } from '../../../../__tests__/util/graphqlMocking';
 import { ExpectedMonthlyTotalReport } from './ExpectedMonthlyTotalReport';
 import TestRouter from '__tests__/util/TestRouter';
 
+const title = 'test title';
+const onNavListToggle = jest.fn();
+
 const router = {
   query: { accountListId: 'aaa' },
   isReady: true,
 };
 
-it('renders with data', async () => {
-  const { getAllByTestId, queryByRole, queryAllByRole } = render(
-    <ThemeProvider theme={theme}>
-      <GqlMockedProvider<GetExpectedMonthlyTotalsQuery>>
-        <ExpectedMonthlyTotalReport accountListId={'abc'} />
-      </GqlMockedProvider>
-    </ThemeProvider>,
-  );
+describe('ExpectedMonthlyTotalReport', () => {
+  it('renders with data', async () => {
+    const { getAllByTestId, queryByRole, queryAllByRole } = render(
+      <ThemeProvider theme={theme}>
+        <GqlMockedProvider<GetExpectedMonthlyTotalsQuery>>
+          <ExpectedMonthlyTotalReport
+            accountListId={'abc'}
+            isNavListOpen={true}
+            onNavListToggle={onNavListToggle}
+            title={title}
+          />
+        </GqlMockedProvider>
+      </ThemeProvider>,
+    );
 
-  await waitFor(() =>
-    expect(queryByRole('progressbar')).not.toBeInTheDocument(),
-  );
+    await waitFor(() =>
+      expect(queryByRole('progressbar')).not.toBeInTheDocument(),
+    );
 
-  expect(queryAllByRole('button')[0]).toBeInTheDocument();
+    expect(queryAllByRole('button')[0]).toBeInTheDocument();
 
-  expect(getAllByTestId('donationColumn')[0]).toBeInTheDocument();
-});
+    expect(getAllByTestId('donationColumn')[0]).toBeInTheDocument();
+  });
 
-it('renders empty', async () => {
-  const mocks = {
-    GetExpectedMonthlyTotals: {
-      expectedMonthlyTotalReport: {
-        received: {
-          donations: [],
-        },
-        likely: {
-          donations: [],
-        },
-        unlikely: {
-          donations: [],
+  it('renders empty', async () => {
+    const mocks = {
+      GetExpectedMonthlyTotals: {
+        expectedMonthlyTotalReport: {
+          received: {
+            donations: [],
+          },
+          likely: {
+            donations: [],
+          },
+          unlikely: {
+            donations: [],
+          },
         },
       },
-    },
-  };
+    };
 
-  const { getByText, queryByRole } = render(
-    <ThemeProvider theme={theme}>
-      <TestRouter router={router}>
-        <GqlMockedProvider<GetExpectedMonthlyTotalsQuery> mocks={mocks}>
-          <ExpectedMonthlyTotalReport accountListId={'abc'} />
-        </GqlMockedProvider>
-      </TestRouter>
-    </ThemeProvider>,
-  );
+    const { getByText, queryByRole } = render(
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<GetExpectedMonthlyTotalsQuery> mocks={mocks}>
+            <ExpectedMonthlyTotalReport
+              accountListId={'abc'}
+              isNavListOpen={true}
+              onNavListToggle={onNavListToggle}
+              title={title}
+            />
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>,
+    );
 
-  await waitFor(() =>
-    expect(queryByRole('progressbar')).not.toBeInTheDocument(),
-  );
+    await waitFor(() =>
+      expect(queryByRole('progressbar')).not.toBeInTheDocument(),
+    );
 
-  expect(
-    getByText('You have no expected donations this month'),
-  ).toBeInTheDocument();
+    expect(
+      getByText('You have no expected donations this month'),
+    ).toBeInTheDocument();
+  });
+
+  it('filters report by designation account', async () => {
+    const mutationSpy = jest.fn();
+    render(
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<GetExpectedMonthlyTotalsQuery>
+            onCall={mutationSpy}
+          >
+            <ExpectedMonthlyTotalReport
+              accountListId={'abc'}
+              designationAccounts={['account-1']}
+              isNavListOpen={true}
+              onNavListToggle={onNavListToggle}
+              title={title}
+            />
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mutationSpy.mock.calls[0][0]).toMatchObject({
+        operation: {
+          operationName: 'GetExpectedMonthlyTotals',
+          variables: {
+            designationAccountIds: ['account-1'],
+          },
+        },
+      }),
+    );
+  });
+
+  it('does not filter report by designation account', async () => {
+    const mutationSpy = jest.fn();
+    render(
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<GetExpectedMonthlyTotalsQuery>
+            onCall={mutationSpy}
+          >
+            <ExpectedMonthlyTotalReport
+              accountListId={'abc'}
+              isNavListOpen={true}
+              onNavListToggle={onNavListToggle}
+              title={title}
+            />
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mutationSpy.mock.calls[0][0]).toMatchObject({
+        operation: {
+          operationName: 'GetExpectedMonthlyTotals',
+          variables: {
+            designationAccountIds: null,
+          },
+        },
+      }),
+    );
+  });
 });

--- a/src/components/Reports/ExpectedMonthlyTotalReport/ExpectedMonthlyTotalReport.tsx
+++ b/src/components/Reports/ExpectedMonthlyTotalReport/ExpectedMonthlyTotalReport.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box, CircularProgress } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { AccountsListHeader as Header } from '../AccountsListLayout/Header/Header';
 import { useGetExpectedMonthlyTotalsQuery } from '../../../../pages/accountLists/[accountListId]/reports/GetExpectedMonthlyTotals.generated';
 import { EmptyDonationsTable } from '../../../../src/components/common/EmptyDonationsTable/EmptyDonationsTable';
 import { ExpectedMonthlyTotalReportHeader } from './Header/ExpectedMonthlyTotalReportHeader';
@@ -9,19 +9,28 @@ import { ExpectedMonthlyTotalReportTable } from './Table/ExpectedMonthlyTotalRep
 
 interface Props {
   accountListId: string;
+  designationAccounts?: string[];
+  isNavListOpen: boolean;
+  onNavListToggle: () => void;
+  title: string;
 }
-
-const LoadingIndicator = styled(CircularProgress)(({ theme }) => ({
-  margin: theme.spacing(0, 1, 0, 0),
-}));
 
 export const ExpectedMonthlyTotalReport: React.FC<Props> = ({
   accountListId,
+  designationAccounts,
+  isNavListOpen,
+  onNavListToggle,
+  title,
 }) => {
   const { t } = useTranslation();
 
   const { data, loading } = useGetExpectedMonthlyTotalsQuery({
-    variables: { accountListId },
+    variables: {
+      accountListId,
+      designationAccountIds: designationAccounts?.length
+        ? designationAccounts
+        : null,
+    },
   });
 
   const { received, likely, unlikely, currency } =
@@ -53,16 +62,30 @@ export const ExpectedMonthlyTotalReport: React.FC<Props> = ({
 
   return (
     <Box>
-      <ExpectedMonthlyTotalReportHeader
-        empty={isEmpty}
-        totalDonations={totalDonations}
-        totalLikely={totalLikely}
-        totalUnlikely={totalUnlikely}
-        total={totalAmount}
-        currency={totalCurrency}
+      <Header
+        isNavListOpen={isNavListOpen}
+        onNavListToggle={onNavListToggle}
+        title={title}
+        rightExtra={
+          <ExpectedMonthlyTotalReportHeader
+            empty={isEmpty}
+            totalDonations={totalDonations}
+            totalLikely={totalLikely}
+            totalUnlikely={totalUnlikely}
+            total={totalAmount}
+            currency={totalCurrency}
+          />
+        }
       />
       {loading ? (
-        <LoadingIndicator color="primary" size={20} />
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          height="100%"
+        >
+          <CircularProgress />
+        </Box>
       ) : !isEmpty ? (
         <>
           <ExpectedMonthlyTotalReportTable

--- a/src/components/Reports/ExpectedMonthlyTotalReport/Header/ExpectedMonthlyTotalReportHeader.test.tsx
+++ b/src/components/Reports/ExpectedMonthlyTotalReport/Header/ExpectedMonthlyTotalReportHeader.test.tsx
@@ -33,7 +33,7 @@ it('renders with data', () => {
 });
 
 it('renders empty', () => {
-  const { getByText, queryByTestId } = render(
+  const { queryByTestId } = render(
     <ThemeProvider theme={theme}>
       <ExpectedMonthlyTotalReportHeader
         empty={true}
@@ -45,7 +45,6 @@ it('renders empty', () => {
       />
     </ThemeProvider>,
   );
-  expect(getByText('Expected Monthly Total')).toBeInTheDocument();
 
   expect(queryByTestId('progressBarWrapper')).not.toBeInTheDocument();
 });

--- a/src/components/Reports/ExpectedMonthlyTotalReport/Header/ExpectedMonthlyTotalReportHeader.tsx
+++ b/src/components/Reports/ExpectedMonthlyTotalReport/Header/ExpectedMonthlyTotalReportHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography, Divider, Tooltip } from '@mui/material';
+import { Box, Typography, Tooltip } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import theme from '../../../../theme';
@@ -13,18 +13,12 @@ interface Props {
   currency: string;
 }
 
-const HeaderWrapper = styled(Box)(({}) => ({
-  display: 'flex',
-  flexDirection: 'row',
-  justifyContent: 'space-between',
-  padding: 24,
-}));
-
-const ProgressBarWrapper = styled(Box)(({}) => ({
+const ProgressBarWrapper = styled(Box)(({ theme }) => ({
   width: 450,
   display: 'flex',
   flexDirection: 'row',
   height: 35,
+  marginRight: theme.spacing(0.5),
   border: '2px solid inherit',
   borderRadius: 30,
   overflow: 'hidden',
@@ -51,71 +45,53 @@ export const ExpectedMonthlyTotalReportHeader: React.FC<Props> = ({
     return (amount / total) * 100;
   };
 
-  return (
-    <Box>
-      <HeaderWrapper>
-        <Typography variant="h4">{t('Expected Monthly Total')}</Typography>
-        {!empty ? (
-          <ProgressBarWrapper data-testid="progressBarWrapper">
-            <Tooltip
-              title={
-                <Typography>
-                  {Math.round(totalDonations) + ' ' + currency}
-                </Typography>
-              }
-              arrow
-            >
-              <ProgressBarSection
-                style={{
-                  backgroundColor: theme.palette.progressBarYellow.main,
-                  width: `${calculateWidth(totalDonations)}%`,
-                }}
-              >
-                <Typography style={{ marginTop: 4 }}>
-                  {t('Received')}
-                </Typography>
-              </ProgressBarSection>
-            </Tooltip>
-            <Tooltip
-              title={
-                <Typography>
-                  {Math.round(totalLikely) + ' ' + currency}
-                </Typography>
-              }
-              arrow
-            >
-              <ProgressBarSection
-                style={{
-                  backgroundColor: theme.palette.progressBarOrange.main,
-                  width: `${calculateWidth(totalLikely)}%`,
-                }}
-              >
-                <Typography style={{ marginTop: 4 }}>{t('Likely')}</Typography>
-              </ProgressBarSection>
-            </Tooltip>
-            <Tooltip
-              title={
-                <Typography>
-                  {Math.round(totalUnlikely) + ' ' + currency}
-                </Typography>
-              }
-              arrow
-            >
-              <ProgressBarSection
-                style={{
-                  backgroundColor: theme.palette.progressBarGray.main,
-                  width: `${calculateWidth(totalUnlikely)}%`,
-                }}
-              >
-                <Typography style={{ marginTop: 4 }}>
-                  {t('Possible')}
-                </Typography>
-              </ProgressBarSection>
-            </Tooltip>
-          </ProgressBarWrapper>
-        ) : null}
-      </HeaderWrapper>
-      <Divider style={{ marginBottom: 8 }} variant="middle"></Divider>
-    </Box>
-  );
+  return !empty ? (
+    <ProgressBarWrapper data-testid="progressBarWrapper">
+      <Tooltip
+        title={
+          <Typography>{Math.round(totalDonations) + ' ' + currency}</Typography>
+        }
+        arrow
+      >
+        <ProgressBarSection
+          style={{
+            backgroundColor: theme.palette.progressBarYellow.main,
+            width: `${calculateWidth(totalDonations)}%`,
+          }}
+        >
+          <Typography style={{ marginTop: 4 }}>{t('Received')}</Typography>
+        </ProgressBarSection>
+      </Tooltip>
+      <Tooltip
+        title={
+          <Typography>{Math.round(totalLikely) + ' ' + currency}</Typography>
+        }
+        arrow
+      >
+        <ProgressBarSection
+          style={{
+            backgroundColor: theme.palette.progressBarOrange.main,
+            width: `${calculateWidth(totalLikely)}%`,
+          }}
+        >
+          <Typography style={{ marginTop: 4 }}>{t('Likely')}</Typography>
+        </ProgressBarSection>
+      </Tooltip>
+      <Tooltip
+        title={
+          <Typography>{Math.round(totalUnlikely) + ' ' + currency}</Typography>
+        }
+        arrow
+      >
+        <ProgressBarSection
+          style={{
+            backgroundColor: theme.palette.progressBarGray.main,
+            width: `${calculateWidth(totalUnlikely)}%`,
+          }}
+        >
+          <Typography style={{ marginTop: 4 }}>{t('Possible')}</Typography>
+        </ProgressBarSection>
+      </Tooltip>
+    </ProgressBarWrapper>
+  ) : null;
 };

--- a/src/components/Reports/ExpectedMonthlyTotalReport/Table/ExpectedMonthlyTotalReportTable.tsx
+++ b/src/components/Reports/ExpectedMonthlyTotalReport/Table/ExpectedMonthlyTotalReportTable.tsx
@@ -92,7 +92,7 @@ export const ExpectedMonthlyTotalReportTable: React.FC<Props> = ({
               <TableBody>
                 {data.map((row, index) => (
                   <TableRow
-                    key={row.contactId}
+                    key={`${row.contactId}${index}`}
                     style={{
                       backgroundColor:
                         index % 2

--- a/src/components/Reports/FourteenMonthReports/FourteenMonthReport.test.tsx
+++ b/src/components/Reports/FourteenMonthReports/FourteenMonthReport.test.tsx
@@ -358,4 +358,67 @@ describe('FourteenMonthReport', () => {
     expect(getByTestId('FourteenMonthReport')).toBeInTheDocument();
     expect(queryByTestId('ReportNavList')).toBeNull();
   });
+
+  it('filters report by designation account', async () => {
+    const mutationSpy = jest.fn();
+    render(
+      <ThemeProvider theme={theme}>
+        <GqlMockedProvider<FourteenMonthReportQuery>
+          mocks={mocks}
+          onCall={mutationSpy}
+        >
+          <FourteenMonthReport
+            accountListId={accountListId}
+            designationAccounts={['account-1']}
+            currencyType={FourteenMonthReportCurrencyType.Donor}
+            isNavListOpen={false}
+            title={title}
+            onNavListToggle={onNavListToggle}
+          />
+        </GqlMockedProvider>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mutationSpy.mock.calls[1][0]).toMatchObject({
+        operation: {
+          operationName: 'FourteenMonthReport',
+          variables: {
+            designationAccountIds: ['account-1'],
+          },
+        },
+      }),
+    );
+  });
+
+  it('does not filter report by designation account', async () => {
+    const mutationSpy = jest.fn();
+    render(
+      <ThemeProvider theme={theme}>
+        <GqlMockedProvider<FourteenMonthReportQuery>
+          mocks={mocks}
+          onCall={mutationSpy}
+        >
+          <FourteenMonthReport
+            accountListId={accountListId}
+            currencyType={FourteenMonthReportCurrencyType.Donor}
+            isNavListOpen={false}
+            title={title}
+            onNavListToggle={onNavListToggle}
+          />
+        </GqlMockedProvider>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mutationSpy.mock.calls[1][0]).toMatchObject({
+        operation: {
+          operationName: 'FourteenMonthReport',
+          variables: {
+            designationAccountIds: null,
+          },
+        },
+      }),
+    );
+  });
 });

--- a/src/components/Reports/FourteenMonthReports/FourteenMonthReport.tsx
+++ b/src/components/Reports/FourteenMonthReports/FourteenMonthReport.tsx
@@ -16,6 +16,7 @@ import { useApiConstants } from 'src/components/Constants/UseApiConstants';
 
 interface Props {
   accountListId: string;
+  designationAccounts?: string[];
   isNavListOpen: boolean;
   onNavListToggle: () => void;
   title: string;
@@ -24,6 +25,7 @@ interface Props {
 
 export const FourteenMonthReport: React.FC<Props> = ({
   accountListId,
+  designationAccounts,
   currencyType,
   isNavListOpen,
   title,
@@ -44,6 +46,9 @@ export const FourteenMonthReport: React.FC<Props> = ({
   const { data, loading, error } = useFourteenMonthReportQuery({
     variables: {
       accountListId,
+      designationAccountIds: designationAccounts?.length
+        ? designationAccounts
+        : null,
       currencyType,
     },
   });

--- a/src/components/Reports/FourteenMonthReports/GetFourteenMonthReport.graphql
+++ b/src/components/Reports/FourteenMonthReports/GetFourteenMonthReport.graphql
@@ -1,9 +1,11 @@
 query FourteenMonthReport(
   $accountListId: ID!
+  $designationAccountIds: [ID!]
   $currencyType: FourteenMonthReportCurrencyType!
 ) {
   fourteenMonthReport(
     accountListId: $accountListId
+    designationAccountId: $designationAccountIds
     currencyType: $currencyType
   ) {
     currencyType

--- a/src/components/Reports/NavReportsList/NavReportsList.stories.tsx
+++ b/src/components/Reports/NavReportsList/NavReportsList.stories.tsx
@@ -9,6 +9,12 @@ export default {
 
 export const Default = (): ReactElement => {
   return (
-    <NavReportsList selectedId={selected} isOpen={true} onClose={() => {}} />
+    <NavReportsList
+      selectedId={selected}
+      isOpen={true}
+      onClose={() => {}}
+      designationAccounts={[]}
+      setDesignationAccounts={() => {}}
+    />
   );
 };

--- a/src/components/Reports/NavReportsList/NavReportsList.test.tsx
+++ b/src/components/Reports/NavReportsList/NavReportsList.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '@mui/material/styles';
 import { NavReportsList } from './NavReportsList';
 import TestRouter from '__tests__/util/TestRouter';
@@ -24,6 +25,8 @@ describe('NavReportsList', () => {
               selectedId={selected}
               isOpen={true}
               onClose={() => {}}
+              designationAccounts={[]}
+              setDesignationAccounts={() => {}}
             />
           </GqlMockedProvider>
         </TestRouter>
@@ -38,5 +41,55 @@ describe('NavReportsList', () => {
     expect(getByText('Expected Monthly Total')).toBeInTheDocument();
     expect(getByText('Partner Giving Analysis')).toBeInTheDocument();
     expect(getByText('Coaching')).toBeInTheDocument();
+  });
+
+  it('has designation account filter', async () => {
+    const mocks = {
+      GetDesignationAccounts: {
+        designationAccounts: [
+          {
+            designationAccounts: [
+              { id: 'account-1', name: 'Account 1' },
+              { id: 'account-2', name: 'Account 2' },
+              { id: 'account-3', name: 'Account 3' },
+            ],
+          },
+        ],
+      },
+    };
+
+    const designationAccounts = ['account-1'];
+    const setDesignationAccounts = jest.fn();
+
+    const { findByRole, getAllByRole, getByRole, getByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider mocks={mocks}>
+            <NavReportsList
+              selectedId={selected}
+              isOpen={true}
+              onClose={() => {}}
+              designationAccounts={designationAccounts}
+              setDesignationAccounts={setDesignationAccounts}
+            />
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>,
+    );
+
+    userEvent.click(
+      await findByRole('combobox', { name: 'Designation Account' }),
+    );
+    expect(getAllByRole('option').map((option) => option.textContent)).toEqual([
+      'Account 2',
+      'Account 3',
+    ]);
+    userEvent.click(getByRole('option', { name: 'Account 2' }));
+    expect(setDesignationAccounts).toHaveBeenLastCalledWith([
+      'account-1',
+      'account-2',
+    ]);
+    userEvent.click(getByTestId('CancelIcon'));
+    expect(setDesignationAccounts).toHaveBeenLastCalledWith([]);
   });
 });

--- a/src/components/Reports/ResponsibilityCentersReport/GetFinancialAccounts.graphql
+++ b/src/components/Reports/ResponsibilityCentersReport/GetFinancialAccounts.graphql
@@ -1,5 +1,9 @@
-query FinancialAccounts($accountListId: ID!) {
-  financialAccounts(accountListId: $accountListId, first: 25) {
+query FinancialAccounts($accountListId: ID!, $designationAccountIds: [ID!]) {
+  financialAccounts(
+    accountListId: $accountListId
+    designationAccountId: $designationAccountIds
+    first: 25
+  ) {
     nodes {
       active
       balance {

--- a/src/components/Reports/ResponsibilityCentersReport/ResponsibilityCentersReport.test.tsx
+++ b/src/components/Reports/ResponsibilityCentersReport/ResponsibilityCentersReport.test.tsx
@@ -24,7 +24,7 @@ const mocks = {
     financialAccounts: {
       nodes: [
         {
-          active: false,
+          active: true,
           balance: {
             conversionDate: '2/2/2021',
             convertedAmount: 3500,
@@ -149,5 +149,66 @@ describe('ResponsibilityCentersReport', () => {
 
     expect(getByText(title)).toBeInTheDocument();
     expect(queryByTestId('EmptyReport')).toBeInTheDocument();
+  });
+
+  it('filters report by designation account', async () => {
+    const mutationSpy = jest.fn();
+    render(
+      <ThemeProvider theme={theme}>
+        <GqlMockedProvider<FinancialAccountsQuery>
+          mocks={mocks}
+          onCall={mutationSpy}
+        >
+          <ResponsibilityCentersReport
+            accountListId={accountListId}
+            designationAccounts={['account-1']}
+            isNavListOpen={true}
+            title={title}
+            onNavListToggle={onNavListToggle}
+          />
+        </GqlMockedProvider>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mutationSpy.mock.calls[0][0]).toMatchObject({
+        operation: {
+          operationName: 'FinancialAccounts',
+          variables: {
+            designationAccountIds: ['account-1'],
+          },
+        },
+      }),
+    );
+  });
+
+  it('does not filter report by designation account', async () => {
+    const mutationSpy = jest.fn();
+    render(
+      <ThemeProvider theme={theme}>
+        <GqlMockedProvider<FinancialAccountsQuery>
+          mocks={mocks}
+          onCall={mutationSpy}
+        >
+          <ResponsibilityCentersReport
+            accountListId={accountListId}
+            isNavListOpen={true}
+            title={title}
+            onNavListToggle={onNavListToggle}
+          />
+        </GqlMockedProvider>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mutationSpy.mock.calls[0][0]).toMatchObject({
+        operation: {
+          operationName: 'FinancialAccounts',
+          variables: {
+            designationAccountIds: null,
+          },
+        },
+      }),
+    );
   });
 });

--- a/src/components/Reports/ResponsibilityCentersReport/ResponsibilityCentersReport.tsx
+++ b/src/components/Reports/ResponsibilityCentersReport/ResponsibilityCentersReport.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Box, CircularProgress, Divider } from '@mui/material';
+import { Box, CircularProgress, Divider, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { AccountsListHeader as Header } from '../AccountsListLayout/Header/Header';
 import { AccountsList as List } from '../AccountsListLayout/List/List';
@@ -22,6 +22,7 @@ import { currencyFormat } from 'src/lib/intlFormat';
 
 interface Props {
   accountListId: string;
+  designationAccounts?: string[];
   isNavListOpen: boolean;
   onNavListToggle: () => void;
   title: string;
@@ -34,6 +35,7 @@ const ScrollBox = styled(Box)(({}) => ({
 
 export const ResponsibilityCentersReport: React.FC<Props> = ({
   accountListId,
+  designationAccounts,
   isNavListOpen,
   onNavListToggle,
   title,
@@ -43,6 +45,9 @@ export const ResponsibilityCentersReport: React.FC<Props> = ({
   const { data, loading, error } = useFinancialAccountsQuery({
     variables: {
       accountListId,
+      designationAccountIds: designationAccounts?.length
+        ? designationAccounts
+        : null,
     },
   });
 
@@ -151,21 +156,22 @@ export const ResponsibilityCentersReport: React.FC<Props> = ({
     },
   });
 
+  const balanceNode =
+    typeof totalBalance !== 'undefined' && financialAccountsGroups ? (
+      <Typography variant="h6">{`${t('Balance')}: ${currencyFormat(
+        totalBalance,
+        financialAccountsGroups[0]?.financialAccounts[0]?.balance
+          ?.convertedCurrency,
+      )}`}</Typography>
+    ) : undefined;
+
   return (
     <Box>
       <Header
         isNavListOpen={isNavListOpen}
         onNavListToggle={onNavListToggle}
         title={title}
-        totalBalance={
-          totalBalance && totalBalance > 0 && financialAccountsGroups
-            ? currencyFormat(
-                totalBalance,
-                financialAccountsGroups[0].financialAccounts[0]?.balance
-                  .convertedCurrency,
-              )
-            : undefined
-        }
+        rightExtra={balanceNode}
       />
       {loading ? (
         <Box

--- a/src/components/Shared/Filters/FilterPanel.tsx
+++ b/src/components/Shared/Filters/FilterPanel.tsx
@@ -90,8 +90,8 @@ const LinkButton = styled(Button)(({ theme }) => ({
   fontWeight: 'bold',
 }));
 
-const FlatAccordionWrapper = styled(Box)(({ theme }) => ({
-  '& .MuiPaper-elevation1': {
+const FlatAccordion = styled(Accordion)(({ theme }) => ({
+  '&.MuiPaper-elevation1': {
     boxShadow: 'none',
     borderBottom: `1px solid ${theme.palette.cruGrayLight.main}`,
   },
@@ -691,40 +691,38 @@ export const FilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
               ) : (
                 <>
                   {savedFilters.length > 0 && (
-                    <FlatAccordionWrapper>
-                      <Accordion>
-                        <AccordionSummary expandIcon={<ExpandMore />}>
-                          <Typography>{t('Saved Filters')}</Typography>
-                        </AccordionSummary>
-                        <AccordionDetails>
-                          <FilterList dense sx={{ paddingY: 0 }}>
-                            {savedFilters.map((filter) => {
-                              const filterName = filter?.key
-                                ?.replace(
-                                  /^(graphql_)?saved_(contacts|tasks|)_filter_/,
-                                  '',
-                                )
-                                .replaceAll('_', ' ');
+                    <FlatAccordion>
+                      <AccordionSummary expandIcon={<ExpandMore />}>
+                        <Typography>{t('Saved Filters')}</Typography>
+                      </AccordionSummary>
+                      <AccordionDetails>
+                        <FilterList dense sx={{ paddingY: 0 }}>
+                          {savedFilters.map((filter) => {
+                            const filterName = filter?.key
+                              ?.replace(
+                                /^(graphql_)?saved_(contacts|tasks|)_filter_/,
+                                '',
+                              )
+                              .replaceAll('_', ' ');
 
-                              return (
-                                <ListItem
-                                  key={filter.id}
-                                  button
-                                  onClick={() => setSelectedSavedFilter(filter)}
-                                >
-                                  <ListItemText
-                                    primary={filterName}
-                                    primaryTypographyProps={{
-                                      variant: 'subtitle1',
-                                    }}
-                                  />
-                                </ListItem>
-                              );
-                            })}
-                          </FilterList>
-                        </AccordionDetails>
-                      </Accordion>
-                    </FlatAccordionWrapper>
+                            return (
+                              <ListItem
+                                key={filter.id}
+                                button
+                                onClick={() => setSelectedSavedFilter(filter)}
+                              >
+                                <ListItemText
+                                  primary={filterName}
+                                  primaryTypographyProps={{
+                                    variant: 'subtitle1',
+                                  }}
+                                />
+                              </ListItem>
+                            );
+                          })}
+                        </FilterList>
+                      </AccordionDetails>
+                    </FlatAccordion>
                   )}
 
                   {filters
@@ -737,43 +735,41 @@ export const FilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
                           in={showAll || isGroupVisible(group)}
                           data-testid="FilterGroup"
                         >
-                          <FlatAccordionWrapper>
-                            <Accordion
-                              TransitionProps={{ unmountOnExit: true }}
-                              defaultExpanded={defaultExpandedFilterGroups.has(
-                                group.name,
-                              )}
-                            >
-                              <AccordionSummary expandIcon={<ExpandMore />}>
-                                <Typography>
-                                  {group.name}
-                                  {selectedOptions.length > 0
-                                    ? ` (${selectedOptions.length})`
-                                    : ''}
-                                </Typography>
-                              </AccordionSummary>
-                              <AccordionDetails>
-                                <FilterList dense>
-                                  {group.filters.map((filter) => {
-                                    const filterKey = snakeToCamel(
-                                      filter.filterKey,
-                                    ) as FilterKey;
+                          <FlatAccordion
+                            TransitionProps={{ unmountOnExit: true }}
+                            defaultExpanded={defaultExpandedFilterGroups.has(
+                              group.name,
+                            )}
+                          >
+                            <AccordionSummary expandIcon={<ExpandMore />}>
+                              <Typography>
+                                {group.name}
+                                {selectedOptions.length > 0
+                                  ? ` (${selectedOptions.length})`
+                                  : ''}
+                              </Typography>
+                            </AccordionSummary>
+                            <AccordionDetails>
+                              <FilterList dense>
+                                {group.filters.map((filter) => {
+                                  const filterKey = snakeToCamel(
+                                    filter.filterKey,
+                                  ) as FilterKey;
 
-                                    return (
-                                      <FilterListItem
-                                        key={filterKey}
-                                        filter={filter}
-                                        value={selectedFilters[filterKey]}
-                                        onUpdate={(value) =>
-                                          updateSelectedFilter(filterKey, value)
-                                        }
-                                      />
-                                    );
-                                  })}
-                                </FilterList>
-                              </AccordionDetails>
-                            </Accordion>
-                          </FlatAccordionWrapper>
+                                  return (
+                                    <FilterListItem
+                                      key={filterKey}
+                                      filter={filter}
+                                      value={selectedFilters[filterKey]}
+                                      onUpdate={(value) =>
+                                        updateSelectedFilter(filterKey, value)
+                                      }
+                                    />
+                                  );
+                                })}
+                              </FilterList>
+                            </AccordionDetails>
+                          </FlatAccordion>
                         </Collapse>
                       );
                     })}


### PR DESCRIPTION
Add a designation account filter to all the other reports (skipping Partner Giving Analysis because it could already be filtered by designation account).

This PR should work in staging, but can't be merged into production until https://github.com/CruGlobal/mpdx_api/pull/2627 and https://github.com/CruGlobal/mpdx_api/pull/2628 are merged.

https://jira.cru.org/browse/MPDX-7648