### PR TITLE
[MPDX-7717] Prevent contact details drawer from overlapping task list

### DIFF
--- a/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
@@ -283,6 +283,8 @@ const TasksPage: React.FC = () => {
   );
   //#endregion
 
+  const contactDetailsWidth = 'max(50%, 530px)';
+
   //#region JSX
   return (
     <>
@@ -365,11 +367,14 @@ const TasksPage: React.FC = () => {
                     ))}
                   </TaskCurrentHistoryButtonGroup>
                   <InfiniteList
-                    data-foo="bar"
                     loading={loading}
                     data={data?.tasks.nodes}
                     style={{
                       height: `calc(100vh - ${navBarHeight} - ${headerHeight} - ${buttonBarHeight})`,
+                      width: contactDetailsOpen
+                        ? `calc(100% - ${contactDetailsWidth})`
+                        : undefined,
+                      overflowX: 'hidden',
                     }}
                     itemContent={(index, task) => (
                       <Box key={index} flexDirection="row" width="100%">
@@ -448,7 +453,7 @@ const TasksPage: React.FC = () => {
               ) : undefined
             }
             rightOpen={contactDetailsOpen}
-            rightWidth="60%"
+            rightWidth={contactDetailsWidth}
             headerHeight={headerHeight}
           />
         </WhiteBackground>

--- a/src/components/Task/TaskRow/TaskRow.tsx
+++ b/src/components/Task/TaskRow/TaskRow.tsx
@@ -1,12 +1,5 @@
 import React from 'react';
-import {
-  Box,
-  Button,
-  Checkbox,
-  Hidden,
-  Tooltip,
-  Typography,
-} from '@mui/material';
+import { Box, Checkbox, Hidden, Tooltip, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { DateTime } from 'luxon';
@@ -228,9 +221,7 @@ export const TaskRow: React.FC<TaskRowProps> = ({
               ))}
             </Box>
             <Hidden smUp>
-              <Button>
-                <ContactText>{assigneeName}</ContactText>
-              </Button>
+              <ContactText>{assigneeName}</ContactText>
             </Hidden>
           </Box>
         </Box>


### PR DESCRIPTION
Shrink the task list when the contact details drawer is open so that all data is still visible.

https://jira.cru.org/browse/MPDX-7717