### PR TITLE
HS 1144092 - Fixing error of setting wrong accountList when impersonating

### DIFF
--- a/pages/api/handoff.page.test.ts
+++ b/pages/api/handoff.page.test.ts
@@ -206,7 +206,7 @@ describe('Handoff', () => {
         const redirectUrl = await returnRedirectUrl(nextApiRequest, true);
 
         expect(redirectUrl).toEqual(
-          `https://${rewriteDomain}/handoff?accessToken=${impersonatorApiToken}&accountListId=${accountListId}-1&userId=${userID}&path=${queryPath}`,
+          `https://${rewriteDomain}/handoff?accessToken=${impersonatorApiToken}&accountListId=${defaultAccountList}&userId=${userID}&path=${queryPath}`,
         );
       });
     });

--- a/pages/api/handoff.page.ts
+++ b/pages/api/handoff.page.ts
@@ -41,9 +41,16 @@ export const returnRedirectUrl = async (
       data: { user, accountLists },
     } = response;
 
+    // When impersonating and useImpersonatorToken is set to TRUE
+    // - Fetch GraphQL data with the Impersonators ApiToken
+    // - This allows us to grab their accountListId when sending the impersonator back to the old MPDx
+    // When not impersonating and useImpersonatorToken is set to FALSE
+    // - We fetch the graphQL data with the user's ApiToken
+    // - By default use the accountListId from the request query
+
     const defaultAccountID =
       isImpersonating && user.defaultAccountList
-        ? user.defaultAccountList
+        ? user.defaultAccountList || accountLists?.nodes[0]?.id
         : req.query?.accountListId ||
           user.defaultAccountList ||
           accountLists?.nodes[0]?.id;


### PR DESCRIPTION
## Description
https://secure.helpscout.net/conversation/2580546553/1144092?folderId=7296147
Fixing error when redirected back to old MPDx after impersonating - Ensuerung the Impersonators accountListId is used.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
