### PR TITLE
HS-1142757 - Organizations links on Settings aren't rendering correctly

### DIFF
--- a/pages/accountLists/[accountListId]/settings/organizations.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/organizations.page.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, useEffect, useState } from 'react';
 import { Autocomplete, Box, Skeleton, TextField } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
-import { enforceAdmin } from 'pages/api/utils/pagePropsHelpers';
+import { loadSession } from 'pages/api/utils/pagePropsHelpers';
 import { ImpersonateUserAccordion } from 'src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion';
 import { ManageOrganizationAccessAccordion } from 'src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion';
 import { AccordionGroup } from 'src/components/Shared/Forms/Accordions/AccordionGroup';
@@ -144,6 +144,6 @@ const Organizations = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = enforceAdmin;
+export const getServerSideProps = loadSession;
 
 export default Organizations;

--- a/pages/accountLists/[accountListId]/settings/organizations/accountLists.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/organizations/accountLists.page.tsx
@@ -10,7 +10,7 @@ import {
 import { styled } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTranslation } from 'react-i18next';
-import { enforceAdmin } from 'pages/api/utils/pagePropsHelpers';
+import { loadSession } from 'pages/api/utils/pagePropsHelpers';
 import { AccountLists } from 'src/components/Settings/Organization/AccountLists/AccountLists';
 import { useDebouncedValue } from 'src/hooks/useDebounce';
 import { SettingsWrapper } from '../Wrapper';
@@ -123,6 +123,6 @@ const AccountListsOrganizations = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = enforceAdmin;
+export const getServerSideProps = loadSession;
 
 export default AccountListsOrganizations;

--- a/pages/accountLists/[accountListId]/settings/organizations/contacts.page.test.tsx
+++ b/pages/accountLists/[accountListId]/settings/organizations/contacts.page.test.tsx
@@ -1,22 +1,15 @@
-import { GetServerSidePropsContext } from 'next';
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { getSession } from 'next-auth/react';
 import { I18nextProvider } from 'react-i18next';
-import { session } from '__tests__/fixtures/session';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { OrganizationsQuery } from '../organizations.generated';
-import OrganizationsContacts, { getServerSideProps } from './contacts.page';
+import OrganizationsContacts from './contacts.page';
 
 jest.useFakeTimers();
