### PR TITLE
[no-jira] task comment does not require person

### DIFF
--- a/src/components/Task/Modal/Comments/Item/TaskModalCommentListItem.tsx
+++ b/src/components/Task/Modal/Comments/Item/TaskModalCommentListItem.tsx
@@ -91,7 +91,7 @@ const TaskModalCommentsListItem: React.FC<Props> = ({
     return (
       <Box>
         <CommentInfoText display="inline">
-          {comment?.person.firstName} {comment?.person.lastName}{' '}
+          {comment?.person?.firstName} {comment?.person?.lastName}{' '}
         </CommentInfoText>
         <Tooltip placement="bottom" title={comment?.createdAt || ''} arrow>
           <CommentInfoText display="inline">


### PR DESCRIPTION
Person will not always be available in the Task Comments.

[Helpscout](https://secure.helpscout.net/conversation/2320771711/992064?folderId=3233957) brought this to our attention and API is about to change:
https://github.com/CruGlobal/mpdx_api/pull/2690