### PR TITLE
[no-Jira] Improve coaching monthly commitment graph

### DIFF
--- a/pages/api/Schema/reports/pledgeHistories/dataHandler.ts
+++ b/pages/api/Schema/reports/pledgeHistories/dataHandler.ts
@@ -16,8 +16,8 @@ const getReportsPledgeHistories = (
     },
   ],
 ): ReportsPledgeHistories[] => {
-  const reportsPledgeHistories: ReportsPledgeHistories[] = data.map(
-    (histories) => {
+  const reportsPledgeHistories: ReportsPledgeHistories[] = data
+    .map((histories) => {
       const {
         id,
         attributes: {
@@ -38,8 +38,16 @@ const getReportsPledgeHistories = (
         updatedAt: updated_at,
         updatedInDbAt: updated_in_db_at,
       };
-    },
-  );
+    })
+    .sort((item1, item2) => {
+      if (item1.startDate < item2.startDate) {
+        return -1;
+      } else if (item1.startDate > item2.startDate) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
   return reportsPledgeHistories;
 };
 

--- a/src/components/Coaching/CoachingDetail/MonthlyCommitment/MonthlyCommitment.tsx
+++ b/src/components/Coaching/CoachingDetail/MonthlyCommitment/MonthlyCommitment.tsx
@@ -105,11 +105,7 @@ export const MonthlyCommitment: React.FC<MonthlyCommitmentProps> = ({
                 domain={[0, domainMax]}
                 label={
                   <Text x={0} y={0} dx={20} dy={150} offset={0} angle={-90}>
-                    {
-                      t('Amount ({{ currencyCode }})', {
-                        currencyCode,
-                      }) as string
-                    }
+                    {t('Amount ({{ currencyCode }})', { currencyCode })}
                   </Text>
                 }
               />
@@ -130,14 +126,18 @@ export const MonthlyCommitment: React.FC<MonthlyCommitmentProps> = ({
               />
               <XAxis tickLine={false} dataKey="startDate" />
               <Bar
-                dataKey="committed"
-                barSize={30}
-                fill={theme.palette.progressBarOrange.main}
-              />
-              <Bar
+                name={t('Received')}
                 dataKey="received"
+                stackId={1}
                 barSize={30}
                 fill={theme.palette.mpdxGreen.main}
+              />
+              <Bar
+                name={t('Committed')}
+                dataKey="committed"
+                stackId={1}
+                barSize={30}
+                fill={theme.palette.progressBarOrange.main}
               />
             </BarChart>
           )}


### PR DESCRIPTION
Changes:

* Reverse data to read from left to right
* Localize committed and received labels
* Make the chart a stacked bar chart

To test, login as `apps+mpdx@cru.org` and go to http://localhost:3000/accountLists/308c5567-a0b6-49f6-922e-f0c338e170ca/coaching/08bb09d1-3b62-4690-9596-b625b8af4750.