### PR TITLE
MPDX-7708 Removing HelpScout Beacon styles when Contact Map unmounts

### DIFF
--- a/pages/accountLists/[accountListId]/contacts/map/map.tsx
+++ b/pages/accountLists/[accountListId]/contacts/map/map.tsx
@@ -110,6 +110,7 @@ export const ContactsMap: React.FC = ({}) => {
     ) as HTMLElement;
     if (!beacon) return;
     beacon.style.setProperty('right', '60px', 'important');
+    return () => beacon.style.setProperty('right', '20px');
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
On the map page, we added CSS to move the HelpScout Beacon from overlapping the Google Map zoom buttons.

This PR is to remove those styles when the page dismounts.