### PR TITLE
[HS-910042] Fix date picker in non-US locales

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonBirthday/PersonBirthday.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonBirthday/PersonBirthday.tsx
@@ -12,6 +12,7 @@ import {
   PersonUpdateInput,
 } from '../../../../../../../../../graphql/types.generated';
 import { NewSocial } from '../PersonModal';
+import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 
 interface PersonBirthdayProps {
   formikProps: FormikProps<(PersonUpdateInput | PersonCreateInput) & NewSocial>;
@@ -51,7 +52,7 @@ export const PersonBirthday: React.FC<PersonBirthdayProps> = ({
             ? new Date(birthdayYear ?? 1900, birthdayMonth - 1, birthdayDay)
             : null
         }
-        inputFormat="MM/dd/yyyy"
+        inputFormat={getDateFormatPattern()}
         label={t('Birthday')}
       />
     </ModalSectionContainer>

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonShowMore/PersonShowMore.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonShowMore/PersonShowMore.tsx
@@ -25,6 +25,7 @@ import {
   PersonUpdateInput,
 } from '../../../../../../../../../graphql/types.generated';
 import { NewSocial } from '../PersonModal';
+import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 
 const DeceasedLabel = styled(FormControlLabel)(() => ({
   margin: 'none',
@@ -144,7 +145,7 @@ export const PersonShowMore: React.FC<PersonShowMoreProps> = ({
                 )
               : null
           }
-          inputFormat="MM/dd/yyyy"
+          inputFormat={getDateFormatPattern()}
           label={t('Anniversary')}
         />
       </ModalSectionContainer>

--- a/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDontationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
@@ -47,6 +47,7 @@ import {
 import { getLocalizedContactStatus } from 'src/utils/functions/getLocalizedContactStatus';
 import { getLocalizedPledgeFrequency } from 'src/utils/functions/getLocalizedPledgeFrequency';
 import { getLocalizedSendNewsletter } from 'src/utils/functions/getLocalizedSendNewsletter';
+import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 
 const ContactInputWrapper = styled(Box)(({ theme }) => ({
   position: 'relative',
@@ -495,11 +496,9 @@ export const EditPartnershipInfoModal: React.FC<
                     setFieldValue('pledgeStartDate', date)
                   }
                   value={
-                    pledgeStartDate
-                      ? DateTime.fromISO(pledgeStartDate).toLocaleString()
-                      : null
+                    pledgeStartDate ? DateTime.fromISO(pledgeStartDate) : null
                   }
-                  inputFormat="MM/dd/yyyy"
+                  inputFormat={getDateFormatPattern()}
                   label={t('Start Date')}
                 />
               </ContactInputWrapper>
@@ -588,10 +587,8 @@ export const EditPartnershipInfoModal: React.FC<
                   onChange={(date) =>
                     !date ? null : setFieldValue('nextAsk', date)
                   }
-                  value={
-                    nextAsk ? DateTime.fromISO(nextAsk).toLocaleString() : null
-                  }
-                  inputFormat="MM/dd/yyyy"
+                  value={nextAsk ? DateTime.fromISO(nextAsk) : null}
+                  inputFormat={getDateFormatPattern()}
                   label={t('Next Ask Increase')}
                 />
               </ContactInputWrapper>

--- a/src/components/Contacts/MassActions/EditFields/MassActionsEditFieldsModal.tsx
+++ b/src/components/Contacts/MassActions/EditFields/MassActionsEditFieldsModal.tsx
@@ -34,6 +34,7 @@ import {
 } from 'src/components/common/Modal/ActionButtons/ActionButtons';
 import { getLocalizedContactStatus } from 'src/utils/functions/getLocalizedContactStatus';
 import { getLocalizedLikelyToGive } from 'src/utils/functions/getLocalizedLikelyToGive';
+import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 
 interface MassActionsEditFieldsModalProps {
   ids: string[];
@@ -290,7 +291,7 @@ export const MassActionsEditFieldsModal: React.FC<
                           </InputAdornment>
                         ),
                       }}
-                      inputFormat="MMM dd, yyyy"
+                      inputFormat={getDateFormatPattern()}
                       closeOnSelect
                       label={t('Next Increase Ask')}
                       value={nextAsk}

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.tsx
@@ -33,6 +33,7 @@ import {
   SubmitButton,
   CancelButton,
 } from 'src/components/common/Modal/ActionButtons/ActionButtons';
+import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 
 interface Props {
   accountListId: string;
@@ -242,7 +243,7 @@ const LogNewsletter = ({
                         onChange={(date): void =>
                           setFieldValue('completedAt', date)
                         }
-                        inputFormat="MM/dd/yyyy"
+                        inputFormat={getDateFormatPattern()}
                         closeOnSelect
                         label={t('Completed Date')}
                         InputProps={{

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/AddDonation/AddDonation.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/AddDonation/AddDonation.tsx
@@ -33,6 +33,7 @@ import {
   CancelButton,
 } from 'src/components/common/Modal/ActionButtons/ActionButtons';
 import { DonorAccountAutocomplete } from 'src/components/common/DonorAccountAutocomplete/DonorAccountAutocomplete';
+import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 
 interface AddDonationProps {
   accountListId: string;
@@ -320,11 +321,9 @@ export const AddDonation = ({
                               !date ? null : setFieldValue('donationDate', date)
                             }
                             value={
-                              field.value
-                                ? DateTime.fromISO(field.value).toLocaleString()
-                                : null
+                              field.value ? DateTime.fromISO(field.value) : null
                             }
-                            inputFormat="MM/dd/yyyy"
+                            inputFormat={getDateFormatPattern()}
                           />
                         </Box>
                       )}

--- a/src/components/Reports/DonationsReport/Table/Modal/EditDonationModal.test.tsx
+++ b/src/components/Reports/DonationsReport/Table/Modal/EditDonationModal.test.tsx
@@ -168,10 +168,10 @@ describe('DonationsReportTable', () => {
     const dateButton = getByRole('textbox', {
       name: 'Choose date, selected date is Mar 25, 2021',
     });
-    expect(dateButton).toHaveValue('Mar 25, 2021');
+    expect(dateButton).toHaveValue('3/25/2021');
     userEvent.click(dateButton);
     userEvent.click(getByRole('gridcell', { name: '27' }));
-    expect(dateButton).toHaveValue('Mar 27, 2021');
+    expect(dateButton).toHaveValue('3/27/2021');
   });
 
   it('saves edits', async () => {

--- a/src/components/Reports/DonationsReport/Table/Modal/EditDonationModal.tsx
+++ b/src/components/Reports/DonationsReport/Table/Modal/EditDonationModal.tsx
@@ -30,6 +30,7 @@ import { useApiConstants } from 'src/components/Constants/UseApiConstants';
 import { FormFieldsGridContainer } from 'src/components/Task/Modal/Form/Container/FormFieldsGridContainer';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useFetchAllPages } from 'src/hooks/useFetchAllPages';
+import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 import theme from 'src/theme';
 import * as yup from 'yup';
 import { Donation } from '../DonationsReportTable';
@@ -257,7 +258,7 @@ export const EditDonationModal: React.FC<EditDonationModalProps> = ({
                           </InputAdornment>
                         ),
                       }}
-                      inputFormat="MMM dd, yyyy"
+                      inputFormat={getDateFormatPattern()}
                       closeOnSelect
                       label={t('Date')}
                       value={date}

--- a/src/components/Shared/Filters/FilterListItem.test.tsx
+++ b/src/components/Shared/Filters/FilterListItem.test.tsx
@@ -107,10 +107,10 @@ describe('FilterListItem', () => {
   it('DateRangeFilter filled', () => {
     const dateRange: DateRangeInput = { min: '2021-08-01', max: '2021-08-30' };
     const convertedMinDate = DateTime.fromISO(dateRange.min || '').toFormat(
-      'MM/dd/yyyy',
+      'M/dd/yyyy',
     );
     const convertedMaxDate = DateTime.fromISO(dateRange.max || '').toFormat(
-      'MM/dd/yyyy',
+      'M/dd/yyyy',
     );
 
     const { getByText, getAllByRole } = render(

--- a/src/components/Shared/Filters/FilterListItemDateRange.tsx
+++ b/src/components/Shared/Filters/FilterListItemDateRange.tsx
@@ -8,6 +8,7 @@ import {
   DaterangeFilter,
   DateRangeInput,
 } from '../../../../graphql/types.generated';
+import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 
 interface Props {
   filter: DaterangeFilter;
@@ -58,7 +59,7 @@ export const FilterListItemDateRange: React.FC<Props> = ({
                   ),
             )
           }
-          inputFormat="MM/dd/yyyy"
+          inputFormat={getDateFormatPattern()}
         />
         <MobileDatePicker
           renderInput={(params) => (
@@ -79,7 +80,7 @@ export const FilterListItemDateRange: React.FC<Props> = ({
                   ),
             )
           }
-          inputFormat="MM/dd/yyyy"
+          inputFormat={getDateFormatPattern()}
         />
       </ListItem>
     </>

--- a/src/components/Task/MassActions/EditTasks/MassActionsEditTasksModal.tsx
+++ b/src/components/Task/MassActions/EditTasks/MassActionsEditTasksModal.tsx
@@ -34,6 +34,7 @@ import {
   CancelButton,
 } from 'src/components/common/Modal/ActionButtons/ActionButtons';
 import { IncompleteWarning } from '../IncompleteWarning/IncompleteWarning';
+import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 
 interface MassActionsEditTasksModalProps {
   ids: string[];
@@ -254,7 +255,7 @@ export const MassActionsEditTasksModal: React.FC<
                           </InputAdornment>
                         ),
                       }}
-                      inputFormat="MMM dd, yyyy"
+                      inputFormat={getDateFormatPattern()}
                       closeOnSelect
                       label={t('Due Date')}
                       value={startAt}

--- a/src/components/Task/Modal/Form/Complete/TaskModalCompleteForm.tsx
+++ b/src/components/Task/Modal/Form/Complete/TaskModalCompleteForm.tsx
@@ -47,6 +47,7 @@ import { GetTaskForTaskModalQuery } from '../../TaskModalTask.generated';
 import { TaskLocation } from '../TaskModalForm';
 import { NullableSelect } from 'src/components/NullableSelect/NullableSelect';
 import { dispatch } from 'src/lib/analytics';
+import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 
 const taskSchema: yup.SchemaOf<
   Pick<
@@ -194,7 +195,7 @@ const TaskModalCompleteForm = ({
                             </InputAdornment>
                           ),
                         }}
-                        inputFormat="MMM dd, yyyy"
+                        inputFormat={getDateFormatPattern()}
                         closeOnSelect
                         label={t('Completed Date')}
                         value={completedAt}

--- a/src/components/Task/Modal/Form/Complete/TaskModalCompletedForm.test.tsx
+++ b/src/components/Task/Modal/Form/Complete/TaskModalCompletedForm.test.tsx
@@ -73,7 +73,7 @@ describe('TaskModalCompleteForm', () => {
     );
     expect(
       getAllByRole('textbox').find((item) => item.id === ':r0:'),
-    ).toHaveValue('Jan 01, 2020');
+    ).toHaveValue('1/01/2020');
   });
 
   it('saves simple', async () => {

--- a/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.test.tsx
+++ b/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.test.tsx
@@ -190,7 +190,7 @@ describe('TaskModalLogForm', () => {
     );
     expect(
       getAllByRole('textbox').find(
-        (item) => (item as HTMLInputElement).value === 'Jan 05, 2016',
+        (item) => (item as HTMLInputElement).value === '1/05/2016',
       ),
     ).toBeInTheDocument();
     userEvent.click(getByLabelText('Action'));

--- a/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.tsx
+++ b/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.tsx
@@ -65,6 +65,7 @@ import { GetTaskForTaskModalQuery } from '../../TaskModalTask.generated';
 import { TaskLocation } from '../TaskModalForm';
 import { NullableSelect } from 'src/components/NullableSelect/NullableSelect';
 import { dispatch } from 'src/lib/analytics';
+import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 
 const LoadingIndicator = styled(CircularProgress)(() => ({
   display: 'flex',
@@ -507,7 +508,7 @@ const TaskModalLogForm = ({
                             </InputAdornment>
                           ),
                         }}
-                        inputFormat="MMM dd, yyyy"
+                        inputFormat={getDateFormatPattern()}
                         closeOnSelect
                         label={t('Completed Date')}
                         value={completedAt}

--- a/src/components/Task/Modal/Form/TaskModalForm.test.tsx
+++ b/src/components/Task/Modal/Form/TaskModalForm.test.tsx
@@ -313,7 +313,7 @@ describe('TaskModalForm', () => {
       );
     expect(
       getAllByRole('textbox').find(
-        (item) => (item as HTMLInputElement).value === 'Jan 05, 2016',
+        (item) => (item as HTMLInputElement).value === '1/05/2016',
       ),
     ).toBeInTheDocument();
     expect(queryByText('Notifications')).not.toBeInTheDocument();

--- a/src/components/Task/Modal/Form/TaskModalForm.tsx
+++ b/src/components/Task/Modal/Form/TaskModalForm.tsx
@@ -64,6 +64,7 @@ import {
 } from 'src/utils/functions/getLocalizedNotificationStrings';
 import { GetTaskForTaskModalQuery } from '../TaskModalTask.generated';
 import { NullableSelect } from 'src/components/NullableSelect/NullableSelect';
+import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 
 export interface TaskLocation {
   location?: string | null | undefined;
@@ -426,7 +427,7 @@ const TaskModalForm = ({
                           renderInput={(params) => (
                             <TextField fullWidth {...params} />
                           )}
-                          inputFormat="MMM dd, yyyy"
+                          inputFormat={getDateFormatPattern()}
                           closeOnSelect
                           label={t('Due Date')}
                           value={startAt}
@@ -472,7 +473,7 @@ const TaskModalForm = ({
                           renderInput={(params) => (
                             <TextField fullWidth {...params} />
                           )}
-                          inputFormat="MMM dd, yyyy"
+                          inputFormat={getDateFormatPattern()}
                           closeOnSelect
                           label={t('Completed Date')}
                           value={completedAt}

--- a/src/lib/intlFormat/intlFormat.test.ts
+++ b/src/lib/intlFormat/intlFormat.test.ts
@@ -1,6 +1,10 @@
 import { DateTime } from 'luxon';
 
-import { dateFormat, monthYearFormat } from './intlFormat';
+import {
+  dateFormat,
+  getDateFormatPattern,
+  monthYearFormat,
+} from './intlFormat';
 import {
   numberFormat,
   percentageFormat,
@@ -14,6 +18,16 @@ describe('intlFormat', () => {
   beforeEach(() => {
     languageMock = jest.spyOn(window.navigator, 'language', 'get');
     languageMock.mockReturnValue(undefined);
+  });
+
+  describe('getDateFormatPattern', () => {
+    it('is M/dd/yyyy for English', () => {
+      expect(getDateFormatPattern('en-US')).toBe('M/dd/yyyy');
+    });
+
+    it('is dd/M/yyyy for Spanish', () => {
+      expect(getDateFormatPattern('es')).toBe('dd/M/yyyy');
+    });
   });
 
   describe('numberFormat', () => {

--- a/src/lib/intlFormat/intlFormat.ts
+++ b/src/lib/intlFormat/intlFormat.ts
@@ -6,6 +6,24 @@ const getLanguage = (): string => {
   return language;
 };
 
+// Return the current locale's date format (i.e. patterns like MM/dd/yyyy, dd.MM.yyyy, yyyy.MM.dd)
+export const getDateFormatPattern = (language = getLanguage()): string =>
+  new Intl.DateTimeFormat(language).formatToParts().reduce((pattern, part) => {
+    switch (part.type) {
+      case 'day':
+        return pattern + 'd'.repeat(part.value.length);
+      case 'month':
+        return pattern + 'M'.repeat(part.value.length);
+      case 'year':
+        return pattern + 'y'.repeat(part.value.length);
+      case 'literal':
+        return pattern + part.value;
+      default:
+        /* istanbul ignore next */
+        return pattern;
+    }
+  }, '');
+
 export const numberFormat = (value: number, language = getLanguage()): string =>
   new Intl.NumberFormat(language, {
     style: 'decimal',


### PR DESCRIPTION
The date picker was getting days and months mixed up when the system locale isn't mm/dd/yyyy. This PR makes all date pickers use the format defined by their current locale. To test on macOS, change your preferred language to something like Spanish and restart your browser.

Reported in https://secure.helpscout.net/conversation/2185479294/910042?folderId=7296729