### PR TITLE
[MPDX-7894] Replace HelpScout beacon with custom help beacon

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Note: there is a test account you can use. Get this from another developer if yo
 - `DATADOG_APP_ID` - Datadog tracking application ID.
 - `DATADOG_CLIENT_TOKEN` - Datadog tracking client token.
 - `DD_ENV` - Datadog environment.
+- `HELP_URL` - URL that the floating help button will redirect to
 - `BEACON_TOKEN` - HelpScout beacon token
 - `HS_CONTACTS_SUGGESTIONS` - Comma-separated IDs of the HelpScout articles to suggest on the contacts page
 - `HS_CONTACTS_CONTACT_SUGGESTIONS` - Comma-separated IDs of the HelpScout articles to suggest on the contact page

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ Note: there is a test account you can use. Get this from another developer if yo
 - `DATADOG_APP_ID` - Datadog tracking application ID.
 - `DATADOG_CLIENT_TOKEN` - Datadog tracking client token.
 - `DD_ENV` - Datadog environment.
-- `HELP_URL` - URL that the floating help button will redirect to
+- `HELP_URLS` - JSON object that maps language codes to the URL that the floating help button will redirect to
+  - Example: `{"en-us":"https://docs.com/en/","fr-fr":"https://docs.com/fr/","default":"https://docs.com/en/"}`
+  - The keys should match the language ids defined in `src/lib/data/languages.ts`
+  - You can also set a `default` key that will be used if there isn't a help URL for the user's language preference
 - `BEACON_TOKEN` - HelpScout beacon token
 - `HS_CONTACTS_SUGGESTIONS` - Comma-separated IDs of the HelpScout articles to suggest on the contacts page
 - `HS_CONTACTS_CONTACT_SUGGESTIONS` - Comma-separated IDs of the HelpScout articles to suggest on the contact page

--- a/amplify.yml
+++ b/amplify.yml
@@ -22,7 +22,7 @@ frontend:
         - yarn -v
         - yarn
         - yarn disable-telemetry
-        - yarn gql
+        - API_URL=https://api.mpdx.org/graphql yarn gql
     build:
       commands:
         - yarn build:amplify

--- a/next.config.js
+++ b/next.config.js
@@ -76,7 +76,7 @@ const config = {
         process.env.DATADOG_APP_ID &&
         process.env.DATADOG_CLIENT_TOKEN,
     ).toString(),
-    HELP_URL: process.env.HELP_URL,
+    HELP_URLS: process.env.HELP_URLS,
     HS_COACHING_ACTIVITY_SUMMARY: process.env.HS_COACHING_ACTIVITY_SUMMARY,
     HS_COACHING_ACTIVITY: process.env.HS_COACHING_ACTIVITY,
     HS_COACHING_APPOINTMENTS_AND_RESULTS:

--- a/next.config.js
+++ b/next.config.js
@@ -76,6 +76,7 @@ const config = {
         process.env.DATADOG_APP_ID &&
         process.env.DATADOG_CLIENT_TOKEN,
     ).toString(),
+    HELP_URL: process.env.HELP_URL,
     HS_COACHING_ACTIVITY_SUMMARY: process.env.HS_COACHING_ACTIVITY_SUMMARY,
     HS_COACHING_ACTIVITY: process.env.HS_COACHING_ACTIVITY,
     HS_COACHING_APPOINTMENTS_AND_RESULTS:

--- a/pages/_app.page.test.tsx
+++ b/pages/_app.page.test.tsx
@@ -1,0 +1,23 @@
+import { parseHelpUrls } from './_app.page';
+
+describe('parseHelpUrls', () => {
+  it('is empty when the input is null', () => {
+    expect(parseHelpUrls(null)).toEqual({});
+  });
+
+  it('is empty when the input is an empty string', () => {
+    expect(parseHelpUrls('')).toEqual({});
+  });
+
+  it('is empty when the input is invalid JSON', () => {
+    expect(parseHelpUrls('{"a":"1"')).toEqual({});
+  });
+
+  it('is empty when the input is not an object', () => {
+    expect(parseHelpUrls('0')).toEqual({});
+  });
+
+  it('parses the input as JSON an object', () => {
+    expect(parseHelpUrls('{"a":"1","b":"2"}')).toEqual({ a: '1', b: '2' });
+  });
+});

