### PR TITLE
MPDX-8155 - Prevent user from dropping contact onto the same column it came from.

### DIFF
--- a/src/components/Tool/Appeal/Flow/ContactFlow.test.tsx
+++ b/src/components/Tool/Appeal/Flow/ContactFlow.test.tsx
@@ -180,6 +180,38 @@ describe('ContactFlow', () => {
       );
     });
 
+    it('should not allow the contact to be dragged to the column it came from', async () => {
+      const { getAllByText, getByTestId } = render(<Components />);
+
+      await waitFor(() =>
+        expect(getAllByText(defaultContact.name)[0]).toBeInTheDocument(),
+      );
+
+      const contactBox = getAllByText(defaultContact.name)[0];
+      const columnAsked = within(getByTestId('contactsFlowAsked')).getByTestId(
+        'contact-flow-drop-zone',
+      );
+      const columnExcluded = within(
+        getByTestId('contactsFlowExcluded'),
+      ).getByTestId('contact-flow-drop-zone');
+
+      fireEvent.dragStart(contactBox);
+      fireEvent.dragEnter(columnAsked);
+      fireEvent.dragOver(columnAsked);
+      fireEvent.dragEnter(columnExcluded);
+      fireEvent.dragOver(columnExcluded);
+      fireEvent.drop(columnExcluded);
+
+      await waitFor(() =>
+        expect(mockEnqueue).not.toHaveBeenCalledWith(
+          'Unable to move Excluded Contact here. If you want to add this Excluded contact to this appeal, please add them to Asked.',
+          {
+            variant: 'warning',
+          },
+        ),
+      );
+    });
+
     it('Excluded to Committed', async () => {
       const { getAllByText, getByTestId, queryByRole } = render(<Components />);
 

--- a/src/components/Tool/Appeal/Flow/ContactFlowDropZone/ContactFlowDropZone.tsx
+++ b/src/components/Tool/Appeal/Flow/ContactFlowDropZone/ContactFlowDropZone.tsx
@@ -22,7 +22,7 @@ export const ContactFlowDropZone: React.FC<Props> = ({
 }: Props) => {
   const [{ isOver, canDrop }, drop] = useDrop(() => ({
     accept: 'contact',
-    canDrop: (contact) => String(contact.status) !== String(status),
+    canDrop: (contact) => String(contact.appealStatus) !== String(status),
     drop: (contact: DraggedContact) => {
       String(contact.status) !== String(status)
         ? changeContactStatus(contact, status)


### PR DESCRIPTION
## Description
In this PR, I prevent the user from dropping contact into the same column from which it came.


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
