### PR TITLE
MPDX-7999 - Fix Amplify previews build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -6,14 +6,12 @@ frontend:
         - nvm install 18.13
         - nvm use 18.13
         - |
-          if [[ "${AWS_BRANCH_ARN#*/branches/}" == *"pr-"* ]]; then
-            PREVIEW_URL="https://${AWS_BRANCH_ARN#*/branches/}.${AWS_APP_ID}.amplifyapp.com";
-            NEXTAUTH_URL=$PREVIEW_URL;
-            echo "PREVIEW_URL=$PREVIEW_URL" >> .env;
-          elif [[ "${AWS_BRANCH}" != "main" && "${AWS_BRANCH}" != "staging" ]]; then
+          if [[ "${AWS_BRANCH}" != "main" && "${AWS_BRANCH}" != "staging" ]]; then
             PREVIEW_URL="https://${AWS_BRANCH}.${AWS_APP_ID}.amplifyapp.com";
             NEXTAUTH_URL=$PREVIEW_URL;
             echo "PREVIEW_URL=$PREVIEW_URL" >> .env;
+            export API_URL=https://api.mpdx.org/graphql
+            export REST_API_URL=https://api.mpdx.org/api/v2/
           fi
         - echo "NEXTAUTH_URL=$NEXTAUTH_URL" >> .env
         - echo "NODE_ENV=$NODE_ENV" >> .env
@@ -23,6 +21,11 @@ frontend:
         - yarn
         - yarn disable-telemetry
         - yarn gql
+        - |
+          if [[ "${AWS_BRANCH}" != "main" && "${AWS_BRANCH}" != "staging" ]]; then
+            export API_URL=https://api.stage.mpdx.org/graphql
+            export REST_API_URL=https://api.stage.mpdx.org/api/v2/
+          fi
     build:
       commands:
         - yarn build:amplify

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,7 +1,7 @@
 generates:
   ./src/graphql/types.generated.ts:
     schema:
-      - ${API_URL:https://api.stage.mpdx.org/graphql}
+      - ${API_URL:https://api.mpdx.org/graphql}
       - ./pages/api/Schema/**/*.graphql
     plugins:
       - typescript
@@ -11,7 +11,7 @@ generates:
         ISO8601DateTime: string
   ./:
     schema:
-      - ${API_URL:https://api.stage.mpdx.org/graphql}
+      - ${API_URL:https://api.mpdx.org/graphql}
       - ./pages/api/Schema/**/*.graphql
     documents: '**/*.graphql'
     preset: near-operation-file
@@ -24,19 +24,19 @@ generates:
       preResolveTypes: false
   ./src/graphql/schema.graphql:
     schema:
-      - ${API_URL:https://api.stage.mpdx.org/graphql}
+      - ${API_URL:https://api.mpdx.org/graphql}
       - ./pages/api/Schema/**/*.graphql
     plugins:
       - schema-ast
   ./src/graphql/possibleTypes.generated.ts:
     schema:
-      - ${API_URL:https://api.stage.mpdx.org/graphql}
+      - ${API_URL:https://api.mpdx.org/graphql}
       - ./pages/api/Schema/**/*.graphql
     plugins:
       - fragment-matcher
   ./pages/api/graphql-rest.page.generated.ts:
     schema:
-      - ${API_URL:https://api.stage.mpdx.org/graphql}
+      - ${API_URL:https://api.mpdx.org/graphql}
       - ./pages/api/Schema/**/*.graphql
     plugins:
       - typescript
@@ -48,7 +48,7 @@ generates:
         ISO8601Date: string
         ISO8601DateTime: string
   ./src/graphql/rootFields.generated.ts:
-    schema: ${API_URL:https://api.stage.mpdx.org/graphql}
+    schema: ${API_URL:https://api.mpdx.org/graphql}
     plugins:
       - ./extractRootFields.js
 hooks:


### PR DESCRIPTION
## Description
Amplify Previews are currently not building and deploying due to an error when building.

The error is because we're hitting the staging API when building the GraphQL and since our graphQL doesn't have the Task Phases changes in it, it causes an error.

 
Fix: Hit the production API when creating the GraphQL, then in the app call the staging API

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
