### PR TITLE
HelpScout - Improving UX on the no results message when searching

### DIFF
--- a/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
@@ -419,7 +419,7 @@ const TasksPage: React.FC = () => {
                         <NullState
                           page="task"
                           totalCount={data?.allTasks?.totalCount || 0}
-                          filtered={isFiltered}
+                          filtered={isFiltered || !!searchTerm}
                           changeFilters={setActiveFilters}
                         />
                       </Box>

--- a/src/components/Contacts/ContactsList/ContactsList.tsx
+++ b/src/components/Contacts/ContactsList/ContactsList.tsx
@@ -70,7 +70,7 @@ export const ContactsList: React.FC = () => {
           <NullState
             page="contact"
             totalCount={data?.allContacts.totalCount || 0}
-            filtered={isFiltered}
+            filtered={isFiltered || !!searchTerm}
             changeFilters={setActiveFilters}
           />
         </Box>


### PR DESCRIPTION
HelpScout - https://secure.helpscout.net/conversation/2237655869/941947?folderId=7296147

If a user searches and doesn't find any results, it returned the message `Looks like you haven't added any contacts yet`.
It now shows the same message, which shows when a user filters and it returns no results. `You have 2 total contacts
Unfortunately none of them match your current search or filters.`