### PR TITLE
MPDX-7663 set primary as first

### DIFF
--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateContact/CreateContact.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateContact/CreateContact.tsx
@@ -114,21 +114,21 @@ const CreateContact = ({
           lastName: lastName ? lastName : findFirstName[1] ?? '',
         });
       }
-      await Promise.all(
-        people.map(async (person) => {
-          const personAttributes: PersonCreateInput = {
-            contactId: contactId,
-            firstName: person.firstName,
-            lastName: person.lastName,
-          };
-          await createPerson({
-            variables: {
-              accountListId,
-              attributes: personAttributes,
-            },
-          });
-        }),
-      );
+
+      for (const person of people) {
+        const personAttributes: PersonCreateInput = {
+          contactId: contactId,
+          firstName: person.firstName,
+          lastName: person.lastName,
+        };
+        await createPerson({
+          variables: {
+            accountListId,
+            attributes: personAttributes,
+          },
+        });
+      }
+
       push({
         pathname: '/accountLists/[accountListId]/contacts/[contactId]',
         query: { accountListId, contactId },

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateMultipleContacts/CreateMultipleContacts.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateMultipleContacts/CreateMultipleContacts.test.tsx
@@ -123,7 +123,7 @@ describe('CreateMultipleContacts', () => {
           primary: true,
         },
       ]);
-    }, 60000);
+    }, 80000);
 
     it('creates multiple contacts - part 1', async () => {
       const { getByText, getAllByRole } = render(
@@ -187,17 +187,17 @@ describe('CreateMultipleContacts', () => {
           primary: true,
         },
       ]);
-      // Contact 1 Person 2
-      const { operation: operation3 } = mutationSpy.mock.calls[4][0];
-      expect(operation3.variables.accountListId).toEqual(accountListId);
-      expect(operation3.variables.attributes.firstName).toEqual(spouse);
-      expect(operation3.variables.attributes.lastName).toEqual(last);
-
       // Contact 2  Person 1
-      const { operation: operation4 } = mutationSpy.mock.calls[5][0];
+      const { operation: operation4 } = mutationSpy.mock.calls[4][0];
       expect(operation4.variables.accountListId).toEqual(accountListId);
       expect(operation4.variables.attributes.firstName).toEqual(first2);
       expect(operation4.variables.attributes.lastName).toEqual(last2);
+
+      // Contact 1 Person 1 - Awaiting on Contact 1 Person 1 to resolve.
+      const { operation: operation3 } = mutationSpy.mock.calls[5][0];
+      expect(operation3.variables.accountListId).toEqual(accountListId);
+      expect(operation3.variables.attributes.firstName).toEqual(spouse);
+      expect(operation3.variables.attributes.lastName).toEqual(last);
     }, 60000);
 
     it('creates multiple contacts - part 2', async () => {
@@ -242,17 +242,17 @@ describe('CreateMultipleContacts', () => {
       expect(operation2.variables.attributes.firstName).toEqual(first2);
       expect(operation2.variables.attributes.lastName).toEqual('');
 
-      // Contact 2  Person 2
-      const { operation: operation3 } = mutationSpy.mock.calls[4][0];
-      expect(operation3.variables.accountListId).toEqual(accountListId);
-      expect(operation3.variables.attributes.firstName).toEqual(spouse2);
-      expect(operation3.variables.attributes.lastName).toEqual('');
-
       // Contact 3  Person 1
-      const { operation: operation4 } = mutationSpy.mock.calls[5][0];
+      const { operation: operation4 } = mutationSpy.mock.calls[4][0];
       expect(operation4.variables.accountListId).toEqual(accountListId);
       expect(operation4.variables.attributes.firstName).toEqual(first3);
       expect(operation4.variables.attributes.lastName).toEqual('');
-    }, 60000);
+
+      // Contact 2  Person 2 - Awaiting on Contact 2 Person 1 to resolve
+      const { operation: operation3 } = mutationSpy.mock.calls[5][0];
+      expect(operation3.variables.accountListId).toEqual(accountListId);
+      expect(operation3.variables.attributes.firstName).toEqual(spouse2);
+      expect(operation3.variables.attributes.lastName).toEqual('');
+    }, 80000);
   });
 });

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateMultipleContacts/CreateMultipleContacts.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateMultipleContacts/CreateMultipleContacts.tsx
@@ -171,16 +171,14 @@ export const CreateMultipleContacts = ({
                 lastName,
               });
             }
-            await Promise.all(
-              people.map((person) =>
-                createPerson({
-                  variables: {
-                    accountListId,
-                    attributes: person,
-                  },
-                }),
-              ),
-            );
+            for (const person of people) {
+              await createPerson({
+                variables: {
+                  accountListId,
+                  attributes: person,
+                },
+              });
+            }
           }
           return data?.createContact?.contact?.id;
         }),


### PR DESCRIPTION
Ensure when creating a contact, the first name is set as primary in the contact.
Task: https://jira.cru.org/browse/MPDX-7663