### PR TITLE
[no-Jira] Fix MUI menu component error

### DIFF
--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
@@ -256,7 +256,7 @@ const ProfileMenu = (): ReactElement => {
           </AccountListSelectorDetails>
         </Accordion>
         {accountListId && (
-          <>
+          <div>
             <Divider />
             <Link
               href={`/accountLists/${accountListId}/settings/preferences`}
@@ -329,7 +329,7 @@ const ProfileMenu = (): ReactElement => {
                 </MenuItem>
               </HandoffLink>
             )}
-          </>
+          </div>
         )}
         <MenuItem>
           {session.impersonating && (


### PR DESCRIPTION
## Description

Fixes the `MUI: The Menu component doesn't accept a Fragment as a child.` error introduced in #925.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
