### PR TITLE
[no-Jira] Replace transferwise/actions-next-bundle-analyzer fork with upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,13 +140,8 @@ jobs:
         env:
           secrets: '{"JWT_SECRET":"JWT_SECRET","OKTA_CLIENT_SECRET":"OKTA_CLIENT_SECRET"}'
       - name: Analyze bundle sizes
-        # Fork of transferwise/actions-next-bundle-analyzer to fix the failure because our repo does not have issues enabled
-        # We can switch back to using transferwise/actions-next-bundle-analyzer if/when https://github.com/transferwise/actions-next-bundle-analyzer/pull/40 is merged
-        uses: CruGlobal/actions-next-bundle-analyzer@disable-issue
+        uses: transferwise/actions-next-bundle-analyzer@v2
         with:
-          # Filename of the workflow this step is defined in
-          base-branch: main
-          workflow-id: ci.yml
           create-issue: false
         env:
           # This secret is automatically injected by GitHub


### PR DESCRIPTION
## Description

* Replace our fork of `transferwise/actions-next-bundle-analyzer` with the upstream action now that transferwise/actions-next-bundle-analyzer#42 has been merged. `master` will not be receiving updates and `v2` is the branch to use going forward ([link to discussion](https://github.com/transferwise/actions-next-bundle-analyzer/pull/42#issuecomment-2023040250)).

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
