### PR TITLE
[MPDX-8190] Render 0 instead of loading when goal is 0

### DIFF
--- a/src/components/Tool/Appeal/AppealDetails/AppealHeaderInfo/AppealHeaderInfo.test.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealHeaderInfo/AppealHeaderInfo.test.tsx
@@ -57,6 +57,16 @@ describe('AppealHeaderInfo', () => {
     expect(getByText(/\$100 \(100%\)/i)).toBeInTheDocument();
   });
 
+  it('renders amount when goal is 0 info', async () => {
+    const { getByText, findByText } = render(
+      <Components appealInfo={{ ...appealInfo, amount: 0 }} loading={false} />,
+    );
+
+    expect(await findByText('Test Appeal')).toBeInTheDocument();
+
+    expect(getByText('$0')).toBeInTheDocument();
+  });
+
   it('should allow user to open the edit appeal info modal', async () => {
     const { findByText, findByRole, getByTestId, getByRole, queryByRole } =
       render(<Components appealInfo={appealInfo} loading={false} />);

--- a/src/components/Tool/Appeal/AppealDetails/AppealHeaderInfo/AppealHeaderInfo.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealHeaderInfo/AppealHeaderInfo.tsx
@@ -108,7 +108,7 @@ export const AppealHeaderInfo: React.FC<AppealHeaderInfoProps> = ({
                 {t('Goal')}:
               </AppealInfoHeader>
               <AppealInfoContainer>
-                {loading || !amount ? (
+                {loading || !appealInfo ? (
                   <Skeleton
                     variant="text"
                     data-testid="appeal-goal-skeleton"


### PR DESCRIPTION
## Description

Appeal header was rendering a loading skeleton instead of $0 when the goal amount was 0.

[MPDX-8190](https://jira.cru.org/browse/MPDX-8190)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
