### PR TITLE
[no-Jira] Display cached contact details data immediately

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsHeader.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsHeader.tsx
@@ -69,9 +69,10 @@ export const ContactDetailsHeader: React.FC<Props> = ({
   setContactDetailsLoaded,
   contactDetailsLoaded,
 }: Props) => {
-  const { data, loading } = useGetContactDetailsHeaderQuery({
+  const { data } = useGetContactDetailsHeaderQuery({
     variables: { accountListId, contactId },
   });
+  const loading = !data;
   const { t } = useTranslation();
 
   const { editModalOpen, setEditModalOpen } = React.useContext(
@@ -90,7 +91,7 @@ export const ContactDetailsHeader: React.FC<Props> = ({
       <HeaderBar>
         <ContactAvatar alt={data?.contact.name} src={data?.contact.avatar} />
         <HeaderBarContactWrap>
-          {loading ? (
+          {!data ? (
             <Box data-testid="Skeleton">
               <Skeleton
                 variant="text"
@@ -102,7 +103,7 @@ export const ContactDetailsHeader: React.FC<Props> = ({
                 }}
               />
             </Box>
-          ) : data?.contact ? (
+          ) : data.contact ? (
             <>
               <PrimaryContactName data-testid="ContactName" variant="h5">
                 {data.contact.name}
@@ -165,10 +166,10 @@ export const ContactDetailsHeader: React.FC<Props> = ({
           />
         </Box>
       </HeaderSectionWrap>
-      {loading || !data ? null : (
+      {data && (
         <EditContactDetailsModal
           accountListId={accountListId}
-          contact={data?.contact}
+          contact={data.contact}
           isOpen={editModalOpen}
           handleClose={() => setEditModalOpen(false)}
         />

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.tsx
@@ -57,7 +57,7 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
   contactId,
   onContactSelected,
 }) => {
-  const { data, loading } = useContactDetailsTabQuery({
+  const { data } = useContactDetailsTabQuery({
     variables: { accountListId, contactId },
   });
 
@@ -72,7 +72,7 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
       <ContactDetailsTabContainer>
         {/* Tag Section */}
         <ContactDetailHeadingContainer mt={-3}>
-          {loading || !data ? (
+          {!data ? (
             <ContactDetailLoadingPlaceHolder variant="rectangular" />
           ) : (
             <ContactTags
@@ -85,7 +85,7 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
         <Divider />
         {/* People Section */}
         <ContactDetailSectionContainer>
-          {loading || !data ? (
+          {!data ? (
             <>
               <ContactDetailLoadingPlaceHolder variant="rectangular" />
               <ContactDetailLoadingPlaceHolder variant="rectangular" />
@@ -93,7 +93,7 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
             </>
           ) : (
             <ContactDetailsTabPeople
-              data={data?.contact}
+              data={data.contact}
               accountListId={accountListId}
             />
           )}
@@ -106,7 +106,7 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
               {t('Mailing')}
             </ContactDetailHeadingText>
           </ContactDetailHeadingContainer>
-          {loading || !data ? (
+          {!data ? (
             <>
               <ContactDetailLoadingPlaceHolder variant="rectangular" />
               <ContactDetailLoadingPlaceHolder variant="rectangular" />
@@ -127,7 +127,7 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
               {t('Other')}
             </ContactDetailHeadingText>
           </ContactDetailHeadingContainer>
-          {loading || !data ? (
+          {!data ? (
             <>
               <ContactDetailLoadingPlaceHolder variant="rectangular" />
               <ContactDetailLoadingPlaceHolder variant="rectangular" />
@@ -142,16 +142,14 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
           )}
         </ContactDetailSectionContainer>
         <Divider />
-        {
-          // Patner Accounts Section
-        }
+        {/* Partner Accounts Section */}
         <ContactDetailSectionContainer>
           <ContactDetailHeadingContainer>
             <ContactDetailHeadingText variant="h6">
               {t('Partner Accounts')}
             </ContactDetailHeadingText>
           </ContactDetailHeadingContainer>
-          {loading || !data ? (
+          {!data ? (
             <>
               <ContactDetailLoadingPlaceHolder variant="rectangular" />
               <ContactDetailLoadingPlaceHolder variant="rectangular" />
@@ -163,12 +161,12 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
         </ContactDetailSectionContainer>
         <Divider />
       </ContactDetailsTabContainer>
-      {loading || !data ? null : (
+      {data && (
         <EditContactOtherModal
           accountListId={accountListId}
           contact={data.contact}
           isOpen={editOtherModalOpen}
-          referral={data.contact.contactReferralsToMe?.nodes[0]}
+          referral={data.contact.contactReferralsToMe.nodes[0]}
           handleClose={() => setEditOtherModalOpen(false)}
         />
       )}

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/ContactDetailsTab.tsx
@@ -70,9 +70,7 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
   return (
     <>
       <ContactDetailsTabContainer>
-        {
-          // Tag Section
-        }
+        {/* Tag Section */}
         <ContactDetailHeadingContainer mt={-3}>
           {loading || !data ? (
             <ContactDetailLoadingPlaceHolder variant="rectangular" />
@@ -85,9 +83,7 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
           )}
         </ContactDetailHeadingContainer>
         <Divider />
-        {
-          // People Section
-        }
+        {/* People Section */}
         <ContactDetailSectionContainer>
           {loading || !data ? (
             <>
@@ -103,9 +99,7 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
           )}
         </ContactDetailSectionContainer>
         <Divider />
-        {
-          // Mailing Section
-        }
+        {/* Mailing Section */}
         <ContactDetailSectionContainer>
           <ContactDetailHeadingContainer>
             <ContactDetailHeadingText variant="h6">
@@ -126,9 +120,7 @@ export const ContactDetailsTab: React.FC<ContactDetailTabProps> = ({
           )}
         </ContactDetailSectionContainer>
         <Divider />
-        {
-          // other Section
-        }
+        {/* Other Section */}
         <ContactDetailSectionContainer>
           <ContactDetailHeadingContainer>
             <ContactDetailHeadingText variant="h6">

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/ContactDonationsTab.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/ContactDonationsTab.tsx
@@ -67,7 +67,7 @@ export const ContactDonationsTab: React.FC<ContactDonationsProp> = ({
   accountListId,
   contactId,
 }) => {
-  const { data, loading } = useGetContactDonationsQuery({
+  const { data } = useGetContactDonationsQuery({
     variables: {
       accountListId: accountListId,
       contactId: contactId,
@@ -127,14 +127,14 @@ export const ContactDonationsTab: React.FC<ContactDonationsProp> = ({
           />
         </StyledTabPanel>
         <StyledTabPanel value={DonationTabKey.PartnershipInfo}>
-          {loading ? (
+          {!data ? (
             new Array(10)
               .fill(null)
               .map((_, index) => (
                 <PartnershipInfoLoadingPlaceHolder key={index} />
               ))
           ) : (
-            <PartnershipInfo contact={data?.contact ?? null} />
+            <PartnershipInfo contact={data.contact} />
           )}
         </StyledTabPanel>
       </TabContext>

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/DonationsGraph/DonationsGraph.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/DonationsGraph/DonationsGraph.tsx
@@ -39,13 +39,12 @@ export const DonationsGraph: React.FC<DonationsGraphProps> = ({
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
-  const skipped = !donorAccountIds;
-  const { data, loading } = useGetDonationsGraphQuery({
+  const { data } = useGetDonationsGraphQuery({
     variables: {
       accountListId: accountListId,
       donorAccountIds: donorAccountIds,
     },
-    skip: skipped,
+    skip: !donorAccountIds,
   });
 
   const monthFormatter = useMemo(
@@ -101,7 +100,7 @@ export const DonationsGraph: React.FC<DonationsGraphProps> = ({
         </Typography>
       )}
       <GraphContainer>
-        {loading || skipped ? (
+        {!data ? (
           <Skeleton
             variant="rounded"
             width="100%"

--- a/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTasksTab.tsx
+++ b/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTasksTab.tsx
@@ -107,7 +107,7 @@ export const ContactTasksTab: React.FC<ContactTasksTabProps> = ({
       tasksFilter: {
         contactIds: [contactId],
         ...starredFilter,
-        wildcardSearch: searchTerm as string,
+        wildcardSearch: searchTerm,
       },
     },
   });
@@ -116,7 +116,7 @@ export const ContactTasksTab: React.FC<ContactTasksTabProps> = ({
     () => ({
       contactIds: [contactId],
       ...starredFilter,
-      wildcardSearch: searchTerm as string,
+      wildcardSearch: searchTerm,
     }),
     [starredFilter, searchTerm],
   );


### PR DESCRIPTION
## Description

When Apollo queries are executed, `data` will be the cached data, but `loading` will still be `true` until the network request completes and the freshest data is available. Any time we show a loading spinner or skeleton when `loading` is true, we are ignoring the cached data that is already available. This PR makes the components in the contact details panel display cached data immediately if it is available.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
