### PR TITLE
Correcting tools notifications count

### DIFF
--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/GetToolNotifcations.graphql
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/GetToolNotifcations.graphql
@@ -25,7 +25,17 @@ query GetToolNotifications($accountListId: ID!) {
     peopleFilter: {
       emailAddressValid: false
       deceased: false
-      contactStatus: [ACTIVE]
+      contactStatus: [
+        NEVER_CONTACTED
+        ASK_IN_FUTURE
+        CULTIVATE_RELATIONSHIP
+        CONTACT_FOR_APPOINTMENT
+        APPOINTMENT_SCHEDULED
+        CALL_FOR_DECISION
+        PARTNER_FINANCIAL
+        PARTNER_SPECIAL
+        PARTNER_PRAY
+      ]
     }
   ) {
     totalCount
@@ -35,7 +45,17 @@ query GetToolNotifications($accountListId: ID!) {
     peopleFilter: {
       phoneNumberValid: false
       deceased: false
-      contactStatus: [ACTIVE]
+      contactStatus: [
+        NEVER_CONTACTED
+        ASK_IN_FUTURE
+        CULTIVATE_RELATIONSHIP
+        CONTACT_FOR_APPOINTMENT
+        APPOINTMENT_SCHEDULED
+        CALL_FOR_DECISION
+        PARTNER_FINANCIAL
+        PARTNER_SPECIAL
+        PARTNER_PRAY
+      ]
     }
   ) {
     totalCount


### PR DESCRIPTION
For `fixEmailAddresses` and `fixPhoneNumbers` the `contactStatus` needed to change, so the number of emails and phones that need fixing matches the old MPDX.