### PR TITLE
[no-Jira] Fix types from TaskCreateInput.id being removed

### DIFF
--- a/src/components/Task/Modal/Form/Complete/TaskModalCompleteForm.tsx
+++ b/src/components/Task/Modal/Form/Complete/TaskModalCompleteForm.tsx
@@ -55,7 +55,7 @@ const taskSchema: yup.SchemaOf<
     'id' | 'result' | 'nextAction' | 'tagList' | 'completedAt'
   >
 > = yup.object({
-  id: yup.string(),
+  id: yup.string().required(),
   result: yup.mixed<ResultEnum>().required(),
   nextAction: yup.mixed<ActivityTypeEnum>(),
   tagList: yup.array().of(yup.string()).default([]),


### PR DESCRIPTION
The code works, but the types will be incorrect when `TaskCreateInput.id` gets removed from the GraphQL API. This code is a little ugly, but I'm in the process of cleaning it up in another branch, so it won't be this bad for long.