### PR TITLE
MPDX-8124 Adding select and deselect all functionality onto each column in the flows view

### DIFF
--- a/src/components/Shared/Header/ListHeader.test.tsx
+++ b/src/components/Shared/Header/ListHeader.test.tsx
@@ -635,4 +635,45 @@ describe('ListHeader', () => {
       ).toBeInTheDocument();
     });
   });
+
+  it('shows the selected count', () => {
+    const { getByText } = render(
+      <MocksProviders>
+        <ListHeader
+          selectedIds={['a', 'b', 'c']}
+          page={PageEnum.Appeal}
+          contactsView={TableViewModeEnum.Flows}
+          activeFilters={false}
+          starredFilter={{}}
+          headerCheckboxState={ListHeaderCheckBoxState.Unchecked}
+          filterPanelOpen={false}
+          contactDetailsOpen={false}
+          {...mockedProps}
+        />
+      </MocksProviders>,
+    );
+
+    expect(getByText('3 Selected')).toBeInTheDocument();
+    expect(getByText('Actions')).toBeInTheDocument();
+  });
+
+  it('does not shows the selected count', () => {
+    const { queryByText } = render(
+      <MocksProviders>
+        <ListHeader
+          selectedIds={[]}
+          page={PageEnum.Appeal}
+          contactsView={TableViewModeEnum.Flows}
+          activeFilters={false}
+          starredFilter={{}}
+          headerCheckboxState={ListHeaderCheckBoxState.Unchecked}
+          filterPanelOpen={false}
+          contactDetailsOpen={false}
+          {...mockedProps}
+        />
+      </MocksProviders>,
+    );
+    expect(queryByText('Selected')).not.toBeInTheDocument();
+    expect(queryByText('Actions')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/Shared/Header/ListHeader.tsx
+++ b/src/components/Shared/Header/ListHeader.tsx
@@ -180,6 +180,13 @@ export const ListHeader: React.FC<ListHeaderProps> = ({
         </Hidden>
       </HeaderWrapInner>
       <HeaderWrapInner style={{ marginLeft: 8 }}>
+        {!!selectedIds.length && (
+          <Hidden smDown>
+            <ItemsShowingText sx={{ marginRight: 2 }}>
+              {t('{{count}} Selected', { count: selectedIds.length })}
+            </ItemsShowingText>
+          </Hidden>
+        )}
         {(page === PageEnum.Contact || page === PageEnum.Appeal) && (
           <ContactsMassActionsDropdown
             filterPanelOpen={filterPanelOpen}

--- a/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
+++ b/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
@@ -57,6 +57,8 @@ export interface AppealsType
     | 'setContactFocus'
     | 'setViewMode'
   > {
+  selectMultipleIds: (ids: string[]) => void;
+  deselectMultipleIds: (ids: string[]) => void;
   setViewMode: (mode: TableViewModeEnum) => void;
   setContactFocus: (id?: string | undefined, openDetails?: boolean) => void;
   contactsQueryResult: ReturnType<typeof useContactsQuery>;
@@ -189,6 +191,8 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
     toggleSelectAll,
     toggleSelectionById,
     deselectAll,
+    selectMultipleIds,
+    deselectMultipleIds,
   } = useMassSelection(
     contactCount,
     allContactIds,
@@ -482,6 +486,8 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
         isRowChecked: isRowChecked,
         toggleSelectAll: toggleSelectAll,
         toggleSelectionById: toggleSelectionById,
+        selectMultipleIds: selectMultipleIds,
+        deselectMultipleIds: deselectMultipleIds,
         filterData: filterData,
         filtersLoading: filtersLoading,
         toggleFilterPanel: toggleFilterPanel,

--- a/src/hooks/useMassSelection.test.ts
+++ b/src/hooks/useMassSelection.test.ts
@@ -1,0 +1,162 @@
+import { renderHook } from '@testing-library/react';
+import { ListHeaderCheckBoxState } from 'src/components/Shared/Header/ListHeader';
+import { useMassSelection } from './useMassSelection';
+
+const defaultTotalCount = 10;
+const defaultIdsList = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'];
+const defaultActiveFilters = {};
+const defaultWildcardSearch = '';
+const defaultStarredFilter = {
+  starred: true,
+};
+
+describe('useMassSelection', () => {
+  describe('toggleSelectAll()', () => {
+    it('should select all the ids', () => {
+      const { result, rerender } = renderHook(() =>
+        useMassSelection(
+          defaultTotalCount,
+          defaultIdsList,
+          defaultActiveFilters,
+          defaultWildcardSearch,
+          defaultStarredFilter,
+        ),
+      );
+
+      expect(result.current.ids).toEqual([]);
+
+      result.current.toggleSelectAll();
+      rerender();
+      expect(result.current.ids).toEqual(defaultIdsList);
+
+      result.current.toggleSelectAll();
+      rerender();
+      expect(result.current.ids).toEqual([]);
+    });
+  });
+
+  describe('deselectAll()', () => {
+    it('should deselect all the ids', () => {
+      const { result, rerender } = renderHook(() =>
+        useMassSelection(
+          defaultTotalCount,
+          defaultIdsList,
+          defaultActiveFilters,
+          defaultWildcardSearch,
+          defaultStarredFilter,
+        ),
+      );
+
+      result.current.toggleSelectAll();
+      rerender();
+      expect(result.current.ids).toEqual(defaultIdsList);
+
+      result.current.deselectAll();
+      rerender();
+      expect(result.current.ids).toEqual([]);
+    });
+  });
+
+  describe('isRowChecked() & toggleSelectionById()', () => {
+    it('should return true/false if the id has been selected', () => {
+      const { result, rerender } = renderHook(() =>
+        useMassSelection(
+          defaultTotalCount,
+          defaultIdsList,
+          defaultActiveFilters,
+          defaultWildcardSearch,
+          defaultStarredFilter,
+        ),
+      );
+
+      result.current.toggleSelectionById('5');
+      rerender();
+      expect(result.current.ids).toEqual(['5']);
+      expect(result.current.isRowChecked('4')).toBe(false);
+      expect(result.current.isRowChecked('5')).toBe(true);
+      expect(result.current.isRowChecked('6')).toBe(false);
+
+      result.current.toggleSelectionById('6');
+      rerender();
+      expect(result.current.isRowChecked('4')).toBe(false);
+      expect(result.current.isRowChecked('5')).toBe(true);
+      expect(result.current.isRowChecked('6')).toBe(true);
+    });
+  });
+
+  describe('selectionType', () => {
+    it('should return what type of selection', () => {
+      const { result, rerender } = renderHook(() =>
+        useMassSelection(
+          defaultTotalCount,
+          defaultIdsList,
+          defaultActiveFilters,
+          defaultWildcardSearch,
+          defaultStarredFilter,
+        ),
+      );
+
+      result.current.toggleSelectionById('5');
+      rerender();
+      expect(result.current.selectionType).toEqual(
+        ListHeaderCheckBoxState.Partial,
+      );
+
+      result.current.toggleSelectAll();
+      rerender();
+      expect(result.current.selectionType).toEqual(
+        ListHeaderCheckBoxState.Checked,
+      );
+
+      result.current.toggleSelectAll();
+      rerender();
+      expect(result.current.selectionType).toEqual(
+        ListHeaderCheckBoxState.Unchecked,
+      );
+    });
+  });
+
+  describe('selectMultipleIds()', () => {
+    it('should return what type of selection', () => {
+      const { result, rerender } = renderHook(() =>
+        useMassSelection(
+          defaultTotalCount,
+          defaultIdsList,
+          defaultActiveFilters,
+          defaultWildcardSearch,
+          defaultStarredFilter,
+        ),
+      );
+
+      result.current.selectMultipleIds(['1', '2', '3']);
+      rerender();
+      expect(result.current.ids).toEqual(['1', '2', '3']);
+
+      result.current.selectMultipleIds(['4', '5', '6']);
+      rerender();
+      expect(result.current.ids).toEqual(['1', '2', '3', '4', '5', '6']);
+    });
+  });
+
+  describe('deselectMultipleIds()', () => {
+    it('should deselect multiple ids', () => {
+      const { result, rerender } = renderHook(() =>
+        useMassSelection(
+          defaultTotalCount,
+          defaultIdsList,
+          defaultActiveFilters,
+          defaultWildcardSearch,
+          defaultStarredFilter,
+        ),
+      );
+
+      result.current.toggleSelectAll();
+      rerender();
+      expect(result.current.ids).toEqual(defaultIdsList);
+
+      result.current.deselectMultipleIds(['4', '5', '6']);
+      rerender();
+      expect(result.current.ids).toEqual(['1', '2', '3', '7', '8', '9', '10']);
+    });
+  });
+});

--- a/src/hooks/useMassSelection.ts
+++ b/src/hooks/useMassSelection.ts
@@ -18,6 +18,8 @@ export const useMassSelection = (
   deselectAll: () => void;
   toggleSelectAll: () => void;
   toggleSelectionById: (id: string) => void;
+  selectMultipleIds: (ids: string[]) => void;
+  deselectMultipleIds: (ids: string[]) => void;
 } => {
   const [selectionType, setSelectionType] = useState(
     ListHeaderCheckBoxState.Unchecked,
@@ -66,6 +68,16 @@ export const useMassSelection = (
     }
   };
 
+  const selectMultipleIds = (newIds: string[]) => {
+    setSelectionType(ListHeaderCheckBoxState.Checked);
+    setIds([...ids, ...newIds]);
+  };
+
+  const deselectMultipleIds = (idsToRemove: string[]) => {
+    setSelectionType(ListHeaderCheckBoxState.Unchecked);
+    setIds(ids.filter((id) => !idsToRemove.includes(id)));
+  };
+
   const deselectAll = () => {
     setSelectionType(ListHeaderCheckBoxState.Unchecked);
     setIds([]);
@@ -107,5 +119,7 @@ export const useMassSelection = (
     deselectAll,
     toggleSelectAll,
     toggleSelectionById,
+    selectMultipleIds,
+    deselectMultipleIds,
   };
 };


### PR DESCRIPTION
## Description
In this pull request, I enabled users to select all and deselect all contacts within a specific column on the flows view. When selecting, contacts are added/removed from the list of previously selected contacts.

This functionality replicates how the old MPDX worked. I had to add 2 more functions to the useMassSelection hook to allow for multiple contact IDs to be passed through for checking or unchecking.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
