### PR TITLE
Helpscout - Fixing blank screen error on contact details

### DIFF
--- a/src/lib/intlFormat.test.ts
+++ b/src/lib/intlFormat.test.ts
@@ -185,6 +185,14 @@ describe('intlFormat', () => {
 
       expect(date).toBeNull();
     });
+
+    it('returns if month is null', () => {
+      const date = dateFromParts(0, 0, 2000, locale);
+
+      expect(date).toBe(
+        'Invalid Date - you specified 0 (of type number) as a month, which is invalid',
+      );
+    });
   });
   //this test often fails locally. It passes on github.
   describe('dateTimeFormat', () => {

--- a/src/lib/intlFormat.ts
+++ b/src/lib/intlFormat.ts
@@ -89,8 +89,16 @@ export const dateFromParts = (
   }
 
   if (typeof year === 'number') {
-    return dateFormat(DateTime.local(year, month, day), locale);
+    const date = DateTime.local(year, month, day);
+    if (date.invalidReason || date.invalidExplanation) {
+      return `Invalid Date - ${date.invalidExplanation}`;
+    }
+    return dateFormat(date, locale);
   } else {
+    const date = DateTime.local().set({ month, day });
+    if (date.invalidReason || date.invalidExplanation) {
+      return `Invalid Date - ${date.invalidExplanation}`;
+    }
     return dayMonthFormat(day, month, locale);
   }
 };


### PR DESCRIPTION
## Description

Please make a note of the following text:

This pull request addresses the issue of a blank screen appearing on the contact details tab within a contact.

The problem stems from a date format function called `dateFromParts`. This function lacks the capability to handle an invalid date, resulting in an error when attempting to convert it into a date.

I resolved this issue by implementing error handling within the function and included a test to verify the correct functionality of the fix.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