--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -21,7 +21,7 @@ import { I18nextProvider, useTranslation } from 'react-i18next';
 import Rollbar from 'rollbar';
 import DataDog from 'src/components/DataDog/DataDog';
 import { GlobalStyles } from 'src/components/GlobalStyles/GlobalStyles';
-import HelpscoutBeacon from 'src/components/Helpscout/HelpscoutBeacon';
+import { HelpBeacon } from 'src/components/HelpBeacon/HelpBeacon';
 import PrimaryLayout from 'src/components/Layouts/Primary';
 import Loading from 'src/components/Loading';
 import { RouterGuard } from 'src/components/RouterGuard/RouterGuard';
@@ -35,7 +35,6 @@ import { useRequiredSession } from 'src/hooks/useRequiredSession';
 import makeClient from 'src/lib/apollo/client';
 import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
-import './helpscout.css';
 import './print.css';
 
 export type PageWithLayout = NextPage & {
@@ -167,11 +166,13 @@ const App = ({
         <ErrorBoundary>
           <AppSettingsProvider>
             <SessionProvider session={session}>
-              <HelpscoutBeacon />
               <I18nextProvider i18n={i18n}>
                 <StyledEngineProvider injectFirst>
                   <CacheProvider value={emotionCache}>
                     <ThemeProvider theme={theme}>
+                      {process.env.HELP_URL && (
+                        <HelpBeacon helpUrl={process.env.HELP_URL} />
+                      )}
                       <LocalizationProvider
                         dateAdapter={AdapterLuxon}
                         localeText={{

--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -37,6 +37,18 @@ import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import './print.css';
 
+export const parseHelpUrls = (
+  helpUrlsEnv: string | null,
+): Record<string, string> => {
+  try {
+    const helpUrls = helpUrlsEnv && JSON.parse(helpUrlsEnv);
+    if (helpUrls && typeof helpUrls === 'object') {
+      return helpUrls;
+    }
+  } catch {}
+  return {};
+};
+
 export type PageWithLayout = NextPage & {
   layout?: React.FC;
 };
@@ -101,6 +113,11 @@ const App = ({
       'A session was not provided via page props. Make sure that getServerSideProps for this page returns the session in its props.',
     );
   }
+
+  const helpUrls = useMemo(
+    () => parseHelpUrls(process.env.HELP_URLS ?? null),
+    [],
+  );
 
   const pageContent = (
     <TaskModalProvider>
@@ -170,9 +187,7 @@ const App = ({
                 <StyledEngineProvider injectFirst>
                   <CacheProvider value={emotionCache}>
                     <ThemeProvider theme={theme}>
-                      {process.env.HELP_URL && (
-                        <HelpBeacon helpUrl={process.env.HELP_URL} />
-                      )}
+                      <HelpBeacon helpUrls={helpUrls} />
                       <LocalizationProvider
                         dateAdapter={AdapterLuxon}
                         localeText={{

--- a/src/components/HelpBeacon/HelpBeacon.test.tsx
+++ b/src/components/HelpBeacon/HelpBeacon.test.tsx
@@ -5,13 +5,16 @@ import theme from 'src/theme';
 import { HelpBeacon } from './HelpBeacon';
 
 const helpUrls = {
-  'en-us': 'https://google.us',
-  'es-419': 'https://google.es',
-  'fr-fr': 'https://google.fr',
-  default: 'https://google.com',
+  'en-us': 'https://google.us/',
+  'es-419': 'https://google.es/',
+  'fr-fr': 'https://google.fr/',
+  default: 'https://google.com/',
 };
 
 describe('HelpBeacon', () => {
+  const attributes =
+    '?mpdxName=First+Last&mpdxEmail=first.last%40cru.org&mpdxUrl=http%3A%2F%2Flocalhost%2F';
+
   it('uses the current language', () => {
     i18n.changeLanguage('en-us');
 
@@ -20,7 +23,10 @@ describe('HelpBeacon', () => {
         <HelpBeacon helpUrls={helpUrls} />
       </ThemeProvider>,
     );
-    expect(getByRole('link')).toHaveAttribute('href', 'https://google.us');
+    expect(getByRole('link')).toHaveAttribute(
+      'href',
+      `https://google.us/${attributes}`,
+    );
   });
 
   it('falls back to the default language', async () => {
@@ -31,7 +37,10 @@ describe('HelpBeacon', () => {
         <HelpBeacon helpUrls={helpUrls} />
       </ThemeProvider>,
     );
-    expect(getByRole('link')).toHaveAttribute('href', 'https://google.com');
+    expect(getByRole('link')).toHaveAttribute(
+      'href',
+      `https://google.com/${attributes}`,
+    );
   });
 
   it('renders nothing if there is no fallback', () => {

--- a/src/components/HelpBeacon/HelpBeacon.test.tsx
+++ b/src/components/HelpBeacon/HelpBeacon.test.tsx
@@ -1,0 +1,16 @@
+import { ThemeProvider } from '@mui/material/styles';
+import { render } from '@testing-library/react';
+import theme from 'src/theme';
+import { HelpBeacon } from './HelpBeacon';
+
+describe('HelpBeacon', () => {
+  it('renders', () => {
+    const url = 'https://google.com';
+    const { getByRole } = render(
+      <ThemeProvider theme={theme}>
+        <HelpBeacon helpUrl={url} />
+      </ThemeProvider>,
+    );
+    expect(getByRole('link')).toHaveAttribute('href', url);
+  });
+});

--- a/src/components/HelpBeacon/HelpBeacon.test.tsx
+++ b/src/components/HelpBeacon/HelpBeacon.test.tsx
@@ -1,16 +1,58 @@
 import { ThemeProvider } from '@mui/material/styles';
-import { render } from '@testing-library/react';
+import { render } from '__tests__/util/testingLibraryReactMock';
+import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { HelpBeacon } from './HelpBeacon';
 
+const helpUrls = {
+  'en-us': 'https://google.us',
+  'es-419': 'https://google.es',
+  'fr-fr': 'https://google.fr',
+  default: 'https://google.com',
+};
+
 describe('HelpBeacon', () => {
-  it('renders', () => {
-    const url = 'https://google.com';
+  it('uses the current language', () => {
+    i18n.changeLanguage('en-us');
+
     const { getByRole } = render(
       <ThemeProvider theme={theme}>
-        <HelpBeacon helpUrl={url} />
+        <HelpBeacon helpUrls={helpUrls} />
       </ThemeProvider>,
     );
-    expect(getByRole('link')).toHaveAttribute('href', url);
+    expect(getByRole('link')).toHaveAttribute('href', 'https://google.us');
+  });
+
+  it('falls back to the default language', async () => {
+    await i18n.changeLanguage('ru');
+
+    const { getByRole } = render(
+      <ThemeProvider theme={theme}>
+        <HelpBeacon helpUrls={helpUrls} />
+      </ThemeProvider>,
+    );
+    expect(getByRole('link')).toHaveAttribute('href', 'https://google.com');
+  });
+
+  it('renders nothing if there is no fallback', () => {
+    i18n.changeLanguage('en-us');
+
+    const { queryByRole } = render(
+      <ThemeProvider theme={theme}>
+        <HelpBeacon helpUrls={{}} />
+      </ThemeProvider>,
+    );
+    expect(queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing if no help URLs are provided', () => {
+    i18n.changeLanguage('en-us');
+
+    const { queryByRole } = render(
+      <ThemeProvider theme={theme}>
+        <HelpBeacon helpUrls={null} />
+      </ThemeProvider>,
+    );
+    expect(queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/src/components/HelpBeacon/HelpBeacon.tsx
+++ b/src/components/HelpBeacon/HelpBeacon.tsx
@@ -1,0 +1,44 @@
+import QuestionMark from '@mui/icons-material/QuestionMark';
+import { styled } from '@mui/material/styles';
+import { useTranslation } from 'react-i18next';
+
+const StyledLink = styled('a')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: '100%',
+  backgroundColor: theme.palette.mpdxBlue.main,
+  ':hover': {
+    backgroundColor: '#055E8B', // 10% darker
+  },
+  position: 'fixed',
+  right: 70,
+  bottom: 30,
+  '@media (max-width: 900px)': {
+    right: 40,
+    bottom: 25,
+    backgroundColor: 'green',
+  },
+  '@media (max-width: 600px)': {
+    right: 30,
+    bottom: 30,
+    backgroundColor: 'red',
+  },
+  width: 60,
+  height: 60,
+  zIndex: 10,
+}));
+
+interface HelpBeaconProps {
+  helpUrl: string;
+}
+
+export const HelpBeacon: React.FC<HelpBeaconProps> = ({ helpUrl }) => {
+  const { t } = useTranslation();
+
+  return (
+    <StyledLink aria-label={t('Help')} href={helpUrl} target="_blank">
+      <QuestionMark sx={{ color: 'white' }} />
+    </StyledLink>
+  );
+};

--- a/src/components/HelpBeacon/HelpBeacon.tsx
+++ b/src/components/HelpBeacon/HelpBeacon.tsx
@@ -17,12 +17,10 @@ const StyledLink = styled('a')(({ theme }) => ({
   '@media (max-width: 900px)': {
     right: 40,
     bottom: 25,
-    backgroundColor: 'green',
   },
   '@media (max-width: 600px)': {
     right: 30,
     bottom: 30,
-    backgroundColor: 'red',
   },
   width: 60,
   height: 60,

--- a/src/components/HelpBeacon/HelpBeacon.tsx
+++ b/src/components/HelpBeacon/HelpBeacon.tsx
@@ -1,5 +1,6 @@
 import QuestionMark from '@mui/icons-material/QuestionMark';
 import { styled } from '@mui/material/styles';
+import { useSession } from 'next-auth/react';
 import { useTranslation } from 'react-i18next';
 
 const StyledLink = styled('a')(({ theme }) => ({
@@ -36,12 +37,27 @@ export const HelpBeacon: React.FC<HelpBeaconProps> = ({ helpUrls }) => {
     t,
     i18n: { language },
   } = useTranslation();
+  const { data: session } = useSession();
 
   const helpUrl = helpUrls?.[language] ?? helpUrls?.default;
+  if (!helpUrl) {
+    return null;
+  }
 
-  return helpUrl ? (
-    <StyledLink aria-label={t('Help')} href={helpUrl} target="_blank">
+  const url = new URL(helpUrl);
+  if (session?.user.name) {
+    url.searchParams.set('mpdxName', session.user.name);
+  }
+  if (session?.user.email) {
+    url.searchParams.set('mpdxEmail', session.user.email);
+  }
+  if (typeof window !== 'undefined') {
+    url.searchParams.set('mpdxUrl', window.location.href);
+  }
+
+  return (
+    <StyledLink aria-label={t('Help')} href={url.href} target="_blank">
       <QuestionMark sx={{ color: 'white' }} />
     </StyledLink>
-  ) : null;
+  );
 };

--- a/src/components/HelpBeacon/HelpBeacon.tsx
+++ b/src/components/HelpBeacon/HelpBeacon.tsx
@@ -28,15 +28,20 @@ const StyledLink = styled('a')(({ theme }) => ({
 }));
 
 interface HelpBeaconProps {
-  helpUrl: string;
+  helpUrls: Record<string, string> | null;
 }
 
-export const HelpBeacon: React.FC<HelpBeaconProps> = ({ helpUrl }) => {
-  const { t } = useTranslation();
+export const HelpBeacon: React.FC<HelpBeaconProps> = ({ helpUrls }) => {
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation();
 
-  return (
+  const helpUrl = helpUrls?.[language] ?? helpUrls?.default;
+
+  return helpUrl ? (
     <StyledLink aria-label={t('Help')} href={helpUrl} target="_blank">
       <QuestionMark sx={{ color: 'white' }} />
     </StyledLink>
-  );
+  ) : null;
 };

--- a/src/lib/helpScout.ts
+++ b/src/lib/helpScout.ts
@@ -25,7 +25,7 @@ export const initBeacon = () => {
 
 export const callBeacon = (name: string, options?: unknown) => {
   if (!window.Beacon) {
-    throw new Error('HelpScout beacon has not been initialized yet');
+    return;
   }
 
   window.Beacon(name, options);


### PR DESCRIPTION
## Description

* Add a help beacon that links to a URL defined by the `HELP_URL` environment variable.
* If we like this approach, I will go through and remove the HelpScout-related code.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
