### PR TITLE
[no-Jira] Move InfiniteList components outside of ContactRow

### DIFF
--- a/src/components/Contacts/ContactRow/ContactRow.tsx
+++ b/src/components/Contacts/ContactRow/ContactRow.tsx
@@ -11,6 +11,7 @@ import {
   Typography,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import clsx from 'clsx';
 import {
   ContactsContext,
   ContactsType,
@@ -21,6 +22,29 @@ import { ContactUncompletedTasksCount } from '../ContactUncompletedTasksCount/Co
 import { preloadContactsRightPanel } from '../ContactsRightPanel/DynamicContactsRightPanel';
 import { StarContactIconButton } from '../StarContactIconButton/StarContactIconButton';
 import { ContactRowFragment } from './ContactRow.generated';
+
+const ListItemButton = styled(ButtonBase)(({ theme }) => ({
+  flex: '1 1 auto',
+  textAlign: 'left',
+  padding: theme.spacing(0, 0.5, 0, 2),
+  [theme.breakpoints.up('sm')]: {
+    padding: theme.spacing(0, 0.5),
+  },
+  '&.top-margin': {
+    marginTop: 16,
+  },
+  '&.checked': {
+    backgroundColor: theme.palette.cruGrayLight.main,
+  },
+}));
+
+const StyledCheckbox = styled(Checkbox, {
+  shouldForwardProp: (prop) => prop !== 'value',
+})(() => ({
+  '&:hover': {
+    backgroundColor: 'rgba(0, 0, 0, 0.04)',
+  },
+}));
 
 interface Props {
   contact: ContactRowFragment;
@@ -35,27 +59,6 @@ export const ContactRow: React.FC<Props> = ({ contact, useTopMargin }) => {
     setContactFocus: onContactSelected,
     toggleSelectionById: onContactCheckToggle,
   } = React.useContext(ContactsContext) as ContactsType;
-
-  const ListItemButton = styled(ButtonBase)(({ theme }) => ({
-    flex: '1 1 auto',
-    textAlign: 'left',
-    marginTop: useTopMargin ? '16px' : '0',
-    padding: theme.spacing(0, 0.5, 0, 2),
-    [theme.breakpoints.up('sm')]: {
-      padding: theme.spacing(0, 0.5),
-    },
-    ...(isChecked(contactId)
-      ? { backgroundColor: theme.palette.cruGrayLight.main }
-      : {}),
-  }));
-
-  const StyledCheckbox = styled(Checkbox, {
-    shouldForwardProp: (prop) => prop !== 'value',
-  })(() => ({
-    '&:hover': {
-      backgroundColor: 'rgba(0, 0, 0, 0.04)',
-    },
-  }));
 
   const onClick = () => {
     onContactSelected(contact.id);
@@ -80,6 +83,10 @@ export const ContactRow: React.FC<Props> = ({ contact, useTopMargin }) => {
       focusRipple
       onClick={onClick}
       onMouseEnter={preloadContactsRightPanel}
+      className={clsx({
+        'top-margin': useTopMargin,
+        checked: isChecked(contactId),
+      })}
       data-testid="rowButton"
     >
       <Hidden xsDown>


### PR DESCRIPTION
## Description

The goal is to optimize the rendering of InfiniteList. One issue was that the contacts list was defining its components inside of another component, causing them to be unmounted and remounted on every render.

It's a little hard to tell in the screen capture, but it appears that there is more whitespace at the bottom when scrolling in the old version.

https://github.com/CruGlobal/mpdx-react/assets/3740187/13d9ae33-4679-42e7-98bd-b817415fd8f5

https://github.com/CruGlobal/mpdx-react/assets/3740187/06ba455d-b85b-45b7-8f60-85dd4bdccfa1

The `InfiniteList` `EmptyPlaceholder` should also be a stable component function, but I ran out of time to fix that.

@caleballdrin Do you want to test this out and see if it helps improve things?

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
