### PR TITLE
GraphQL Fix - Removing duplicate GraphQL

### DIFF
--- a/src/components/Tool/Appeal/Modals/AddExcludedContactModal/AddExcludedContactModal.graphql
+++ b/src/components/Tool/Appeal/Modals/AddExcludedContactModal/AddExcludedContactModal.graphql
@@ -1,8 +1,0 @@
-mutation AssignContactsToAppeal($input: AssignContactsToAppealMutationInput!) {
-  assignContactsToAppeal(input: $input) {
-    appeal {
-      id
-      name
-    }
-  }
-}

--- a/src/components/Tool/Appeal/Modals/AddExcludedContactModal/AddExcludedContactModal.tsx
+++ b/src/components/Tool/Appeal/Modals/AddExcludedContactModal/AddExcludedContactModal.tsx
@@ -18,8 +18,8 @@ import {
   AppealsContext,
   AppealsType,
 } from '../../AppealsContext/AppealsContext';
+import { useAssignContactsToAppealMutation } from '../AddContactToAppealModal/AddContactToAppeal.generated';
 import { useAppealQuery } from '../AddContactToAppealModal/AppealInfo.generated';
-import { useAssignContactsToAppealMutation } from './AddExcludedContactModal.generated';
 
 const LoadingIndicator = styled(CircularProgress)(({ theme }) => ({
   margin: theme.spacing(0, 1, 0, 0),


### PR DESCRIPTION
## Description
In this PR I remove the `AddExcludedContactModal.graphql` file as it creates a duplicate `AssignContactsToAppeal` GraphQL mutation, since `AddContactToAppeal.graphql` already has defined it.


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
