### PR TITLE
[no-Jira] Use hasOwnProperty instead of hasOwn

### DIFF
--- a/src/hooks/useDataDog.ts
+++ b/src/hooks/useDataDog.ts
@@ -8,7 +8,7 @@ export const isDataDogConfigured = (): boolean => {
   if (typeof window === 'undefined') return false;
   return !!(
     process.env.DATADOG_CONFIGURED &&
-    Object.hasOwn(window?.DD_RUM ?? {}, 'getUser')
+    (window?.DD_RUM ?? {}).hasOwnProperty('getUser')
   );
 };
 


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn#browser_compatibility), `Object.hasOwn` isn't supported on Safari until 15.4, which was released just two weeks ago. We need to wait for usage to pick up to be able to use it.

Here's a Rollbar event where someone got an exception from `Object.hasOwn` not being defined https://app.rollbar.com/a/Cru/fix/item/mpdx_web/11679.