### PR TITLE
HelpScout 948647  - Tags not showing when viewing in different languages.

### DIFF
--- a/src/components/Shared/Filters/FilterPanel.tsx
+++ b/src/components/Shared/Filters/FilterPanel.tsx
@@ -676,7 +676,7 @@ export const FilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
 
   const tagsFilters =
     (
-      filters.find((filter) => filter.name === 'Tags')
+      filters.find((filter) => filter?.filters[0]?.filterKey === 'tags')
         ?.filters[0] as MultiselectFilter
     )?.options ?? [];
   const noSelectedFilters =
@@ -776,7 +776,9 @@ export const FilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
                   )}
 
                   {filters
-                    ?.filter((filter) => filter.name !== 'Tags')
+                    ?.filter(
+                      (filter) => filter?.filters[0]?.filterKey !== 'tags',
+                    )
                     ?.map((group) => {
                       const selectedOptions = getOptionsSelected(group);
                       return (

--- a/src/components/Tool/Appeal/AddAppealForm.tsx
+++ b/src/components/Tool/Appeal/AddAppealForm.tsx
@@ -112,7 +112,7 @@ const AddAppealForm = (): ReactElement => {
   const contactStatuses = contactFilterGroups?.accountList?.contactFilterGroups
     ? (
         contactFilterGroups.accountList.contactFilterGroups
-          .find((group) => group.name === 'Status')
+          .find((group) => group?.filters[0]?.filterKey === 'status')
           ?.filters.find(
             (filter: { filterKey: string }) => filter.filterKey === 'status',
           ) as MultiselectFilter

--- a/src/components/Tool/FixCommitmentInfo/FixCommitmentInfo.tsx
+++ b/src/components/Tool/FixCommitmentInfo/FixCommitmentInfo.tsx
@@ -88,7 +88,7 @@ const FixCommitmentInfo: React.FC<Props> = ({ accountListId }: Props) => {
   const contactStatuses = contactFilterGroups?.accountList?.contactFilterGroups
     ? (
         contactFilterGroups.accountList.contactFilterGroups
-          .find((group) => group.name === 'Status')
+          .find((group) => group?.filters[0]?.filterKey === 'status')
           ?.filters.find(
             (filter: { filterKey: string }) => filter.filterKey === 'status',
           ) as MultiselectFilter
@@ -99,7 +99,6 @@ const FixCommitmentInfo: React.FC<Props> = ({ accountListId }: Props) => {
           status.value !== 'ACTIVE',
       )
     : [{ name: '', value: '' }];
-
   //TODO: Make currency field a select element
 
   const updateContact = async (


### PR DESCRIPTION
We were only showing tags for English language as we were looking for the English name `Tags`. I've now changed this to find the filterKey `tags`.

I've also ensured all other languages have the same filters as the `english` language does. This will solve the issue Juergen mentioned about the filters not working.