### PR TITLE
[no-Jira] Wait until all tests complete to post CodeCov status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    # Github actions is running 4 test jobs so wait until all those have finished
-    after_n_builds: 4
+    # Github actions is running 8 test jobs so wait until all those have finished
+    after_n_builds: 8
 
 comment: false


### PR DESCRIPTION
## Description

Now that we shard test runs into 8 chunks, CodeCov is updating its check in PRs too early. It needs to wait until all 8 test runs have completed and uploaded their code coverage results.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
