### PR TITLE
[no-Jira] Use local GraphQL schema file

### DIFF
--- a/apollo.config.js
+++ b/apollo.config.js
@@ -2,7 +2,7 @@ module.exports = {
   client: {
     service: {
       name: 'MPDX',
-      url: 'https://api.stage.mpdx.org/graphql',
+      localSchemaFile: 'src/graphql/schema.graphql',
     },
     // Added generated files to avoid duplicate operation name errors https://www.apollographql.com/docs/devtools/apollo-config/#clientexcludes
     excludes: ['**/node_modules', '**/__tests__', '**/*.generated.ts'],


### PR DESCRIPTION
This fixes validation errors in VS Code for REST proxy queries and lets you hover over them to view their types. This wasn't working before because those queries and types aren't present on the schema at https://api.stage.mpdx.org/graphql.

**Caveat**: `yarn gql` will now need to be run to generate the `schema.graphql` before *any* validation will work in VS Code. I think this is an acceptable tradeoff.

## Description

Please explain a bullet-point summary of the changes.
List any PRs that this PR is dependent on and any Jira tickets that this PR is related to.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
