### PR TITLE
Show loader when fetching contacts initially, but not when refetching…

### DIFF
--- a/src/components/Contacts/ContactFlow/ContactFlowColumn/ContactFlowColumn.tsx
+++ b/src/components/Contacts/ContactFlow/ContactFlowColumn/ContactFlowColumn.tsx
@@ -92,7 +92,7 @@ export const ContactFlowColumn: React.FC<Props> = ({
     }),
   }));
 
-  return loading ? (
+  return loading && !data ? (
     <CircularProgress />
   ) : (
     <Card>


### PR DESCRIPTION
HelpScout - https://secure.helpscout.net/conversation/2237772925/942031?folderId=7296147

On contacts flow, when a user scrolls the list of contacts after scrolling past the initial 25, we load more contacts. But we had it remove the infinite scroll when loading, causing the user to be scrolled to the top of the list.

Ensuring only the loader renders for the initial loading of the contacts solves this issue.