### PR TITLE
Hs 915181 contacts flow bug

### DIFF
--- a/src/components/Contacts/ContactFlow/ContactFlowRow/ContactFlowRow.tsx
+++ b/src/components/Contacts/ContactFlow/ContactFlowRow/ContactFlowRow.tsx
@@ -65,19 +65,22 @@ export const ContactFlowRow: React.FC<Props> = ({
   columnWidth,
   avatar,
 }: Props) => {
-  const [{ isDragging }, drag, preview] = useDrag(() => ({
-    type: 'contact',
-    item: {
-      id,
-      status,
-      name,
-      starred,
-      width: columnWidth,
-    },
-    collect: (monitor) => ({
-      isDragging: !!monitor.isDragging(),
+  const [{ isDragging }, drag, preview] = useDrag(
+    () => ({
+      type: 'contact',
+      item: {
+        id,
+        status,
+        name,
+        starred,
+        width: columnWidth,
+      },
+      collect: (monitor) => ({
+        isDragging: !!monitor.isDragging(),
+      }),
     }),
-  }));
+    [id],
+  );
 
   useEffect(() => {
     preview(getEmptyImage(), { captureDraggingState: true });


### PR DESCRIPTION
## Description
Fixed bug when moving multiple contacts one after the other from the same flow.

To reproduce the error:
1. Move one contact (John Doe, ordered 3rd in list) from one contact flow (Flow 1) to another (Flow 2). _Flow 1 & 2 would update automatically._ 
2. From Flow 1, move the new contact ordered 3rd (Jane Doe) to Flow 2.
3. If you do the above, it will try to move John Doe again.
