### PR TITLE
MPDX 7863 - Donations report - Partner column order fix

### DIFF
--- a/src/components/Reports/DonationsReport/Table/DonationsReportTable.tsx
+++ b/src/components/Reports/DonationsReport/Table/DonationsReportTable.tsx
@@ -242,7 +242,7 @@ export const DonationsReportTable: React.FC<DonationReportTableProps> = ({
       renderCell: date,
     },
     {
-      field: 'partner',
+      field: 'donorAccountName',
       headerName: t('Partner'),
       width: 360,
       renderCell: link,


### PR DESCRIPTION
## Description
Jira: https://jira.cru.org/browse/MPDX-7863
On the Donations report, the column `Partner` wasn't allowing users to order by name. This was highlighted to me in a [HelpScout ticket ](https://secure.helpscout.net/conversation/2528550158/1114264?folderId=7296147).

The bug came from the PR https://github.com/CruGlobal/mpdx-react/pull/844. 

Please explain a bullet-point summary of the changes.
- Updated column partner to have the field `donorAccountName`

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
