### PR TITLE
HelpScout 909891 - Adding null coalescing operator on DesignationAccountRest.name

### DIFF
--- a/pages/api/Schema/reports/designationAccounts/datahandler.ts
+++ b/pages/api/Schema/reports/designationAccounts/datahandler.ts
@@ -18,7 +18,7 @@ export interface DesignationAccountsResponse {
     display_name: string;
     exchange_rate: number;
     legacy_designation_number: null;
-    name: string;
+    name: string | null;
     organization_name: string;
     updated_at: string | null;
     updated_in_db_at: string | null;
@@ -53,7 +53,7 @@ const createDesignationAccount = (
   currency: account.attributes.currency,
   designationNumber: account.attributes.designation_number,
   id: account.id,
-  name: account.attributes.name,
+  name: account.attributes.name ?? '',
   convertedBalance: account.attributes.converted_balance,
 });
 


### PR DESCRIPTION
I believe this could fix the issue Mary is describing on her Tix https://secure.helpscout.net/conversation/2185061412/909891?folderId=7296147

This error happens on my PROD account, so I'm assuming it could be happening to her, preventing the `Designation Accounts` from loading in.