### PR TITLE
Removing the limitations of the new Tools Wrapper menu on appeals.

### DIFF
--- a/pages/accountLists/[accountListId]/tools/ToolsWrapper.tsx
+++ b/pages/accountLists/[accountListId]/tools/ToolsWrapper.tsx
@@ -20,6 +20,7 @@ interface ToolsWrapperProps {
   pageTitle?: string;
   pageUrl: string;
   selectedMenuId?: string;
+  showToolsHeader?: boolean;
   children: ReactElement<unknown, string | JSXElementConstructor<unknown>>;
 }
 
@@ -27,6 +28,7 @@ export const ToolsWrapper: React.FC<ToolsWrapperProps> = ({
   pageTitle,
   pageUrl,
   selectedMenuId,
+  showToolsHeader = true,
   children,
 }) => {
   const { appName } = useGetAppSettings();
@@ -56,20 +58,27 @@ export const ToolsWrapper: React.FC<ToolsWrapperProps> = ({
             leftWidth="290px"
             mainContent={
               <>
-                <MultiPageHeader
-                  isNavListOpen={isToolDrawerOpen}
-                  onNavListToggle={() => setIsToolDrawerOpen(!isToolDrawerOpen)}
-                  title={pageTitle || ''}
-                  headerType={HeaderTypeEnum.Tools}
-                />
-                <PageContentWrapper
-                  maxWidth="lg"
-                  style={{
-                    height: `calc(100vh - ${navBarHeight} - ${multiPageHeaderHeight})`,
-                  }}
-                >
-                  {children}
-                </PageContentWrapper>
+                {showToolsHeader && (
+                  <>
+                    <MultiPageHeader
+                      isNavListOpen={isToolDrawerOpen}
+                      onNavListToggle={() =>
+                        setIsToolDrawerOpen(!isToolDrawerOpen)
+                      }
+                      title={pageTitle || ''}
+                      headerType={HeaderTypeEnum.Tools}
+                    />
+                    <PageContentWrapper
+                      maxWidth="lg"
+                      style={{
+                        height: `calc(100vh - ${navBarHeight} - ${multiPageHeaderHeight})`,
+                      }}
+                    >
+                      {children}
+                    </PageContentWrapper>
+                  </>
+                )}
+                {!showToolsHeader && children}
               </>
             }
             rightPanel={

--- a/pages/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]].page.test.tsx
+++ b/pages/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]].page.test.tsx
@@ -112,6 +112,23 @@ const Components = ({ router = defaultRouter }: { router?: object }) => (
 );
 
 describe('Appeal navigation', () => {
+  it('does not show Appeals Tools menu', async () => {
+    const { queryByRole } = render(
+      <Components
+        router={{
+          ...defaultRouter,
+          query: {
+            ...defaultRouter.query,
+            appealId: ['1', 'list'],
+          },
+        }}
+      />,
+    );
+
+    expect(
+      queryByRole('button', { name: 'Toggle Tools Menu' }),
+    ).not.toBeInTheDocument();
+  });
   it('should show list detail appeal page and close filters', async () => {
     const { getByText, findByTestId, queryByText, getByRole, queryByRole } =
       render(

--- a/pages/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]].page.tsx
@@ -14,6 +14,7 @@ const Appeals = (): ReactElement => {
       pageTitle={t('Appeals')}
       pageUrl={pageUrl}
       selectedMenuId="appeals"
+      showToolsHeader={false}
     >
       <AppealsDetailsPage />
     </ToolsWrapper>


### PR DESCRIPTION
## Description
In this PR, I edit the Tools wrapper to allow for the appeals page to be full width & height of the screen.
I haven't added this to the initial appeals page, as this is currently like the old MPDX.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
