### PR TITLE
MPDX-7955 - Add list filter functionality

### DIFF
--- a/src/components/Task/Modal/Form/Inputs/ContactsAutocomplete/ContactsAutocomplete.tsx
+++ b/src/components/Task/Modal/Form/Inputs/ContactsAutocomplete/ContactsAutocomplete.tsx
@@ -8,12 +8,14 @@ interface ContactsAutocompleteProps {
   accountListId: string;
   value: string[];
   onChange: (value: string[]) => void;
+  excludeContactIds?: string[];
 }
 
 export const ContactsAutocomplete: React.FC<ContactsAutocompleteProps> = ({
   accountListId,
   value,
   onChange,
+  excludeContactIds = [],
 }) => {
   const { t } = useTranslation();
 
@@ -27,6 +29,15 @@ export const ContactsAutocomplete: React.FC<ContactsAutocompleteProps> = ({
 
   // There are too many contacts to display all of them as options, so we load the contacts that
   // the user has selected and the contacts matching the user's current search, and merge the results
+
+  const contactsFilters = excludeContactIds.length
+    ? {
+        wildcardSearch: searchTerm,
+        ids: excludeContactIds,
+        reverseIds: true,
+      }
+    : { wildcardSearch: searchTerm };
+
   const {
     data: currentSearchedContacts,
     previousData: previousSearchedContacts,
@@ -35,7 +46,7 @@ export const ContactsAutocomplete: React.FC<ContactsAutocompleteProps> = ({
     variables: {
       accountListId,
       first: 10,
-      contactsFilters: { wildcardSearch: searchTerm },
+      contactsFilters,
     },
   });
   // When this query loads contacts once and the user changes the search query, `data` will be

--- a/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
+++ b/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
@@ -112,7 +112,7 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
       ids: [],
       appeal: [appealId || ''],
     }),
-    [sanitizedFilters, starredFilter, searchTerm],
+    [sanitizedFilters, starredFilter, searchTerm, appealId],
   );
 
   const contactsQueryResult = useContactsQuery({

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AddContactToAppealModal/AddContactToAppeal.graphql
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AddContactToAppealModal/AddContactToAppeal.graphql
@@ -1,0 +1,8 @@
+mutation AssignContactsToAppeal($input: AssignContactsToAppealMutationInput!) {
+  assignContactsToAppeal(input: $input) {
+    appeal {
+      id
+      name
+    }
+  }
+}

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AddContactToAppealModal/AddContactToAppealModal.test.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AddContactToAppealModal/AddContactToAppealModal.test.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SnackbarProvider } from 'notistack';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import TestRouter from '__tests__/util/TestRouter';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { AppealsWrapper } from 'pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper';
+import { ContactOptionsQuery } from 'src/components/Task/Modal/Form/Inputs/ContactsAutocomplete/ContactsAutocomplete.generated';
+import theme from 'src/theme';
+import { AppealsContext } from '../../../AppealsContext/AppealsContext';
+import { AddContactToAppealModal } from './AddContactToAppealModal';
+import { AppealQuery } from './appealInfo.generated';
+
+const accountListId = 'abc';
+const appealId = 'appealId';
+const router = {
+  query: { accountListId },
+  isReady: true,
+};
+const handleClose = jest.fn();
+const mutationSpy = jest.fn();
+const refetch = jest.fn();
+
+interface ComponentsProps {
+  appealMock?: AppealQuery;
+  contactOptionsMock?: ContactOptionsQuery;
+}
+
+const defaultAppealMock: AppealQuery = {
+  appeal: {
+    id: appealId,
+    contactIds: ['contact-1', 'contact-2'],
+  },
+};
+
+const defaultContactOptionsMock: ContactOptionsQuery = {
+  contacts: {
+    nodes: [
+      { id: 'contact-3', name: 'Alice' },
+      { id: 'contact-4', name: 'Bob' },
+      { id: 'contact-5', name: 'Charlie' },
+    ],
+  },
+};
+
+const Components = ({
+  appealMock = defaultAppealMock,
+  contactOptionsMock = defaultContactOptionsMock,
+}: ComponentsProps) => (
+  <SnackbarProvider>
+    <DndProvider backend={HTML5Backend}>
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<{
+            Appeal: AppealQuery;
+            ContactOptions: ContactOptionsQuery;
+          }>
+            mocks={{
+              Appeal: appealMock,
+              ContactOptions: contactOptionsMock,
+            }}
+            onCall={mutationSpy}
+          >
+            <AppealsWrapper>
+              <AppealsContext.Provider
+                value={{
+                  accountListId,
+                  appealId: appealId,
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-ignore
+                  contactsQueryResult: { refetch },
+                }}
+              >
+                <AddContactToAppealModal handleClose={handleClose} />
+              </AppealsContext.Provider>
+            </AppealsWrapper>
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>
+    </DndProvider>
+  </SnackbarProvider>
+);
+
+describe('AddContactToAppealModal', () => {
+  beforeEach(() => {
+    handleClose.mockClear();
+    refetch.mockClear();
+  });
+  it('default', () => {
+    const { getByRole } = render(<Components />);
+
+    expect(
+      getByRole('heading', { name: 'Add Contact(s)' }),
+    ).toBeInTheDocument();
+    expect(getByRole('combobox', { name: 'Contacts' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
+
+  it('should close modal', () => {
+    const { getByRole } = render(<Components />);
+
+    expect(handleClose).toHaveBeenCalledTimes(0);
+    userEvent.click(getByRole('button', { name: 'Cancel' }));
+    expect(handleClose).toHaveBeenCalledTimes(1);
+
+    userEvent.click(getByRole('button', { name: 'Close' }));
+    expect(handleClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('adds 2 contacts to appeal and refreshes contacts list', async () => {
+    const { getByRole, getByText, queryByText } = render(<Components />);
+
+    expect(mutationSpy).toHaveBeenCalledTimes(0);
+
+    userEvent.click(getByRole('combobox', { name: 'Contacts' }));
+
+    await waitFor(() => {
+      expect(getByRole('option', { name: 'Alice' })).toBeInTheDocument();
+      userEvent.click(getByRole('option', { name: 'Alice' }));
+      expect(getByText('Alice')).toBeInTheDocument();
+    });
+
+    expect(queryByText('Bob')).not.toBeInTheDocument();
+    userEvent.click(getByRole('combobox', { name: 'Contacts' }));
+
+    await waitFor(() => {
+      expect(getByRole('option', { name: 'Bob' })).toBeInTheDocument();
+      userEvent.click(getByRole('option', { name: 'Bob' }));
+      expect(getByText('Bob')).toBeInTheDocument();
+    });
+
+    userEvent.click(getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mutationSpy.mock.calls[8][0].operation.operationName).toEqual(
+        'AssignContactsToAppeal',
+      );
+      expect(mutationSpy.mock.calls[8][0].operation.variables).toEqual({
+        input: {
+          accountListId,
+          attributes: {
+            id: appealId,
+            contactIds: ['contact-1', 'contact-2', 'contact-3', 'contact-4'],
+          },
+        },
+      });
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AddContactToAppealModal/AddContactToAppealModal.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AddContactToAppealModal/AddContactToAppealModal.tsx
@@ -1,0 +1,122 @@
+import React, { ReactElement } from 'react';
+import { DialogActions, DialogContent, Grid } from '@mui/material';
+import { Formik } from 'formik';
+import { useSnackbar } from 'notistack';
+import { useTranslation } from 'react-i18next';
+import * as yup from 'yup';
+import { ContactsAutocomplete } from 'src/components/Task/Modal/Form/Inputs/ContactsAutocomplete/ContactsAutocomplete';
+import {
+  CancelButton,
+  SubmitButton,
+} from 'src/components/common/Modal/ActionButtons/ActionButtons';
+import Modal from 'src/components/common/Modal/Modal';
+import {
+  AppealsContext,
+  AppealsType,
+} from '../../../AppealsContext/AppealsContext';
+import { useAssignContactsToAppealMutation } from './AddContactToAppeal.generated';
+import { useAppealQuery } from './appealInfo.generated';
+
+interface AddContactToAppealModalProps {
+  handleClose: () => void;
+}
+
+export type AddContactFormikSchema = {
+  contactIds: string[];
+};
+
+const AddContactSchema: yup.SchemaOf<AddContactFormikSchema> = yup.object({
+  contactIds: yup.array().of(yup.string().required()).default([]),
+});
+
+export const AddContactToAppealModal: React.FC<
+  AddContactToAppealModalProps
+> = ({ handleClose }) => {
+  const { t } = useTranslation();
+  const { enqueueSnackbar } = useSnackbar();
+  const [assignContactsToAppeal] = useAssignContactsToAppealMutation();
+  const { accountListId, appealId, contactsQueryResult } = React.useContext(
+    AppealsContext,
+  ) as AppealsType;
+
+  const { data } = useAppealQuery({
+    variables: {
+      accountListId: accountListId ?? '',
+      appealId: appealId ?? '',
+    },
+  });
+
+  const existingContactIds = data?.appeal?.contactIds ?? [];
+
+  const onSubmit = async (attributes: AddContactFormikSchema) => {
+    await assignContactsToAppeal({
+      variables: {
+        input: {
+          accountListId: accountListId ?? '',
+          attributes: {
+            id: appealId,
+            contactIds: [...existingContactIds, ...attributes.contactIds],
+          },
+        },
+      },
+      update: () => {
+        contactsQueryResult.refetch();
+      },
+      onCompleted: () => {
+        enqueueSnackbar(t('Successfully updated the appeal'), {
+          variant: 'success',
+        });
+        handleClose();
+      },
+      onError: () => {
+        enqueueSnackbar(t('Failed to update the appeal'), {
+          variant: 'error',
+        });
+      },
+    });
+  };
+
+  return (
+    <Modal title={t('Add Contact(s)')} isOpen={true} handleClose={handleClose}>
+      <Formik
+        initialValues={{
+          contactIds: [],
+        }}
+        validationSchema={AddContactSchema}
+        validateOnMount
+        onSubmit={onSubmit}
+      >
+        {({
+          values: { contactIds },
+          setFieldValue,
+          handleSubmit,
+          isSubmitting,
+          isValid,
+        }): ReactElement => (
+          <form onSubmit={handleSubmit}>
+            <DialogContent>
+              <Grid item>
+                <ContactsAutocomplete
+                  accountListId={accountListId ?? ''}
+                  value={contactIds}
+                  onChange={(contactIds) => {
+                    contactIds;
+                    setFieldValue('contactIds', contactIds);
+                  }}
+                  excludeContactIds={existingContactIds}
+                />
+              </Grid>
+            </DialogContent>
+            <DialogActions>
+              <CancelButton onClick={handleClose} disabled={isSubmitting} />
+
+              <SubmitButton disabled={!isValid || isSubmitting}>
+                {t('Save')}
+              </SubmitButton>
+            </DialogActions>
+          </form>
+        )}
+      </Formik>
+    </Modal>
+  );
+};

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AddContactToAppealModal/DynamicAddContactToAppealModal.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AddContactToAppealModal/DynamicAddContactToAppealModal.tsx
@@ -1,0 +1,12 @@
+import dynamic from 'next/dynamic';
+import { DynamicModalPlaceholder } from 'src/components/DynamicPlaceholders/DynamicModalPlaceholder';
+
+export const preloadAddContactToAppealModal = () =>
+  import(
+    /* webpackChunkName: "AddContactToAppealModal" */ './AddContactToAppealModal'
+  ).then(({ AddContactToAppealModal }) => AddContactToAppealModal);
+
+export const DynamicAddContactToAppealModal = dynamic(
+  preloadAddContactToAppealModal,
+  { loading: DynamicModalPlaceholder },
+);

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AddContactToAppealModal/appealInfo.graphql
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AddContactToAppealModal/appealInfo.graphql
@@ -1,0 +1,6 @@
+query Appeal($accountListId: ID!, $appealId: ID!) {
+  appeal(accountListId: $accountListId, id: $appealId) {
+    id
+    contactIds
+  }
+}

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
@@ -26,6 +26,10 @@ import {
   AppealsContext,
   AppealsType,
 } from '../../AppealsContext/AppealsContext';
+import {
+  DynamicAddContactToAppealModal,
+  preloadAddContactToAppealModal,
+} from './AddContactToAppealModal/DynamicAddContactToAppealModal';
 import { AppealsListFilterPanelButton } from './AppealsListFilterPanelButton';
 import { AppealsListFilterPanelItem } from './AppealsListFilterPanelItem';
 import { useContactsCountQuery } from './contactsCount.generated';
@@ -78,6 +82,7 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
   const [exportsModalOpen, setExportsModalOpen] = useState(false);
   const [labelModalOpen, setLabelModalOpen] = useState(false);
   const [exportEmailsModalOpen, setExportEmailsModalOpen] = useState(false);
+  const [addContactsModalOpen, setAddContactsModalOpen] = useState(false);
   const nameSearch = searchTerm ? { wildcardSearch: searchTerm as string } : {};
   const defaultFilters = {
     appeal: [appealId || ''],
@@ -255,9 +260,12 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
                 />
                 <AppealsListFilterPanelButton
                   title={t('Add Contact to Appeal')}
-                  onClick={handleFilterButtonClick}
                   buttonText={t('Select Contact')}
                   disabled={false}
+                  onClick={() => {
+                    setAddContactsModalOpen(true);
+                  }}
+                  onMouseEnter={preloadAddContactToAppealModal}
                 />
                 <AppealsListFilterPanelButton
                   title={t('Delete Appeal')}
@@ -293,6 +301,12 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
           ids={selectedIds}
           accountListId={accountListId ?? ''}
           handleClose={() => setExportEmailsModalOpen(false)}
+        />
+      )}
+
+      {addContactsModalOpen && (
+        <DynamicAddContactToAppealModal
+          handleClose={() => setAddContactsModalOpen(false)}
         />
       )}
     </Box>

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Close from '@mui/icons-material/Close';
 import {
   Box,
@@ -11,6 +11,15 @@ import {
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
+import {
+  DynamicExportsModal,
+  preloadExportsModal,
+} from 'src/components/Contacts/MassActions/Exports/DynamicExportsModal';
+import {
+  DynamicMassActionsExportEmailsModal,
+  preloadMassActionsExportEmailsModal,
+} from 'src/components/Contacts/MassActions/Exports/Emails/DynamicMassActionsExportEmailsModal';
+import { DynamicMailMergedLabelModal } from 'src/components/Contacts/MassActions/Exports/MailMergedLabelModal/DynamicMailMergedLabelModal';
 import { sanitizeFilters } from 'src/lib/sanitizeFilters';
 import {
   AppealStatusEnum,
@@ -66,7 +75,9 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
     selectedIds,
     deselectAll,
   } = React.useContext(AppealsContext) as AppealsType;
-
+  const [exportsModalOpen, setExportsModalOpen] = useState(false);
+  const [labelModalOpen, setLabelModalOpen] = useState(false);
+  const [exportEmailsModalOpen, setExportEmailsModalOpen] = useState(false);
   const nameSearch = searchTerm ? { wildcardSearch: searchTerm as string } : {};
   const defaultFilters = {
     appeal: [appealId || ''],
@@ -222,19 +233,25 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
 
                 <AppealsListFilterPanelButton
                   title={t('Export to CSV')}
-                  onClick={handleFilterButtonClick}
                   buttonText={t('Export {{number}} Selected', {
                     number: selectedIds.length,
                   })}
                   disabled={noContactsSelected}
+                  onClick={() => {
+                    setExportsModalOpen(true);
+                  }}
+                  onMouseEnter={preloadExportsModal}
                 />
                 <AppealsListFilterPanelButton
                   title={t('Export Emails')}
-                  onClick={handleFilterButtonClick}
                   buttonText={t('Export {{number}} Selected', {
                     number: selectedIds.length,
                   })}
                   disabled={noContactsSelected}
+                  onClick={() => {
+                    setExportEmailsModalOpen(true);
+                  }}
+                  onMouseEnter={preloadMassActionsExportEmailsModal}
                 />
                 <AppealsListFilterPanelButton
                   title={t('Add Contact to Appeal')}
@@ -255,6 +272,29 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
           </div>
         </Slide>
       </div>
+
+      {exportsModalOpen && (
+        <DynamicExportsModal
+          ids={selectedIds}
+          accountListId={accountListId ?? ''}
+          handleClose={() => setExportsModalOpen(false)}
+          openMailMergedLabelModal={() => setLabelModalOpen(true)}
+        />
+      )}
+      {labelModalOpen && (
+        <DynamicMailMergedLabelModal
+          accountListId={accountListId ?? ''}
+          ids={selectedIds}
+          handleClose={() => setLabelModalOpen(false)}
+        />
+      )}
+      {exportEmailsModalOpen && (
+        <DynamicMassActionsExportEmailsModal
+          ids={selectedIds}
+          accountListId={accountListId ?? ''}
+          handleClose={() => setExportEmailsModalOpen(false)}
+        />
+      )}
     </Box>
   );
 };

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
@@ -3,6 +3,7 @@ import Close from '@mui/icons-material/Close';
 import {
   Box,
   BoxProps,
+  Button,
   IconButton,
   List,
   Slide,
@@ -10,6 +11,7 @@ import {
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
+import { sanitizeFilters } from 'src/lib/sanitizeFilters';
 import {
   AppealStatusEnum,
   AppealsContext,
@@ -42,6 +44,15 @@ export interface FilterPanelProps {
   onClose: () => void;
 }
 
+const LinkButton = styled(Button)(({ theme }) => ({
+  width: '100%',
+  textTransform: 'none',
+  fontSize: 16,
+  color: theme.palette.info.main,
+  fontWeight: 'bold',
+  marginTop: theme.spacing(1),
+}));
+
 export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
   onClose,
 }) => {
@@ -51,15 +62,22 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
     appealId,
     activeFilters,
     setActiveFilters,
+    searchTerm,
     selectedIds,
     deselectAll,
   } = React.useContext(AppealsContext) as AppealsType;
+
+  const nameSearch = searchTerm ? { wildcardSearch: searchTerm as string } : {};
+  const defaultFilters = {
+    appeal: [appealId || ''],
+    ...nameSearch,
+  };
 
   const { data: askedCount, loading: askedLoading } = useContactsCountQuery({
     variables: {
       accountListId: accountListId || '',
       contactsFilter: {
-        appeal: [appealId || ''],
+        ...defaultFilters,
         appealStatus: AppealStatusEnum.Asked,
       },
     },
@@ -70,7 +88,7 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
       variables: {
         accountListId: accountListId || '',
         contactsFilter: {
-          appeal: [appealId || ''],
+          ...defaultFilters,
           appealStatus: AppealStatusEnum.Excluded,
         },
       },
@@ -81,7 +99,7 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
       variables: {
         accountListId: accountListId || '',
         contactsFilter: {
-          appeal: [appealId || ''],
+          ...defaultFilters,
           appealStatus: AppealStatusEnum.NotReceived,
         },
       },
@@ -91,7 +109,7 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
     variables: {
       accountListId: accountListId || '',
       contactsFilter: {
-        appeal: [appealId || ''],
+        ...defaultFilters,
         appealStatus: AppealStatusEnum.Processed,
       },
     },
@@ -102,7 +120,7 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
       variables: {
         accountListId: accountListId || '',
         contactsFilter: {
-          appeal: [appealId || ''],
+          ...defaultFilters,
           appealStatus: AppealStatusEnum.ReceivedNotProcessed,
         },
       },
@@ -121,6 +139,13 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
 
   // TODO - Finish this function off
   const handleFilterButtonClick = () => {};
+
+  const handleClearAllClick = () => {
+    setActiveFilters({});
+  };
+
+  const noActiveFilters =
+    Object.keys(sanitizeFilters(activeFilters)).length === 0;
 
   return (
     <Box>
@@ -142,6 +167,13 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
                   <Close titleAccess={t('Close')} />
                 </IconButton>
               </Box>
+              <LinkButton
+                disabled={noActiveFilters}
+                onClick={handleClearAllClick}
+                variant="outlined"
+              >
+                {t('Clear All')}
+              </LinkButton>
             </FilterHeader>
             <FilterList dense sx={{ paddingY: 0 }}>
               <List sx={{ padding: '0' }}>

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
@@ -32,6 +32,10 @@ import {
 } from './AddContactToAppealModal/DynamicAddContactToAppealModal';
 import { AppealsListFilterPanelButton } from './AppealsListFilterPanelButton';
 import { AppealsListFilterPanelItem } from './AppealsListFilterPanelItem';
+import {
+  DynamicDeleteAppealModal,
+  preloadDeleteAppealModal,
+} from './DeleteAppealModal/DynamicAddContactToAppealModal';
 import { useContactsCountQuery } from './contactsCount.generated';
 
 const FilterHeader = styled(Box)(({ theme }) => ({
@@ -83,6 +87,7 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
   const [labelModalOpen, setLabelModalOpen] = useState(false);
   const [exportEmailsModalOpen, setExportEmailsModalOpen] = useState(false);
   const [addContactsModalOpen, setAddContactsModalOpen] = useState(false);
+  const [deleteAppealModalOpen, setDeleteAppealModalOpen] = useState(false);
   const nameSearch = searchTerm ? { wildcardSearch: searchTerm as string } : {};
   const defaultFilters = {
     appeal: [appealId || ''],
@@ -152,9 +157,6 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
 
   const appealListView = activeFilters.appealStatus;
   const noContactsSelected = !selectedIds.length;
-
-  // TODO - Finish this function off
-  const handleFilterButtonClick = () => {};
 
   const handleClearAllClick = () => {
     setActiveFilters({});
@@ -269,11 +271,14 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
                 />
                 <AppealsListFilterPanelButton
                   title={t('Delete Appeal')}
-                  onClick={handleFilterButtonClick}
                   buttonText={t('Permanently Delete Appeal')}
                   disabled={false}
                   buttonError={'error'}
                   buttonVariant={'outlined'}
+                  onClick={() => {
+                    setDeleteAppealModalOpen(true);
+                  }}
+                  onMouseEnter={preloadDeleteAppealModal}
                 />
               </List>
             </FilterList>
@@ -303,10 +308,14 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
           handleClose={() => setExportEmailsModalOpen(false)}
         />
       )}
-
       {addContactsModalOpen && (
         <DynamicAddContactToAppealModal
           handleClose={() => setAddContactsModalOpen(false)}
+        />
+      )}
+      {deleteAppealModalOpen && (
+        <DynamicDeleteAppealModal
+          handleClose={() => setDeleteAppealModalOpen(false)}
         />
       )}
     </Box>

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanelButton.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanelButton.tsx
@@ -30,6 +30,7 @@ export interface AppealsListFilterPanelButtonProps {
   buttonError?: ButtonTypeMap['props']['color'];
   buttonVariant?: ButtonTypeMap['props']['variant'];
   disabled?: boolean;
+  onMouseEnter?: React.MouseEventHandler<HTMLLIElement> | undefined;
 }
 
 export const AppealsListFilterPanelButton = ({
@@ -39,11 +40,12 @@ export const AppealsListFilterPanelButton = ({
   buttonError = 'primary',
   buttonVariant = 'contained',
   disabled,
+  onMouseEnter,
 }: AppealsListFilterPanelButtonProps): ReactElement => {
   const { classes } = useStyles();
 
   return (
-    <ListItem className={classes.li}>
+    <ListItem className={classes.li} onMouseEnter={onMouseEnter}>
       <Box display="flex" flexDirection="column" className={classes.itemBox}>
         <ListItemText
           primaryTypographyProps={{

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/DeleteAppealModal/AddContactToAppealModal.test.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/DeleteAppealModal/AddContactToAppealModal.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SnackbarProvider } from 'notistack';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import TestRouter from '__tests__/util/TestRouter';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import theme from 'src/theme';
+import {
+  AppealsContext,
+  AppealsType,
+} from '../../../AppealsContext/AppealsContext';
+import { DeleteAppealModal } from './DeleteAppealModal';
+
+const mockEnqueue = jest.fn();
+const handleClose = jest.fn();
+const mutationSpy = jest.fn();
+const routerPush = jest.fn();
+
+jest.mock('notistack', () => ({
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  ...jest.requireActual('notistack'),
+  useSnackbar: () => {
+    return {
+      enqueueSnackbar: mockEnqueue,
+    };
+  },
+}));
+
+const accountListId = 'abc';
+const appealId = 'appealId';
+const router = {
+  query: { accountListId },
+  isReady: true,
+  push: routerPush,
+};
+
+const Components = () => (
+  <SnackbarProvider>
+    <DndProvider backend={HTML5Backend}>
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider onCall={mutationSpy}>
+            <AppealsContext.Provider
+              value={
+                {
+                  accountListId,
+                  appealId: appealId,
+                } as AppealsType
+              }
+            >
+              <DeleteAppealModal handleClose={handleClose} />
+            </AppealsContext.Provider>
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>
+    </DndProvider>
+  </SnackbarProvider>
+);
+
+describe('DeleteAppealModal', () => {
+  beforeEach(() => {
+    handleClose.mockClear();
+  });
+  it('default', () => {
+    const { getByRole, getByText } = render(<Components />);
+
+    expect(getByRole('heading', { name: 'Delete Appeal' })).toBeInTheDocument();
+    expect(
+      getByText(/you are about to permanently delete this appeal/i),
+    ).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
+
+  it('should close modal', () => {
+    const { getByRole } = render(<Components />);
+
+    expect(handleClose).toHaveBeenCalledTimes(0);
+    userEvent.click(getByRole('button', { name: 'Cancel' }));
+    expect(handleClose).toHaveBeenCalledTimes(1);
+
+    userEvent.click(getByRole('button', { name: 'Close' }));
+    expect(handleClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('should delete appeal and redirect back to the main appeals page', async () => {
+    const { getByRole } = render(<Components />);
+
+    expect(mutationSpy).toHaveBeenCalledTimes(0);
+
+    userEvent.click(getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(mockEnqueue).toHaveBeenCalledWith('Successfully deleted appeal.', {
+        variant: 'success',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mutationSpy.mock.lastCall[0].operation.operationName).toEqual(
+        'DeleteAppeal',
+      );
+      expect(mutationSpy.mock.lastCall[0].operation.variables).toEqual({
+        input: {
+          accountListId,
+          id: appealId,
+        },
+      });
+    });
+
+    expect(routerPush).toHaveBeenCalledWith(
+      `/accountLists/${accountListId}/tools/appeals`,
+    );
+  });
+});

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/DeleteAppealModal/DeleteAppeal.graphql
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/DeleteAppealModal/DeleteAppeal.graphql
@@ -1,0 +1,5 @@
+mutation DeleteAppeal($input: AppealDeleteMutationInput!) {
+  deleteAppeal(input: $input) {
+    id
+  }
+}

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/DeleteAppealModal/DeleteAppealModal.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/DeleteAppealModal/DeleteAppealModal.tsx
@@ -1,0 +1,101 @@
+import { useRouter } from 'next/router';
+import React, { useContext, useState } from 'react';
+import {
+  Alert,
+  DialogActions,
+  DialogContent,
+  Grid,
+  Typography,
+} from '@mui/material';
+import { useSnackbar } from 'notistack';
+import { useTranslation } from 'react-i18next';
+import {
+  ActionButton,
+  CancelButton,
+} from 'src/components/common/Modal/ActionButtons/ActionButtons';
+import Modal from 'src/components/common/Modal/Modal';
+import {
+  AppealsContext,
+  AppealsType,
+} from '../../../AppealsContext/AppealsContext';
+import { useDeleteAppealMutation } from './DeleteAppeal.generated';
+
+interface DeleteAppealModalProps {
+  handleClose: () => void;
+}
+
+export const DeleteAppealModal: React.FC<DeleteAppealModalProps> = ({
+  handleClose,
+}) => {
+  const { t } = useTranslation();
+  const { push } = useRouter();
+  const { enqueueSnackbar } = useSnackbar();
+  const [deleteAppeal] = useDeleteAppealMutation();
+  const { accountListId, appealId } = useContext(AppealsContext) as AppealsType;
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleDelete = async () => {
+    if (!accountListId) {
+      enqueueSnackbar(t('"accountListId" is not defined'), {
+        variant: 'error',
+      });
+      return;
+    }
+    if (!appealId) {
+      enqueueSnackbar(t('"appealId" is not defined'), {
+        variant: 'error',
+      });
+      return;
+    }
+    setIsSubmitting(true);
+    await deleteAppeal({
+      variables: {
+        input: {
+          accountListId: accountListId,
+          id: appealId,
+        },
+      },
+      onCompleted: () => {
+        enqueueSnackbar(t('Successfully deleted appeal.'), {
+          variant: 'success',
+        });
+
+        push(`/accountLists/${accountListId}/tools/appeals`);
+      },
+      onError: () => {
+        enqueueSnackbar(t('There was an error trying to delete the appeal.'), {
+          variant: 'error',
+        });
+      },
+    });
+
+    setIsSubmitting(false);
+  };
+
+  return (
+    <Modal title={t('Delete Appeal')} isOpen={true} handleClose={handleClose}>
+      <DialogContent>
+        <Grid item>
+          <Alert severity="warning">
+            <Typography>
+              {t(
+                'You are about to permanently delete this Appeal. This will remove all contacts, and delete all pledges, and progress towards this appeal. Are you sure you want to continue?',
+              )}
+            </Typography>
+          </Alert>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <CancelButton onClick={handleClose} />
+
+        <ActionButton
+          disabled={isSubmitting}
+          onClick={handleDelete}
+          color="error"
+        >
+          {t('Delete Appeal')}
+        </ActionButton>
+      </DialogActions>
+    </Modal>
+  );
+};

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/DeleteAppealModal/DynamicAddContactToAppealModal.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/DeleteAppealModal/DynamicAddContactToAppealModal.tsx
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic';
+import { DynamicModalPlaceholder } from 'src/components/DynamicPlaceholders/DynamicModalPlaceholder';
+
+export const preloadDeleteAppealModal = () =>
+  import(
+    /* webpackChunkName: "DeleteAppealModal" */ './DeleteAppealModal'
+  ).then(({ DeleteAppealModal }) => DeleteAppealModal);
+
+export const DynamicDeleteAppealModal = dynamic(preloadDeleteAppealModal, {
+  loading: DynamicModalPlaceholder,
+});


### PR DESCRIPTION
## Description
In this PR, I added functionality to the list view filter buttons. This includes exporting contacts & emails, adding contacts to appeals and deleting appeals. All models are dynamically loaded and preloaded when the mouse is hovered over the button that opens the modal in question.


#### Fixes
- Updated the panel contact number if the user searched to show how many contacts are under each appeal status.
- Added the ability to load dynamic components on the filter panel buttons on the mouse hover


#### Export contacts & emails
These models already existed, so there was less work to get them working.

#### Add Contacts Modal
Created a new modal that allows the user to add contacts to the appeal.
- Edited the`<ContactsAutocomplete/>` to exclude contact IDs so the user doesn't see contacts that are already a part of the appeal.
- Refreshes the contacts list to show new contacts in the contact list.

#### Delete Appeal Modal
Created this modal to allow the user to delete the appeal.
- after deletion, it redirects to the user back to the appeals page


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
