### PR TITLE
[MPDX-7648] Hide the selector unless there are multiple options

### DIFF
--- a/src/components/Reports/NavReportsList/NavReportsList.tsx
+++ b/src/components/Reports/NavReportsList/NavReportsList.tsx
@@ -97,7 +97,7 @@ export const NavReportsList: React.FC<Props & BoxProps> = ({
               </Box>
             </FilterHeader>
             <FilterList dense>
-              {data && (
+              {accounts.length > 1 && (
                 <FilterListItemMultiselect
                   filter={filter}
                   selected={designationAccounts}


### PR DESCRIPTION
Hide the report designation account selector unless the user has more than one designation account.

Follow-up for https://jira.cru.org/browse/MPDX-7648