### PR TITLE
[no-Jira] Migrate off of deprecated deleteAccountListCoach inputs

### DIFF
--- a/src/components/Coaching/CoachingRow/CoachingRow.graphql
+++ b/src/components/Coaching/CoachingRow/CoachingRow.graphql
@@ -1,5 +1,7 @@
-mutation DeleteCoachingAccountList($id: ID!) {
-  deleteAccountListCoach(input: { id: $id }) {
+mutation DeleteCoachingAccountList($accountListId: ID!, $coachId: ID!) {
+  deleteAccountListCoach(
+    input: { accountListId: $accountListId, coachId: $coachId }
+  ) {
     id
   }
 }

--- a/src/components/Coaching/CoachingRow/CoachingRow.test.tsx
+++ b/src/components/Coaching/CoachingRow/CoachingRow.test.tsx
@@ -11,6 +11,12 @@ import {
 } from '../LoadCoachingList.generated';
 import { CoachingRow } from './CoachingRow';
 
+jest.mock('src/hooks/useUser.tsx', () => ({
+  useUser: jest.fn().mockReturnValue({
+    id: 'user-1',
+  }),
+}));
+
 const accountListId = 'account-list-1';
 
 const router = {
@@ -61,11 +67,9 @@ describe('CoachingRow', () => {
     userEvent.click(getByRole('button', { name: 'Yes' }));
 
     await waitFor(() => {
-      expect(mutationSpy.mock.calls[0][0].operation).toMatchObject({
-        operationName: 'DeleteCoachingAccountList',
-        variables: {
-          id: 'coaching-account',
-        },
+      expect(mutationSpy).toHaveGraphqlOperation('DeleteCoachingAccountList', {
+        accountListId: 'coaching-account',
+        coachId: 'user-1',
       });
     });
   });

--- a/src/components/Coaching/CoachingRow/CoachingRow.tsx
+++ b/src/components/Coaching/CoachingRow/CoachingRow.tsx
@@ -6,6 +6,7 @@ import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import HandoffLink from 'src/components/HandoffLink';
+import { useUser } from 'src/hooks/useUser';
 import { Confirmation } from '../../common/Modal/Confirmation/Confirmation';
 import { AppealProgress } from '../AppealProgress/AppealProgress';
 import { CoachedPersonFragment } from '../LoadCoachingList.generated';
@@ -30,6 +31,7 @@ const CoachingNameText = styled(Typography)(({ theme }) => ({
 }));
 
 export const CoachingRow: React.FC<Props> = ({ coachingAccount }) => {
+  const user = useUser();
   const {
     id,
     monthlyGoal,
@@ -48,7 +50,10 @@ export const CoachingRow: React.FC<Props> = ({ coachingAccount }) => {
   const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   const [deleteCoachingAccountList] = useDeleteCoachingAccountListMutation({
-    variables: { id },
+    variables: {
+      accountListId: id,
+      coachId: user?.id ?? '',
+    },
     update: (cache) => {
       cache.evict({ id: cache.identify(coachingAccount) });
       cache.gc();


### PR DESCRIPTION
## Description

* Delete account list coaches using a `coachId` (which is the logged in user's id in this component) and an `accountListId`, the id of the coached account list. Deleting using an `id` was deprecated in https://github.com/CruGlobal/mpdx_api/pull/2669.

This change also needs to be done at some point in unmerged PR #843.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
