### PR TITLE
[no-Jira] Fix codegen retry action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,7 @@ jobs:
       - name: 📈 Run GraphQL Codegen
         uses: nick-fields/retry@v3
         with:
-          command: |
-            yarn gql
-            yarn gql:server
+          command: yarn gql && yarn gql:server
           timeout_minutes: 1
           retry_wait_seconds: 60
           max_attempts: 5
@@ -55,9 +53,7 @@ jobs:
       - name: 📈 Run GraphQL Codegen
         uses: nick-fields/retry@v3
         with:
-          command: |
-            yarn gql
-            yarn gql:server
+          command: yarn gql && yarn gql:server
           timeout_minutes: 1
           retry_wait_seconds: 60
           max_attempts: 5
@@ -76,9 +72,7 @@ jobs:
       - name: 📈 Run GraphQL Codegen
         uses: nick-fields/retry@v3
         with:
-          command: |
-            yarn gql
-            yarn gql:server
+          command: yarn gql && yarn gql:server
           timeout_minutes: 1
           retry_wait_seconds: 60
           max_attempts: 5


### PR DESCRIPTION
## Description

Fix codegen retry added in #880. As mentioned in [this issue](https://github.com/nick-fields/retry/issues/53), the action will succeed unless the last command in a multiline command fails. This can cause the action to succeed even when the `yarn gql` step fails, as seen in this [action run](https://github.com/CruGlobal/mpdx-react/actions/runs/8023987205/job/21921578959).

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
