### PR TITLE
MPDX-7891 - Allow contact search on Organization Accounts without organization selected

### DIFF
--- a/pages/accountLists/[accountListId]/settings/organizations/accountLists.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/organizations/accountLists.page.tsx
@@ -64,26 +64,24 @@ const AccountListsOrganizations = (): ReactElement => {
         {organizations?.length && (
           <HeaderAndDropdown>
             <Box>
-              {selectedOrganization && (
-                <TextField
-                  label={t('Search Account Lists')}
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  fullWidth
-                  multiline
-                  inputProps={{ 'aria-label': 'Search Account Lists' }}
-                  style={{
-                    width: matches ? '150px' : '250px',
-                  }}
-                  InputProps={{
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <PersonSearchIcon />
-                      </InputAdornment>
-                    ),
-                  }}
-                />
-              )}
+              <TextField
+                label={t('Search Account Lists')}
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                fullWidth
+                multiline
+                inputProps={{ 'aria-label': 'Search Account Lists' }}
+                style={{
+                  width: matches ? '150px' : '250px',
+                }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <PersonSearchIcon />
+                    </InputAdornment>
+                  ),
+                }}
+              />
             </Box>
             <Box>
               <Autocomplete

--- a/pages/api/Schema/Settings/Organizations/SearchOrganizationsAccountLists/SearchOrganizationsAccountLists.graphql
+++ b/pages/api/Schema/Settings/Organizations/SearchOrganizationsAccountLists/SearchOrganizationsAccountLists.graphql
@@ -5,7 +5,7 @@ extend type Query {
 }
 
 input SearchOrganizationsAccountListsInput {
-  organizationId: ID!
+  organizationId: ID
   search: String!
   pageNumber: Int
 }

--- a/pages/api/Schema/Settings/Organizations/SearchOrganizationsAccountLists/resolvers.ts
+++ b/pages/api/Schema/Settings/Organizations/SearchOrganizationsAccountLists/resolvers.ts
@@ -8,9 +8,9 @@ const SearchOrganizationsAccountListsResolvers: Resolvers = {
       { dataSources },
     ) => {
       return dataSources.mpdxRestApi.searchOrganizationsAccountLists(
-        organizationId,
         search,
         pageNumber || 1,
+        organizationId || '',
       );
     },
   },

--- a/pages/api/graphql-rest.page.ts
+++ b/pages/api/graphql-rest.page.ts
@@ -1221,18 +1221,19 @@ class MpdxRestApi extends RESTDataSource {
   //
 
   async searchOrganizationsAccountLists(
-    organizationId: string,
     search: string,
     pageNumber = 1,
+    organizationId?: string,
   ) {
     const include =
       'account_list_users,account_list_coaches,account_list_users.user_email_addresses,' +
       'account_list_coaches.coach_email_addresses,designation_accounts,' +
       'designation_accounts.organization,account_list_invites,' +
       'account_list_invites.invited_by_user';
-    const filters =
-      `filter[organization_id]=${organizationId}` +
-      `&filter[wildcard_search]=${search}`;
+    const organizationIdFilter = organizationId
+      ? `&filter[organization_id]=${organizationId}`
+      : '';
+    const filters = `filter[wildcard_search]=${search}` + organizationIdFilter;
     const fields =
       'fields[account_lists]=name,account_list_coaches,account_list_users,account_list_invites,designation_accounts' +
       '&fields[account_list_coaches]=coach_first_name,coach_last_name,coach_email_addresses' +

--- a/src/components/Settings/Organization/AccountLists/AccountLists.tsx
+++ b/src/components/Settings/Organization/AccountLists/AccountLists.tsx
@@ -30,7 +30,7 @@ export const AccountLists: React.FC = () => {
         search: search,
       },
     },
-    skip: !selectedOrganizationId,
+    skip: !selectedOrganizationId && !search,
   });
 
   const accountLists = data?.searchOrganizationsAccountLists.accountLists;


### PR DESCRIPTION
## Description
[MPDX-7891](https://jira.cru.org/secure/RapidBoard.jspa?rapidView=3&view=detail&selectedIssue=MPDX-7891)
Allow contact search on the Organization Accounts page without an organization being selected. I added this to speed up the search, but the admin needs to search contacts without an organization being selected for a broader search.


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
