### PR TITLE
[no-Jira] Migrate off of deprecated DeleteAccountListCoach inputs

### DIFF
--- a/src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion.test.tsx
+++ b/src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion.test.tsx
@@ -119,7 +119,7 @@ describe('ManageCoachesAccessAccordion', () => {
       'DeleteAccountListCoach',
     );
     expect(mutationSpy.mock.calls[3][0].operation.variables.input).toEqual({
-      id: accountListId,
+      accountListId,
       coachId: '123',
     });
   });

--- a/src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion.tsx
+++ b/src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion.tsx
@@ -39,7 +39,7 @@ export const ManageCoachesAccessAccordion: React.FC<AccordionProps> = ({
     await deleteAccountListCoach({
       variables: {
         input: {
-          id: accountListId,
+          accountListId,
           coachId: coach.id,
         },
       },


### PR DESCRIPTION
## Description

* Delete account list coaches using a `coachId` (which is the logged in user's id in this component) and an `accountListId`, the id of the coached account list. Deleting using an `id` was deprecated in https://github.com/CruGlobal/mpdx_api/pull/2669.
* Follow up to #879 for the new preferences pages

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
