### PR TITLE
[MPDX-7705] Close delete confirmation modal

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonModal.tsx
@@ -435,6 +435,7 @@ export const PersonModal: React.FC<PersonModalProps> = ({
         ],
       });
     }
+    handleRemoveDialogOpen(false);
     enqueueSnackbar(t('Person deleted successfully'), {
       variant: 'success',
     });


### PR DESCRIPTION
Close the delete person confirmation modal after confirming the delete. Otherwise, when editing another person, the delete modal confirmation modal will immediately pop up on the new person.

https://jira.cru.org/browse/MPDX-7705