### PR TITLE
Helpscout 984133 - Contact flow titles isn't updated when column moved

### DIFF
--- a/pages/accountLists/[accountListId]/contacts/flows/setup.page.tsx
+++ b/pages/accountLists/[accountListId]/contacts/flows/setup.page.tsx
@@ -209,10 +209,15 @@ const ContactFlowSetupPage: React.FC = () => {
                 style={{ overflowX: 'auto' }}
                 gridAutoColumns="300px"
               >
-                {flowOptions.map((column, index) => (
-                  <Box width={'100%'} minWidth={300} p={2} key={index}>
+                {flowOptions.map((column, idx) => (
+                  <Box
+                    width={'100%'}
+                    minWidth={300}
+                    p={2}
+                    key={`flow-column-${column.id ?? idx}`}
+                  >
                     <ContactFlowSetupColumn
-                      index={index}
+                      index={idx}
                       loading={loading}
                       accountListId={accountListId}
                       title={column.name}


### PR DESCRIPTION
## Description
Making the flow columns have unique keys so React updates the title when the user moves the column.

## Changes
- Made the key value more unique so React understands each column is different.