### PR TITLE
[MPDX-8186] Preserve the appeals list the user was viewing

### DIFF
--- a/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
+++ b/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
@@ -125,24 +125,23 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
   //User options for display view
   const { loading: userOptionsLoading } = useGetUserOptionsQuery({
     onCompleted: ({ userOptions }) => {
-      if (contactId?.includes('list')) {
+      const defaultView =
+        (userOptions.find((option) => option.key === 'contacts_view')
+          ?.value as TableViewModeEnum) || TableViewModeEnum.Flows;
+      if (
+        contactId?.includes('list') ||
+        defaultView === TableViewModeEnum.List
+      ) {
         setViewMode(TableViewModeEnum.List);
         setFilterPanelOpen(true);
-        setActiveFilters({
-          appealStatus: AppealStatusEnum.Asked,
-        });
-      } else {
-        const defaultView =
-          (userOptions.find((option) => option.key === 'contacts_view')
-            ?.value as TableViewModeEnum) || TableViewModeEnum.Flows;
-        setViewMode(defaultView);
-
-        if (defaultView === TableViewModeEnum.List) {
-          setFilterPanelOpen(true);
+        // Default to showing the asked contacts
+        if (!activeFilters.appealStatus) {
           setActiveFilters({
             appealStatus: AppealStatusEnum.Asked,
           });
         }
+      } else {
+        setViewMode(defaultView);
       }
     },
   });


### PR DESCRIPTION
## Description

In the appeals list view if you switch off of the Asked list to another list, like Given, then reload the page, you were taken back to the Asked list. This PR preserves the list that the user was on and only takes them to Asked if they didn't have `appealStatus` set in the filters in the URL.

[MPDX-8186](https://jira.cru.org/browse/MPDX-8186)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
