### PR TITLE
Adding alert message for when there is conection issues with the API

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -47,9 +47,9 @@ module.exports = withPlugins([
     env: {
       NEXTAUTH_URL: process.env.NEXTAUTH_URL,
       JWT_SECRET: process.env.JWT_SECRET ?? 'development-key',
-      API_URL: process.env.API_URL ?? 'https://api.stage.mpdx.org/graphql',
+      API_URL: process.env.API_URL ?? 'https://api.stage.mpdxs.org/graphql',
       REST_API_URL:
-        process.env.REST_API_URL ?? 'https://api.stage.mpdx.org/api/v2/',
+        process.env.REST_API_URL ?? 'https://api.stage.mpdxs.org/api/v2/',
       SITE_URL: siteUrl,
       CLIENT_ID: process.env.CLIENT_ID ?? '4027334344069527005',
       CLIENT_SECRET: process.env.CLIENT_SECRET,

--- a/pages/login.page.tsx
+++ b/pages/login.page.tsx
@@ -45,11 +45,11 @@ const IndexPage = ({
       return;
     }
     new Promise((resolve) => setTimeout(resolve, 500 * (attemptsFailed + 1)))
-      .then(async () => {
-        await fetch(process.env.API_URL || '', {
+      .then(() =>
+        fetch(process.env.API_URL || '', {
           method: 'POST',
-        });
-      })
+        }),
+      )
       .catch(() => {
         setAttemptsFailed(attemptsFailed + 1);
       });
@@ -95,7 +95,7 @@ const IndexPage = ({
         {!ableToConnect ? (
           <AlertBox severity="warning">
             {t(
-              'We are experiencing issues connecting to our database. This may interrupt your session.',
+              'We are experiencing issues connecting to our internal API. This may interrupt your session.',
             )}
           </AlertBox>
         ) : null}


### PR DESCRIPTION
Added an alert message that shows when MPDX login page cannot connect to the API.

The useEffect tries to connect to the API; if it fails, it tries again. On the third time, it gives up and shows an error message to the user.

There's lots more we could do with this, but since MPDX will be down for maintenance tomorrow, I was thinking of removing this functionality after tomorrow until we can create more of a robust functionality to check API connection.