### PR TITLE
Amplify Preview - Preview to be named after PR instead of branch name

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -24,7 +24,7 @@ jobs:
       - name: deploy PR preview
         uses: CruGlobal/amplify-preview-actions@handle-existing-branches
         with:
-          branch_name: ${{ github.head_ref }}
+          branch_name: 'pr-${{ github.event.number}}'
           amplify_command: deploy
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
@@ -32,4 +32,4 @@ jobs:
           AmplifyAppId: ${{ secrets.AMPLIFY_APP_ID }}
           AWS_REGION: 'us-east-1'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EnvironmentVariables: 'SITE_URL=https://${{ github.head_ref }}.${{ secrets.AMPLIFY_APP_ID }}.amplifyapp.com'
+          EnvironmentVariables: 'SITE_URL=https://pr-${{ github.event.number }}.${{ secrets.AMPLIFY_APP_ID }}.amplifyapp.com'


### PR DESCRIPTION
In this PR, I changed the way we name Amplify previews so that they are called after their PR ID instead of their branch.

Applying this fix will allow us to use previews again, as I've made the amplified build hit the production GraphQL server when building if the preview is prefixed with `pr-`.

This also lets us know what preview belongs to what PR and if we can delete it. 

An idea we should roll out in a different PR is removing the preview once the PR is merged into `main`.

## Description

Please explain a bullet-point summary of the changes.
List any PRs that this PR is dependent on and any Jira tickets that this PR is related to.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
