### PR TITLE
Addresses without state now show on contact.

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactHeaderSection/ContactHeaderAddressSection.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactHeaderSection/ContactHeaderAddressSection.tsx
@@ -47,8 +47,9 @@ export const ContactHeaderAddressSection = ({
   } else if (envelope && primaryAddress) {
     const { street, city, state, postalCode } = primaryAddress;
 
-    if (street && city && state && postalCode) {
-      const mapURL = `https://www.google.com/maps/search/?api=1&query=${street}%2C+${city}%2C+${state}+${postalCode}`;
+    if (street && city && postalCode) {
+      const additionalOptions = state ? `${state}+${postalCode}` : postalCode;
+      const mapURL = `https://www.google.com/maps/search/?api=1&query=${street}%2C+${city}%2C+${additionalOptions}`;
 
       return (
         <ContactHeaderSection icon={<LocationIcon />}>


### PR DESCRIPTION
The primary address was being shown as N/A on the contact's address if a STATE wasn't present. This is typical behaviour in the States but not in other countries such as Germany.

- https://secure.helpscout.net/conversation/2277780060/965164?folderId=7296147