### PR TITLE
Hs 1166672 send correct user id on handover

### DIFF
--- a/src/components/HandoffLink/HandoffLink.test.tsx
+++ b/src/components/HandoffLink/HandoffLink.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { UserPreferenceContext } from '../User/Preferences/UserPreferenceProvider';
 import HandoffLink from '.';
 
 describe('HandoffLink', () => {
@@ -10,6 +11,7 @@ describe('HandoffLink', () => {
   let originalOpen: Window['open'];
   const useRouter = jest.spyOn(nextRouter, 'useRouter');
   const rewriteDomain = process.env.REWRITE_DOMAIN;
+  const userId = 'userID123';
 
   beforeEach(() => {
     open = jest.fn();
@@ -32,9 +34,11 @@ describe('HandoffLink', () => {
   it('default', async () => {
     const { getByRole } = render(
       <GqlMockedProvider>
-        <HandoffLink path="/contacts">
-          <a>Link</a>
-        </HandoffLink>
+        <UserPreferenceContext.Provider value={{ userId, locale: 'en-US' }}>
+          <HandoffLink path="/contacts">
+            <a>Link</a>
+          </HandoffLink>
+        </UserPreferenceContext.Provider>
       </GqlMockedProvider>,
     );
     const linkElement = getByRole('link', { hidden: true, name: 'Link' });
@@ -43,9 +47,8 @@ describe('HandoffLink', () => {
       `https://${rewriteDomain}/contacts`,
     );
     userEvent.click(linkElement);
-    // TODO investigate why the user is undefined when click fires
     expect(open).toHaveBeenCalledWith(
-      `${process.env.SITE_URL}/api/handoff?accountListId=accountListId&userId=user-1&path=%2Fcontacts`,
+      `${process.env.SITE_URL}/api/handoff?accountListId=accountListId&userId=${userId}&path=%2Fcontacts`,
       '_blank',
     );
   });

--- a/src/components/HandoffLink/HandoffLink.tsx
+++ b/src/components/HandoffLink/HandoffLink.tsx
@@ -1,6 +1,6 @@
 import { Children, ReactElement, ReactNode, cloneElement } from 'react';
-import { useRequiredSession } from 'src/hooks/useRequiredSession';
 import { useAccountListId } from '../../hooks/useAccountListId';
+import { useUserPreferenceContext } from '../User/Preferences/UserPreferenceProvider';
 
 interface Props {
   path: string;
@@ -9,8 +9,8 @@ interface Props {
 }
 
 const HandoffLink = ({ path, auth, children }: Props): ReactElement => {
-  const session = useRequiredSession();
   const accountListId = useAccountListId();
+  const { userId } = useUserPreferenceContext();
 
   const url = new URL(
     `${process.env.SITE_URL || window.location.origin}/api/handoff`,
@@ -20,7 +20,7 @@ const HandoffLink = ({ path, auth, children }: Props): ReactElement => {
     url.searchParams.append('auth', 'true');
   } else {
     url.searchParams.append('accountListId', accountListId ?? '');
-    url.searchParams.append('userId', session.userID);
+    url.searchParams.append('userId', userId ?? '');
   }
   url.searchParams.append('path', path);
 

--- a/src/components/Settings/preferences/accordions/EarlyAdopterAccordion/EarlyAdopterAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/EarlyAdopterAccordion/EarlyAdopterAccordion.test.tsx
@@ -2,9 +2,9 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { session } from '__tests__/fixtures/session';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { UserPreferenceContext } from 'src/components/User/Preferences/UserPreferenceProvider';
 import theme from 'src/theme';
 import { EarlyAdopterAccordion } from './EarlyAdopterAccordion';
 
@@ -35,18 +35,20 @@ interface ComponentsProps {
   tester: boolean;
   expandedPanel: string;
 }
-
+const userId = 'userID123';
 const Components: React.FC<ComponentsProps> = ({ tester, expandedPanel }) => (
   <SnackbarProvider>
     <TestRouter router={router}>
       <ThemeProvider theme={theme}>
         <GqlMockedProvider onCall={mutationSpy}>
-          <EarlyAdopterAccordion
-            handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
-            tester={tester}
-            accountListId={accountListId}
-          />
+          <UserPreferenceContext.Provider value={{ userId, locale: 'en-US' }}>
+            <EarlyAdopterAccordion
+              handleAccordionChange={handleAccordionChange}
+              expandedPanel={expandedPanel}
+              tester={tester}
+              accountListId={accountListId}
+            />
+          </UserPreferenceContext.Provider>
         </GqlMockedProvider>
       </ThemeProvider>
     </TestRouter>
@@ -161,7 +163,7 @@ describe('EarlyAdopterAccordion', () => {
       );
 
       expect(window.location.href).toEqual(
-        `${process.env.SITE_URL}/api/handoff?accountListId=${accountListId}&userId=${session.user.userID}&path=%2Fpreferences%2Fpersonal`,
+        `${process.env.SITE_URL}/api/handoff?accountListId=${accountListId}&userId=${userId}&path=%2Fpreferences%2Fpersonal`,
       );
     });
   });

--- a/src/components/Settings/preferences/accordions/EarlyAdopterAccordion/EarlyAdopterAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/EarlyAdopterAccordion/EarlyAdopterAccordion.tsx
@@ -7,9 +7,9 @@ import * as yup from 'yup';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
+import { useUserPreferenceContext } from 'src/components/User/Preferences/UserPreferenceProvider';
 import { AccountListSettingsInput } from 'src/graphql/types.generated';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
-import { useRequiredSession } from 'src/hooks/useRequiredSession';
 import { useUpdateAccountPreferencesMutation } from '../UpdateAccountPreferences.generated';
 
 const accountPreferencesSchema: yup.SchemaOf<
@@ -32,7 +32,7 @@ export const EarlyAdopterAccordion: React.FC<EarlyAdopterAccordionProps> = ({
   accountListId,
 }) => {
   const { t } = useTranslation();
-  const { userID } = useRequiredSession();
+  const { userId } = useUserPreferenceContext();
   const { appName } = useGetAppSettings();
   const { enqueueSnackbar } = useSnackbar();
   const [updateAccountPreferences] = useUpdateAccountPreferencesMutation();
@@ -69,7 +69,7 @@ export const EarlyAdopterAccordion: React.FC<EarlyAdopterAccordionProps> = ({
             `${process.env.SITE_URL || window.location.origin}/api/handoff`,
           );
           url.searchParams.append('accountListId', accountListId ?? '');
-          url.searchParams.append('userId', userID);
+          url.searchParams.append('userId', userId ?? '');
           url.searchParams.append('path', '/preferences/personal');
 
           window.location.href = url.toString();

--- a/src/components/User/Preferences/UserPreferenceProvider.test.tsx
+++ b/src/components/User/Preferences/UserPreferenceProvider.test.tsx
@@ -2,12 +2,23 @@ import { render } from '@testing-library/react';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { useLocale } from 'src/hooks/useLocale';
 import { GetUserQuery } from '../GetUser.generated';
-import { UserPreferenceProvider } from './UserPreferenceProvider';
+import {
+  UserPreferenceProvider,
+  useUserPreferenceContext,
+} from './UserPreferenceProvider';
+
+const userId = 'userID123';
 
 const Consumer: React.FC = () => {
   const locale = useLocale();
+  const { userId } = useUserPreferenceContext();
 
-  return <p>Locale: {locale}</p>;
+  return (
+    <>
+      <p>User ID: {userId}</p>
+      <p>Locale: {locale}</p>
+    </>
+  );
 };
 
 describe('UserPreferenceProvider', () => {
@@ -27,6 +38,7 @@ describe('UserPreferenceProvider', () => {
         mocks={{
           GetUser: {
             user: {
+              id: userId,
               preferences: {
                 localeDisplay: 'es',
               },
@@ -42,8 +54,12 @@ describe('UserPreferenceProvider', () => {
 
     // Initial default locale
     expect(getByText('Locale: en-US')).toBeInTheDocument();
+    expect(getByText(`User ID:`)).toBeInTheDocument();
 
     // Locale loaded from query
     expect(await findByText('Locale: es')).toBeInTheDocument();
+
+    // Locale loaded from query
+    expect(await findByText(`User ID: ${userId}`)).toBeInTheDocument();
   });
 });

--- a/src/components/User/Preferences/UserPreferenceProvider.tsx
+++ b/src/components/User/Preferences/UserPreferenceProvider.tsx
@@ -5,10 +5,12 @@ import { useGetUserQuery } from '../GetUser.generated';
 export type UserPreferenceType = {
   defaultCurrency?: string;
   locale: string;
+  userId: string;
 };
 
 export const UserPreferenceContext = createContext<UserPreferenceType>({
   locale: 'en-US',
+  userId: '',
 });
 
 export const useUserPreferenceContext = (): UserPreferenceType =>
@@ -29,7 +31,12 @@ export const UserPreferenceProvider: React.FC<Props> = ({ children }) => {
   }, [data]);
 
   return (
-    <UserPreferenceContext.Provider value={{ locale }}>
+    <UserPreferenceContext.Provider
+      value={{
+        locale,
+        userId: data?.user.id ?? '',
+      }}
+    >
       {children}
     </UserPreferenceContext.Provider>
   );

--- a/src/components/common/DateTimePickers/DateTimeFieldPair.test.tsx
+++ b/src/components/common/DateTimePickers/DateTimeFieldPair.test.tsx
@@ -16,7 +16,7 @@ const onChange = jest.fn();
 const TestComponent: React.FC<TestComponentProps> = ({
   value = DateTime.local(2024, 1, 2, 3, 4, 5),
 }) => (
-  <UserPreferenceContext.Provider value={{ locale: 'en-US' }}>
+  <UserPreferenceContext.Provider value={{ locale: 'en-US', userId: 'userId' }}>
     <LocalizationProvider dateAdapter={AdapterLuxon} adapterLocale="en-US">
       <DateTimeFieldPair
         value={value}

--- a/src/components/common/DateTimePickers/DesktopDateField.test.tsx
+++ b/src/components/common/DateTimePickers/DesktopDateField.test.tsx
@@ -17,7 +17,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
   value = DateTime.local(2024, 1, 2, 3, 4, 5),
   locale = 'en-US',
 }) => (
-  <UserPreferenceContext.Provider value={{ locale }}>
+  <UserPreferenceContext.Provider value={{ locale, userId: 'userId' }}>
     <LocalizationProvider dateAdapter={AdapterLuxon} adapterLocale={locale}>
       <DesktopDateField value={value} onChange={onChange} label="Date" />
     </LocalizationProvider>

--- a/src/components/common/DateTimePickers/DesktopTimeField.test.tsx
+++ b/src/components/common/DateTimePickers/DesktopTimeField.test.tsx
@@ -17,7 +17,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
   value = DateTime.local(2024, 1, 2, 3, 4, 5),
   locale = 'en-US',
 }) => (
-  <UserPreferenceContext.Provider value={{ locale }}>
+  <UserPreferenceContext.Provider value={{ locale, userId: 'userId' }}>
     <LocalizationProvider dateAdapter={AdapterLuxon} adapterLocale={locale}>
       <DesktopTimeField value={value} onChange={onChange} label="Time" />
     </LocalizationProvider>


### PR DESCRIPTION
## Description
This pull request updates the user handover process by ensuring the correct user ID is sent. It modifies the user preferences context to include the user ID, ensuring that all relevant components use this updated information.

### Changes
- Added `userId` to the `userPreference` context.
- Updated handoff link to utilize the new `userId` from `userPreferences`.
- Revised all relevant components to use `userId` from `userPreferencesContext`.
- Updated tests

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
