### PR TITLE
Making the Edit Commitment message different than the add commitment.

### DIFF
--- a/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.test.tsx
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.test.tsx
@@ -155,7 +155,7 @@ describe('PledgeModal', () => {
 
   it('Edit commitment', async () => {
     const pledgeId = 'pledge-1';
-    const { getByRole, findByText } = render(
+    const { getByRole, getByText, findByText } = render(
       <Components
         pledge={{
           id: pledgeId,
@@ -175,6 +175,7 @@ describe('PledgeModal', () => {
     expect(
       getByRole('heading', { name: 'Edit Commitment' }),
     ).toBeInTheDocument();
+    expect(getByText('You are editing the commitment for')).toBeInTheDocument();
 
     const amountInput = getByRole('textbox', { name: 'Amount' });
 

--- a/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
@@ -196,7 +196,10 @@ export const PledgeModal: React.FC<PledgeModalProps> = ({
               <Grid item>
                 <Alert severity="info" sx={{ marginBottom: 1 }}>
                   <Typography>
-                    {t('You are adding a commitment for')} <b>{contact.name}</b>
+                    {isNewPledge
+                      ? t('You are adding a commitment for')
+                      : t('You are editing the commitment for')}
+                    <b> {contact.name}</b>
                   </Typography>
                 </Alert>
               </Grid>


### PR DESCRIPTION
## Description
In this PR, I fixed an issue which I created where when someone is editing a commitment in Appeals, they see the message "You are adding a commitment to {name}".

I've now made a different message show when the user is editing the commitment.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
