### PR TITLE
MPDX-7670 Fixing 502 handoff error

### DIFF
--- a/pages/api/getDefaultAccount.graphql
+++ b/pages/api/getDefaultAccount.graphql
@@ -1,0 +1,10 @@
+query GetDefaultAccount {
+  user {
+    defaultAccountList
+  }
+  accountLists(first: 1) {
+    nodes {
+      id
+    }
+  }
+}

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.test.tsx
@@ -177,7 +177,7 @@ describe('EditContactAddressModal', () => {
     expect(operation2.variables.primaryAddressId).toEqual(
       mockContact.addresses.nodes[0].id,
     );
-  });
+  }, 80000);
 
   it('should edit not set primary address when it has not changed', async () => {
     const mutationSpy = jest.fn();


### PR DESCRIPTION
## Description
This error happens when `/api/handoff` doesn't receive the user's `userid` and/or `accountListId`. this can be for many reasons.

I've added functionality to ensure we get the user's `userid` and find the default or first `accountListId`, if not specified to prevent the error.