### PR TITLE
HelpScout 937488 - Autocomplete error when window is idle

### DIFF
--- a/pages/accountLists/[accountListId]/contacts/map/map.tsx
+++ b/pages/accountLists/[accountListId]/contacts/map/map.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import {
   GoogleMap,
-  useLoadScript,
   Marker,
   MarkerClusterer,
   InfoWindow,
+  useJsApiLoader,
 } from '@react-google-maps/api';
 import { Box, CircularProgress, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
@@ -99,8 +99,9 @@ export const ContactsMap: React.FC = ({}) => {
     mapRef.current = map;
   }, []);
 
-  const { isLoaded, loadError } = useLoadScript({
+  const { isLoaded, loadError } = useJsApiLoader({
     googleMapsApiKey: process.env.GOOGLE_MAPS_API_KEY || '',
+    libraries: useRef(['places' as const]).current,
   });
 
   useEffect(() => {

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/StreetAutocomplete/StreetAutocomplete.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/StreetAutocomplete/StreetAutocomplete.tsx
@@ -96,6 +96,8 @@ export const StreetAutocomplete: React.FC<StreetAutocompleteProps> = ({
 
   useEffect(() => {
     if (isLoaded) {
+      // Bizz 05/23/2023 - Removing this as a precaution as we think we've fixed the error.
+      // if (!window.google.maps.places) return;
       mapsApi.current = {
         autocompleteService:
           new window.google.maps.places.AutocompleteService(),


### PR DESCRIPTION
## Changes
When the window is idle for a long period of time, then the user navigates to edit a donor's address, it produces an error if Google Places cannot be loaded.

## Changes
The fix ensures Google Places is loaded.

## Testing
`useJsApiLoader` has a property `loadError`, which I'm currently testing to see if I can use this instead of checking if `places` is undefined.