### PR TITLE
HelpScout 1199960 - Fixing intlFormat.ts error when currency is not defined

### DIFF
--- a/src/lib/intlFormat.test.ts
+++ b/src/lib/intlFormat.test.ts
@@ -82,6 +82,13 @@ describe('intlFormat', () => {
       it('handles undefined case', () => {
         expect(currencyFormat(1000, undefined, 'en-US')).toEqual('$1,000');
       });
+      it('handles empty string case', () => {
+        expect(currencyFormat(1234.56, '', 'en-GB')).toEqual('US$1,234.56');
+      });
+
+      it('handles an error', () => {
+        expect(currencyFormat(1234.56, ' ', 'en-GB')).toEqual('1234.56  ');
+      });
     });
 
     describe('different language', () => {

--- a/src/lib/intlFormat.ts
+++ b/src/lib/intlFormat.ts
@@ -22,12 +22,18 @@ export const currencyFormat = (
   if (!currency) {
     currency = 'USD';
   }
-  return new Intl.NumberFormat(locale, {
-    style: 'currency',
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
       currency: currency,
-    minimumFractionDigits: decimal ? 2 : 0,
-    maximumFractionDigits: decimal ? 2 : 0,
-  }).format(Number.isFinite(amount) ? amount : 0);
+      minimumFractionDigits: decimal ? 2 : 0,
+      maximumFractionDigits: decimal ? 2 : 0,
+    }).format(Number.isFinite(amount) ? amount : 0);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`Error formatting currency: ${error}`);
+    return `${amount} ${currency}`;
+  }
 };
 
 export const dayMonthFormat = (

--- a/src/lib/intlFormat.ts
+++ b/src/lib/intlFormat.ts
@@ -22,6 +22,7 @@ export const currencyFormat = (
   if (!currency) {
     currency = 'USD';
   }
+  window.Intl;
   try {
     return new Intl.NumberFormat(locale, {
       style: 'currency',

--- a/src/lib/intlFormat.ts
+++ b/src/lib/intlFormat.ts
@@ -19,9 +19,12 @@ export const currencyFormat = (
 ): string => {
   const amount = Number.isNaN(value) ? 0 : value;
   const decimal = amount % 1 !== 0;
+  if (!currency) {
+    currency = 'USD';
+  }
   return new Intl.NumberFormat(locale, {
     style: 'currency',
-    currency: currency ?? 'USD',
+      currency: currency,
     minimumFractionDigits: decimal ? 2 : 0,
     maximumFractionDigits: decimal ? 2 : 0,
   }).format(Number.isFinite(amount) ? amount : 0);

--- a/src/lib/intlFormat.ts
+++ b/src/lib/intlFormat.ts
@@ -22,7 +22,6 @@ export const currencyFormat = (
   if (!currency) {
     currency = 'USD';
   }
-  window.Intl;
   try {
     return new Intl.NumberFormat(locale, {
       style: 'currency',


### PR DESCRIPTION
## Description
In this PR, I've fixed an error that happens when the currency is not defined. If the currency is not defined, it shows the white screen of death.

I've ensured the currency is defined and that even if it fails, it will return some value to prevent the white screen of death from happening.

HelpScout issue: https://secure.helpscout.net/conversation/2666844539/1199960?folderId=7296147

#### To Test:
- Impersonate the user in question.
- Navigate to contacts and click on the contact with the last name "Dose"
- Click on the donations tab in the contact drawer.
- The donations should now show without an error.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
