### PR TITLE
[MPDX-8094] Add makeGetServerSideProps helper to reduce boilerplate in `getServerSideProps`

### DIFF
--- a/pages/accountLists.page.test.tsx
+++ b/pages/accountLists.page.test.tsx
@@ -3,6 +3,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { getSession } from 'next-auth/react';
 import { I18nextProvider } from 'react-i18next';
+import { session } from '__tests__/fixtures/session';
 import makeSsrClient from 'src/lib/apollo/ssrClient';
 import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
@@ -27,12 +28,7 @@ describe('Account Lists page', () => {
 
   describe('NextAuth unauthorized', () => {
     it('should redirect to login', async () => {
-      (getSession as jest.Mock).mockResolvedValue({
-        user: {
-          apiToken: null,
-          userID: null,
-        },
-      });
+      (getSession as jest.Mock).mockResolvedValue(null);
 
       const { props, redirect } = (await getServerSideProps(
         context as GetServerSidePropsContext,
@@ -48,12 +44,7 @@ describe('Account Lists page', () => {
 
   describe('NextAuth authorized', () => {
     beforeEach(() => {
-      (getSession as jest.Mock).mockResolvedValue({
-        user: {
-          apiToken: 'apiToken',
-          userID: 'userID',
-        },
-      });
+      (getSession as jest.Mock).mockResolvedValue(session);
     });
 
     it('redirects user to their accountList page if only one accountList', async () => {
@@ -69,15 +60,6 @@ describe('Account Lists page', () => {
         context as GetServerSidePropsContext,
       )) as GetServerSidePropsReturn;
 
-      const { queryByText } = render(
-        <ThemeProvider theme={theme}>
-          <I18nextProvider i18n={i18n}>
-            <AccountListsPage {...props} />
-          </I18nextProvider>
-        </ThemeProvider>,
-      );
-
-      expect(queryByText('My Accounts')).not.toBeInTheDocument();
       expect(props).toBeUndefined();
       expect(redirect).toEqual({
         destination: `/accountLists/${accountListId}`,

--- a/pages/accountLists/[accountListId].page.test.tsx
+++ b/pages/accountLists/[accountListId].page.test.tsx
@@ -3,6 +3,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { getSession } from 'next-auth/react';
 import { I18nextProvider } from 'react-i18next';
+import { session } from '__tests__/fixtures/session';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import makeSsrClient from 'src/lib/apollo/ssrClient';
@@ -30,12 +31,7 @@ describe('AccountListsId page', () => {
 
   describe('NextAuth unauthorized', () => {
     it('should redirect to login', async () => {
-      (getSession as jest.Mock).mockResolvedValue({
-        user: {
-          apiToken: null,
-          userID: null,
-        },
-      });
+      (getSession as jest.Mock).mockResolvedValue(null);
 
       const { props, redirect } = (await getServerSideProps(
         context,
@@ -51,12 +47,7 @@ describe('AccountListsId page', () => {
 
   describe('NextAuth authorized', () => {
     beforeEach(() => {
-      (getSession as jest.Mock).mockResolvedValue({
-        user: {
-          apiToken: 'apiToken',
-          userID: 'userID',
-        },
-      });
+      (getSession as jest.Mock).mockResolvedValue(session);
     });
 
     it('redirects to the home page on GraphQL query error', async () => {

--- a/pages/api/utils/pagePropsHelpers.ts
+++ b/pages/api/utils/pagePropsHelpers.ts
@@ -50,21 +50,48 @@ export const loadSession: GetServerSideProps<PagePropsWithSession> = async (
   };
 };
 
-// It is a common pattern in getServerSideProps to need to first extract the API
-// token from the session, redirect to the login page if the API token is
-// missing, then use the API token to do custom logic and eventually return the
-// page props. This helper eliminates some of that boilerplate. Use it like this:
-//
-// export const getServerSideProps = makeGetServerSideProps<PageProps>(async (session) => {
-//   const ssrClient = makeSsrClient(session.user.apiToken);
-//   // Use the ssrClient
-//   return {
-//     props: {
-//       pageData,
-//     },
-//   };
-// })
+/**
+ * It is a common pattern in `getServerSideProps` to need to first extract the
+ * API token from the session, redirect to the login page if the API token is
+ * missing, then use the API token to do custom logic and eventually return the
+ * page props. This helper eliminates some of that boilerplate.
+ *
+ * Calling this function doesn't return the page props directly, it returns a
+ * `getServerSideProps` function. That returned `getServerSideProps` function is
+ * a wrapper around the function you pass into `makeGetServerSideProps`. The
+ * wrapper extracts the session, redirects to the login page if the session is
+ * invalid, and passes the session along to the function you pass into
+ * `makeGetServerSideProps` to run your custom logic.
+ *
+ * When the page is rendered, this is the flow:
+ *
+ * 1. Next.js calls the closure returned from `makeGetServerSideProps`
+ * 2. That closure extracts the session
+ * 3. If the session is valid, it calls the `getServerSidePropsFromSession`
+ *    passed to `makeGetServerSideProps`
+ * 4. The closure takes the props returned from `getServerSidePropsFromSession`,
+ *    adds the `session` to them, and returns the combined props to Next.js,
+ *    which it uses to render the page
+ *
+ * Usage:
+ *
+ * ```
+ * export const getServerSideProps = makeGetServerSideProps<PageProps>(async (session) => {
+ *   const ssrClient = makeSsrClient(session.user.apiToken);
+ *
+ *   // Use the ssrClient to generate the pageData...
+ *
+ *   return {
+ *     props: {
+ *       pageData,
+ *     },
+ *   };
+ * });
+ * ```
+ */
 export const makeGetServerSideProps = <PageProps = Record<string, unknown>>(
+  // Every time the page is rendered, this function will be called with the session
+  // It should use the session to return the props needed to render the page
   getServerSidePropsFromSession: (
     session: Session,
     context: GetServerSidePropsContext,
@@ -72,7 +99,7 @@ export const makeGetServerSideProps = <PageProps = Record<string, unknown>>(
 ): GetServerSideProps<PageProps & PagePropsWithSession> => {
   // Return a getServerSideProps method
   return async (context) => {
-    // Start by loading the session and redirecting if it is missing
+    // Start by loading the session and redirecting to the login page if it is missing
     const session = await getSession(context);
     if (!session) {
       return {
@@ -83,8 +110,11 @@ export const makeGetServerSideProps = <PageProps = Record<string, unknown>>(
       };
     }
 
-    // Pass the session off to the page's custom logic to build out the page props
+    // Pass the session to the page's custom logic to generate the page props
     const result = await getServerSidePropsFromSession(session, context);
+
+    // If the page's custom logic returned props, add the session to them.
+    // _app.page.tsx will use the session to initialize <SessionProvider>.
     if ('props' in result) {
       // Add the session to the returned props
       return {
@@ -97,7 +127,9 @@ export const makeGetServerSideProps = <PageProps = Record<string, unknown>>(
         },
       };
     } else {
-      // Pass redirects and not found results through without modification
+      // The custom logic returned a redirect or a not found response, so we
+      // return that response without modification. We don't need to add the
+      // session to the props.
       return result;
     }
   };

--- a/pages/api/utils/pagePropsHelpers.ts
+++ b/pages/api/utils/pagePropsHelpers.ts
@@ -1,4 +1,8 @@
-import { GetServerSideProps } from 'next';
+import {
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  GetServerSidePropsResult,
+} from 'next';
 import { Session } from 'next-auth';
 import { getSession } from 'next-auth/react';
 
@@ -43,5 +47,58 @@ export const loadSession: GetServerSideProps<PagePropsWithSession> = async (
     props: {
       session,
     },
+  };
+};
+
+// It is a common pattern in getServerSideProps to need to first extract the API
+// token from the session, redirect to the login page if the API token is
+// missing, then use the API token to do custom logic and eventually return the
+// page props. This helper eliminates some of that boilerplate. Use it like this:
+//
+// export const getServerSideProps = makeGetServerSideProps<PageProps>(async (session) => {
+//   const ssrClient = makeSsrClient(session.user.apiToken);
+//   // Use the ssrClient
+//   return {
+//     props: {
+//       pageData,
+//     },
+//   };
+// })
+export const makeGetServerSideProps = <PageProps = Record<string, unknown>>(
+  getServerSidePropsFromSession: (
+    session: Session,
+    context: GetServerSidePropsContext,
+  ) => Promise<GetServerSidePropsResult<PageProps>>,
+): GetServerSideProps<PageProps & PagePropsWithSession> => {
+  // Return a getServerSideProps method
+  return async (context) => {
+    // Start by loading the session and redirecting if it is missing
+    const session = await getSession(context);
+    if (!session) {
+      return {
+        redirect: {
+          destination: '/login',
+          permanent: false,
+        },
+      };
+    }
+
+    // Pass the session off to the page's custom logic to build out the page props
+    const result = await getServerSidePropsFromSession(session, context);
+    if ('props' in result) {
+      // Add the session to the returned props
+      return {
+        props: {
+          session,
+          // Props can either be a promise or the actual props
+          ...(result.props instanceof Promise
+            ? await result.props
+            : result.props),
+        },
+      };
+    } else {
+      // Pass redirects and not found results through without modification
+      return result;
+    }
   };
 };


### PR DESCRIPTION
## Description

Virtually every `getServerSideProps` method needs to first load the session, redirect to the login page if it is missing, then uses the session to run custom logic. This PR adds a helper method `makeGetServerSideProps` to reduce some of this boilerplate. Simply pass it a function that accepts a `session` and returns the page props. The helper function will load the session, pass it to the custom function you provided, and add the session to any page props returned.

Will be used in [MPDX-8084](https://jira.cru.org/browse/MPDX-8084) and [MPDX-8087](https://jira.cru.org/browse/MPDX-8087)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
