### PR TITLE
MPDX-7678 - GraphQL error when filtering by completed tasks 

### DIFF
--- a/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
@@ -432,9 +432,9 @@ const TasksPage: React.FC = () => {
               contactDetailsId ? (
                 <ContactsProvider
                   urlFilters={urlFilters}
-                  activeFilters={activeFilters}
+                  activeFilters={{}}
                   setActiveFilters={setActiveFilters}
-                  starredFilter={starredFilter}
+                  starredFilter={{}}
                   setStarredFilter={setStarredFilter}
                   filterPanelOpen={filterPanelOpen}
                   setFilterPanelOpen={setFilterPanelOpen}


### PR DESCRIPTION
## Description
When on the tasks page, click on a Contact, then switch Tasks tab. An error occurs regarding contacts filters not being able to filter on Tasks filters.

This is caused as we're using Context to share contacts' global state across all of the components of the contact. We really need to spend a day or 2 switching Context to Redux as the contact data is used throughout the app and not just on contacts components. I'll create a task for this.

## Changes
- Fixed the error by not passing down Tasks filters to the contact context. We don't need the `activeFilters` or `starredFilters`, as we're just showing the contact drawer.