### PR TITLE
[no-Jira] Fix task breakpoints

### DIFF
--- a/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
@@ -399,7 +399,7 @@ const TasksPage: React.FC = () => {
                         variant="text"
                         startIcon={<TaskAddIcon />}
                       >
-                        <Hidden mdUp>{t('Add')}</Hidden>
+                        <Hidden smUp>{t('Add')}</Hidden>
                         <Hidden smDown>{t('Add Task')}</Hidden>
                       </TaskHeaderButton>
                       <TaskHeaderButton
@@ -407,7 +407,7 @@ const TasksPage: React.FC = () => {
                         variant="text"
                         startIcon={<TaskCheckIcon />}
                       >
-                        <Hidden mdUp>{t('Log')}</Hidden>
+                        <Hidden smUp>{t('Log')}</Hidden>
                         <Hidden smDown>{t('Log Task')}</Hidden>
                       </TaskHeaderButton>
                     </Hidden>

--- a/src/components/Task/TaskRow/TaskRow.tsx
+++ b/src/components/Task/TaskRow/TaskRow.tsx
@@ -233,7 +233,7 @@ export const TaskRow: React.FC<TaskRowProps> = ({
           </Box>
         </Box>
         <Box display="flex" justifyContent="flex-end" alignItems="center">
-          <Hidden xsDown>
+          <Hidden smDown>
             <ContactText>{assigneeName}</ContactText>
             <TaskDueDate isComplete={isComplete} dueDate={dueDate} />
             <Box onClick={(e) => e.stopPropagation()}>
@@ -257,7 +257,7 @@ export const TaskRow: React.FC<TaskRowProps> = ({
               </Box>
             </Box>
           </Hidden>
-          <Hidden xsDown>
+          <Hidden smDown>
             <Box onClick={(e) => e.stopPropagation()}>
               <DeleteTaskIconButton
                 accountListId={accountListId}


### PR DESCRIPTION
Contrary to [the docs](https://mui.com/material-ui/api/hidden/#props), the MUI `<Hidden />` down props are **exclusive**, not inclusive ([source](https://github.com/mui/material-ui/blob/v5.x/packages/mui-material/src/Hidden/withWidth.js#L20)). Fix some elements being shown twice because two `<Hidden />` elements that were supposed to be mutually exclusive are both being displayed.