### PR TITLE
[no-Jira] Fix transferwise/actions-next-bundle-analyzer failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Analyze bundle sizes
         # Fork of transferwise/actions-next-bundle-analyzer to fix the failure because our repo does not have issues enabled
         # We can switch back to using transferwise/actions-next-bundle-analyzer if/when https://github.com/transferwise/actions-next-bundle-analyzer/pull/40 is merged
-        uses: canac/actions-next-bundle-analyzer@disable-issue
+        uses: CruGlobal/actions-next-bundle-analyzer@disable-issue
         with:
           # Filename of the workflow this step is defined in
           base-branch: main


### PR DESCRIPTION
## Description

* Fix transferwise/actions-next-bundle-analyzer failure when attempting to create the bundle size summary issue because this repo does not have issues enabled.
  * Follow-up to #896
  * I tested the updated workflow in a fork.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
