### PR TITLE
MPDX-8183 Simplifying the UX of the Pledge modal when status given or received

### DIFF
--- a/src/components/Tool/Appeal/InitialPage/AddAppealForm/AddAppealForm.test.tsx
+++ b/src/components/Tool/Appeal/InitialPage/AddAppealForm/AddAppealForm.test.tsx
@@ -223,6 +223,7 @@ describe('AddAppealForm', () => {
 
       expect(await findByText('New Connection')).toBeInTheDocument();
       expect(getByText('Ask in Future')).toBeInTheDocument();
+      expect(getByText('-- None --')).toBeInTheDocument();
       // Ensures the '--- All Active ---' option isn't added
       expect(queryByText('--- All Active ---')).not.toBeInTheDocument();
     });
@@ -315,12 +316,36 @@ describe('AddAppealForm', () => {
       const tags = ['tag-1', 'tag-2'];
       const statuses = [
         {
+          name: '-- None --',
+          value: 'NULL',
+        },
+        {
+          name: '--- All Active ---',
+          value: 'ACTIVE',
+        },
+        {
+          name: '--- All Hidden ---',
+          value: 'HIDDEN',
+        },
+        {
           name: 'New Connection',
           value: 'NEVER_CONTACTED',
         },
         {
           name: 'Ask in Future',
           value: 'ASK_IN_FUTURE',
+        },
+        {
+          name: 'Call For Decision',
+          value: 'CALL_FOR_DECISION',
+        },
+        {
+          name: 'Not Interested',
+          value: 'NOT_INTERESTED',
+        },
+        {
+          name: 'Expired Referral',
+          value: 'EXPIRED_REFERRAL',
         },
       ];
 
@@ -377,7 +402,8 @@ describe('AddAppealForm', () => {
         ).toStrictEqual({
           any_tags: true,
           tags: 'tag-1,tag-2',
-          status: 'NEVER_CONTACTED,ASK_IN_FUTURE',
+          status:
+            'null,active,hidden,never_contacted,ask_in_future,call_for_decision,not_interested,expired_referral',
         });
       });
     });
