### PR TITLE
MPDX-7892 - Connect Services organization modals referring to incorrect organization

### DIFF
--- a/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
+++ b/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
@@ -364,7 +364,9 @@ describe('OrganizationAccordion', () => {
 
       await waitFor(() => {
         expect(
-          getByText('Are you sure you wish to disconnect this organization?'),
+          getByText(
+            'Are you sure you wish to disconnect the organization "organizationName"?',
+          ),
         ).toBeInTheDocument();
       });
       userEvent.click(getByText('Yes'));

--- a/src/components/Settings/integrations/Organization/OrganizationAccordion.tsx
+++ b/src/components/Settings/integrations/Organization/OrganizationAccordion.tsx
@@ -87,15 +87,6 @@ export const OrganizationAccordion: React.FC<OrganizationAccordionProps> = ({
   handleAccordionChange,
   expandedPanel,
 }) => {
-  const [selectedOrganization, setSelectedOrganization] =
-    useState<OrganizationAccountPartial | null>(null);
-  const [showAddAccountModal, setShowAddAccountModal] = useState(false);
-  const [showImportDataSyncModal, setShowImportDataSyncModal] = useState(false);
-  const [showDeleteOrganizationModal, setShowDeleteOrganizationModal] =
-    useState(false);
-  const [showEditOrganizationModal, setShowEditOrganizationModal] =
-    useState(false);
-
   const { t } = useTranslation();
   const accountListId = useAccountListId();
   const { enqueueSnackbar } = useSnackbar();
@@ -103,6 +94,14 @@ export const OrganizationAccordion: React.FC<OrganizationAccordionProps> = ({
   const [deleteOrganizationAccount] = useDeleteOrganizationAccountMutation();
   const [syncOrganizationAccount] = useSyncOrganizationAccountMutation();
   const { getOrganizationOauthUrl: getOauthUrl } = useOauthUrl();
+
+  const [showAddAccountModal, setShowAddAccountModal] = useState(false);
+  const [importDataSyncModal, setImportDataSyncModal] =
+    useState<OrganizationAccountPartial | null>(null);
+  const [deleteOrganizationModal, setDeleteOrganizationModal] =
+    useState<OrganizationAccountPartial | null>(null);
+  const [editOrganizationModal, setEditOrganizationModal] =
+    useState<OrganizationAccountPartial | null>(null);
 
   const {
     data,
@@ -176,27 +175,6 @@ export const OrganizationAccordion: React.FC<OrganizationAccordionProps> = ({
         );
       },
     });
-  };
-
-  const handleOpenEditOrganizationModal = (
-    organizationAccount: OrganizationAccountPartial,
-  ) => {
-    setShowEditOrganizationModal(true);
-    setSelectedOrganization(organizationAccount);
-  };
-
-  const handleOpenDeleteOrganizationModal = (
-    organizationAccount: OrganizationAccountPartial,
-  ) => {
-    setShowDeleteOrganizationModal(true);
-    setSelectedOrganization(organizationAccount);
-  };
-
-  const handleOpenImportDataSyncModal = (
-    organizationAccount: OrganizationAccountPartial,
-  ) => {
-    setShowImportDataSyncModal(true);
-    setSelectedOrganization(organizationAccount);
   };
 
   return (
@@ -284,7 +262,7 @@ export const OrganizationAccordion: React.FC<OrganizationAccordionProps> = ({
                         size="small"
                         sx={{ m: '0 0 0 10px' }}
                         onClick={() =>
-                          handleOpenImportDataSyncModal(organizationAccount)
+                          setImportDataSyncModal(organizationAccount)
                         }
                       >
                         {t('Import TntConnect DataSync file')}
@@ -304,7 +282,7 @@ export const OrganizationAccordion: React.FC<OrganizationAccordionProps> = ({
                     {type === OrganizationTypesEnum.LOGIN && (
                       <OrganizationDeleteIconButton
                         onClick={() =>
-                          handleOpenEditOrganizationModal(organizationAccount)
+                          setEditOrganizationModal(organizationAccount)
                         }
                       >
                         <Edit />
@@ -312,7 +290,7 @@ export const OrganizationAccordion: React.FC<OrganizationAccordionProps> = ({
                     )}
                     <OrganizationDeleteIconButton
                       onClick={() =>
-                        handleOpenDeleteOrganizationModal(organizationAccount)
+                        setDeleteOrganizationModal(organizationAccount)
                       }
                     >
                       <DeleteIcon />
@@ -365,31 +343,31 @@ export const OrganizationAccordion: React.FC<OrganizationAccordionProps> = ({
         />
       )}
 
-      {showImportDataSyncModal && selectedOrganization && (
+      {importDataSyncModal && (
         <OrganizationImportDataSyncModal
-          handleClose={() => setShowImportDataSyncModal(false)}
-          organizationId={selectedOrganization.id}
-          organizationName={selectedOrganization.organization.name}
+          handleClose={() => setImportDataSyncModal(null)}
+          organizationId={importDataSyncModal.id}
+          organizationName={importDataSyncModal.organization.name}
           accountListId={accountListId ?? ''}
         />
       )}
 
-      {showEditOrganizationModal && selectedOrganization && (
+      {editOrganizationModal && (
         <OrganizationEditAccountModal
-          handleClose={() => setShowEditOrganizationModal(false)}
-          organizationId={selectedOrganization.id}
+          handleClose={() => setEditOrganizationModal(null)}
+          organizationId={editOrganizationModal.id}
         />
       )}
 
-      {showDeleteOrganizationModal && selectedOrganization && (
+      {deleteOrganizationModal && (
         <Confirmation
           isOpen={true}
           title={t('Confirm')}
           message={t(
-            `Are you sure you wish to disconnect the organization "${selectedOrganization.organization.name}"?`,
+            `Are you sure you wish to disconnect the organization "${deleteOrganizationModal.organization.name}"?`,
           )}
-          handleClose={() => setShowDeleteOrganizationModal(false)}
-          mutation={() => handleDelete(selectedOrganization.id)}
+          handleClose={() => setDeleteOrganizationModal(null)}
+          mutation={() => handleDelete(deleteOrganizationModal.id)}
         />
       )}
     </AccordionItem>


### PR DESCRIPTION
## Description
[HelpScout ticket](https://secure.helpscout.net/conversation/2583630493/1145680?folderId=7296147)
On Connect Services, the organization modals "OrganizationImportDataSyncModal", "OrganizationEditAccountModal" etc. were always defaulting to the first organization.

This fix ensures if the users have multiple organizations, the organization selected is the organization referred to in the modals.

Changed the deleted text to ensure the user understands which organization they are deleting.


## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
