### PR TITLE
[MPDX-8174] Missing contact name on hidden contact

### DIFF
--- a/src/components/Task/Modal/Form/Inputs/ContactsAutocomplete/ContactsAutocomplete.test.tsx
+++ b/src/components/Task/Modal/Form/Inputs/ContactsAutocomplete/ContactsAutocomplete.test.tsx
@@ -66,24 +66,21 @@ describe('ContactsAutocomplete', () => {
       <TestComponent value={['contact-1', 'contact-2']} />,
     );
 
-    await waitFor(() => expect(mutationSpy).toHaveBeenCalledTimes(2));
-    expect(mutationSpy.mock.calls[0][0].operation.operationName).toEqual(
-      'ContactOptions',
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('ContactOptions', {
+        accountListId,
+        first: 10,
+        contactsFilters: { wildcardSearch: '' },
+      }),
     );
-    expect(mutationSpy.mock.calls[0][0].operation.variables).toEqual({
-      accountListId,
-      first: 10,
-      contactsFilters: { wildcardSearch: '' },
-    });
 
-    expect(mutationSpy.mock.lastCall[0].operation.operationName).toEqual(
-      'ContactOptions',
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('ContactOptions', {
+        accountListId,
+        first: 2,
+        contactsFilters: { ids: ['contact-1', 'contact-2'], status: [] },
+      }),
     );
-    expect(mutationSpy.mock.lastCall[0].operation.variables).toEqual({
-      accountListId,
-      first: 2,
-      contactsFilters: { ids: ['contact-1', 'contact-2'] },
-    });
 
     userEvent.click(getByRole('combobox', { name: 'Contacts' }));
     expect(getAllByRole('option')).toHaveLength(3);

--- a/src/components/Task/Modal/Form/Inputs/ContactsAutocomplete/ContactsAutocomplete.tsx
+++ b/src/components/Task/Modal/Form/Inputs/ContactsAutocomplete/ContactsAutocomplete.tsx
@@ -65,7 +65,14 @@ export const ContactsAutocomplete: React.FC<ContactsAutocompleteProps> = ({
     variables: {
       accountListId,
       first: value.length,
-      contactsFilters: { ids: value },
+      contactsFilters: {
+        ids: value,
+        // When the status filter is omitted, only contacts with an active status are loaded. But
+        // we need to load hidden contacts as well in case the user is adding a task to a hidden
+        // contact. Setting status to an empty array overrides the default status filter and loads
+        // contacts with any status.
+        status: [],
+      },
     },
     skip: value.length === 0,
   });

--- a/src/components/Task/Modal/TaskModal.tsx
+++ b/src/components/Task/Modal/TaskModal.tsx
@@ -95,11 +95,7 @@ const TaskModal = ({
               defaultValues={defaultValues}
             />
           )}
-          {[
-            TaskModalEnum.Complete,
-            TaskModalEnum.Comments,
-            TaskModalEnum.Log,
-          ].indexOf(view) === -1 && (
+          {(view === TaskModalEnum.Add || view === TaskModalEnum.Edit) && (
             <DynamicTaskModalForm
               accountListId={accountListId}
               task={task}


### PR DESCRIPTION
## Description

When creating or editing a task on a hidden contact, the contact name wasn't showing in the contacts autocomplete because the query to load contacts only returns active contacts by default.

To test, add a task on a contact with the status "Never Ask" and verify that the contact name shows up.

Before:

<img width="619" alt="Screenshot 2024-09-10 at 1 14 19 PM" src="https://github.com/user-attachments/assets/1ae2623d-8757-4526-8cc0-86a66a3a64e4">

After:

<img width="618" alt="Screenshot 2024-09-10 at 1 14 29 PM" src="https://github.com/user-attachments/assets/3ebe87af-c0d0-4c81-87a9-7e0d003511d2">

This is likely the issue that Keely experienced during task phases UAT.

I'm basing this PR on `main` because it is present in production and can be fixed without depending on task phases.

https://jira.cru.org/browse/MPDX-8174
https://jira.cru.org/browse/MPDX-8097 (same ticket reported earlier by me)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
