### PR TITLE
[no-Jira] Remove duplicate GraphQL operation

### DIFF
--- a/src/components/Tool/FixMailingAddresses/FixMailingAddresses.tsx
+++ b/src/components/Tool/FixMailingAddresses/FixMailingAddresses.tsx
@@ -19,6 +19,7 @@ import { makeStyles } from 'tss-react/mui';
 import { SetContactFocus } from 'pages/accountLists/[accountListId]/tools/useToolsHelper';
 import { DynamicAddAddressModal } from 'src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/AddAddressModal/DynamicAddAddressModal';
 import { DynamicEditContactAddressModal } from 'src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/DynamicEditContactAddressModal';
+import { useUpdateContactAddressMutation } from 'src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddress.generated';
 import { Confirmation } from 'src/components/common/Modal/Confirmation/Confirmation';
 import theme from '../../../theme';
 import NoData from '../NoData';
@@ -28,7 +29,6 @@ import {
   InvalidAddressesDocument,
   InvalidAddressesQuery,
   useInvalidAddressesQuery,
-  useUpdateContactAddressMutation,
 } from './GetInvalidAddresses.generated';
 
 export type HandleSingleConfirmProps = {

--- a/src/components/Tool/FixMailingAddresses/GetInvalidAddresses.graphql
+++ b/src/components/Tool/FixMailingAddresses/GetInvalidAddresses.graphql
@@ -32,26 +32,3 @@ fragment ContactAddress on Address {
   createdAt
   historic
 }
-
-mutation UpdateContactAddress(
-  $accountListId: ID!
-  $attributes: AddressUpdateInput!
-) {
-  updateAddress(
-    input: { accountListId: $accountListId, attributes: $attributes }
-  ) {
-    address {
-      city
-      country
-      historic
-      id
-      location
-      metroArea
-      postalCode
-      primaryMailingAddress
-      region
-      state
-      street
-    }
-  }
-}


### PR DESCRIPTION
## Description

* Remove duplicate UpdateContactAddress mutation definition. It was causing errors in the Apollo VS Code extension. Cmd+click to jump to definition in `.graphql` files should work again.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