-interface GetServerSidePropsReturn {
-  props: unknown;
-  redirect: unknown;
-}
 
 const Components = ({ mutationSpy }: { mutationSpy?: () => void }) => (
   <ThemeProvider theme={theme}>
@@ -49,140 +42,87 @@ const Components = ({ mutationSpy }: { mutationSpy?: () => void }) => (
 );
 
 describe('OrganizationsContacts', () => {
-  const context = {
-    query: {
-      accountListId: 'accountListId',
-    },
-  } as unknown as GetServerSidePropsContext;
+  it('should render skeletons while contacts are loading', async () => {
+    const { queryByRole, getByTestId, queryByTestId, getByRole } = render(
+      <Components />,
+    );
 
-  describe('No admin access', () => {
-    it('should redirect to dashboard', async () => {
-      (getSession as jest.MockedFn<typeof getSession>).mockResolvedValue({
-        ...session,
-        user: {
-          ...session.user,
-          admin: false,
-        },
-      });
+    expect(getByTestId('skeleton')).toBeInTheDocument();
+    expect(
+      queryByRole('combobox', {
+        name: /filter by organization/i,
+      }),
+    ).not.toBeInTheDocument();
 
-      const { props, redirect } = (await getServerSideProps(
-        context,
-      )) as GetServerSidePropsReturn;
-
-      expect(props).toBeUndefined();
-      expect(redirect).toEqual({
-        destination: '/accountLists/accountListId',
-        permanent: false,
-      });
+    await waitFor(() => {
+      expect(queryByTestId('skeleton')).not.toBeInTheDocument();
     });
+
+    const autoCompleteInput = getByRole('combobox', {
+      name: /filter by organization/i,
+    });
+    expect(autoCompleteInput).toBeInTheDocument();
   });
 
-  describe('Has admin access', () => {
-    const adminSession = {
-      ...session,
-      user: {
-        ...session.user,
-        admin: true,
-      },
-    };
+  it('should call GraphQL on organization and contact search, debouncing requests every 1000ms', async () => {
+    const mutationSpy = jest.fn();
+    const { getByRole, queryByRole, queryByTestId } = render(
+      <Components mutationSpy={mutationSpy} />,
+    );
 
-    beforeEach(() => {
-      (getSession as jest.MockedFn<typeof getSession>).mockResolvedValue(
-        adminSession,
-      );
+    await waitFor(() => {
+      expect(queryByTestId('skeleton')).not.toBeInTheDocument();
     });
 
-    it('renders page without redirecting admin', async () => {
-      const { props, redirect } = (await getServerSideProps(
-        context as GetServerSidePropsContext,
-      )) as GetServerSidePropsReturn;
-
-      expect(redirect).toBeUndefined();
-      expect(props).toEqual({ session: adminSession });
+    const autoCompleteInput = getByRole('combobox', {
+      name: /filter by organization/i,
     });
 
-    it('should render skeletons while contacts are loading', async () => {
-      const { queryByRole, getByTestId, queryByTestId, getByRole } = render(
-        <Components />,
-      );
-
-      expect(getByTestId('skeleton')).toBeInTheDocument();
-      expect(
-        queryByRole('combobox', {
-          name: /filter by organization/i,
-        }),
-      ).not.toBeInTheDocument();
-
-      await waitFor(() => {
-        expect(queryByTestId('skeleton')).not.toBeInTheDocument();
-      });
-
-      const autoCompleteInput = getByRole('combobox', {
-        name: /filter by organization/i,
-      });
-      expect(autoCompleteInput).toBeInTheDocument();
-    });
-
-    it('should call GraphQL on organization and contact search, debouncing requests every 1000ms', async () => {
-      const mutationSpy = jest.fn();
-      const { getByRole, queryByRole, queryByTestId } = render(
-        <Components mutationSpy={mutationSpy} />,
-      );
-
-      await waitFor(() => {
-        expect(queryByTestId('skeleton')).not.toBeInTheDocument();
-      });
-
-      const autoCompleteInput = getByRole('combobox', {
-        name: /filter by organization/i,
-      });
-
-      expect(
-        queryByRole('textbox', {
-          name: /search contacts/i,
-        }),
-      ).not.toBeInTheDocument();
-
-      await waitFor(() =>
-        expect(mutationSpy).toHaveGraphqlOperation('Organizations'),
-      );
-
-      userEvent.type(autoCompleteInput, 'Org');
-      expect(getByRole('option', { name: 'Org1' })).toBeInTheDocument();
-      userEvent.click(getByRole('option', { name: 'Org2' }));
-
-      const accountInput = getByRole('textbox', {
+    expect(
+      queryByRole('textbox', {
         name: /search contacts/i,
-      });
+      }),
+    ).not.toBeInTheDocument();
 
-      userEvent.type(accountInput, 'T');
-      jest.advanceTimersByTime(300);
-      userEvent.type(accountInput, 'e');
-      jest.advanceTimersByTime(300);
-      userEvent.type(accountInput, 'st');
-      jest.advanceTimersByTime(1000);
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('Organizations'),
+    );
 
-      await waitFor(() =>
-        expect(mutationSpy).toHaveGraphqlOperation(
-          'SearchOrganizationsContacts',
-          {
-            input: {
-              organizationId: '222',
-              search: 'Test',
-            },
-          },
-        ),
-      );
+    userEvent.type(autoCompleteInput, 'Org');
+    expect(getByRole('option', { name: 'Org1' })).toBeInTheDocument();
+    userEvent.click(getByRole('option', { name: 'Org2' }));
 
-      // Ensure that debouncing worked and intermediate searches were not performed
-      expect(mutationSpy).not.toHaveGraphqlOperation(
+    const accountInput = getByRole('textbox', {
+      name: /search contacts/i,
+    });
+
+    userEvent.type(accountInput, 'T');
+    jest.advanceTimersByTime(300);
+    userEvent.type(accountInput, 'e');
+    jest.advanceTimersByTime(300);
+    userEvent.type(accountInput, 'st');
+    jest.advanceTimersByTime(1000);
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation(
         'SearchOrganizationsContacts',
         {
           input: {
-            search: 'T',
+            organizationId: '222',
+            search: 'Test',
           },
         },
-      );
-    });
+      ),
+    );
+
+    // Ensure that debouncing worked and intermediate searches were not performed
+    expect(mutationSpy).not.toHaveGraphqlOperation(
+      'SearchOrganizationsContacts',
+      {
+        input: {
+          search: 'T',
+        },
+      },
+    );
   });
 });

--- a/pages/accountLists/[accountListId]/settings/organizations/contacts.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/organizations/contacts.page.tsx
@@ -10,7 +10,7 @@ import {
 import { styled } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTranslation } from 'react-i18next';
-import { enforceAdmin } from 'pages/api/utils/pagePropsHelpers';
+import { loadSession } from 'pages/api/utils/pagePropsHelpers';
 import { Contacts } from 'src/components/Settings/Organization/Contacts/Contacts';
 import { useDebouncedValue } from 'src/hooks/useDebounce';
 import { SettingsWrapper } from '../Wrapper';
@@ -124,6 +124,6 @@ const OrganizationsContacts = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = enforceAdmin;
+export const getServerSideProps = loadSession;
 
 export default OrganizationsContacts;

--- a/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.graphql
+++ b/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.graphql
@@ -1,0 +1,9 @@
+query ManageOrganizationsAccess {
+  user {
+    administrativeOrganizations(first: 1) {
+      nodes {
+        id
+      }
+    }
+  }
+}

--- a/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import Close from '@mui/icons-material/Close';
 import {
   Box,
@@ -9,6 +9,7 @@ import {
   Typography,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { Session } from 'next-auth';
 import { useTranslation } from 'react-i18next';
 import { makeStyles } from 'tss-react/mui';
 import { useGetDesignationAccountsQuery } from 'src/components/EditDonationModal/EditDonationModal.generated';
@@ -18,7 +19,11 @@ import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useRequiredSession } from 'src/hooks/useRequiredSession';
 import { Item } from './Item/Item';
 import { useManageOrganizationsAccessQuery } from './MultiPageMenu.generated';
-import { reportNavItems, settingsNavItems } from './MultiPageMenuItems';
+import {
+  NavItems,
+  reportNavItems,
+  settingsNavItems,
+} from './MultiPageMenuItems';
 
 export enum NavTypeEnum {
   Reports = 'reports',
@@ -54,6 +59,31 @@ const FilterList = styled(List)(({ theme }) => ({
     marginBottom: theme.spacing(2),
   },
 }));
+
+type ShowMenuItemProps = {
+  item: NavItems;
+  user: Session['user'];
+  hasOrganizationsAccess: boolean;
+};
+
+const showMenuItem = ({
+  item,
+  user,
+  hasOrganizationsAccess,
+}: ShowMenuItemProps): boolean => {
+  if (item?.grantedAccess?.length) {
+    if (hasOrganizationsAccess && item.id.startsWith('organizations')) {
+      return true;
+    }
+    if (item.grantedAccess.indexOf('admin') !== -1 && user.admin) {
+      return true;
+    }
+    if (item.grantedAccess.indexOf('developer') !== -1 && user.developer) {
+      return true;
+    }
+  } else return true;
+  return false;
+};
 
 export const MultiPageMenu: React.FC<Props & BoxProps> = ({
   selectedId,
@@ -130,31 +160,9 @@ export const MultiPageMenu: React.FC<Props & BoxProps> = ({
                   />
                 )}
               {navItems.map((item) => {
-                const showItem = useMemo(() => {
-                  if (item?.grantedAccess?.length) {
-                    if (
-                      hasOrganizationsAccess &&
-                      ['organizations'].includes(item.id)
-                    ) {
-                      return true;
-                    }
-                    if (
-                      item.grantedAccess.indexOf('admin') !== -1 &&
-                      user.admin
-                    ) {
-                      return true;
-                    }
-                    if (
-                      item.grantedAccess.indexOf('developer') !== -1 &&
-                      user.developer
-                    ) {
-                      return true;
-                    }
-                  } else return true;
-                  return false;
-                }, [item, user]);
-
-                if (!showItem) return null;
+                if (!showMenuItem({ item, user, hasOrganizationsAccess })) {
+                  return null;
+                }
                 return (
                   <Item
                     key={item.id}

--- a/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.tsx
@@ -17,6 +17,7 @@ import { MultiselectFilter } from 'src/graphql/types.generated';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useRequiredSession } from 'src/hooks/useRequiredSession';
 import { Item } from './Item/Item';
+import { useManageOrganizationsAccessQuery } from './MultiPageMenu.generated';
 import { reportNavItems, settingsNavItems } from './MultiPageMenuItems';
 
 export enum NavTypeEnum {
@@ -72,6 +73,12 @@ export const MultiPageMenu: React.FC<Props & BoxProps> = ({
   const navTitle =
     navType === NavTypeEnum.Reports ? t('Reports') : t('Settings');
 
+  const { data: organizations } = useManageOrganizationsAccessQuery({
+    skip: navType === NavTypeEnum.Reports,
+  });
+  const hasOrganizationsAccess =
+    !!organizations?.user.administrativeOrganizations.nodes.length;
+
   const { data } = useGetDesignationAccountsQuery({
     variables: {
       accountListId: accountListId ?? '',
@@ -125,6 +132,12 @@ export const MultiPageMenu: React.FC<Props & BoxProps> = ({
               {navItems.map((item) => {
                 const showItem = useMemo(() => {
                   if (item?.grantedAccess?.length) {
+                    if (
+                      hasOrganizationsAccess &&
+                      ['organizations'].includes(item.id)
+                    ) {
+                      return true;
+                    }
                     if (
                       item.grantedAccess.indexOf('admin') !== -1 &&
                       user.admin


### PR DESCRIPTION
## Description
[HelpScout issue](https://secure.helpscout.net/conversation/2578696149/1142757?folderId=7296147)
The Organization links are only shown if the user is an admin. However, on the old MPDx, users who weren't admins but managed at least one organization could see the page.

This PR allows users who manage an organization and aren't an admin to view the links and visit the page.


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
