### PR TITLE
[MPDX-8091] Hide links in the navbar when the user is on the setup tour

### DIFF
--- a/pages/accountLists/[accountListId]/settings/integrations/index.page.test.tsx
+++ b/pages/accountLists/[accountListId]/settings/integrations/index.page.test.tsx
@@ -22,6 +22,7 @@ const push = jest.fn();
 
 const router = {
   query: { accountListId },
+  pathname: '/accountLists/[accountListId]/settings/integrations',
   isReady: true,
   push,
 };

--- a/pages/accountLists/[accountListId]/settings/integrations/index.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/integrations/index.page.tsx
@@ -29,7 +29,7 @@ const Integrations: React.FC = () => {
   const accountListId = useAccountListId() || '';
   const { appName } = useGetAppSettings();
   const { enqueueSnackbar } = useSnackbar();
-  const { settingUp } = useSetupContext();
+  const { onSetupTour } = useSetupContext();
   const [setup, setSetup] = useState(0);
 
   const setupAccordions = ['google', 'mailchimp', 'prayerletters.com'];
@@ -37,7 +37,7 @@ const Integrations: React.FC = () => {
   const [updateUserOptions] = useUpdateUserOptionsMutation();
 
   const handleSetupChange = async () => {
-    if (!settingUp) {
+    if (!onSetupTour) {
       return;
     }
     const nextNav = setup + 1;
@@ -70,10 +70,10 @@ const Integrations: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (settingUp) {
+    if (onSetupTour) {
       setExpandedPanel(setupAccordions[0]);
     }
-  }, [settingUp]);
+  }, [onSetupTour]);
 
   return (
     <SettingsWrapper
@@ -81,7 +81,7 @@ const Integrations: React.FC = () => {
       pageHeading={t('Connect Services')}
       selectedMenuId="integrations"
     >
-      {settingUp && (
+      {onSetupTour && (
         <StickyBox>
           <SetupBanner
             button={
@@ -99,34 +99,34 @@ const Integrations: React.FC = () => {
         <TheKeyAccordion
           handleAccordionChange={handleAccordionChange}
           expandedPanel={expandedPanel}
-          disabled={settingUp}
+          disabled={onSetupTour}
         />
         <OrganizationAccordion
           handleAccordionChange={handleAccordionChange}
           expandedPanel={expandedPanel}
-          disabled={settingUp}
+          disabled={onSetupTour}
         />
       </AccordionGroup>
       <AccordionGroup title={t('External Services')}>
         <GoogleAccordion
           handleAccordionChange={handleAccordionChange}
           expandedPanel={expandedPanel}
-          disabled={settingUp && setup !== 0}
+          disabled={onSetupTour && setup !== 0}
         />
         <MailchimpAccordion
           handleAccordionChange={handleAccordionChange}
           expandedPanel={expandedPanel}
-          disabled={settingUp && setup !== 1}
+          disabled={onSetupTour && setup !== 1}
         />
         <PrayerlettersAccordion
           handleAccordionChange={handleAccordionChange}
           expandedPanel={expandedPanel}
-          disabled={settingUp && setup !== 2}
+          disabled={onSetupTour && setup !== 2}
         />
         <ChalklineAccordion
           handleAccordionChange={handleAccordionChange}
           expandedPanel={expandedPanel}
-          disabled={settingUp}
+          disabled={onSetupTour}
         />
       </AccordionGroup>
     </SettingsWrapper>

--- a/pages/accountLists/[accountListId]/settings/notifications.page.test.tsx
+++ b/pages/accountLists/[accountListId]/settings/notifications.page.test.tsx
@@ -23,6 +23,7 @@ const push = jest.fn();
 
 const router = {
   query: { accountListId },
+  pathname: '/accountLists/[accountListId]/settings/notifications',
   isReady: true,
   push,
 };

--- a/pages/accountLists/[accountListId]/settings/notifications.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/notifications.page.tsx
@@ -19,12 +19,12 @@ const Notifications: React.FC = () => {
   const accountListId = useAccountListId() || '';
   const { push } = useRouter();
   const { enqueueSnackbar } = useSnackbar();
-  const { settingUp } = useSetupContext();
+  const { onSetupTour } = useSetupContext();
 
   const [updateUserOptions] = useUpdateUserOptionsMutation();
 
   const handleSetupChange = async () => {
-    if (!settingUp) {
+    if (!onSetupTour) {
       return;
     }
 
@@ -48,7 +48,7 @@ const Notifications: React.FC = () => {
       pageHeading={t('Notifications')}
       selectedMenuId="notifications"
     >
-      {settingUp && (
+      {onSetupTour && (
         <StickyBox>
           <SetupBanner
             button={

--- a/pages/accountLists/[accountListId]/settings/preferences.page.test.tsx
+++ b/pages/accountLists/[accountListId]/settings/preferences.page.test.tsx
@@ -27,6 +27,7 @@ const push = jest.fn();
 
 const router = {
   query: { accountListId },
+  pathname: '/accountLists/[accountListId]/settings/preferences',
   isReady: true,
   push,
 };

--- a/pages/accountLists/[accountListId]/settings/preferences.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/preferences.page.tsx
@@ -46,7 +46,7 @@ const Preferences: React.FC = () => {
   const accountListId = useAccountListId() || '';
   const { push, query } = useRouter();
   const { enqueueSnackbar } = useSnackbar();
-  const { settingUp } = useSetupContext();
+  const { onSetupTour } = useSetupContext();
 
   const setupAccordions = ['locale', 'monthly goal', 'home country'];
   const [setup, setSetup] = useState(0);
@@ -85,10 +85,10 @@ const Preferences: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (settingUp) {
+    if (onSetupTour) {
       setExpandedPanel(setupAccordions[0]);
     }
-  }, [settingUp]);
+  }, [onSetupTour]);
 
   const handleAccordionChange = (panel: string) => {
     const panelLowercase = panel.toLowerCase();
@@ -111,7 +111,7 @@ const Preferences: React.FC = () => {
   };
 
   const handleSetupChange = async () => {
-    if (!settingUp) {
+    if (!onSetupTour) {
       return;
     }
     const nextNav = setup + 1;
@@ -154,7 +154,7 @@ const Preferences: React.FC = () => {
       pageHeading={t('Preferences')}
       selectedMenuId={'preferences'}
     >
-      {settingUp && (
+      {onSetupTour && (
         <StickyBox>
           <SetupBanner
             button={
@@ -183,7 +183,7 @@ const Preferences: React.FC = () => {
               handleAccordionChange={handleAccordionChange}
               expandedPanel={expandedPanel}
               locale={personalPreferencesData?.user?.preferences?.locale || ''}
-              disabled={settingUp}
+              disabled={onSetupTour}
             />
             <LocaleAccordion
               handleAccordionChange={handleAccordionChange}
@@ -191,7 +191,7 @@ const Preferences: React.FC = () => {
               localeDisplay={
                 personalPreferencesData?.user?.preferences?.localeDisplay || ''
               }
-              disabled={settingUp && setup !== 0}
+              disabled={onSetupTour && setup !== 0}
               handleSetupChange={handleSetupChange}
             />
             <DefaultAccountAccordion
@@ -202,7 +202,7 @@ const Preferences: React.FC = () => {
               defaultAccountList={
                 personalPreferencesData?.user?.defaultAccountList || ''
               }
-              disabled={settingUp}
+              disabled={onSetupTour}
             />
             <TimeZoneAccordion
               handleAccordionChange={handleAccordionChange}
@@ -211,7 +211,7 @@ const Preferences: React.FC = () => {
                 personalPreferencesData?.user?.preferences?.timeZone || ''
               }
               timeZones={timeZones}
-              disabled={settingUp}
+              disabled={onSetupTour}
             />
             <HourToSendNotificationsAccordion
               handleAccordionChange={handleAccordionChange}
@@ -220,7 +220,7 @@ const Preferences: React.FC = () => {
                 personalPreferencesData?.user?.preferences
                   ?.hourToSendNotifications || null
               }
-              disabled={settingUp}
+              disabled={onSetupTour}
             />
           </>
         )}
@@ -242,7 +242,7 @@ const Preferences: React.FC = () => {
               expandedPanel={expandedPanel}
               name={accountPreferencesData?.accountList?.name || ''}
               accountListId={accountListId}
-              disabled={settingUp}
+              disabled={onSetupTour}
             />
             <MonthlyGoalAccordion
               handleAccordionChange={handleAccordionChange}
@@ -255,7 +255,7 @@ const Preferences: React.FC = () => {
               currency={
                 accountPreferencesData?.accountList?.settings?.currency || ''
               }
-              disabled={settingUp && setup !== 1}
+              disabled={onSetupTour && setup !== 1}
               handleSetupChange={handleSetupChange}
             />
             <HomeCountryAccordion
@@ -266,7 +266,7 @@ const Preferences: React.FC = () => {
               }
               accountListId={accountListId}
               countries={countries}
-              disabled={settingUp && setup !== 2}
+              disabled={onSetupTour && setup !== 2}
               handleSetupChange={handleSetupChange}
             />
             <CurrencyAccordion
@@ -276,7 +276,7 @@ const Preferences: React.FC = () => {
                 accountPreferencesData?.accountList?.settings?.currency || ''
               }
               accountListId={accountListId}
-              disabled={settingUp}
+              disabled={onSetupTour}
             />
             {userOrganizationAccountsData?.userOrganizationAccounts &&
               userOrganizationAccountsData?.userOrganizationAccounts?.length >
@@ -290,7 +290,7 @@ const Preferences: React.FC = () => {
                     ''
                   }
                   accountListId={accountListId}
-                  disabled={settingUp}
+                  disabled={onSetupTour}
                 />
               )}
             <EarlyAdopterAccordion
@@ -300,7 +300,7 @@ const Preferences: React.FC = () => {
                 accountPreferencesData?.accountList?.settings?.tester || false
               }
               accountListId={accountListId}
-              disabled={settingUp}
+              disabled={onSetupTour}
             />
             <MpdInfoAccordion
               handleAccordionChange={handleAccordionChange}
@@ -319,7 +319,7 @@ const Preferences: React.FC = () => {
                 accountPreferencesData?.accountList?.settings?.currency || ''
               }
               accountListId={accountListId}
-              disabled={settingUp}
+              disabled={onSetupTour}
             />
             {canUserExportData?.canUserExportData.allowed && (
               <ExportAllDataAccordion
@@ -330,7 +330,7 @@ const Preferences: React.FC = () => {
                 }
                 accountListId={accountListId}
                 data={personalPreferencesData}
-                disabled={settingUp}
+                disabled={onSetupTour}
               />
             )}
           </>

--- a/src/components/Layouts/Primary/LogoLink/LogoLink.test.tsx
+++ b/src/components/Layouts/Primary/LogoLink/LogoLink.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import { useSetupContext } from 'src/components/Setup/SetupProvider';
+import { LogoLink } from './LogoLink';
+
+jest.mock('src/components/Setup/SetupProvider');
+
+describe('LogoLink', () => {
+  it('renders a link when not on the setup tour', () => {
+    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
+      onSetupTour: false,
+    });
+
+    const { getByRole } = render(<LogoLink />);
+    expect(getByRole('link')).toBeInTheDocument();
+  });
+
+  it('does not render a link when on the setup tour', () => {
+    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
+      onSetupTour: true,
+    });
+
+    const { queryByRole } = render(<LogoLink />);
+    expect(queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Layouts/Primary/LogoLink/LogoLink.test.tsx
+++ b/src/components/Layouts/Primary/LogoLink/LogoLink.test.tsx
@@ -1,25 +1,23 @@
 import { render } from '@testing-library/react';
-import { useSetupContext } from 'src/components/Setup/SetupProvider';
+import { TestSetupProvider } from 'src/components/Setup/SetupProvider';
 import { LogoLink } from './LogoLink';
-
-jest.mock('src/components/Setup/SetupProvider');
 
 describe('LogoLink', () => {
   it('renders a link when not on the setup tour', () => {
-    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
-      onSetupTour: false,
-    });
-
-    const { getByRole } = render(<LogoLink />);
+    const { getByRole } = render(
+      <TestSetupProvider>
+        <LogoLink />
+      </TestSetupProvider>,
+    );
     expect(getByRole('link')).toBeInTheDocument();
   });
 
   it('does not render a link when on the setup tour', () => {
-    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
-      onSetupTour: true,
-    });
-
-    const { queryByRole } = render(<LogoLink />);
+    const { queryByRole } = render(
+      <TestSetupProvider onSetupTour>
+        <LogoLink />
+      </TestSetupProvider>,
+    );
     expect(queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Layouts/Primary/LogoLink/LogoLink.tsx
+++ b/src/components/Layouts/Primary/LogoLink/LogoLink.tsx
@@ -1,0 +1,17 @@
+import NextLink from 'next/link';
+import { useSetupContext } from 'src/components/Setup/SetupProvider';
+
+export const LogoLink: React.FC = () => {
+  const { onSetupTour } = useSetupContext();
+
+  const logo = <img src={process.env.NEXT_PUBLIC_MEDIA_LOGO} alt="logo" />;
+
+  return onSetupTour ? (
+    logo
+  ) : (
+    <NextLink href="/">
+      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+      <a>{logo}</a>
+    </NextLink>
+  );
+};

--- a/src/components/Layouts/Primary/NavBar/NavBar.test.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavBar.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MockedProvider } from '@apollo/client/testing';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
+import { SetupProvider } from 'src/components/Setup/SetupProvider';
 import theme from 'src/theme';
 import { getTopBarMultipleMock } from '../TopBar/TopBar.mock';
 import { NavBar } from './NavBar';
@@ -22,7 +23,11 @@ describe('NavBar', () => {
   it('default', async () => {
     const { queryByTestId } = render(
       <ThemeProvider theme={theme}>
-        <NavBar onMobileClose={onMobileClose} openMobile={false} />
+        <MockedProvider>
+          <SetupProvider>
+            <NavBar onMobileClose={onMobileClose} openMobile={false} />
+          </SetupProvider>
+        </MockedProvider>
       </ThemeProvider>,
     );
 
@@ -33,7 +38,9 @@ describe('NavBar', () => {
     const { queryByTestId } = render(
       <ThemeProvider theme={theme}>
         <MockedProvider mocks={mocks} addTypename={false}>
-          <NavBar onMobileClose={onMobileClose} openMobile={true} />
+          <SetupProvider>
+            <NavBar onMobileClose={onMobileClose} openMobile={true} />
+          </SetupProvider>
         </MockedProvider>
       </ThemeProvider>,
     );

--- a/src/components/Layouts/Primary/NavBar/NavBar.test.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavBar.test.tsx
@@ -2,49 +2,72 @@ import React from 'react';
 import { MockedProvider } from '@apollo/client/testing';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
-import { SetupProvider } from 'src/components/Setup/SetupProvider';
+import TestRouter from '__tests__/util/TestRouter';
+import { useSetupContext } from 'src/components/Setup/SetupProvider';
 import theme from 'src/theme';
 import { getTopBarMultipleMock } from '../TopBar/TopBar.mock';
 import { NavBar } from './NavBar';
 
-jest.mock('next/router', () => ({
-  useRouter: () => {
-    return {
-      query: { accountListId: 'abc' },
-      isReady: true,
-    };
-  },
-}));
+jest.mock('src/components/Setup/SetupProvider');
+
+const router = {
+  query: { accountListId: 'abc' },
+  isReady: true,
+  push: jest.fn(),
+};
+
+interface TestComponentProps {
+  openMobile?: boolean;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({
+  openMobile = false,
+}) => (
+  <ThemeProvider theme={theme}>
+    <TestRouter router={router}>
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NavBar onMobileClose={onMobileClose} openMobile={openMobile} />
+      </MockedProvider>
+    </TestRouter>
+  </ThemeProvider>
+);
 
 const onMobileClose = jest.fn();
 const mocks = [getTopBarMultipleMock()];
 
 describe('NavBar', () => {
-  it('default', async () => {
-    const { queryByTestId } = render(
-      <ThemeProvider theme={theme}>
-        <MockedProvider>
-          <SetupProvider>
-            <NavBar onMobileClose={onMobileClose} openMobile={false} />
-          </SetupProvider>
-        </MockedProvider>
-      </ThemeProvider>,
-    );
+  beforeEach(() => {
+    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
+      onSetupTour: false,
+    });
+  });
+
+  it('default', () => {
+    const { queryByTestId } = render(<TestComponent />);
 
     expect(queryByTestId('NavBarDrawer')).not.toBeInTheDocument();
   });
 
-  it('opened', async () => {
-    const { queryByTestId } = render(
-      <ThemeProvider theme={theme}>
-        <MockedProvider mocks={mocks} addTypename={false}>
-          <SetupProvider>
-            <NavBar onMobileClose={onMobileClose} openMobile={true} />
-          </SetupProvider>
-        </MockedProvider>
-      </ThemeProvider>,
+  it('opened', () => {
+    const { getAllByRole, queryByTestId } = render(
+      <TestComponent openMobile />,
     );
 
     expect(queryByTestId('NavBarDrawer')).toBeInTheDocument();
+    expect(
+      getAllByRole('button', { name: 'Dashboard' })[0],
+    ).toBeInTheDocument();
+  });
+
+  it('hides links during the setup tour', () => {
+    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
+      onSetupTour: true,
+    });
+
+    const { queryByRole } = render(<TestComponent openMobile />);
+
+    expect(
+      queryByRole('button', { name: 'Dashboard' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/Layouts/Primary/NavBar/NavBar.test.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavBar.test.tsx
@@ -3,12 +3,10 @@ import { MockedProvider } from '@apollo/client/testing';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import TestRouter from '__tests__/util/TestRouter';
-import { useSetupContext } from 'src/components/Setup/SetupProvider';
+import { TestSetupProvider } from 'src/components/Setup/SetupProvider';
 import theme from 'src/theme';
 import { getTopBarMultipleMock } from '../TopBar/TopBar.mock';
 import { NavBar } from './NavBar';
-
-jest.mock('src/components/Setup/SetupProvider');
 
 const router = {
   query: { accountListId: 'abc' },
@@ -18,15 +16,19 @@ const router = {
 
 interface TestComponentProps {
   openMobile?: boolean;
+  onSetupTour?: boolean;
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({
   openMobile = false,
+  onSetupTour,
 }) => (
   <ThemeProvider theme={theme}>
     <TestRouter router={router}>
       <MockedProvider mocks={mocks} addTypename={false}>
-        <NavBar onMobileClose={onMobileClose} openMobile={openMobile} />
+        <TestSetupProvider onSetupTour={onSetupTour}>
+          <NavBar onMobileClose={onMobileClose} openMobile={openMobile} />
+        </TestSetupProvider>
       </MockedProvider>
     </TestRouter>
   </ThemeProvider>
@@ -36,12 +38,6 @@ const onMobileClose = jest.fn();
 const mocks = [getTopBarMultipleMock()];
 
 describe('NavBar', () => {
-  beforeEach(() => {
-    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
-      onSetupTour: false,
-    });
-  });
-
   it('default', () => {
     const { queryByTestId } = render(<TestComponent />);
 
@@ -60,11 +56,7 @@ describe('NavBar', () => {
   });
 
   it('hides links during the setup tour', () => {
-    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
-      onSetupTour: true,
-    });
-
-    const { queryByRole } = render(<TestComponent openMobile />);
+    const { queryByRole } = render(<TestComponent openMobile onSetupTour />);
 
     expect(
       queryByRole('button', { name: 'Dashboard' }),

--- a/src/components/Layouts/Primary/NavBar/NavBar.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavBar.tsx
@@ -1,4 +1,4 @@
-import NextLink, { LinkProps } from 'next/link';
+import { LinkProps } from 'next/link';
 import { useRouter } from 'next/router';
 import React, { ReactElement, useEffect } from 'react';
 import type { FC } from 'react';
@@ -8,6 +8,7 @@ import { makeStyles } from 'tss-react/mui';
 import { reportNavItems } from 'src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenuItems';
 import { ToolsListNav } from 'src/components/Tool/Home/ToolsListNav';
 import { useAccountListId } from 'src/hooks/useAccountListId';
+import { LogoLink } from '../LogoLink/LogoLink';
 import { toolsRedirectLinks } from '../TopBar/Items/NavMenu/NavMenu';
 import { NavItem } from './NavItem/NavItem';
 import { NavTools } from './NavTools/NavTools';
@@ -174,13 +175,7 @@ export const NavBar: FC<NavBarProps> = ({ onMobileClose, openMobile }) => {
         variant="temporary"
       >
         <Box p={2} display="flex" justifyContent="center">
-          <NextLink href="/">
-            <img
-              src={process.env.NEXT_PUBLIC_MEDIA_LOGO}
-              alt="logo"
-              style={{ cursor: 'pointer' }}
-            />
-          </NextLink>
+          <LogoLink />
         </Box>
         <Box p={2}>
           {renderNavItems({

--- a/src/components/Layouts/Primary/NavBar/NavBar.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavBar.tsx
@@ -5,6 +5,7 @@ import type { FC } from 'react';
 import { Box, Drawer, Hidden, List, Theme, useMediaQuery } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { makeStyles } from 'tss-react/mui';
+import { useSetupContext } from 'src/components/Setup/SetupProvider';
 import { reportNavItems } from 'src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenuItems';
 import { ToolsListNav } from 'src/components/Tool/Home/ToolsListNav';
 import { useAccountListId } from 'src/hooks/useAccountListId';
@@ -115,6 +116,7 @@ export const NavBar: FC<NavBarProps> = ({ onMobileClose, openMobile }) => {
   const accountListId = useAccountListId();
   const { pathname } = useRouter();
   const { t } = useTranslation();
+  const { onSetupTour } = useSetupContext();
 
   const sections: Section[] = [
     {
@@ -177,13 +179,15 @@ export const NavBar: FC<NavBarProps> = ({ onMobileClose, openMobile }) => {
         <Box p={2} display="flex" justifyContent="center">
           <LogoLink />
         </Box>
-        <Box p={2}>
-          {renderNavItems({
-            accountListId,
-            items: sections,
-            pathname,
-          })}
-        </Box>
+        {!onSetupTour && (
+          <Box p={2}>
+            {renderNavItems({
+              accountListId,
+              items: sections,
+              pathname,
+            })}
+          </Box>
+        )}
         <Box p={2}>
           <NavTools />
         </Box>

--- a/src/components/Layouts/Primary/NavBar/NavTools/NavTools.test.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/NavTools.test.tsx
@@ -3,12 +3,10 @@ import { MockedProvider } from '@apollo/client/testing';
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import TestRouter from '__tests__/util/TestRouter';
-import { useSetupContext } from 'src/components/Setup/SetupProvider';
+import { TestSetupProvider } from 'src/components/Setup/SetupProvider';
 import theme from 'src/theme';
 import { getTopBarMultipleMock } from '../../TopBar/TopBar.mock';
 import { NavTools } from './NavTools';
-
-jest.mock('src/components/Setup/SetupProvider');
 
 const router = {
   query: { accountListId: 'abc' },
@@ -16,11 +14,17 @@ const router = {
   push: jest.fn(),
 };
 
-const TestComponent = () => (
+interface TestComponentProps {
+  onSetupTour?: boolean;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({ onSetupTour }) => (
   <ThemeProvider theme={theme}>
     <TestRouter router={router}>
       <MockedProvider mocks={[getTopBarMultipleMock()]} addTypename={false}>
-        <NavTools />
+        <TestSetupProvider onSetupTour={onSetupTour}>
+          <NavTools />
+        </TestSetupProvider>
       </MockedProvider>
     </TestRouter>
   </ThemeProvider>
@@ -28,10 +32,6 @@ const TestComponent = () => (
 
 describe('NavTools', () => {
   it('default', async () => {
-    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
-      onSetupTour: false,
-    });
-
     const { findByText, getByTestId, getByText } = render(<TestComponent />);
 
     expect(getByTestId('NavTools')).toBeInTheDocument();
@@ -40,11 +40,7 @@ describe('NavTools', () => {
   });
 
   it('hides links during the setup tour', async () => {
-    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
-      onSetupTour: true,
-    });
-
-    const { queryByText, getByTestId } = render(<TestComponent />);
+    const { queryByText, getByTestId } = render(<TestComponent onSetupTour />);
 
     expect(getByTestId('NavTools')).toBeInTheDocument();
     expect(queryByText('Add')).not.toBeInTheDocument();

--- a/src/components/Layouts/Primary/NavBar/NavTools/NavTools.test.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/NavTools.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MockedProvider } from '@apollo/client/testing';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
+import { SetupProvider } from 'src/components/Setup/SetupProvider';
 import theme from 'src/theme';
 import { getTopBarMultipleMock } from '../../TopBar/TopBar.mock';
 import { NavTools } from './NavTools';
@@ -22,7 +23,9 @@ describe('AddMenuPanel', () => {
     const { getByTestId } = render(
       <ThemeProvider theme={theme}>
         <MockedProvider mocks={mocks} addTypename={false}>
-          <NavTools />
+          <SetupProvider>
+            <NavTools />
+          </SetupProvider>
         </MockedProvider>
       </ThemeProvider>,
     );

--- a/src/components/Layouts/Primary/NavBar/NavTools/NavTools.test.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/NavTools.test.tsx
@@ -1,35 +1,55 @@
 import React from 'react';
 import { MockedProvider } from '@apollo/client/testing';
 import { ThemeProvider } from '@mui/material/styles';
-import { render } from '@testing-library/react';
-import { SetupProvider } from 'src/components/Setup/SetupProvider';
+import { render, waitFor } from '@testing-library/react';
+import TestRouter from '__tests__/util/TestRouter';
+import { useSetupContext } from 'src/components/Setup/SetupProvider';
 import theme from 'src/theme';
 import { getTopBarMultipleMock } from '../../TopBar/TopBar.mock';
 import { NavTools } from './NavTools';
 
-jest.mock('next/router', () => ({
-  useRouter: () => {
-    return {
-      query: { accountListId: 'abc' },
-      isReady: true,
-    };
-  },
-}));
+jest.mock('src/components/Setup/SetupProvider');
 
-const mocks = [getTopBarMultipleMock()];
+const router = {
+  query: { accountListId: 'abc' },
+  isReady: true,
+  push: jest.fn(),
+};
 
-describe('AddMenuPanel', () => {
+const TestComponent = () => (
+  <ThemeProvider theme={theme}>
+    <TestRouter router={router}>
+      <MockedProvider mocks={[getTopBarMultipleMock()]} addTypename={false}>
+        <NavTools />
+      </MockedProvider>
+    </TestRouter>
+  </ThemeProvider>
+);
+
+describe('NavTools', () => {
   it('default', async () => {
-    const { getByTestId } = render(
-      <ThemeProvider theme={theme}>
-        <MockedProvider mocks={mocks} addTypename={false}>
-          <SetupProvider>
-            <NavTools />
-          </SetupProvider>
-        </MockedProvider>
-      </ThemeProvider>,
-    );
+    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
+      onSetupTour: false,
+    });
+
+    const { findByText, getByTestId, getByText } = render(<TestComponent />);
 
     expect(getByTestId('NavTools')).toBeInTheDocument();
+    expect(getByText('Add')).toBeInTheDocument();
+    expect(await findByText('John Smith')).toBeInTheDocument();
+  });
+
+  it('hides links during the setup tour', async () => {
+    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
+      onSetupTour: true,
+    });
+
+    const { queryByText, getByTestId } = render(<TestComponent />);
+
+    expect(getByTestId('NavTools')).toBeInTheDocument();
+    expect(queryByText('Add')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(queryByText('John Smith')).not.toBeInTheDocument(),
+    );
   });
 });

--- a/src/components/Layouts/Primary/NavBar/NavTools/NavTools.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/NavTools.tsx
@@ -6,6 +6,7 @@ import NotificationsIcon from '@mui/icons-material/Notifications';
 import SearchIcon from '@mui/icons-material/Search';
 import { List } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { useSetupContext } from 'src/components/Setup/SetupProvider';
 import { useGetTopBarQuery } from '../../TopBar/GetTopBar.generated';
 import NotificationMenu from '../../TopBar/Items/NotificationMenu/NotificationMenu';
 import { NavItem } from '../NavItem/NavItem';
@@ -16,18 +17,23 @@ import { SearchMenuPanel } from './SearchMenuPanel/SearchMenuPanel';
 export const NavTools: FC = () => {
   const { data } = useGetTopBarQuery();
   const { t } = useTranslation();
+  const { onSetupTour } = useSetupContext();
 
   return (
     <List disablePadding data-testid="NavTools">
-      <NavItem icon={SearchIcon} title={t('Search')}>
-        <SearchMenuPanel />
-      </NavItem>
-      <NavItem icon={AddIcon} title={t('Add')}>
-        <AddMenuPanel />
-      </NavItem>
-      <NavItem icon={NotificationsIcon} title={t('Notifications')}>
-        <NotificationMenu isInDrawer={true} />
-      </NavItem>
+      {!onSetupTour && (
+        <>
+          <NavItem icon={SearchIcon} title={t('Search')}>
+            <SearchMenuPanel />
+          </NavItem>
+          <NavItem icon={AddIcon} title={t('Add')}>
+            <AddMenuPanel />
+          </NavItem>
+          <NavItem icon={NotificationsIcon} title={t('Notifications')}>
+            <NotificationMenu isInDrawer={true} />
+          </NavItem>
+        </>
+      )}
       <NavItem
         icon={AccountCircleIcon}
         title={[data?.user.firstName, data?.user.lastName]

--- a/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.test.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.test.tsx
@@ -5,12 +5,10 @@ import userEvent from '@testing-library/user-event';
 import { signOut } from 'next-auth/react';
 import TestRouter from '__tests__/util/TestRouter';
 import TestWrapper from '__tests__/util/TestWrapper';
-import { useSetupContext } from 'src/components/Setup/SetupProvider';
+import { TestSetupProvider } from 'src/components/Setup/SetupProvider';
 import theme from '../../../../../../theme';
 import { getTopBarMock } from '../../../TopBar/TopBar.mock';
 import { ProfileMenuPanel } from './ProfileMenuPanel';
-
-jest.mock('src/components/Setup/SetupProvider');
 
 const router = {
   pathname: '/accountLists/[accountListId]/test',
@@ -18,23 +16,23 @@ const router = {
   push: jest.fn(),
 };
 
-const TestComponent = () => (
+interface TestComponentProps {
+  onSetupTour?: boolean;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({ onSetupTour }) => (
   <ThemeProvider theme={theme}>
     <TestWrapper mocks={[getTopBarMock()]}>
       <TestRouter router={router}>
-        <ProfileMenuPanel />
+        <TestSetupProvider onSetupTour={onSetupTour}>
+          <ProfileMenuPanel />
+        </TestSetupProvider>
       </TestRouter>
     </TestWrapper>
   </ThemeProvider>
 );
 
 describe('ProfileMenuPanelForNavBar', () => {
-  beforeEach(() => {
-    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
-      onSetupTour: false,
-    });
-  });
-
   it('default', () => {
     const { getByTestId } = render(<TestComponent />);
 
@@ -86,12 +84,8 @@ describe('ProfileMenuPanelForNavBar', () => {
   });
 
   it('hides links during the setup tour', async () => {
-    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
-      onSetupTour: true,
-    });
-
     const { findByTestId, getByRole, getByTestId, queryByText } = render(
-      <TestComponent />,
+      <TestComponent onSetupTour />,
     );
 
     userEvent.click(await findByTestId('accountListSelectorButton'));

--- a/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.test.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { signOut } from 'next-auth/react';
 import TestRouter from '__tests__/util/TestRouter';
 import TestWrapper from '__tests__/util/TestWrapper';
+import { SetupProvider } from 'src/components/Setup/SetupProvider';
 import theme from '../../../../../../theme';
 import { getTopBarMock } from '../../../TopBar/TopBar.mock';
 import { ProfileMenuPanel } from './ProfileMenuPanel';
@@ -15,29 +16,27 @@ const router = {
   push: jest.fn(),
 };
 
+const TestComponent = () => (
+  <ThemeProvider theme={theme}>
+    <TestWrapper mocks={[getTopBarMock()]}>
+      <TestRouter router={router}>
+        <SetupProvider>
+          <ProfileMenuPanel />
+        </SetupProvider>
+      </TestRouter>
+    </TestWrapper>
+  </ThemeProvider>
+);
+
 describe('ProfileMenuPanelForNavBar', () => {
   it('default', async () => {
-    const { getByTestId } = render(
-      <ThemeProvider theme={theme}>
-        <TestWrapper mocks={[getTopBarMock()]}>
-          <ProfileMenuPanel />
-        </TestWrapper>
-      </ThemeProvider>,
-    );
+    const { getByTestId } = render(<TestComponent />);
 
     expect(getByTestId('ProfileMenuPanelForNavBar')).toBeInTheDocument();
   });
 
   it('render an account list button', async () => {
-    const { getByTestId } = render(
-      <TestRouter router={router}>
-        <ThemeProvider theme={theme}>
-          <TestWrapper mocks={[getTopBarMock()]}>
-            <ProfileMenuPanel />
-          </TestWrapper>
-        </ThemeProvider>
-      </TestRouter>,
-    );
+    const { getByTestId } = render(<TestComponent />);
 
     await waitFor(() =>
       expect(getByTestId('accountListSelectorButton')).toBeInTheDocument(),
@@ -50,15 +49,7 @@ describe('ProfileMenuPanelForNavBar', () => {
   });
 
   it('should toggle the account list selector drawer', async () => {
-    const { getByTestId, queryByTestId } = render(
-      <TestRouter router={router}>
-        <ThemeProvider theme={theme}>
-          <TestWrapper mocks={[getTopBarMock()]}>
-            <ProfileMenuPanel />
-          </TestWrapper>
-        </ThemeProvider>
-      </TestRouter>,
-    );
+    const { getByTestId, queryByTestId } = render(<TestComponent />);
 
     await waitFor(() =>
       expect(getByTestId('accountListSelectorButton')).toBeInTheDocument(),
@@ -71,15 +62,7 @@ describe('ProfileMenuPanelForNavBar', () => {
   });
 
   it('should call router push', async () => {
-    const { getByTestId } = render(
-      <ThemeProvider theme={theme}>
-        <TestWrapper mocks={[getTopBarMock()]}>
-          <TestRouter router={router}>
-            <ProfileMenuPanel />
-          </TestRouter>
-        </TestWrapper>
-      </ThemeProvider>,
-    );
+    const { getByTestId } = render(<TestComponent />);
 
     await waitFor(() =>
       expect(getByTestId('accountListSelectorButton')).toBeInTheDocument(),
@@ -95,15 +78,7 @@ describe('ProfileMenuPanelForNavBar', () => {
   });
 
   it('Ensure Sign Out is called with callback', async () => {
-    const { getByText } = render(
-      <TestRouter router={router}>
-        <ThemeProvider theme={theme}>
-          <TestWrapper mocks={[getTopBarMock()]}>
-            <ProfileMenuPanel />
-          </TestWrapper>
-        </ThemeProvider>
-      </TestRouter>,
-    );
+    const { getByText } = render(<TestComponent />);
 
     await waitFor(() => expect(getByText(/sign out/i)).toBeInTheDocument());
     userEvent.click(getByText(/sign out/i));

--- a/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.tsx
@@ -7,6 +7,7 @@ import { Box, Button, Drawer, List } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { signOut } from 'next-auth/react';
 import { useTranslation } from 'react-i18next';
+import { useSetupContext } from 'src/components/Setup/SetupProvider';
 import {
   PrivacyPolicyLink,
   TermsOfUseLink,
@@ -83,6 +84,7 @@ export const ProfileMenuPanel: React.FC = () => {
   const accountListId = useAccountListId();
   const { push, pathname } = useRouter();
   const client = useApolloClient();
+  const { onSetupTour } = useSetupContext();
   const [accountsDrawerOpen, setAccountsDrawerOpen] = useState<boolean>(false);
 
   const toggleAccountsDrawer = (): void => {
@@ -162,54 +164,58 @@ export const ProfileMenuPanel: React.FC = () => {
           </MobileDrawer>
         </>
       )}
-      {addProfileContent.map(({ text, path, onClick }, index) => (
-        <LeafListItem key={index} disableGutters onClick={onClick}>
-          <StyledButton
-            component={NextLinkComposed}
-            to={`/accountLists/${accountListId}${path}`}
-          >
-            <Title>{t(text)}</Title>
-          </StyledButton>
-        </LeafListItem>
-      ))}
-      {(data?.user?.admin ||
-        !!data?.user?.administrativeOrganizations?.nodes?.length) && (
-        <LeafListItem disableGutters>
-          <StyledButton
-            component={NextLinkComposed}
-            to={`/accountLists/${accountListId}/settings/organizations`}
-          >
-            <Title>{t('Manage Organizations')}</Title>
-          </StyledButton>
-        </LeafListItem>
-      )}
-      {(data?.user?.admin || data?.user?.developer) && (
-        <LeafListItem disableGutters>
-          <StyledButton
-            component={NextLinkComposed}
-            to={`/accountLists/${accountListId}/settings/admin`}
-          >
-            <Title>{t('Admin Console')}</Title>
-          </StyledButton>
-        </LeafListItem>
-      )}
-      {data?.user?.developer && (
-        <LeafListItem disableGutters>
-          <HandoffLink path="/auth/user/admin" auth>
-            <StyledButton>
-              <Title>{t('Backend Admin')}</Title>
-            </StyledButton>
-          </HandoffLink>
-        </LeafListItem>
-      )}
-      {data?.user?.developer && (
-        <LeafListItem disableGutters>
-          <HandoffLink path="/auth/user/sidekiq" auth>
-            <StyledButton>
-              <Title>{t('Sidekiq')}</Title>
-            </StyledButton>
-          </HandoffLink>
-        </LeafListItem>
+      {!onSetupTour && (
+        <>
+          {addProfileContent.map(({ text, path, onClick }, index) => (
+            <LeafListItem key={index} disableGutters onClick={onClick}>
+              <StyledButton
+                component={NextLinkComposed}
+                to={`/accountLists/${accountListId}${path}`}
+              >
+                <Title>{t(text)}</Title>
+              </StyledButton>
+            </LeafListItem>
+          ))}
+          {(data?.user?.admin ||
+            !!data?.user?.administrativeOrganizations?.nodes?.length) && (
+            <LeafListItem disableGutters>
+              <StyledButton
+                component={NextLinkComposed}
+                to={`/accountLists/${accountListId}/settings/organizations`}
+              >
+                <Title>{t('Manage Organizations')}</Title>
+              </StyledButton>
+            </LeafListItem>
+          )}
+          {(data?.user?.admin || data?.user?.developer) && (
+            <LeafListItem disableGutters>
+              <StyledButton
+                component={NextLinkComposed}
+                to={`/accountLists/${accountListId}/settings/admin`}
+              >
+                <Title>{t('Admin Console')}</Title>
+              </StyledButton>
+            </LeafListItem>
+          )}
+          {data?.user?.developer && (
+            <LeafListItem disableGutters>
+              <HandoffLink path="/auth/user/admin" auth>
+                <StyledButton>
+                  <Title>{t('Backend Admin')}</Title>
+                </StyledButton>
+              </HandoffLink>
+            </LeafListItem>
+          )}
+          {data?.user?.developer && (
+            <LeafListItem disableGutters>
+              <HandoffLink path="/auth/user/sidekiq" auth>
+                <StyledButton>
+                  <Title>{t('Sidekiq')}</Title>
+                </StyledButton>
+              </HandoffLink>
+            </LeafListItem>
+          )}
+        </>
       )}
       <LeafListItem disableGutters>
         <Box display="flex" flexDirection="column" px={4} py={2}>

--- a/src/components/Layouts/Primary/Primary.test.tsx
+++ b/src/components/Layouts/Primary/Primary.test.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import TestWrapper from '__tests__/util/TestWrapper';
 import matchMediaMock from '__tests__/util/matchMediaMock';
+import { SetupProvider } from 'src/components/Setup/SetupProvider';
 import theme from '../../../theme';
 import { getNotificationsMocks } from './TopBar/Items/NotificationMenu/NotificationMenu.mock';
 import { getTopBarMock } from './TopBar/TopBar.mock';
@@ -28,9 +29,11 @@ describe('Primary', () => {
     const { getByTestId } = render(
       <ThemeProvider theme={theme}>
         <TestWrapper mocks={mocks}>
-          <Primary>
-            <div data-testid="PrimaryTestChildren"></div>
-          </Primary>
+          <SetupProvider>
+            <Primary>
+              <div data-testid="PrimaryTestChildren"></div>
+            </Primary>
+          </SetupProvider>
         </TestWrapper>
       </ThemeProvider>,
     );

--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.test.tsx
@@ -9,15 +9,13 @@ import { session } from '__tests__/fixtures/session';
 import TestRouter from '__tests__/util/TestRouter';
 import TestWrapper from '__tests__/util/TestWrapper';
 import { render, waitFor } from '__tests__/util/testingLibraryReactMock';
-import { useSetupContext } from 'src/components/Setup/SetupProvider';
+import { TestSetupProvider } from 'src/components/Setup/SetupProvider';
 import theme from '../../../../../../theme';
 import {
   getTopBarMock,
   getTopBarMockWithMultipleAccountLists,
 } from '../../TopBar.mock';
 import ProfileMenu from './ProfileMenu';
-
-jest.mock('src/components/Setup/SetupProvider');
 
 const mockEnqueue = jest.fn();
 
@@ -48,25 +46,26 @@ const routerNoAccountListId = {
 interface TestComponentProps {
   router?: Partial<NextRouter>;
   mocks?: MockedResponse[];
+  onSetupTour?: boolean;
 }
 
-const TestComponent: React.FC<TestComponentProps> = ({ router, mocks }) => (
+const TestComponent: React.FC<TestComponentProps> = ({
+  router,
+  mocks,
+  onSetupTour,
+}) => (
   <ThemeProvider theme={theme}>
     <TestWrapper mocks={mocks ?? [getTopBarMock()]}>
       <TestRouter router={router ?? defaultRouter}>
-        <ProfileMenu />
+        <TestSetupProvider onSetupTour={onSetupTour}>
+          <ProfileMenu />
+        </TestSetupProvider>
       </TestRouter>
     </TestWrapper>
   </ThemeProvider>
 );
 
 describe('ProfileMenu', () => {
-  beforeEach(() => {
-    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
-      onSetupTour: false,
-    });
-  });
-
   it('default', async () => {
     const { getByTestId, getByRole, getByText, findByText } = render(
       <TestComponent />,
@@ -175,12 +174,8 @@ describe('ProfileMenu', () => {
   });
 
   it('hides links during the setup tour', async () => {
-    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
-      onSetupTour: true,
-    });
-
     const { findByText, getByRole, getByTestId, queryByText } = render(
-      <TestComponent router={routerNoAccountListId} />,
+      <TestComponent router={routerNoAccountListId} onSetupTour />,
     );
 
     expect(await findByText('John Smith')).toBeInTheDocument();

--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
@@ -21,6 +21,7 @@ import { styled } from '@mui/material/styles';
 import { signOut } from 'next-auth/react';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
+import { useSetupContext } from 'src/components/Setup/SetupProvider';
 import {
   PrivacyPolicyLink,
   TermsOfUseLink,
@@ -124,6 +125,7 @@ const ProfileMenu = (): ReactElement => {
   const { contactId: _, ...queryWithoutContactId } = router.query;
   const accountListId = useAccountListId();
   const { data } = useGetTopBarQuery();
+  const { onSetupTour } = useSetupContext();
   const [profileMenuAnchorEl, setProfileMenuAnchorEl] =
     useState<HTMLButtonElement>();
   const profileMenuOpen = Boolean(profileMenuAnchorEl);
@@ -275,7 +277,7 @@ const ProfileMenu = (): ReactElement => {
             ))}
           </AccountListSelectorDetails>
         </Accordion>
-        {accountListId && (
+        {!onSetupTour && accountListId && (
           <div>
             <Divider />
             <Link

--- a/src/components/Layouts/Primary/TopBar/TopBar.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/TopBar.test.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
+import { SetupProvider } from 'src/components/Setup/SetupProvider';
 import theme from '../../../../theme';
 import { getNotificationsMocks } from './Items/NotificationMenu/NotificationMenu.mock';
 import TopBar from './TopBar';
@@ -51,10 +52,12 @@ describe('TopBar', () => {
         <ThemeProvider theme={theme}>
           <TestRouter router={router}>
             <MockedProvider mocks={mocks} addTypename={false}>
-              <TopBar
-                accountListId={accountListId}
-                onMobileNavOpen={onMobileNavOpen}
-              />
+              <SetupProvider>
+                <TopBar
+                  accountListId={accountListId}
+                  onMobileNavOpen={onMobileNavOpen}
+                />
+              </SetupProvider>
             </MockedProvider>
           </TestRouter>
         </ThemeProvider>

--- a/src/components/Layouts/Primary/TopBar/TopBar.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/TopBar.test.tsx
@@ -4,13 +4,11 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
-import { useSetupContext } from 'src/components/Setup/SetupProvider';
+import { TestSetupProvider } from 'src/components/Setup/SetupProvider';
 import theme from '../../../../theme';
 import { getNotificationsMocks } from './Items/NotificationMenu/NotificationMenu.mock';
 import TopBar from './TopBar';
 import { getTopBarMultipleMock } from './TopBar.mock';
-
-jest.mock('src/components/Setup/SetupProvider');
 
 const accountListId = 'accountListId';
 const onMobileNavOpen = jest.fn();
@@ -33,7 +31,11 @@ jest.mock('notistack', () => ({
   },
 }));
 
-const TestComponent = () => (
+interface TestComponentProps {
+  onSetupTour?: boolean;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({ onSetupTour }) => (
   <SnackbarProvider>
     <ThemeProvider theme={theme}>
       <TestRouter router={router}>
@@ -41,10 +43,12 @@ const TestComponent = () => (
           mocks={[getTopBarMultipleMock(), ...getNotificationsMocks()]}
           addTypename={false}
         >
-          <TopBar
-            accountListId={accountListId}
-            onMobileNavOpen={onMobileNavOpen}
-          />
+          <TestSetupProvider onSetupTour={onSetupTour}>
+            <TopBar
+              accountListId={accountListId}
+              onMobileNavOpen={onMobileNavOpen}
+            />
+          </TestSetupProvider>
         </MockedProvider>
       </TestRouter>
     </ThemeProvider>
@@ -53,10 +57,6 @@ const TestComponent = () => (
 
 describe('TopBar', () => {
   it('default', () => {
-    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
-      onSetupTour: false,
-    });
-
     const { getByTestId, getByText } = render(<TestComponent />);
 
     expect(getByTestId('TopBar')).toBeInTheDocument();
@@ -64,11 +64,7 @@ describe('TopBar', () => {
   });
 
   it('hides links during the setup tour', () => {
-    (useSetupContext as jest.MockedFn<typeof useSetupContext>).mockReturnValue({
-      onSetupTour: true,
-    });
-
-    const { queryByText } = render(<TestComponent />);
+    const { queryByText } = render(<TestComponent onSetupTour />);
 
     expect(queryByText('Dashboard')).not.toBeInTheDocument();
   });

--- a/src/components/Layouts/Primary/TopBar/TopBar.tsx
+++ b/src/components/Layouts/Primary/TopBar/TopBar.tsx
@@ -1,4 +1,3 @@
-import NextLink from 'next/link';
 import React, { ReactElement } from 'react';
 import MenuIcon from '@mui/icons-material/Menu';
 import {
@@ -11,6 +10,7 @@ import {
   useScrollTrigger,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { LogoLink } from '../LogoLink/LogoLink';
 import AddMenu from './Items/AddMenu/AddMenu';
 import NavMenu from './Items/NavMenu/NavMenu';
 import NotificationMenu from './Items/NotificationMenu/NotificationMenu';
@@ -54,13 +54,7 @@ const TopBar = ({
               </IconButton>
             </Hidden>
           )}
-          <NextLink href="/">
-            <img
-              src={process.env.NEXT_PUBLIC_MEDIA_LOGO}
-              alt="logo"
-              style={{ cursor: 'pointer' }}
-            />
-          </NextLink>
+          <LogoLink />
           <Hidden mdDown>
             {accountListId && (
               <>

--- a/src/components/Layouts/Primary/TopBar/TopBar.tsx
+++ b/src/components/Layouts/Primary/TopBar/TopBar.tsx
@@ -10,6 +10,7 @@ import {
   useScrollTrigger,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { useSetupContext } from 'src/components/Setup/SetupProvider';
 import { LogoLink } from '../LogoLink/LogoLink';
 import AddMenu from './Items/AddMenu/AddMenu';
 import NavMenu from './Items/NavMenu/NavMenu';
@@ -32,6 +33,7 @@ const TopBar = ({
   accountListId,
   onMobileNavOpen,
 }: TopBarProps): ReactElement => {
+  const { onSetupTour } = useSetupContext();
   const trigger = useScrollTrigger({
     disableHysteresis: true,
     threshold: 0,
@@ -56,7 +58,8 @@ const TopBar = ({
           )}
           <LogoLink />
           <Hidden mdDown>
-            {accountListId && (
+            {onSetupTour && <Box flexGrow={1} />}
+            {!onSetupTour && accountListId && (
               <>
                 <Box ml={10} flexGrow={1}>
                   <NavMenu />

--- a/src/components/Setup/SetupProvider.test.tsx
+++ b/src/components/Setup/SetupProvider.test.tsx
@@ -14,11 +14,13 @@ interface TestComponentProps {
 }
 
 const ContextTestingComponent = () => {
-  const { settingUp } = useSetupContext();
+  const { onSetupTour } = useSetupContext();
 
   return (
     <div data-testid="setting-up">
-      {typeof settingUp === 'undefined' ? 'undefined' : settingUp.toString()}
+      {typeof onSetupTour === 'undefined'
+        ? 'undefined'
+        : onSetupTour.toString()}
     </div>
   );
 };
@@ -100,7 +102,7 @@ describe('SetupProvider', () => {
     await waitFor(() => expect(push).not.toHaveBeenCalled());
   });
 
-  describe('settingUp context', () => {
+  describe('onSetupTour context', () => {
     it('is undefined while data is loading', () => {
       const { getByTestId } = render(
         <TestComponent setup={null} setupPosition="" />,
@@ -109,11 +111,12 @@ describe('SetupProvider', () => {
       expect(getByTestId('setting-up')).toHaveTextContent('undefined');
     });
 
-    it('is true when setup is set', async () => {
+    it('is true when setup is set on a tour page', async () => {
       const { getByTestId } = render(
         <TestComponent
           setup={UserSetupStageEnum.NoDefaultAccountList}
           setupPosition=""
+          pathname="/setup/start"
         />,
       );
 
@@ -122,13 +125,27 @@ describe('SetupProvider', () => {
       );
     });
 
-    it('is true when setup_position is set', async () => {
+    it('is true when setup_position is set on a tour page', async () => {
+      const { getByTestId } = render(
+        <TestComponent
+          setup={null}
+          setupPosition="start"
+          pathname="/setup/start"
+        />,
+      );
+
+      await waitFor(() =>
+        expect(getByTestId('setting-up')).toHaveTextContent('true'),
+      );
+    });
+
+    it('is false when not on a tour page', async () => {
       const { getByTestId } = render(
         <TestComponent setup={null} setupPosition="start" />,
       );
 
       await waitFor(() =>
-        expect(getByTestId('setting-up')).toHaveTextContent('true'),
+        expect(getByTestId('setting-up')).toHaveTextContent('false'),
       );
     });
 

--- a/src/components/Setup/SetupProvider.tsx
+++ b/src/components/Setup/SetupProvider.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import React, {
+  PropsWithChildren,
   ReactNode,
   createContext,
   useContext,
@@ -43,13 +44,13 @@ const setupPages = new Set([
   '/accountLists/[accountListId]/setup/finish',
 ]);
 
-interface Props {
+interface SetupProviderProps {
   children: ReactNode;
 }
 
 // This context component ensures that users have gone through the setup process
 // and provides the setup state to the rest of the application
-export const SetupProvider: React.FC<Props> = ({ children }) => {
+export const SetupProvider: React.FC<SetupProviderProps> = ({ children }) => {
   const { data } = useSetupStageQuery();
   const { push, pathname } = useRouter();
 
@@ -99,3 +100,15 @@ export const SetupProvider: React.FC<Props> = ({ children }) => {
     </SetupContext.Provider>
   );
 };
+
+// This provider is meant for use in tests. It lets tests easily override the
+// onSetupTour without needing to mock useSetupProvider or the pathname and
+// SetupStage GraphQL query.
+export const TestSetupProvider: React.FC<PropsWithChildren<SetupContext>> = ({
+  children,
+  onSetupTour,
+}) => (
+  <SetupContext.Provider value={{ onSetupTour }}>
+    {children}
+  </SetupContext.Provider>
+);

--- a/src/components/Setup/SetupProvider.tsx
+++ b/src/components/Setup/SetupProvider.tsx
@@ -20,18 +20,9 @@ export interface SetupContext {
   onSetupTour?: boolean;
 }
 
-const SetupContext = createContext<SetupContext | null>(null);
+const SetupContext = createContext<SetupContext>({ onSetupTour: undefined });
 
-export const useSetupContext = (): SetupContext => {
-  const setupContext = useContext(SetupContext);
-  if (!setupContext) {
-    throw new Error(
-      'SetupProvider not found! Make sure that you are calling useSetupContext inside a component wrapped by <SetupProvider>.',
-    );
-  }
-
-  return setupContext;
-};
+export const useSetupContext = (): SetupContext => useContext(SetupContext);
 
 // The list of page pathnames that are part of the setup tour
 const setupPages = new Set([

--- a/src/components/Shared/MultiPageLayout/MultiPageHeader.test.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageHeader.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { TestSetupProvider } from 'src/components/Setup/SetupProvider';
 import theme from 'src/theme';
 import { HeaderTypeEnum, MultiPageHeader } from './MultiPageHeader';
 
@@ -9,19 +10,33 @@ const totalBalance = 'CA111';
 const title = 'test title';
 const onNavListToggle = jest.fn();
 
+interface TestComponentProps {
+  headerType?: HeaderTypeEnum;
+  noRightExtra?: boolean;
+  onSetupTour?: boolean;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({
+  headerType = HeaderTypeEnum.Report,
+  noRightExtra = false,
+  onSetupTour,
+}) => (
+  <ThemeProvider theme={theme}>
+    <TestSetupProvider onSetupTour={onSetupTour}>
+      <MultiPageHeader
+        isNavListOpen={true}
+        title={title}
+        onNavListToggle={onNavListToggle}
+        rightExtra={noRightExtra ? undefined : totalBalance}
+        headerType={headerType}
+      />
+    </TestSetupProvider>
+  </ThemeProvider>
+);
+
 describe('MultiPageHeader', () => {
   it('default', async () => {
-    const { getByRole, getByText } = render(
-      <ThemeProvider theme={theme}>
-        <MultiPageHeader
-          isNavListOpen={true}
-          title={title}
-          onNavListToggle={onNavListToggle}
-          rightExtra={totalBalance}
-          headerType={HeaderTypeEnum.Report}
-        />
-      </ThemeProvider>,
-    );
+    const { getByRole, getByText } = render(<TestComponent />);
 
     expect(getByText(title)).toBeInTheDocument();
     expect(getByText('CA111')).toBeInTheDocument();
@@ -32,49 +47,41 @@ describe('MultiPageHeader', () => {
   });
 
   it('should not render rightExtra if undefined', async () => {
-    const { queryByText } = render(
-      <ThemeProvider theme={theme}>
-        <MultiPageHeader
-          isNavListOpen={true}
-          title={title}
-          onNavListToggle={onNavListToggle}
-          rightExtra={undefined}
-          headerType={HeaderTypeEnum.Report}
-        />
-      </ThemeProvider>,
+    const { queryByText } = render(<TestComponent noRightExtra />);
+
+    expect(queryByText('CA111')).not.toBeInTheDocument();
+  });
+
+  it('should render the Reports menu', async () => {
+    const { getByTestId, getByText } = render(
+      <TestComponent headerType={HeaderTypeEnum.Report} />,
     );
 
-    expect(queryByText('CA111')).toBeNull();
+    expect(getByText('Toggle Navigation Panel')).toBeInTheDocument();
+    expect(getByTestId('ReportsFilterIcon')).toBeInTheDocument();
   });
 
   it('should render the Settings menu', async () => {
     const { getByTestId, getByText } = render(
-      <ThemeProvider theme={theme}>
-        <MultiPageHeader
-          isNavListOpen={true}
-          title={title}
-          onNavListToggle={onNavListToggle}
-          rightExtra={undefined}
-          headerType={HeaderTypeEnum.Settings}
-        />
-      </ThemeProvider>,
+      <TestComponent headerType={HeaderTypeEnum.Settings} />,
     );
 
     expect(getByText('Toggle Preferences Menu')).toBeInTheDocument();
     expect(getByTestId('SettingsMenuIcon')).toBeInTheDocument();
   });
 
+  it('should not render the Settings menu during the setup tour', async () => {
+    const { queryByTestId, queryByText } = render(
+      <TestComponent headerType={HeaderTypeEnum.Settings} onSetupTour />,
+    );
+
+    expect(queryByText('Toggle Preferences Menu')).not.toBeInTheDocument();
+    expect(queryByTestId('SettingsMenuIcon')).not.toBeInTheDocument();
+  });
+
   it('should render the Tools menu', async () => {
     const { getByTestId, getByText } = render(
-      <ThemeProvider theme={theme}>
-        <MultiPageHeader
-          isNavListOpen={true}
-          title={title}
-          onNavListToggle={onNavListToggle}
-          rightExtra={undefined}
-          headerType={HeaderTypeEnum.Tools}
-        />
-      </ThemeProvider>,
+      <TestComponent headerType={HeaderTypeEnum.Tools} />,
     );
 
     expect(getByText('Toggle Tools Menu')).toBeInTheDocument();

--- a/src/components/Shared/MultiPageLayout/MultiPageHeader.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageHeader.tsx
@@ -4,6 +4,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import { Box, IconButton, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
+import { useSetupContext } from 'src/components/Setup/SetupProvider';
 import theme from 'src/theme';
 
 export enum HeaderTypeEnum {
@@ -65,6 +66,7 @@ export const MultiPageHeader: FC<MultiPageHeaderProps> = ({
   headerType,
 }) => {
   const { t } = useTranslation();
+  const { onSetupTour } = useSetupContext();
 
   let titleAccess;
   if (headerType === HeaderTypeEnum.Report) {
@@ -90,7 +92,7 @@ export const MultiPageHeader: FC<MultiPageHeaderProps> = ({
               data-testid="ReportsFilterIcon"
             />
           )}
-          {headerType === HeaderTypeEnum.Settings && (
+          {!onSetupTour && headerType === HeaderTypeEnum.Settings && (
             <NavMenuIcon
               titleAccess={titleAccess}
               data-testid="SettingsMenuIcon"


### PR DESCRIPTION
## Description

* Hide navbar links when the user is on the setup tour, while keeping things like the logo, Sign Out button, and username
* Hide the left panel that contains the settings links and hide the toggle button when on settings pages during the setup tour
* Various improvements to existing navbar tests

There isn't a specific Jira ticket for this, but it is related to tickets like [MPDX-8091](https://jira.cru.org/browse/MPDX-8091), [MPDX-8092](https://jira.cru.org/browse/MPDX-8092), [MPDX-8093](https://jira.cru.org/browse/MPDX-8093)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
