### PR TITLE
MPDX-7671 & MPDX-7655 Task & Log Modal alterations

### DIFF
--- a/src/components/Shared/MassActions/TasksMassActionsDropdown.test.tsx
+++ b/src/components/Shared/MassActions/TasksMassActionsDropdown.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SnackbarProvider } from 'notistack';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '@mui/material/styles';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
@@ -82,9 +82,8 @@ describe('TasksMassActionsDropdown', () => {
   });
 
   it('opens the more actions menu and clicks the edit tasks action', async () => {
-    const { queryByTestId, getByText, queryByText } = render(
-      <TaskComponents />,
-    );
+    const { queryByTestId, getByText, queryByText, getByLabelText, getByRole } =
+      render(<TaskComponents />);
 
     expect(queryByText('Edit Tasks')).not.toBeInTheDocument();
     const actionsButton = getByText('Actions') as HTMLInputElement;
@@ -94,7 +93,13 @@ describe('TasksMassActionsDropdown', () => {
     await waitFor(() =>
       expect(queryByTestId('EditTasksModal')).toBeInTheDocument(),
     );
-    userEvent.click(queryByTestId('CloseIcon') as HTMLInputElement);
+    userEvent.click(getByLabelText('Action'));
+    userEvent.click(
+      within(getByRole('listbox', { hidden: true, name: 'Action' })).getByText(
+        'Appointment',
+      ),
+    );
+    userEvent.click(getByText('Save'));
     await waitFor(() =>
       expect(
         queryByTestId('EditTasksModal') as HTMLInputElement,

--- a/src/components/Task/MassActions/EditTasks/MassActionsEditTasksModal.tsx
+++ b/src/components/Task/MassActions/EditTasks/MassActionsEditTasksModal.tsx
@@ -8,9 +8,6 @@ import {
   FormControlLabel,
   Grid,
   InputAdornment,
-  InputLabel,
-  MenuItem,
-  Select,
   TextField,
 } from '@mui/material';
 import CalendarToday from '@mui/icons-material/CalendarToday';
@@ -36,9 +33,9 @@ import {
   SubmitButton,
   CancelButton,
 } from 'src/components/common/Modal/ActionButtons/ActionButtons';
+import { getLocalizedTaskType } from 'src/utils/functions/getLocalizedTaskType';
 import { IncompleteWarning } from '../IncompleteWarning/IncompleteWarning';
 import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
-import { getLocalizedTaskType } from 'src/utils/functions/getLocalizedTaskType';
 
 interface MassActionsEditTasksModalProps {
   ids: string[];
@@ -171,29 +168,41 @@ export const MassActionsEditTasksModal: React.FC<
                 </Grid>
                 <Grid item xs={12} lg={6}>
                   <FormControl fullWidth>
-                    <InputLabel id="activityType">{t('Action')}</InputLabel>
-                    <Select
-                      label={t('Action')}
-                      labelId="activityType"
-                      value={activityType}
-                      onChange={(e) =>
-                        setFieldValue('activityType', e.target.value)
+                    <Autocomplete
+                      openOnFocus
+                      value={
+                        activityType === null ||
+                        typeof activityType === 'undefined'
+                          ? ''
+                          : activityType
                       }
-                    >
-                      <MenuItem value={''}>
-                        <em>{t("Don't change")}</em>
-                      </MenuItem>
-                      <MenuItem value={ActivityTypeEnum.None}>
-                        {t('None')}
-                      </MenuItem>
-                      {Object.values(ActivityTypeEnum)
-                        .filter((val) => val !== ActivityTypeEnum.None)
-                        .map((val) => (
-                          <MenuItem key={val} value={val}>
-                            {getLocalizedTaskType(t, val)}
-                          </MenuItem>
-                        ))}
-                    </Select>
+                      // Sort None to top
+                      options={[
+                        'DONT_CHANGE',
+                        ...Object.values(ActivityTypeEnum).sort((a) =>
+                          a === ActivityTypeEnum.None ? -1 : 1,
+                        ),
+                      ]}
+                      getOptionLabel={(activity) =>
+                        activity === ActivityTypeEnum.None
+                          ? t('None')
+                          : activity === 'DONT_CHANGE'
+                          ? t("Don't change")
+                          : getLocalizedTaskType(
+                              t,
+                              activity as ActivityTypeEnum,
+                            )
+                      }
+                      renderInput={(params): ReactElement => (
+                        <TextField {...params} label={t('Action')} />
+                      )}
+                      onChange={(_, activity): void => {
+                        setFieldValue(
+                          'activityType',
+                          activity === 'DONT_CHANGE' ? '' : activity,
+                        );
+                      }}
+                    />
                   </FormControl>
                 </Grid>
                 <Grid item xs={12} lg={6}>

--- a/src/components/Task/Modal/Form/Complete/TaskModalCompleteForm.tsx
+++ b/src/components/Task/Modal/Form/Complete/TaskModalCompleteForm.tsx
@@ -45,7 +45,6 @@ import { getLocalizedTaskType } from 'src/utils/functions/getLocalizedTaskType';
 import { getLocalizedResultString } from 'src/utils/functions/getLocalizedResultStrings';
 import { GetTaskForTaskModalQuery } from '../../TaskModalTask.generated';
 import { TaskLocation } from '../TaskModalForm';
-import { NullableSelect } from 'src/components/NullableSelect/NullableSelect';
 import { dispatch } from 'src/lib/analytics';
 import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 
@@ -253,23 +252,37 @@ const TaskModalCompleteForm = ({
               {availableNextActions.length > 0 && (
                 <Grid item>
                   <FormControl fullWidth>
-                    <InputLabel id="nextAction">{t('Next Action')}</InputLabel>
-                    <NullableSelect
-                      label={t('Next Action')}
-                      labelId="nextAction"
-                      value={nextAction}
-                      onChange={(e) =>
-                        setFieldValue('nextAction', e.target.value)
+                    <Autocomplete
+                      openOnFocus
+                      value={
+                        nextAction === null || typeof nextAction === 'undefined'
+                          ? ''
+                          : nextAction
                       }
-                    >
-                      {availableNextActions
-                        .filter((val) => val !== ActivityTypeEnum.None)
-                        .map((val) => (
-                          <MenuItem key={val} value={val}>
-                            {getLocalizedTaskType(t, val)}
-                          </MenuItem>
-                        ))}
-                    </NullableSelect>
+                      // Sort none to top
+                      options={availableNextActions.sort((a) =>
+                        a === ActivityTypeEnum.None ? -1 : 1,
+                      )}
+                      getOptionLabel={(activity) => {
+                        if (activity === ActivityTypeEnum.None) {
+                          return t('None');
+                        } else {
+                          return getLocalizedTaskType(
+                            t,
+                            activity as ActivityTypeEnum,
+                          );
+                        }
+                      }}
+                      renderInput={(params): ReactElement => (
+                        <TextField {...params} label={t('Next Action')} />
+                      )}
+                      onChange={(_, activity): void => {
+                        setFieldValue(
+                          'nextAction',
+                          activity === ActivityTypeEnum.None ? null : activity,
+                        );
+                      }}
+                    />
                   </FormControl>
                 </Grid>
               )}

--- a/src/components/Task/Modal/Form/Complete/TaskModalCompletedForm.test.tsx
+++ b/src/components/Task/Modal/Form/Complete/TaskModalCompletedForm.test.tsx
@@ -155,7 +155,9 @@ describe('TaskModalCompleteForm', () => {
         'Completed',
       ),
     );
-    userEvent.click(getByRole('button', { hidden: true, name: 'Next Action' }));
+    userEvent.click(
+      getByRole('combobox', { hidden: true, name: 'Next Action' }),
+    );
     userEvent.click(
       within(
         getByRole('listbox', { hidden: true, name: 'Next Action' }),
@@ -200,15 +202,13 @@ describe('TaskModalCompleteForm', () => {
       userEvent.click(getByRole('option', { hidden: true, name: 'None' }));
     }
     let nextActions: ActivityTypeEnum[] = [];
-    if (queryByRole('button', { hidden: true, name: 'Next Action' })) {
+    if (queryByRole('combobox', { hidden: true, name: /next action/i })) {
       userEvent.click(
-        getByRole('button', { hidden: true, name: 'Next Action' }),
+        getByRole('combobox', { hidden: true, name: /next action/i }),
       );
-      nextActions = within(
-        getByRole('listbox', { hidden: true, name: 'Next Action' }),
-      )
+      nextActions = within(getByRole('listbox'))
         .getAllByRole('option')
-        .map((option) => option.textContent)
+        .map((option) => option[Object.keys(option)[0]]?.key)
         .filter(Boolean) as ActivityTypeEnum[];
     }
     return { results, nextActions };

--- a/src/components/Task/Modal/Form/TaskModalForm.test.tsx
+++ b/src/components/Task/Modal/Form/TaskModalForm.test.tsx
@@ -222,7 +222,7 @@ describe('TaskModalForm', () => {
 
     userEvent.type(getByLabelText('Location'), '123 Test Street');
 
-    userEvent.click(getByRole('listbox', { hidden: true, name: 'Action' }));
+    userEvent.click(getByRole('combobox', { hidden: true, name: 'Action' }));
     userEvent.click(
       within(getByRole('listbox', { hidden: true, name: 'Action' })).getByText(
         'Call',


### PR DESCRIPTION
## Description
**MPDX-7671**
- When logging a task, default the result field to "Completed".

**MPDX-7655**
- On open for Log & Task Modals, autofocus to the task name input.
- On pressing `tab` to input `actions`, the options should render, plus when the user types filter results.