### PR TITLE
[MPDX-7698] Adds locales for multiline TextField support in EditMailingInfoModal.

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditMailingInfoModal/EditMailingInfoModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditMailingInfoModal/EditMailingInfoModal.tsx
@@ -24,6 +24,7 @@ import {
   ContactUpdateInput,
   SendNewsletterEnum,
 } from 'src/graphql/types.generated';
+import { useLocale } from 'src/hooks/useLocale';
 import { getLocalizedSendNewsletter } from 'src/utils/functions/getLocalizedSendNewsletter';
 import Modal from '../../../../../common/Modal/Modal';
 import { useEditMailingInfoMutation } from './EditMailingInfoModal.generated';
@@ -60,8 +61,11 @@ export const EditMailingInfoModal: React.FC<EditMailingInfoModalProps> = ({
   handleClose,
 }): ReactElement<EditMailingInfoModalProps> => {
   const { t } = useTranslation();
+  const locale = useLocale();
   const { enqueueSnackbar } = useSnackbar();
   const [editMailingInfo, { loading: updating }] = useEditMailingInfoMutation();
+  // Add additional language locales here, for multiline TextField support
+  const multilineLocales = ['de'];
 
   const mailingInfoSchema: yup.SchemaOf<
     Pick<
@@ -135,6 +139,7 @@ export const EditMailingInfoModal: React.FC<EditMailingInfoModalProps> = ({
                 <ContactInputWrapper>
                   <TextField
                     label={t('Envelope Name Line')}
+                    multiline={multilineLocales.includes(locale)}
                     value={envelopeGreeting}
                     onChange={handleChange('envelopeGreeting')}
                     inputProps={{ 'aria-label': t('Envelope Name Line') }}


### PR DESCRIPTION
## Description

In the old MPDx while viewing it in German, we previously programmed the field "Envelope Name Line" under "Details / Communication" to have several lines using return, while in English and other languages returns weren't allowed.

This is important for the German kind of addresses on letters that this is added to the new MPDx. Ticket [#MPDX-7698](https://jira.cru.org/browse/MPDX-7698).

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
