### PR TITLE
MPDX-8181 - Showing excluded contacts message when adding contacts that are excluded

### DIFF
--- a/src/components/Tool/Appeal/Modals/AddContactToAppealModal/AddContactToAppealModal.test.tsx
+++ b/src/components/Tool/Appeal/Modals/AddContactToAppealModal/AddContactToAppealModal.test.tsx
@@ -138,18 +138,12 @@ describe('AddContactToAppealModal', () => {
     expect(mutationSpy).toHaveBeenCalledTimes(0);
 
     userEvent.click(getByRole('combobox', { name: 'Contacts' }));
-
-    expect(await findByRole('option', { name: 'Alice' })).toBeInTheDocument();
-
-    userEvent.click(getByRole('option', { name: 'Alice' }));
+    userEvent.click(await findByRole('option', { name: 'Alice' }));
     expect(getByText('Alice')).toBeInTheDocument();
 
     expect(queryByText('Bob')).not.toBeInTheDocument();
     userEvent.click(getByRole('combobox', { name: 'Contacts' }));
-
-    expect(await findByRole('option', { name: 'Bob' })).toBeInTheDocument();
-
-    userEvent.click(getByRole('option', { name: 'Bob' }));
+    userEvent.click(await findByRole('option', { name: 'Bob' }));
     expect(getByText('Bob')).toBeInTheDocument();
 
     userEvent.click(getByRole('button', { name: 'Save' }));
@@ -175,18 +169,16 @@ describe('AddContactToAppealModal', () => {
   });
 
   it('adds an excluded contact and shows excluded message', async () => {
-    const { getByRole, getAllByText, findByRole, findByTestId, queryByTestId } =
+    const { getByRole, getAllByText, findByTestId, findByRole, queryByTestId } =
       render(<Components />);
 
     userEvent.click(getByRole('combobox', { name: 'Contacts' }));
-    expect(await findByRole('option', { name: 'Alice' })).toBeInTheDocument();
-    userEvent.click(getByRole('option', { name: 'Alice' }));
+    userEvent.click(await findByRole('option', { name: 'Alice' }));
 
     expect(queryByTestId('excludedContactMessage')).not.toBeInTheDocument();
 
     userEvent.click(getByRole('combobox', { name: 'Contacts' }));
-    expect(await findByRole('option', { name: 'Charlie' })).toBeInTheDocument();
-    userEvent.click(getByRole('option', { name: 'Charlie' }));
+    userEvent.click(await findByRole('option', { name: 'Charlie' }));
 
     expect(await findByTestId('excludedContactMessage')).toBeInTheDocument();
 

--- a/src/components/Tool/Appeal/Modals/AddContactToAppealModal/AddContactToAppealModal.tsx
+++ b/src/components/Tool/Appeal/Modals/AddContactToAppealModal/AddContactToAppealModal.tsx
@@ -30,12 +30,6 @@ const AddContactSchema: yup.SchemaOf<AddContactFormikSchema> = yup.object({
   contactIds: yup.array().of(yup.string().required()).default([]),
 });
 
-interface Attributes {
-  id: string | undefined;
-  contactIds: string[];
-  forceListDeletion?: boolean;
-}
-
 export const AddContactToAppealModal: React.FC<
   AddContactToAppealModalProps
 > = ({ handleClose }) => {
@@ -64,20 +58,15 @@ export const AddContactToAppealModal: React.FC<
       excludedContactIds.includes(contactId),
     );
 
-    const attributes: Attributes = {
-      id: appealId,
-      contactIds: [...existingContactIds, ...contactIds],
-    };
-
-    if (addingExcludedContact) {
-      attributes.forceListDeletion = true;
-    }
-
     await assignContactsToAppeal({
       variables: {
         input: {
           accountListId: accountListId ?? '',
-          attributes,
+          attributes: {
+            id: appealId,
+            contactIds: [...existingContactIds, ...contactIds],
+            forceListDeletion: addingExcludedContact,
+          },
         },
       },
       refetchQueries: ['Contacts'],
@@ -132,13 +121,17 @@ export const AddContactToAppealModal: React.FC<
               }
               return result;
             }, []);
-          }, [contactIds]);
+          }, [contactIds, excludedContacts]);
           return (
             <form onSubmit={handleSubmit} data-testid="addContactToAppealModal">
               <DialogContent>
                 <Grid item>
                   {!!excludedContactNames.length && (
-                    <Alert severity="info" data-testid="excludedContactMessage">
+                    <Alert
+                      severity="info"
+                      data-testid="excludedContactMessage"
+                      sx={{ marginBottom: 1 }}
+                    >
                       {t(
                         'Some of the contact(s) you have selected to add to this appeal are currently excluded. You will not be able to exclude these contacts once you add them to this appeal. Instead, you will be able to remove them from it.',
                       )}

--- a/src/components/Tool/Appeal/Modals/AddContactToAppealModal/AddContactToAppealModal.tsx
+++ b/src/components/Tool/Appeal/Modals/AddContactToAppealModal/AddContactToAppealModal.tsx
@@ -1,5 +1,6 @@
-import React, { ReactElement } from 'react';
-import { DialogActions, DialogContent, Grid } from '@mui/material';
+import React, { ReactElement, useMemo } from 'react';
+import { Alert, DialogActions, DialogContent, Grid } from '@mui/material';
+import { Box } from '@mui/system';
 import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
@@ -15,7 +16,7 @@ import {
   AppealsType,
 } from '../../AppealsContext/AppealsContext';
 import { useAssignContactsToAppealMutation } from './AddContactToAppeal.generated';
-import { useAppealQuery } from './AppealInfo.generated';
+import { useAppealContactsQuery } from './AppealContacts.generated';
 
 interface AddContactToAppealModalProps {
   handleClose: () => void;
@@ -29,6 +30,12 @@ const AddContactSchema: yup.SchemaOf<AddContactFormikSchema> = yup.object({
   contactIds: yup.array().of(yup.string().required()).default([]),
 });
 
+interface Attributes {
+  id: string | undefined;
+  contactIds: string[];
+  forceListDeletion?: boolean;
+}
+
 export const AddContactToAppealModal: React.FC<
   AddContactToAppealModalProps
 > = ({ handleClose }) => {
@@ -39,7 +46,7 @@ export const AddContactToAppealModal: React.FC<
     AppealsContext,
   ) as AppealsType;
 
-  const { data } = useAppealQuery({
+  const { data } = useAppealContactsQuery({
     variables: {
       accountListId: accountListId ?? '',
       appealId: appealId ?? '',
@@ -47,25 +54,39 @@ export const AddContactToAppealModal: React.FC<
   });
 
   const existingContactIds = data?.appeal?.contactIds ?? [];
+  const excludedContacts = data?.appeal?.excludedAppealContacts ?? [];
 
-  const onSubmit = async (attributes: AddContactFormikSchema) => {
+  const onSubmit = async ({ contactIds }: AddContactFormikSchema) => {
+    const excludedContactIds = excludedContacts.map(
+      (excludedContact) => excludedContact.contact?.id,
+    );
+    const addingExcludedContact = contactIds.some((contactId) =>
+      excludedContactIds.includes(contactId),
+    );
+
+    const attributes: Attributes = {
+      id: appealId,
+      contactIds: [...existingContactIds, ...contactIds],
+    };
+
+    if (addingExcludedContact) {
+      attributes.forceListDeletion = true;
+    }
+
     await assignContactsToAppeal({
       variables: {
         input: {
           accountListId: accountListId ?? '',
-          attributes: {
-            id: appealId,
-            contactIds: [...existingContactIds, ...attributes.contactIds],
-          },
+          attributes,
         },
       },
       refetchQueries: ['Contacts'],
       onCompleted: () => {
         const successMessage =
-          attributes.contactIds.length === 1
+          contactIds.length === 1
             ? t('1 contact successfully added to your appeal.')
             : t('{{count}} contacts successfully added to your appeal.', {
-                count: attributes.contactIds.length,
+                count: contactIds.length,
               });
         enqueueSnackbar(successMessage, {
           variant: 'success',
@@ -100,29 +121,54 @@ export const AddContactToAppealModal: React.FC<
           handleSubmit,
           isSubmitting,
           isValid,
-        }): ReactElement => (
-          <form onSubmit={handleSubmit} data-testid="addContactToAppealModal">
-            <DialogContent>
-              <Grid item>
-                <ContactsAutocomplete
-                  accountListId={accountListId ?? ''}
-                  value={contactIds}
-                  onChange={(contactIds) => {
-                    setFieldValue('contactIds', contactIds);
-                  }}
-                  excludeContactIds={existingContactIds}
-                />
-              </Grid>
-            </DialogContent>
-            <DialogActions>
-              <CancelButton onClick={handleClose} disabled={isSubmitting} />
+        }): ReactElement => {
+          const excludedContactNames = useMemo(() => {
+            return contactIds.reduce<string[]>((result, contactId) => {
+              const excludedContact = excludedContacts.find(
+                (excludedContact) => excludedContact.contact?.id === contactId,
+              );
+              if (excludedContact && excludedContact.contact?.name) {
+                return [...result, excludedContact.contact?.name];
+              }
+              return result;
+            }, []);
+          }, [contactIds]);
+          return (
+            <form onSubmit={handleSubmit} data-testid="addContactToAppealModal">
+              <DialogContent>
+                <Grid item>
+                  {!!excludedContactNames.length && (
+                    <Alert severity="info" data-testid="excludedContactMessage">
+                      {t(
+                        'Some of the contact(s) you have selected to add to this appeal are currently excluded. You will not be able to exclude these contacts once you add them to this appeal. Instead, you will be able to remove them from it.',
+                      )}
+                      <Box pt={1} display="flex" gap={1}>
+                        {excludedContactNames.map((name) => (
+                          <Box key={name}>{name}</Box>
+                        ))}
+                      </Box>
+                    </Alert>
+                  )}
+                  <ContactsAutocomplete
+                    accountListId={accountListId ?? ''}
+                    value={contactIds}
+                    onChange={(contactIds) => {
+                      setFieldValue('contactIds', contactIds);
+                    }}
+                    excludeContactIds={existingContactIds}
+                  />
+                </Grid>
+              </DialogContent>
+              <DialogActions>
+                <CancelButton onClick={handleClose} disabled={isSubmitting} />
 
-              <SubmitButton disabled={!isValid || isSubmitting}>
-                {t('Save')}
-              </SubmitButton>
-            </DialogActions>
-          </form>
-        )}
+                <SubmitButton disabled={!isValid || isSubmitting}>
+                  {t('Save')}
+                </SubmitButton>
+              </DialogActions>
+            </form>
+          );
+        }}
       </Formik>
     </Modal>
   );

--- a/src/components/Tool/Appeal/Modals/AddContactToAppealModal/AppealContacts.graphql
+++ b/src/components/Tool/Appeal/Modals/AddContactToAppealModal/AppealContacts.graphql
@@ -1,0 +1,13 @@
+query AppealContacts($accountListId: ID!, $appealId: ID!) {
+  appeal(accountListId: $accountListId, id: $appealId) {
+    id
+    contactIds
+    excludedAppealContacts {
+      id
+      contact {
+        id
+        name
+      }
+    }
+  }
+}

--- a/src/components/Tool/Appeal/Modals/AddContactToAppealModal/AppealInfo.graphql
+++ b/src/components/Tool/Appeal/Modals/AddContactToAppealModal/AppealInfo.graphql
@@ -1,6 +1,0 @@
-query Appeal($accountListId: ID!, $appealId: ID!) {
-  appeal(accountListId: $accountListId, id: $appealId) {
-    id
-    contactIds
-  }
-}

--- a/src/components/Tool/Appeal/Modals/AddExcludedContactModal/AddExcludedContactModal.test.tsx
+++ b/src/components/Tool/Appeal/Modals/AddExcludedContactModal/AddExcludedContactModal.test.tsx
@@ -15,7 +15,7 @@ import {
   AppealsContext,
   AppealsType,
 } from '../../AppealsContext/AppealsContext';
-import { AppealQuery } from '../AddContactToAppealModal/AppealInfo.generated';
+import { AppealContactsQuery } from '../AddContactToAppealModal/AppealContacts.generated';
 import { AddExcludedContactModal } from './AddExcludedContactModal';
 
 const accountListId = 'abc';
@@ -41,7 +41,7 @@ jest.mock('notistack', () => ({
   },
 }));
 
-const appealMock: AppealQuery = {
+const appealMock: AppealContactsQuery = {
   appeal: {
     id: appealId,
     contactIds: ['contact-1', 'contact-2'],
@@ -59,10 +59,10 @@ const Components = ({
         <ThemeProvider theme={theme}>
           <TestRouter router={router}>
             <GqlMockedProvider<{
-              Appeal: AppealQuery;
+              AppealContacts: AppealContactsQuery;
             }>
               mocks={{
-                Appeal: appealMock,
+                AppealContacts: appealMock,
               }}
               onCall={mutationSpy}
             >

--- a/src/components/Tool/Appeal/Modals/AddExcludedContactModal/AddExcludedContactModal.tsx
+++ b/src/components/Tool/Appeal/Modals/AddExcludedContactModal/AddExcludedContactModal.tsx
@@ -19,7 +19,7 @@ import {
   AppealsType,
 } from '../../AppealsContext/AppealsContext';
 import { useAssignContactsToAppealMutation } from '../AddContactToAppealModal/AddContactToAppeal.generated';
-import { useAppealQuery } from '../AddContactToAppealModal/AppealInfo.generated';
+import { useAppealContactsQuery } from '../AddContactToAppealModal/AppealContacts.generated';
 
 const LoadingIndicator = styled(CircularProgress)(({ theme }) => ({
   margin: theme.spacing(0, 1, 0, 0),
@@ -39,7 +39,7 @@ export const AddExcludedContactModal: React.FC<
     useAssignContactsToAppealMutation();
   const { accountListId, appealId } = useContext(AppealsContext) as AppealsType;
 
-  const { data, loading } = useAppealQuery({
+  const { data, loading } = useAppealContactsQuery({
     variables: {
       accountListId: accountListId ?? '',
       appealId: appealId ?? '',


### PR DESCRIPTION
## Description

In this PR, I add a message to the add Contact modal to inform the user that they are adding excluded contacts.

In the old MPDX, they close the modal and open the add excluded modal, but since I allow multiple contacts to be added and I think it's better UX, I have added an info alert that shows when an excluded contact is selected.
I also list out the excluded contact names.

I have added tests for this new functionality.

This PR is related to task [MPDX-8181](https://jira.cru.org/browse/MPDX-8181) not 1880. My mistake.


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
