### PR TITLE
HelpScout 1199118 Update cache after contact deletion to prevent refresh

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import React, { ReactElement, useState } from 'react';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
@@ -10,10 +9,7 @@ import { Box, IconButton, ListItemText, Menu } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
-import {
-  ContactsDocument,
-  ContactsQuery,
-} from 'pages/accountLists/[accountListId]/contacts/Contacts.generated';
+import { ContactsDocument } from 'pages/accountLists/[accountListId]/contacts/Contacts.generated';
 import {
   ContactsContext,
   ContactsType,
@@ -124,10 +120,7 @@ export const ContactDetailsMoreAcitions: React.FC<
 > = ({ contactId, status, onClose }) => {
   const { openTaskModal, preloadTaskModal } = useTaskModal();
   const { t } = useTranslation();
-  const { query, push } = useRouter();
-  const { accountListId, searchTerm } = React.useContext(
-    ContactsContext,
-  ) as ContactsType;
+  const { accountListId } = React.useContext(ContactsContext) as ContactsType;
 
   const {
     referralsModalOpen,
@@ -144,7 +137,6 @@ export const ContactDetailsMoreAcitions: React.FC<
 
   const [openHideModal, setOpenHideModal] = useState(false);
   const [updateHiding, setUpdateHiding] = useState(false);
-  const { contactId: _, ...queryWithoutContactId } = query;
   const hideContact = async (): Promise<void> => {
     setUpdateHiding(true);
     const attributes = {
@@ -175,39 +167,13 @@ export const ContactDetailsMoreAcitions: React.FC<
         accountListId: accountListId ?? '',
         contactId,
       },
-      update: (cache, { data: deletedContactData }) => {
-        const deletedContactId = deletedContactData?.deleteContact?.id;
-        const query = {
-          query: ContactsDocument,
-          variables: {
-            accountListId,
-            searchTerm,
-          },
-        };
+      update: (cache) => {
+        cache.evict({ id: `Contact:${contactId}` });
 
-        const dataFromCache = cache.readQuery<ContactsQuery>(query);
-
-        if (dataFromCache) {
-          const data = {
-            ...dataFromCache,
-            contacts: {
-              ...dataFromCache.contacts,
-              nodes: dataFromCache.contacts.nodes.filter(
-                (contact) => contact.id !== deletedContactId,
-              ),
-              totalCount: dataFromCache.contacts.totalCount - 1,
-            },
-          };
-          cache.writeQuery({ ...query, data });
-
-          push({
-            pathname: '/accountLists/[accountListId]/contacts',
-            query: { searchTerm, ...queryWithoutContactId },
-          });
-          enqueueSnackbar(t('Contact successfully deleted'), {
-            variant: 'success',
-          });
-        }
+        enqueueSnackbar(t('Contact successfully deleted'), {
+          variant: 'success',
+        });
+        onClose();
       },
     });
     setDeleteModalOpen(false);

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
@@ -169,6 +169,7 @@ export const ContactDetailsMoreAcitions: React.FC<
       },
       update: (cache) => {
         cache.evict({ id: `Contact:${contactId}` });
+        cache.gc();
 
         enqueueSnackbar(t('Contact successfully deleted'), {
           variant: 'success',


### PR DESCRIPTION
## Description
In this PR, I removed the functionality to refresh the page after deletion and instead updated the cache to remove the contact in question. I also improved the way we update the cache and tests.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
