### PR TITLE
Helpscout - Show invalid date in person modal with error to fix

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonBirthday/PersonBirthday.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonBirthday/PersonBirthday.tsx
@@ -32,16 +32,27 @@ export const PersonBirthday: React.FC<PersonBirthdayProps> = ({
     setFieldValue('birthdayYear', date?.year || null);
   };
 
+  const birthdayDate =
+    birthdayMonth && birthdayDay
+      ? DateTime.local(birthdayYear ?? 1900, birthdayMonth, birthdayDay)
+      : null;
+
+  const invalidDate =
+    birthdayMonth === 0 && birthdayDay === 0
+      ? DateTime.local(birthdayYear ?? 1900, birthdayMonth, birthdayDay)
+          .invalidExplanation !== ''
+      : false;
+
+  const backupBirthdayDate =
+    `${birthdayMonth}/${birthdayDay}/${birthdayYear}` as unknown as DateTime<boolean>;
+
   return (
     <ModalSectionContainer>
       <ModalSectionIcon transform="translateY(-100%)" icon={<CakeIcon />} />
       <CustomDateField
         label={t('Birthday')}
-        value={
-          birthdayMonth && birthdayDay
-            ? DateTime.local(birthdayYear ?? 1900, birthdayMonth, birthdayDay)
-            : null
-        }
+        invalidDate={invalidDate}
+        value={invalidDate ? backupBirthdayDate : birthdayDate}
         onChange={(date) => handleDateChange(date)}
       />
     </ModalSectionContainer>

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonModal.test.tsx
@@ -295,6 +295,47 @@ describe('PersonModal', () => {
       expect(queryByText('Show Less')).not.toBeInTheDocument(),
     );
   });
+
+  it('should show invalid dates and highlight them as errors', async () => {
+    const { getByText, getByRole, queryAllByText } = render(
+      <SnackbarProvider>
+        <LocalizationProvider dateAdapter={AdapterLuxon}>
+          <ThemeProvider theme={theme}>
+            <GqlMockedProvider>
+              <ContactDetailProvider>
+                <PersonModal
+                  contactId={contactId}
+                  accountListId={accountListId}
+                  handleClose={handleClose}
+                  person={{
+                    ...mockPerson,
+                    anniversaryDay: 0,
+                    anniversaryMonth: 0,
+                    anniversaryYear: 2000,
+                    birthdayDay: 0,
+                    birthdayMonth: 0,
+                    birthdayYear: 2000,
+                  }}
+                />
+              </ContactDetailProvider>
+            </GqlMockedProvider>
+          </ThemeProvider>
+        </LocalizationProvider>
+      </SnackbarProvider>,
+    );
+
+    const birthdayInput = getByRole('textbox', { name: 'Birthday' });
+    expect(birthdayInput).toHaveValue('0/0/2000');
+    expect(birthdayInput.parentElement).toHaveClass('Mui-error');
+
+    userEvent.click(queryAllByText('Show More')[0]);
+    await waitFor(() => expect(getByText('Show Less')).toBeInTheDocument());
+
+    const anniversaryInput = getByRole('textbox', { name: 'Anniversary' });
+    expect(anniversaryInput).toHaveValue('0/0/2000');
+    expect(anniversaryInput.parentElement).toHaveClass('Mui-error');
+  });
+
   describe('Updating', () => {
     const createObjectURL = jest
       .fn()

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonShowMore/PersonShowMore.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonShowMore/PersonShowMore.tsx
@@ -63,6 +63,28 @@ export const PersonShowMore: React.FC<PersonShowMoreProps> = ({
     setFieldValue('anniversaryMonth', date?.month || null);
     setFieldValue('anniversaryYear', date?.year || null);
   };
+
+  const anniversaryDate =
+    anniversaryMonth && anniversaryDay
+      ? DateTime.local(
+          anniversaryYear ?? 1900,
+          anniversaryMonth,
+          anniversaryDay,
+        )
+      : null;
+
+  const invalidAnniversaryDate =
+    anniversaryMonth === 0 && anniversaryDay === 0
+      ? DateTime.local(
+          anniversaryYear ?? 1900,
+          anniversaryMonth,
+          anniversaryDay,
+        ).invalidExplanation !== ''
+      : false;
+
+  const backupAnniversaryDate =
+    `${anniversaryMonth}/${anniversaryDay}/${anniversaryYear}` as unknown as DateTime<boolean>;
+
   return (
     <>
       {/* Legal First Name and Gender Section */}
@@ -142,14 +164,9 @@ export const PersonShowMore: React.FC<PersonShowMoreProps> = ({
           <Grid item xs={12} sm={6}>
             <CustomDateField
               label={t('Anniversary')}
+              invalidDate={invalidAnniversaryDate}
               value={
-                anniversaryMonth && anniversaryDay
-                  ? DateTime.local(
-                      anniversaryYear ?? 1900,
-                      anniversaryMonth,
-                      anniversaryDay,
-                    )
-                  : null
+                invalidAnniversaryDate ? backupAnniversaryDate : anniversaryDate
               }
               onChange={(date) => date && handleDateChange(date)}
             />

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonShowMore/PersonShowMore.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonShowMore/PersonShowMore.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import BusinessIcon from '@mui/icons-material/Business';
 import SchoolIcon from '@mui/icons-material/School';
 import {
@@ -20,11 +20,14 @@ import {
   PersonCreateInput,
   PersonUpdateInput,
 } from 'src/graphql/types.generated';
+import { useLocale } from 'src/hooks/useLocale';
+import { validateAndFormatInvalidDate } from 'src/lib/intlFormat';
 import { RingIcon } from '../../../../../../RingIcon';
 import { ModalSectionContainer } from '../ModalSectionContainer/ModalSectionContainer';
 import { ModalSectionIcon } from '../ModalSectionIcon/ModalSectionIcon';
 import { NewSocial } from '../PersonModal';
 import { PersonSocial } from '../PersonSocials/PersonSocials';
+import { buildDate } from '../personModalHelper';
 
 const DeceasedLabel = styled(FormControlLabel)(() => ({
   margin: 'none',
@@ -40,6 +43,11 @@ export const PersonShowMore: React.FC<PersonShowMoreProps> = ({
   showDeceased = true,
 }) => {
   const { t } = useTranslation();
+  const locale = useLocale();
+  const [anniversaryDateIsInvalid, setAnniversaryDateIsInvalid] =
+    useState(false);
+  const [backupAnniversaryDate, setBackupAnniversaryDate] =
+    useState<DateTime<boolean> | null>(null);
 
   const {
     values: {
@@ -58,32 +66,39 @@ export const PersonShowMore: React.FC<PersonShowMoreProps> = ({
     setFieldValue,
   } = formikProps;
 
+  useEffect(() => {
+    if (
+      typeof anniversaryMonth !== 'number' ||
+      typeof anniversaryDay !== 'number'
+    ) {
+      return;
+    }
+
+    const date = validateAndFormatInvalidDate(
+      anniversaryYear,
+      anniversaryMonth,
+      anniversaryDay,
+      locale,
+    );
+
+    setBackupAnniversaryDate(
+      date.formattedInvalidDate as unknown as DateTime<boolean>,
+    );
+    if (date.dateTime.invalidExplanation) {
+      setAnniversaryDateIsInvalid(true);
+    }
+  }, [anniversaryMonth, anniversaryDay, anniversaryYear]);
+
   const handleDateChange = (date: DateTime | null) => {
-    setFieldValue('anniversaryDay', date?.day || null);
-    setFieldValue('anniversaryMonth', date?.month || null);
-    setFieldValue('anniversaryYear', date?.year || null);
+    setFieldValue('anniversaryDay', date?.day ?? null);
+    setFieldValue('anniversaryMonth', date?.month ?? null);
+    setFieldValue('anniversaryYear', date?.year ?? null);
   };
 
-  const anniversaryDate =
-    anniversaryMonth && anniversaryDay
-      ? DateTime.local(
-          anniversaryYear ?? 1900,
-          anniversaryMonth,
-          anniversaryDay,
-        )
-      : null;
-
-  const invalidAnniversaryDate =
-    anniversaryMonth === 0 && anniversaryDay === 0
-      ? DateTime.local(
-          anniversaryYear ?? 1900,
-          anniversaryMonth,
-          anniversaryDay,
-        ).invalidExplanation !== ''
-      : false;
-
-  const backupAnniversaryDate =
-    `${anniversaryMonth}/${anniversaryDay}/${anniversaryYear}` as unknown as DateTime<boolean>;
+  const anniversaryDate = useMemo(
+    () => buildDate(anniversaryMonth, anniversaryDay, anniversaryYear),
+    [anniversaryMonth, anniversaryDay, anniversaryYear],
+  );
 
   return (
     <>
@@ -164,9 +179,11 @@ export const PersonShowMore: React.FC<PersonShowMoreProps> = ({
           <Grid item xs={12} sm={6}>
             <CustomDateField
               label={t('Anniversary')}
-              invalidDate={invalidAnniversaryDate}
+              invalidDate={anniversaryDateIsInvalid}
               value={
-                invalidAnniversaryDate ? backupAnniversaryDate : anniversaryDate
+                anniversaryDateIsInvalid
+                  ? backupAnniversaryDate
+                  : anniversaryDate
               }
               onChange={(date) => date && handleDateChange(date)}
             />

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/personModalHelper.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/personModalHelper.tsx
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import { TFunction } from 'react-i18next';
 import * as yup from 'yup';
 import {
@@ -262,4 +263,8 @@ export const formatSubmittedFields = (
         })),
     ),
   };
+};
+
+export const buildDate = (month, day, year) => {
+  return month && day ? DateTime.local(year ?? 1900, month, day) : null;
 };

--- a/src/components/common/DateTimePickers/CustomDateField.tsx
+++ b/src/components/common/DateTimePickers/CustomDateField.tsx
@@ -11,12 +11,13 @@ export const CustomDateField: React.FC<DesktopDateFieldProps> = (props) => {
   const isDesktop = useMediaQuery(DEFAULT_DESKTOP_MODE_MEDIA_QUERY, {
     defaultMatches: true,
   });
+  const { label, value, invalidDate, onChange, ...textFieldProps } = props;
 
-  if (isDesktop) {
+  // If value is not valid render desktop input as it can render invalid value
+  if (isDesktop || invalidDate) {
     return <DesktopDateField {...props} />;
   }
 
-  const { label, value, onChange, ...textFieldProps } = props;
   return (
     <MobileDatePicker<DateTime>
       label={label}

--- a/src/components/common/DateTimePickers/DesktopDateField.test.tsx
+++ b/src/components/common/DateTimePickers/DesktopDateField.test.tsx
@@ -9,6 +9,7 @@ import { DesktopDateField } from './DesktopDateField';
 interface TestComponentProps {
   value?: DateTime | null;
   locale?: string;
+  invalidDate?: boolean;
 }
 
 const onChange = jest.fn();
@@ -16,10 +17,16 @@ const onChange = jest.fn();
 const TestComponent: React.FC<TestComponentProps> = ({
   value = DateTime.local(2024, 1, 2, 3, 4, 5),
   locale = 'en-US',
+  invalidDate = false,
 }) => (
   <UserPreferenceContext.Provider value={{ locale, userId: 'userId' }}>
     <LocalizationProvider dateAdapter={AdapterLuxon} adapterLocale={locale}>
-      <DesktopDateField value={value} onChange={onChange} label="Date" />
+      <DesktopDateField
+        value={value}
+        onChange={onChange}
+        label="Date"
+        invalidDate={invalidDate}
+      />
     </LocalizationProvider>
   </UserPreferenceContext.Provider>
 );
@@ -38,6 +45,30 @@ describe('DesktopDateField', () => {
       );
 
       expect(getByRole('textbox')).toHaveValue('');
+    });
+
+    it('shows invalid date when invalidDate prop is TRUE', () => {
+      const { getByRole, rerender } = render(<TestComponent />);
+      rerender(
+        <TestComponent
+          value={'0/0/2000' as unknown as DateTime}
+          invalidDate={true}
+        />,
+      );
+
+      expect(getByRole('textbox')).toHaveValue('0/0/2000');
+    });
+
+    it('shows default date with a invalid date when invalidDate prop is FALSE', () => {
+      const { getByRole, rerender } = render(<TestComponent />);
+      rerender(
+        <TestComponent
+          value={'0/0/2000' as unknown as DateTime}
+          invalidDate={false}
+        />,
+      );
+
+      expect(getByRole('textbox')).toHaveValue('1/2/2024');
     });
 
     it('the formatted value', () => {

--- a/src/components/common/DateTimePickers/DesktopDateField.tsx
+++ b/src/components/common/DateTimePickers/DesktopDateField.tsx
@@ -12,11 +12,13 @@ export interface DesktopDateFieldProps
   extends Omit<StandardTextFieldProps, 'onChange'> {
   value: DateTime | null;
   onChange: (date: DateTime | null) => void;
+  invalidDate?: boolean;
 }
 
 export const DesktopDateField: React.FC<DesktopDateFieldProps> = ({
   value,
   onChange,
+  invalidDate,
   ...props
 }) => {
   const locale = useLocale();
@@ -30,6 +32,8 @@ export const DesktopDateField: React.FC<DesktopDateFieldProps> = ({
       setRawDate('');
     } else if (value.isValid) {
       setRawDate(value.toFormat('D', options));
+    } else if (invalidDate) {
+      setRawDate(value as unknown as string);
     }
   }, [locale, value]);
 

--- a/src/lib/intlFormat.test.ts
+++ b/src/lib/intlFormat.test.ts
@@ -9,6 +9,7 @@ import {
   monthYearFormat,
   numberFormat,
   percentageFormat,
+  validateAndFormatInvalidDate,
 } from './intlFormat';
 
 describe('intlFormat', () => {
@@ -186,12 +187,42 @@ describe('intlFormat', () => {
       expect(date).toBeNull();
     });
 
-    it('returns if month is null', () => {
+    it('handle an invalid date', () => {
+      const date = dateFromParts(2000, 0, 0, locale);
+
+      expect(date).toBe('0/0/2000 - Invalid Date, please fix.');
+    });
+
+    it('handle an invalid date without a year', () => {
+      const date = dateFromParts(null, 0, 0, locale);
+
+      expect(date).toBe('0/0/2020 - Invalid Date, please fix.');
+    });
+
+    it('handle an invalid date where we can not format the invalid date', () => {
       const date = dateFromParts(0, 0, 2000, locale);
 
       expect(date).toBe(
         'Invalid Date - you specified 0 (of type number) as a month, which is invalid',
       );
+    });
+  });
+
+  describe('validateAndFormatInvalidDate', () => {
+    const locale = 'en-US';
+    it('returns invalid date en-US formatted', () => {
+      const date = validateAndFormatInvalidDate(2000, 0, 0, locale);
+      expect(date.formattedInvalidDate).toBe('0/0/2000');
+    });
+
+    it('returns invalid date en-UK formatted', () => {
+      const date = validateAndFormatInvalidDate(2000, 0, 0, 'en-UK');
+      expect(date.formattedInvalidDate).toBe('0/00/2000');
+    });
+
+    it('returns invalid date de formatted', () => {
+      const date = validateAndFormatInvalidDate(2000, 0, 0, 'de');
+      expect(date.formattedInvalidDate).toBe('0.0.2000');
     });
   });
   //this test often fails locally. It passes on github.

--- a/src/lib/intlFormat.ts
+++ b/src/lib/intlFormat.ts
@@ -88,17 +88,17 @@ export const dateFromParts = (
     return null;
   }
 
+  const date = validateAndFormatInvalidDate(year, month, day, locale);
+  if (date.dateTime.invalidExplanation) {
+    if (date.formattedInvalidDate) {
+      return `${date.formattedInvalidDate} - Invalid Date, please fix.`;
+    } else {
+      return `Invalid Date - ${date.dateTime.invalidExplanation}`;
+    }
+  }
   if (typeof year === 'number') {
-    const date = DateTime.local(year, month, day);
-    if (date.invalidReason || date.invalidExplanation) {
-      return `Invalid Date - ${date.invalidExplanation}`;
-    }
-    return dateFormat(date, locale);
+    return dateFormat(date.dateTime, locale);
   } else {
-    const date = DateTime.local().set({ month, day });
-    if (date.invalidReason || date.invalidExplanation) {
-      return `Invalid Date - ${date.invalidExplanation}`;
-    }
     return dayMonthFormat(day, month, locale);
   }
 };
@@ -118,6 +118,41 @@ export const dateTimeFormat = (
     minute: 'numeric',
     timeZoneName: 'short',
   }).format(date.toJSDate());
+};
+
+export const validateAndFormatInvalidDate = (
+  year: number | null | undefined,
+  month: number,
+  day: number,
+  locale: string,
+) => {
+  const yyyy = year ?? DateTime.local().year;
+  const date = DateTime.local(yyyy, month, day);
+  let formattedInvalidDate = '';
+  if (date.invalidExplanation && month === 0 && day === 0) {
+    const placeholderYear = 2024;
+    const placeholderMonth = 8;
+    const placeholderDay = 15;
+    const placeholderDate = new Date(
+      placeholderYear,
+      placeholderMonth - 1,
+      placeholderDay,
+    );
+    const formattedPlaceholderDate = dateFormatShort(
+      DateTime.fromISO(placeholderDate.toISOString()),
+      locale,
+    );
+
+    formattedInvalidDate = formattedPlaceholderDate
+      .replace(`${placeholderYear}`, `${yyyy}`)
+      .replace(`${placeholderMonth}`, `${month}`)
+      .replace(`${placeholderDay}`, `${day}`);
+  }
+
+  return {
+    formattedInvalidDate,
+    dateTime: date,
+  };
 };
 
 const intlFormat = {


### PR DESCRIPTION
## Description

This pull request follows the pull request at https://github.com/CruGlobal/mpdx-react/pull/961. In this pull request, we ensure that the Person Modal displays an error for invalid dates in order to prompt the user to make the necessary corrections.

Without this update, the input fields will remain empty and retain the incorrect values. This change will ensure that the invalid values are corrected.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
