### PR TITLE
no-jira Improvments to husky post-checkout yarn gql

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,12 +1,14 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
-if [ -e graphql-digest.txt ]; then
-  previous_hash=`cat graphql-digest.txt`
+digest='graphql-digest.txt'
+if [ -e $digest ]; then
+  previous_hash=`cat $digest`
   current_hash=`cat $(find . -type f -name "*.graphql") | openssl dgst -sha256`
   if [ "$previous_hash" != "$current_hash" ]; then
     # Only update the hash if the gql codegen succeeded
-    yarn gql && yarn gql:server && echo $current_hash > graphql-digest.txt
+    yarn gql && yarn gql:server && echo $current_hash > $digest
   fi
 else
   current_hash=`cat $(find . -type f -name "*.graphql") | openssl dgst -sha256`
+  yarn gql && yarn gql:server && echo $current_hash > $digest
 fi


### PR DESCRIPTION
Improved yarn checkout script.

It was running every time I switched branches because it couldn't find the digest file. I've made it create the digest file if not there and added safety quotes around variables so if variables don't exist it doesn't cause an error.