### PR TITLE
[MPDX-7852] -clear contact selection after merge

### DIFF
--- a/pages/accountLists/[accountListId]/contacts/ContactsContext.tsx
+++ b/pages/accountLists/[accountListId]/contacts/ContactsContext.tsx
@@ -77,6 +77,7 @@ export type ContactsType = {
   urlFilters: any;
   isFiltered: boolean;
   selectedIds: string[];
+  deselectAll: () => void;
   userOptionsLoading: boolean;
 };
 
@@ -206,6 +207,7 @@ export const ContactsProvider: React.FC<Props> = ({
     isRowChecked,
     toggleSelectAll,
     toggleSelectionById,
+    deselectAll,
   } = useMassSelection(
     data?.contacts?.totalCount ?? 0,
     allContactIds,
@@ -425,6 +427,7 @@ export const ContactsProvider: React.FC<Props> = ({
         urlFilters: urlFilters,
         isFiltered: isFiltered,
         selectedIds: ids,
+        deselectAll: deselectAll,
         userOptionsLoading: userOptionsLoading,
       }}
     >

--- a/src/components/Contacts/MassActions/Merge/MassActionsMergeModal.tsx
+++ b/src/components/Contacts/MassActions/Merge/MassActionsMergeModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import {
   Alert,
   Avatar,
@@ -20,6 +20,10 @@ import { useLocale } from 'src/hooks/useLocale';
 import { dateFormatShort } from 'src/lib/intlFormat/intlFormat';
 import theme from 'src/theme';
 import { getLocalizedContactStatus } from 'src/utils/functions/getLocalizedContactStatus';
+import {
+  ContactsContext,
+  ContactsType,
+} from '../../../../../pages/accountLists/[accountListId]/contacts/ContactsContext';
 import Modal from '../../../common/Modal/Modal';
 import {
   useGetContactsForMergingQuery,
@@ -41,6 +45,7 @@ export const MassActionsMergeModal: React.FC<MassActionsMergeModalProps> = ({
   accountListId,
   ids,
 }) => {
+  const { deselectAll } = useContext(ContactsContext) as ContactsType;
   const { t } = useTranslation();
   const locale = useLocale();
   const { enqueueSnackbar } = useSnackbar();
@@ -75,6 +80,8 @@ export const MassActionsMergeModal: React.FC<MassActionsMergeModalProps> = ({
     enqueueSnackbar(t('Contacts merged!'), {
       variant: 'success',
     });
+
+    deselectAll();
     handleClose();
   };
 

--- a/src/components/Shared/MassActions/ContactsMassActionsDropdown.test.tsx
+++ b/src/components/Shared/MassActions/ContactsMassActionsDropdown.test.tsx
@@ -5,7 +5,9 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
+import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { ContactsProvider } from 'pages/accountLists/[accountListId]/contacts/ContactsContext';
 import { AppSettingsProvider } from 'src/components/common/AppSettings/AppSettingsProvider';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import theme from 'src/theme';
@@ -255,18 +257,31 @@ describe('ContactsMassActionsDropdown', () => {
     const selectedIdsMerge = ['abc', 'def'];
     const { getByTestId, getByText, queryByText } = render(
       <ThemeProvider theme={theme}>
-        <GqlMockedProvider>
-          <LocalizationProvider dateAdapter={AdapterLuxon}>
-            <SnackbarProvider>
-              <ContactsMassActionsDropdown
-                filterPanelOpen={false}
-                contactDetailsOpen={false}
-                contactsView={TableViewModeEnum.List}
-                selectedIds={selectedIdsMerge}
-              />
-            </SnackbarProvider>
-          </LocalizationProvider>
-        </GqlMockedProvider>
+        <TestRouter>
+          <GqlMockedProvider>
+            <LocalizationProvider dateAdapter={AdapterLuxon}>
+              <SnackbarProvider>
+                <ContactsProvider
+                  activeFilters={{}}
+                  setActiveFilters={() => {}}
+                  starredFilter={{}}
+                  setStarredFilter={() => {}}
+                  filterPanelOpen={false}
+                  setFilterPanelOpen={() => {}}
+                  contactId={[]}
+                  searchTerm={''}
+                >
+                  <ContactsMassActionsDropdown
+                    filterPanelOpen={false}
+                    contactDetailsOpen={false}
+                    contactsView={TableViewModeEnum.List}
+                    selectedIds={selectedIdsMerge}
+                  />
+                </ContactsProvider>
+              </SnackbarProvider>
+            </LocalizationProvider>
+          </GqlMockedProvider>
+        </TestRouter>
       </ThemeProvider>,
     );
     expect(queryByText('Merge')).not.toBeInTheDocument();


### PR DESCRIPTION
## Description

Jira ticket [#7852](https://jira.cru.org/browse/MPDX-7852). After a successful contact merge, we need to clear the checkboxes. Currently, it keeps the checkboxes checked, causing people to merge multiple contacts if they aren't paying close attention to the prompts (It is easy to miss).

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