@@ -436,8 +462,8 @@ describe('AddAppealForm', () => {
 
       // Contact to include
       const contactStatusSelect = await findByTestId('contactStatusSelect');
-      userEvent.type(contactStatusSelect, 'New Connection');
-      userEvent.selectOptions(getByRole('listbox'), 'New Connection');
+      userEvent.type(contactStatusSelect, 'Partner - Financial');
+      userEvent.selectOptions(getByRole('listbox'), 'Partner - Financial');
 
       // Contact with tags to include
       const selectAllTagsButton = await findByTestId(
@@ -474,7 +500,7 @@ describe('AddAppealForm', () => {
           inclusionFilter: {
             any_tags: true,
             tags: 'tag-1,tag-2,tag-3,tag-4',
-            status: 'NEVER_CONTACTED',
+            status: 'partner_financial',
           },
           exclusionFilter: {
             gave_more_than_pledged_range: '2019-10-01..2020-01-01',

--- a/src/components/Tool/Appeal/InitialPage/AddAppealForm/AddAppealForm.tsx
+++ b/src/components/Tool/Appeal/InitialPage/AddAppealForm/AddAppealForm.tsx
@@ -80,6 +80,27 @@ export const calculateGoal = (
   return Math.round(((initialGoal + letterCost) / adminPercent) * 100) / 100;
 };
 
+const gqlStatusesToDBStatusMap: { [key: string]: string } = {
+  NULL: 'null',
+  ACTIVE: 'active',
+  HIDDEN: 'hidden',
+  NEVER_CONTACTED: 'never_contacted',
+  ASK_IN_FUTURE: 'ask_in_future',
+  CULTIVATE_RELATIONSHIP: 'cultivate_relationship',
+  CONTACT_FOR_APPOINTMENT: 'contact_for_appointment',
+  APPOINTMENT_SCHEDULED: 'appointment_scheduled',
+  CALL_FOR_DECISION: 'call_for_decision',
+  PARTNER_FINANCIAL: 'partner_financial',
+  PARTNER_SPECIAL: 'partner_special',
+  PARTNER_PRAY: 'partner_pray',
+  NOT_INTERESTED: 'not_interested',
+  UNRESPONSIVE: 'unresponsive',
+  NEVER_ASK: 'never_ask',
+  RESEARCH_ABANDONED: 'research_abandoned',
+  EXPIRED_REFERRAL: 'expired_referral',
+  RESEARCH_CONTACT_INFO: 'research_contact_info',
+};
+
 type BuildInclusionFilterProps = {
   appealIncludes: object;
   tags: Attributes['tags'];
@@ -94,13 +115,18 @@ export const buildInclusionFilter = ({
     any_tags: true,
   };
 
+  const dbStatues =
+    statuses && statuses.length
+      ? statuses
+          .map((status) =>
+            status.value ? gqlStatusesToDBStatusMap[status.value] : '',
+          )
+          .join(',')
+      : null;
   const inclusionFilter = removeObjectNulls({
     ...defaultInclusionFilter,
     tags: tags && tags.length ? tags.join(',') : null,
-    status:
-      statuses && statuses.length
-        ? statuses.map((status) => status.value).join(',')
-        : null,
+    status: dbStatues,
     ...appealIncludes,
   });
 
@@ -323,9 +349,7 @@ const AddAppealForm: React.FC<AddAppealFormProps> = ({
       'statuses',
       contactStatuses?.filter(
         (status: { value: string }) =>
-          status.value !== 'ACTIVE' &&
-          status.value !== 'HIDDEN' &&
-          status.value !== 'NULL',
+          status.value !== 'ACTIVE' && status.value !== 'HIDDEN',
       ),
     );
   };

--- a/src/components/Tool/Appeal/InitialPage/AddAppealForm/AddAppealFormMocks.ts
+++ b/src/components/Tool/Appeal/InitialPage/AddAppealForm/AddAppealFormMocks.ts
@@ -53,6 +53,12 @@ export const contactFiltersMock: ContactFiltersQuery = {
                 __typename: 'FilterOption',
               },
               {
+                name: '-- None --',
+                placeholder: null,
+                value: 'NULL',
+                __typename: 'FilterOption',
+              },
+              {
                 name: 'New Connection',
                 placeholder: null,
                 value: 'NEVER_CONTACTED',
@@ -62,6 +68,12 @@ export const contactFiltersMock: ContactFiltersQuery = {
                 name: 'Ask in Future',
                 placeholder: null,
                 value: 'ASK_IN_FUTURE',
+                __typename: 'FilterOption',
+              },
+              {
+                name: 'Partner - Financial',
+                placeholder: null,
+                value: 'PARTNER_FINANCIAL',
                 __typename: 'FilterOption',
               },
             ],

--- a/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.test.tsx
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.test.tsx
@@ -205,11 +205,10 @@ describe('PledgeModal', () => {
   });
 
   it('Edit Processed commitment', async () => {
-    const pledgeId = 'pledge-1';
     const { getByRole, findByText } = render(
       <Components
         pledge={{
-          id: pledgeId,
+          id: 'abc',
           amount: 444,
           amountCurrency: 'USD',
           appeal: {
@@ -230,5 +229,28 @@ describe('PledgeModal', () => {
     expect(getByRole('combobox', { name: 'Status' })).toHaveClass(
       'Mui-disabled',
     );
+  });
+
+  it('can not select the status given or received if the pledge does not have one of those statuses already', async () => {
+    const { getByRole, queryByRole } = render(
+      <Components
+        pledge={{
+          id: 'abc',
+          amount: 444,
+          amountCurrency: 'USD',
+          appeal: {
+            id: 'appeal-1',
+          },
+          expectedDate: '2024-08-08',
+          status: PledgeStatusEnum.NotReceived,
+        }}
+      />,
+    );
+
+    userEvent.click(getByRole('combobox', { name: 'Status' }));
+
+    expect(getByRole('option', { name: 'Committed' })).toBeInTheDocument();
+    expect(queryByRole('option', { name: 'Received' })).not.toBeInTheDocument();
+    expect(queryByRole('option', { name: 'Given' })).not.toBeInTheDocument();
   });
 });

--- a/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.test.tsx
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.test.tsx
@@ -203,4 +203,32 @@ describe('PledgeModal', () => {
       });
     });
   });
+
+  it('Edit Processed commitment', async () => {
+    const pledgeId = 'pledge-1';
+    const { getByRole, findByText } = render(
+      <Components
+        pledge={{
+          id: pledgeId,
+          amount: 444,
+          amountCurrency: 'USD',
+          appeal: {
+            id: 'appeal-1',
+          },
+          expectedDate: '2024-08-08',
+          status: PledgeStatusEnum.Processed,
+        }}
+      />,
+    );
+
+    expect(
+      getByRole('heading', { name: 'Edit Commitment' }),
+    ).toBeInTheDocument();
+
+    expect(getByRole('textbox', { name: 'Amount' })).toBeDisabled();
+    expect(await findByText('Given')).toBeInTheDocument();
+    expect(getByRole('combobox', { name: 'Status' })).toHaveClass(
+      'Mui-disabled',
+    );
+  });
 });

--- a/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
@@ -354,6 +354,9 @@ export const PledgeModal: React.FC<PledgeModalProps> = ({
                             fullWidth
                             id="status-select"
                             variant="outlined"
+                            disabled={
+                              pledge?.status === PledgeStatusEnum.Processed
+                            }
                             labelId="status-select-label"
                             inputProps={{
                               'aria-labelledby': 'status-select-label',
@@ -380,15 +383,18 @@ export const PledgeModal: React.FC<PledgeModalProps> = ({
                             <MenuItem value={PledgeStatusEnum.NotReceived}>
                               {t('Committed')}
                             </MenuItem>
-                            <MenuItem
-                              value={PledgeStatusEnum.ReceivedNotProcessed}
-                            >
-                              {t('Received')}
-                            </MenuItem>
+                            {pledge?.status ===
+                              PledgeStatusEnum.ReceivedNotProcessed && (
+                              <MenuItem
+                                value={PledgeStatusEnum.ReceivedNotProcessed}
+                              >
+                                {t('Received')}
+                              </MenuItem>
+                            )}
                             {pledge?.status === PledgeStatusEnum.Processed && (
-                            <MenuItem value={PledgeStatusEnum.Processed}>
-                              {t('Given')}
-                            </MenuItem>
+                              <MenuItem value={PledgeStatusEnum.Processed}>
+                                {t('Given')}
+                              </MenuItem>
                             )}
                           </Select>
                         </Box>

--- a/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
@@ -228,6 +228,9 @@ export const PledgeModal: React.FC<PledgeModalProps> = ({
                             size="small"
                             variant="outlined"
                             fullWidth
+                            disabled={
+                              pledge?.status === PledgeStatusEnum.Processed
+                            }
                             type="text"
                             inputProps={{
                               'aria-labelledby': 'amount-input-label',
@@ -382,6 +385,11 @@ export const PledgeModal: React.FC<PledgeModalProps> = ({
                             >
                               {t('Received')}
                             </MenuItem>
+                            {pledge?.status === PledgeStatusEnum.Processed && (
+                            <MenuItem value={PledgeStatusEnum.Processed}>
+                              {t('Given')}
+                            </MenuItem>
+                            )}
                           </Select>
                         </Box>
                       )}


### PR DESCRIPTION
## Description
In this PR, I will make the edit Pledge model more like the old MPDX. 

**When the pledge has a status of `given`:**
- The amount should be disabled and not editable.
- The status should be `Given`, but this shouldn't show as an option to select.

**When the pledge has a status of `Received`:**
- It should show the received status, but otherwise, it should be hidden.
_This is unlike the old MPDX, the old MPDX shows the received status as a option, but when users select it, the contact/pledge stays in committed and causes a lot of confusion._
We have thought about removing the received column entirely, that is a large change. This might help with some of the confusion.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
