### PR TITLE
[MPDX-7832] Fix form errors not displaying

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/AddAddressModal/AddAddressModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/AddAddressModal/AddAddressModal.tsx
@@ -145,6 +145,7 @@ export const AddAddressModal: React.FC<EditContactAddressModalProps> = ({
           primaryMailingAddress: true,
         }}
         validationSchema={createAddressSchema}
+        validateOnMount
         onSubmit={onSubmit}
       >
         {({

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/PartnerAccounts/ContactDetailsPartnerAccounts.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/PartnerAccounts/ContactDetailsPartnerAccounts.tsx
@@ -21,8 +21,10 @@ import {
 import { useDeleteDonorAccountMutation } from './DeleteDonorAccount.generated';
 
 const newPartnerAccountSchema = yup.object({
-  accountNumber: yup.string(),
+  accountNumber: yup.string().required(),
 });
+
+type Attributes = yup.InferType<typeof newPartnerAccountSchema>;
 
 const ContactPartnerAccountsContainer = styled(Box)(({ theme }) => ({
   margin: theme.spacing(1, 1, 1, 5),
@@ -76,7 +78,7 @@ export const ContactDetailsPartnerAccounts: React.FC<
     enqueueSnackbar('Partner account deleted!', { variant: 'success' });
   };
 
-  const onAddPartnerAccount = async (fields) => {
+  const onAddPartnerAccount = async (fields: Attributes) => {
     await updateContact({
       variables: {
         accountListId,
@@ -108,17 +110,19 @@ export const ContactDetailsPartnerAccounts: React.FC<
     <ContactPartnerAccountsContainer>
       <ActionButton onClick={() => setShowForm(!showForm)}>
         <Add />
-        Add Partner Account
+        {t('Add Partner Account')}
       </ActionButton>
       {showForm && (
         <Formik
           initialValues={{ accountNumber: '' }}
           validationSchema={newPartnerAccountSchema}
+          validateOnMount
           onSubmit={onAddPartnerAccount}
         >
           {({
             values: { accountNumber },
             handleChange,
+            handleBlur,
             handleSubmit,
             isSubmitting,
             isValid,
@@ -127,9 +131,11 @@ export const ContactDetailsPartnerAccounts: React.FC<
           }): ReactElement => (
             <form onSubmit={handleSubmit} noValidate>
               <TextField
+                name="accountNumber"
                 label={t('Account Number')}
                 value={accountNumber}
-                onChange={handleChange('accountNumber')}
+                onChange={handleChange}
+                onBlur={handleBlur}
                 inputProps={{ 'aria-label': t('Account Number') }}
                 error={!!errors.accountNumber && touched.accountNumber}
                 helperText={

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/EditContactDetailsModal/EditContactDetailsModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/EditContactDetailsModal/EditContactDetailsModal.tsx
@@ -20,8 +20,7 @@ import {
   CancelButton,
   SubmitButton,
 } from 'src/components/common/Modal/ActionButtons/ActionButtons';
-import { ContactUpdateInput } from 'src/graphql/types.generated';
-import Modal from '../../../../../../common/Modal/Modal';
+import Modal from 'src/components/common/Modal/Modal';
 import {
   ContactDetailsFragment,
   useUpdateContactDetailsMutation,
@@ -52,6 +51,13 @@ const LoadingIndicator = styled(CircularProgress)(({ theme }) => ({
   margin: theme.spacing(0, 1, 0, 0),
 }));
 
+const contactSchema = yup.object({
+  name: yup.string().required(),
+  primaryPersonId: yup.string().required(),
+});
+
+type Attributes = yup.InferType<typeof contactSchema>;
+
 interface EditContactDetailsModalProps {
   contact: ContactDetailsFragment;
   accountListId: string;
@@ -72,20 +78,13 @@ export const EditContactDetailsModal: React.FC<
   const [updateContact, { loading: updating }] =
     useUpdateContactDetailsMutation();
 
-  const contactSchema: yup.SchemaOf<Pick<ContactUpdateInput, 'name' | 'id'>> =
-    yup.object({
-      name: yup.string().required(),
-      id: yup.string().required(),
-      primaryPersonId: yup.string().required(),
-    });
-
-  const onSubmit = async (attributes: ContactUpdateInput) => {
+  const onSubmit = async (attributes: Attributes) => {
     await updateContact({
       variables: {
         accountListId,
         attributes: {
+          id: contact.id,
           name: attributes.name,
-          id: attributes.id,
           primaryPersonId: attributes.primaryPersonId,
         },
       },
@@ -105,7 +104,6 @@ export const EditContactDetailsModal: React.FC<
       <Formik
         initialValues={{
           name: contact.name,
-          id: contact.id,
           primaryPersonId: contact?.primaryPerson?.id ?? '',
         }}
         validationSchema={contactSchema}
@@ -114,6 +112,7 @@ export const EditContactDetailsModal: React.FC<
         {({
           values: { name, primaryPersonId },
           handleChange,
+          handleBlur,
           handleSubmit,
           setFieldValue,
           isSubmitting,
@@ -126,9 +125,11 @@ export const EditContactDetailsModal: React.FC<
               <ContactEditContainer>
                 <ContactInputWrapper>
                   <TextField
+                    name="name"
                     label={t('Contact')}
                     value={name}
-                    onChange={handleChange('name')}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
                     inputProps={{ 'aria-label': t('Contact') }}
                     error={!!errors.name && touched.name}
                     helperText={
@@ -155,14 +156,12 @@ export const EditContactDetailsModal: React.FC<
                       }
                       fullWidth={true}
                     >
-                      {contact.people.nodes.map((person) => {
-                        return (
-                          <MenuItem
-                            key={person.id}
-                            value={person.id}
-                          >{`${person.firstName} ${person.lastName}`}</MenuItem>
-                        );
-                      })}
+                      {contact.people.nodes.map((person) => (
+                        <MenuItem
+                          key={person.id}
+                          value={person.id}
+                        >{`${person.firstName} ${person.lastName}`}</MenuItem>
+                      ))}
                     </Select>
                   </FormControl>
                 </ContactInputWrapper>

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonModal.tsx
@@ -661,6 +661,7 @@ export const PersonModal: React.FC<PersonModalProps> = ({
       <Formik
         initialValues={initialPerson}
         validationSchema={personSchema}
+        validateOnMount
         onSubmit={onSubmit}
       >
         {(formikProps): ReactElement => (

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonName/PersonName.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonName/PersonName.tsx
@@ -40,6 +40,8 @@ export const PersonName: React.FC<PersonNameProps> = ({
   const {
     values: { firstName, lastName, title, suffix },
     handleChange,
+    handleBlur,
+    touched,
     errors,
   } = formikProps;
 
@@ -87,12 +89,18 @@ export const PersonName: React.FC<PersonNameProps> = ({
         <Grid container spacing={3}>
           <Grid item xs={12} md={6}>
             <TextField
+              name="firstName"
               label={t('First Name')}
               value={firstName}
-              onChange={handleChange('firstName')}
+              onChange={handleChange}
+              onBlur={handleBlur}
               inputProps={{ 'aria-label': t('First Name') }}
-              error={!!errors.firstName}
-              helperText={errors.firstName && t('First Name is required')}
+              error={touched.firstName && !!errors.firstName}
+              helperText={
+                touched.firstName &&
+                errors.firstName &&
+                t('First Name is required')
+              }
               fullWidth
               required
             />
@@ -103,8 +111,6 @@ export const PersonName: React.FC<PersonNameProps> = ({
               value={lastName}
               onChange={handleChange('lastName')}
               inputProps={{ 'aria-label': t('Last Name') }}
-              error={!!errors.lastName}
-              helperText={errors.lastName && t('Last Name is required')}
               fullWidth
               required
             />

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.tsx
@@ -92,6 +92,8 @@ const taskSchema = yup.object({
   subject: yup.string().required(),
 });
 
+type Attributes = yup.InferType<typeof taskSchema>;
+
 const LogNewsletter = ({
   accountListId,
   handleClose,
@@ -103,13 +105,13 @@ const LogNewsletter = ({
 
   const [createTasks, { loading: creating }] = useCreateTasksMutation();
 
-  const initialTask: yup.InferType<typeof taskSchema> = {
+  const initialTask = {
     activityType: ActivityTypeEnum.NewsletterPhysical,
     completedAt: null,
     subject: '',
   };
 
-  const onSubmit = async (attributes: yup.InferType<typeof taskSchema>) => {
+  const onSubmit = async (attributes: Attributes) => {
     const body = commentBody.trim();
 
     // Create two tasks when the activity type is both
@@ -147,12 +149,14 @@ const LogNewsletter = ({
     <Formik
       initialValues={initialTask}
       validationSchema={taskSchema}
+      validateOnMount
       onSubmit={onSubmit}
     >
       {({
         values: { activityType, subject, completedAt },
         setFieldValue,
         handleChange,
+        handleBlur,
         handleSubmit,
         isSubmitting,
         isValid,
@@ -172,8 +176,10 @@ const LogNewsletter = ({
                 <LogFormControl>
                   <LogFormLabel required>{t('Subject')}</LogFormLabel>
                   <LogTextField
+                    name="subject"
                     value={subject}
-                    onChange={handleChange('subject')}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
                     fullWidth
                     multiline
                     inputProps={{ 'aria-label': t('Subject') }}

--- a/src/components/Dashboard/ThisWeek/WeeklyActivity/WeeklyReportModal/WeeklyReportModal.tsx
+++ b/src/components/Dashboard/ThisWeek/WeeklyActivity/WeeklyReportModal/WeeklyReportModal.tsx
@@ -153,6 +153,11 @@ export const WeeklyReportModal = ({
         {questions.map((question, index) => {
           const answerId = getAnswer(question.id)?.id ?? null;
           const currentQuestion = initialValues[index];
+
+          const schema = yup.object().shape({
+            [question.id]: yup.string().required(t('Required')),
+          });
+
           return (
             <React.Fragment key={question.id}>
               {activeStep === index + 1 && (
@@ -161,10 +166,8 @@ export const WeeklyReportModal = ({
                     initialValues={{
                       [currentQuestion[0]]: currentQuestion[1],
                     }}
-                    validationSchema={yup.object().shape({
-                      [question.id]: yup.string().required(t('Required')),
-                    })}
-                    onSubmit={(values: Record<string, string>) => {
+                    validationSchema={schema}
+                    onSubmit={(values: yup.InferType<typeof schema>) => {
                       saveAnswer(answerId, question, values[question.id]);
                       handleWeeklyReportNext();
                     }}
@@ -174,6 +177,7 @@ export const WeeklyReportModal = ({
                       handleSubmit,
                       isValid,
                       handleChange,
+                      handleBlur,
                       touched,
                       values,
                     }) => (
@@ -230,6 +234,7 @@ export const WeeklyReportModal = ({
                               label={question.prompt}
                               name={question.id}
                               onChange={handleChange}
+                              onBlur={handleBlur}
                               rows={3}
                               value={values[question.id]}
                               variant="outlined"

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/AddDonation/AddDonation.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/AddDonation/AddDonation.tsx
@@ -27,7 +27,6 @@ import {
   CancelButton,
   SubmitButton,
 } from 'src/components/common/Modal/ActionButtons/ActionButtons';
-import { DonationCreateInput } from 'src/graphql/types.generated';
 import { useLocale } from 'src/hooks/useLocale';
 import { getDateFormatPattern } from 'src/lib/intlFormat/intlFormat';
 import { useApiConstants } from '../../../../../../../Constants/UseApiConstants';
@@ -41,46 +40,47 @@ interface AddDonationProps {
   handleClose: () => void;
 }
 
-const donationSchema: yup.SchemaOf<Omit<DonationCreateInput, 'id'>> =
-  yup.object({
-    amount: yup
-      .number()
-      .typeError('Amount must be a valid number')
-      .required()
-      .test(
-        'Is amount in valid currency format?',
-        'Amount must be in valid currency format',
-        (amount) => /\$?[0-9][0-9.,]*/.test(amount as unknown as string),
-      )
-      .test(
-        'Is positive?',
-        'Must use a positive number for amount',
-        (value) => parseFloat(value as unknown as string) > 0,
-      ),
-    appealAmount: yup
-      .number()
-      .typeError('Appeal amount must be a valid number')
-      .nullable()
-      .test(
-        'Is appeal amount in valid currency format?',
-        'Appeal amount must be in valid currency format',
-        (amount) =>
-          !amount || /\$?[0-9][0-9.,]*/.test(amount as unknown as string),
-      )
-      .test(
-        'Is positive?',
-        'Must use a positive number for appeal amount',
-        (value) => !value || parseFloat(value as unknown as string) > 0,
-      ),
-    appealId: yup.string().nullable(),
-    currency: yup.string().required(),
-    designationAccountId: yup.string().required(),
-    donationDate: yup.string().required(),
-    donorAccountId: yup.string().required(),
-    memo: yup.string().nullable(),
-    motivation: yup.string().nullable(),
-    paymentMethod: yup.string().nullable(),
-  });
+const donationSchema = yup.object({
+  amount: yup
+    .number()
+    .typeError('Amount must be a valid number')
+    .required()
+    .test(
+      'Is amount in valid currency format?',
+      'Amount must be in valid currency format',
+      (amount) => /\$?[0-9][0-9.,]*/.test(amount as unknown as string),
+    )
+    .test(
+      'Is positive?',
+      'Must use a positive number for amount',
+      (value) => parseFloat(value as unknown as string) > 0,
+    ),
+  appealAmount: yup
+    .number()
+    .typeError('Appeal amount must be a valid number')
+    .nullable()
+    .test(
+      'Is appeal amount in valid currency format?',
+      'Appeal amount must be in valid currency format',
+      (amount) =>
+        !amount || /\$?[0-9][0-9.,]*/.test(amount as unknown as string),
+    )
+    .test(
+      'Is positive?',
+      'Must use a positive number for appeal amount',
+      (value) => !value || parseFloat(value as unknown as string) > 0,
+    ),
+  appealId: yup.string().nullable(),
+  currency: yup.string().required(),
+  designationAccountId: yup.string().required(),
+  donationDate: yup.string().required(),
+  donorAccountId: yup.string().required(),
+  memo: yup.string().nullable(),
+  motivation: yup.string().nullable(),
+  paymentMethod: yup.string().nullable(),
+});
+
+type Attributes = yup.InferType<typeof donationSchema>;
 
 const LogFormLabel = styled(FormLabel)(({ theme }) => ({
   margin: theme.spacing(1, 0),
@@ -129,7 +129,7 @@ export const AddDonation = ({
     data?.designationAccounts &&
     data?.designationAccounts.flatMap((x) => x.designationAccounts);
 
-  const initialDonation: Omit<DonationCreateInput, 'id'> = {
+  const initialDonation = {
     amount: 0,
     appealAmount: null,
     appealId: null,
@@ -142,7 +142,7 @@ export const AddDonation = ({
     paymentMethod: null,
   };
 
-  const onSubmit = async (attributes: Omit<DonationCreateInput, 'id'>) => {
+  const onSubmit = async (attributes: Attributes) => {
     const amount = (attributes.amount as unknown as string).replace(
       /[^\d.-]/g,
       '',
@@ -187,6 +187,7 @@ export const AddDonation = ({
     >
       {({
         values: { appealId },
+        handleBlur,
         setFieldValue,
         isSubmitting,
         isValid,
@@ -393,6 +394,7 @@ export const AddDonation = ({
                             onChange={(donorAccountId) =>
                               setFieldValue('donorAccountId', donorAccountId)
                             }
+                            onBlur={handleBlur('donorAccountId')}
                             value={field.value}
                             autocompleteId="partner-account-input"
                             labelId="partner-account-label"

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateContact/CreateContact.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateContact/CreateContact.tsx
@@ -144,11 +144,13 @@ const CreateContact = ({
     <Formik
       initialValues={initialContact}
       validationSchema={contactSchema}
+      validateOnMount
       onSubmit={onSubmit}
     >
       {({
         values: { name },
         handleChange,
+        handleBlur,
         handleSubmit,
         isSubmitting,
         isValid,
@@ -162,8 +164,10 @@ const CreateContact = ({
                 <LogFormControl>
                   <LogFormLabel required>{t('Name')}</LogFormLabel>
                   <LogTextField
+                    name="name"
                     value={name}
-                    onChange={handleChange('name')}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
                     fullWidth
                     multiline
                     placeholder={t('Last Name, First Name and Spouse Name')}

--- a/src/components/Reports/DonationsReport/Table/Modal/EditDonationModal.tsx
+++ b/src/components/Reports/DonationsReport/Table/Modal/EditDonationModal.tsx
@@ -180,6 +180,7 @@ export const EditDonationModal: React.FC<EditDonationModalProps> = ({
           },
           setFieldValue,
           handleChange,
+          handleBlur,
           handleSubmit,
           isSubmitting,
           errors,
@@ -190,9 +191,11 @@ export const EditDonationModal: React.FC<EditDonationModalProps> = ({
               <FormFieldsGridContainer>
                 <Grid item xs={12} md={6}>
                   <TextField
+                    name="convertedAmount"
                     value={convertedAmount}
                     label={t('Amount')}
-                    onChange={handleChange('convertedAmount')}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
                     fullWidth
                     inputProps={{ 'aria-label': t('Amount') }}
                     error={!!errors.convertedAmount && touched.convertedAmount}

--- a/src/components/Settings/integrations/Organization/Modals/OrganizationAddAccountModal.test.tsx
+++ b/src/components/Settings/integrations/Organization/Modals/OrganizationAddAccountModal.test.tsx
@@ -120,7 +120,7 @@ describe('OrganizationAddAccountModal', () => {
 
   it('should select offline Organization and add it', async () => {
     const mutationSpy = jest.fn();
-    const { getByText, getByRole } = render(
+    const { getByText, getByRole, findByRole } = render(
       <Components>
         <GqlMockedProvider<{
           GetOrganizations: GetOrganizationsQuery;
@@ -142,11 +142,7 @@ describe('OrganizationAddAccountModal', () => {
     );
 
     userEvent.click(getByRole('combobox'));
-    await waitFor(() =>
-      expect(
-        getByRole('option', { name: 'organizationName' }),
-      ).toBeInTheDocument(),
-    );
+    userEvent.click(await findByRole('option', { name: 'organizationName' }));
 
     await waitFor(() => {
       expect(getByText('Add Account')).not.toBeDisabled();

--- a/src/components/Settings/integrations/Organization/Modals/OrganizationAddAccountModal.tsx
+++ b/src/components/Settings/integrations/Organization/Modals/OrganizationAddAccountModal.tsx
@@ -186,6 +186,7 @@ export const OrganizationAddAccountModal: React.FC<
           password: '',
         }}
         validationSchema={OrganizationSchema}
+        validateOnMount
         onSubmit={onSubmit}
       >
         {({
@@ -282,7 +283,7 @@ export const OrganizationAddAccountModal: React.FC<
                         {t('click here to log out of {{appName}}', { appName })}
                       </Link>
                       {t(
-                        ' so you can log back in with your offical key account.',
+                        ' so you can log back in with your official key account.',
                       )}
                     </li>
                   </ol>

--- a/src/components/Settings/integrations/Organization/Modals/OrganizationEditAccountModal.tsx
+++ b/src/components/Settings/integrations/Organization/Modals/OrganizationEditAccountModal.tsx
@@ -88,6 +88,7 @@ export const OrganizationEditAccountModal: React.FC<
           password: '',
         }}
         validationSchema={OrganizationSchema}
+        validateOnMount
         onSubmit={onSubmit}
       >
         {({

--- a/src/components/Shared/Filters/SaveFilterModal/SaveFilterModal.tsx
+++ b/src/components/Shared/Filters/SaveFilterModal/SaveFilterModal.tsx
@@ -19,13 +19,22 @@ import {
 } from 'src/components/common/Modal/ActionButtons/ActionButtons';
 import {
   ContactFilterSetInput,
-  CreateOrUpdateOptionMutationInput,
   TaskFilterSetInput,
 } from 'src/graphql/types.generated';
 import { useAccountListId } from '../../../../hooks/useAccountListId';
 import Modal from '../../../common/Modal/Modal';
 import { UserOptionFragment } from '../FilterPanel.generated';
 import { useSaveFilterMutation } from './SaveFilterModal.generated';
+
+const savedFilterSchema = yup.object({
+  key: yup
+    .string()
+    .matches(/^[a-zA-Z0-9 ]*$/, 'Invalid character in filter name')
+    .required('Please enter a valid filter name'),
+  value: yup.string().required(),
+});
+
+type Attributes = yup.InferType<typeof savedFilterSchema>;
 
 interface SaveFilterModalProps {
   isOpen: boolean;
@@ -53,15 +62,6 @@ export const SaveFilterModal: React.FC<SaveFilterModalProps> = ({
   //#endregion
 
   //#region Saving Filter Logic
-  const savedFilterSchema: yup.SchemaOf<
-    Omit<CreateOrUpdateOptionMutationInput, 'clientMutationId'>
-  > = yup.object({
-    key: yup
-      .string()
-      .matches(/^[a-zA-Z0-9 ]*$/, 'Invalid character in filter name')
-      .required('Please enter a valid filter name'),
-    value: yup.string().required(),
-  });
 
   const filterPrefix = route.includes('contacts')
     ? 'graphql_saved_contacts_filter_'
@@ -127,7 +127,7 @@ export const SaveFilterModal: React.FC<SaveFilterModalProps> = ({
     );
   };
 
-  const onSubmit = async (attributes: CreateOrUpdateOptionMutationInput) => {
+  const onSubmit = async (attributes: Attributes) => {
     const formatedFilterName = attributes.key.replaceAll(' ', '_');
     const key = `${filterPrefix}${formatedFilterName}`;
     if (currentSavedFiltersNames.includes(formatedFilterName)) {
@@ -147,6 +147,7 @@ export const SaveFilterModal: React.FC<SaveFilterModalProps> = ({
           value: JSON.stringify({ ...currentFilters, accountListId }),
         }}
         validationSchema={savedFilterSchema}
+        validateOnMount
         onSubmit={onSubmit}
       >
         {({ isValid, isSubmitting }) => (

--- a/src/components/Task/Modal/Comments/Form/TaskModalCommentsListForm.tsx
+++ b/src/components/Task/Modal/Comments/Form/TaskModalCommentsListForm.tsx
@@ -101,6 +101,7 @@ const TaskModalCommentsListForm = ({
         <Formik
           initialValues={{ body: '' }}
           validationSchema={commentSchema}
+          validateOnMount
           onSubmit={onSubmit}
         >
           {({

--- a/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.tsx
+++ b/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.tsx
@@ -3,6 +3,7 @@ import React, {
   ReactElement,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -126,18 +127,21 @@ const TaskModalLogForm = ({
   onClose,
   defaultValues,
 }: Props): ReactElement => {
-  const initialTask: Attributes = {
-    activityType: defaultValues?.activityType ?? null,
-    subject: defaultValues?.subject ?? '',
-    contactIds: defaultValues?.contactIds ?? [],
-    completedAt: DateTime.local().toISO(),
-    userId: defaultValues?.userId ?? null,
-    tagList: defaultValues?.tagList ?? [],
-    result: defaultValues?.result ?? ResultEnum.Completed,
-    nextAction: defaultValues?.nextAction ?? null,
-    location: '',
-    comment: '',
-  };
+  const initialTask: Attributes = useMemo(
+    () => ({
+      activityType: defaultValues?.activityType ?? null,
+      subject: defaultValues?.subject ?? '',
+      contactIds: defaultValues?.contactIds ?? [],
+      completedAt: DateTime.local().toISO(),
+      userId: defaultValues?.userId ?? null,
+      tagList: defaultValues?.tagList ?? [],
+      result: defaultValues?.result ?? ResultEnum.Completed,
+      nextAction: defaultValues?.nextAction ?? null,
+      location: '',
+      comment: '',
+    }),
+    [],
+  );
 
   const { t } = useTranslation();
   const locale = useLocale();
@@ -152,10 +156,13 @@ const TaskModalLogForm = ({
   });
   const [createTasks, { loading: creating }] = useCreateTasksMutation();
   const { update } = useUpdateTasksQueries();
-  const inputRef = useRef(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
   useEffect(() => {
-    if (inputRef.current) (inputRef.current as HTMLInputElement).focus();
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
   }, []);
+
   const handleSearchTermChange = useCallback<
     ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>
   >(
@@ -242,6 +249,8 @@ const TaskModalLogForm = ({
       initialValues={initialTask}
       validationSchema={taskSchema}
       onSubmit={onSubmit}
+      validateOnMount
+      enableReinitialize
     >
       {({
         values: {
@@ -258,6 +267,7 @@ const TaskModalLogForm = ({
         },
         setFieldValue,
         handleChange,
+        handleBlur,
         handleSubmit,
         isSubmitting,
         isValid,
@@ -269,9 +279,11 @@ const TaskModalLogForm = ({
             <FormFieldsGridContainer>
               <Grid item>
                 <TextField
+                  name="subject"
                   label={t('Task Name')}
                   value={subject}
-                  onChange={handleChange('subject')}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
                   fullWidth
                   multiline
                   inputProps={{ 'aria-label': t('Subject') }}

--- a/src/components/Task/Modal/Form/TaskModalForm.tsx
+++ b/src/components/Task/Modal/Form/TaskModalForm.tsx
@@ -3,6 +3,7 @@ import React, {
   ReactElement,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -106,41 +107,45 @@ const TaskModalForm = ({
   defaultValues,
   view,
 }: Props): ReactElement => {
-  const initialTask: Attributes = task
-    ? {
-        id: task.id,
-        activityType: task.activityType ?? null,
-        location: task.location ?? '',
-        subject: task.subject ?? '',
-        startAt: task.startAt ?? null,
-        completedAt: task.completedAt ?? null,
-        result: task.result ?? null,
-        nextAction: task.nextAction ?? null,
-        tagList: task.tagList ?? [],
-        contactIds: task.contacts.nodes.map(({ id }) => id),
-        userId: task.user?.id ?? null,
-        notificationTimeBefore: task.notificationTimeBefore,
-        notificationType: task.notificationType,
-        notificationTimeUnit: task.notificationTimeUnit,
-        comment: '',
-      }
-    : {
-        id: null,
-        activityType: defaultValues?.activityType ?? null,
-        location: '',
-        subject: defaultValues?.subject ?? '',
-        startAt: DateTime.local().toISO(),
-        completedAt: null,
-        result: defaultValues?.result ?? null,
-        nextAction: defaultValues?.nextAction ?? null,
-        tagList: defaultValues?.tagList ?? [],
-        contactIds: defaultValues?.contactIds ?? [],
-        userId: defaultValues?.userId ?? null,
-        notificationTimeBefore: null,
-        notificationType: null,
-        notificationTimeUnit: null,
-        comment: '',
-      };
+  const initialTask: Attributes = useMemo(
+    () =>
+      task
+        ? {
+            id: task.id,
+            activityType: task.activityType ?? null,
+            location: task.location ?? '',
+            subject: task.subject ?? '',
+            startAt: task.startAt ?? null,
+            completedAt: task.completedAt ?? null,
+            result: task.result ?? null,
+            nextAction: task.nextAction ?? null,
+            tagList: task.tagList ?? [],
+            contactIds: task.contacts.nodes.map(({ id }) => id),
+            userId: task.user?.id ?? null,
+            notificationTimeBefore: task.notificationTimeBefore,
+            notificationType: task.notificationType,
+            notificationTimeUnit: task.notificationTimeUnit,
+            comment: '',
+          }
+        : {
+            id: null,
+            activityType: defaultValues?.activityType ?? null,
+            location: '',
+            subject: defaultValues?.subject ?? '',
+            startAt: DateTime.local().toISO(),
+            completedAt: null,
+            result: defaultValues?.result ?? null,
+            nextAction: defaultValues?.nextAction ?? null,
+            tagList: defaultValues?.tagList ?? [],
+            contactIds: defaultValues?.contactIds ?? [],
+            userId: defaultValues?.userId ?? null,
+            notificationTimeBefore: null,
+            notificationType: null,
+            notificationTimeUnit: null,
+            comment: '',
+          },
+    [],
+  );
 
   const { t } = useTranslation();
   const locale = useLocale();
@@ -158,9 +163,11 @@ const TaskModalForm = ({
   const { update } = useUpdateTasksQueries();
 
   const [searchTerm, setSearchTerm] = useState('');
-  const inputRef = useRef(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
   useEffect(() => {
-    if (inputRef.current) (inputRef.current as HTMLInputElement).focus();
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
   }, []);
 
   const handleSearchTermChange = useCallback<
@@ -262,6 +269,8 @@ const TaskModalForm = ({
       initialValues={initialTask}
       validationSchema={taskSchema}
       onSubmit={onSubmit}
+      validateOnMount
+      enableReinitialize
     >
       {({
         values: {
@@ -282,6 +291,7 @@ const TaskModalForm = ({
         },
         setFieldValue,
         handleChange,
+        handleBlur,
         handleSubmit,
         isSubmitting,
         isValid,
@@ -293,9 +303,11 @@ const TaskModalForm = ({
             <FormFieldsGridContainer>
               <Grid item>
                 <TextField
+                  name="subject"
                   label={t('Task Name')}
                   value={subject}
-                  onChange={handleChange('subject')}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
                   fullWidth
                   multiline
                   inputProps={{ 'aria-label': t('Subject') }}

--- a/src/components/common/DonorAccountAutocomplete/DonorAccountAutocomplete.tsx
+++ b/src/components/common/DonorAccountAutocomplete/DonorAccountAutocomplete.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import { FocusEventHandler, ReactElement } from 'react';
 import {
   Autocomplete,
   BaseTextFieldProps,
@@ -12,6 +12,7 @@ import { useGetDonorAccountsLazyQuery } from './DonorAccountAutocomplete.generat
 export interface DonorAccountAutocompleteProps {
   accountListId: string;
   onChange: (donorAccountId: string | null) => void;
+  onBlur?: FocusEventHandler<HTMLDivElement>;
   value: string;
   preloadedDonors?: Array<{ id: string; name: string }>;
   autocompleteId?: string;
@@ -25,6 +26,7 @@ export const DonorAccountAutocomplete: React.FC<
 > = ({
   accountListId,
   onChange,
+  onBlur,
   value,
   preloadedDonors = [],
   autocompleteId,
@@ -82,7 +84,7 @@ export const DonorAccountAutocomplete: React.FC<
       )}
       value={value}
       onChange={(_, donorAccountId) => onChange(donorAccountId)}
-      isOptionEqualToValue={(option, value): boolean => option === value}
+      onBlur={onBlur}
     />
   );
 };


### PR DESCRIPTION
## Description

For Formik `touched` to be populated, we have to call `handleBlur` in our `blur` event handler. Field errors weren't being displayed before because `touched` was always false.

Also improved the type-safety of forms by inferring the type of attributes from the schema vs explicitly telling yup what the type is (which could be inaccurate).

https://jira.cru.org/browse/MPDX-7832

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
