### PR TITLE
MPDX-8187 + MPDX-8188 Add more warning messages when dragging contact to different columns.

### DIFF
--- a/src/components/Tool/Appeal/Flow/ContactFlow.test.tsx
+++ b/src/components/Tool/Appeal/Flow/ContactFlow.test.tsx
@@ -431,7 +431,7 @@ describe('ContactFlow', () => {
 
       await waitFor(() =>
         expect(mockEnqueue).toHaveBeenCalledWith(
-          'Unable to move contact here as gift has not been received by Cru.',
+          'Unable to move contact to the "Received" column as gift has not been received by Cru. Status set to "Committed".',
           {
             variant: 'warning',
           },
@@ -559,7 +559,7 @@ describe('ContactFlow', () => {
 
       await waitFor(() =>
         expect(mockEnqueue).toHaveBeenCalledWith(
-          'Unable to move contact to Committed as part of the pledge has been Received.',
+          'Unable to move contact to the "Committed" column as part of the pledge has been Received.',
           {
             variant: 'warning',
           },

--- a/src/components/Tool/Appeal/Flow/ContactFlow.tsx
+++ b/src/components/Tool/Appeal/Flow/ContactFlow.tsx
@@ -17,6 +17,7 @@ import { DynamicDeletePledgeModal } from '../Modals/DeletePledgeModal/DynamicDel
 import { useUpdateAccountListPledgeMutation } from '../Modals/PledgeModal/ContactPledge.generated';
 import { DynamicPledgeModal } from '../Modals/PledgeModal/DynamicPledgeModal';
 import { DynamicUpdateDonationsModal } from '../Modals/UpdateDonationsModal/DynamicUpdateDonationsModal';
+import handleReceivedSnackBarNotifications from '../Shared/handleReceivedSnackBarNotifications/handleReceivedSnackBarNotifications';
 import { ContactFlowColumn } from './ContactFlowColumn/ContactFlowColumn';
 import { ContactFlowDragLayer } from './ContactFlowDragLayer/ContactFlowDragLayer';
 import { DraggedContact } from './ContactFlowRow/ContactFlowRow';
@@ -100,6 +101,8 @@ export const ContactFlow: React.FC<ContactFlowProps> = ({
     useState(false);
 
   const [contact, setContact] = useState<DraggedContact | null>(null);
+  const [selectedAppealStatus, setSelectedAppealStatus] =
+    useState<AppealStatusEnum | null>(null);
 
   const [updateAccountListPledge] = useUpdateAccountListPledgeMutation();
 
@@ -124,6 +127,7 @@ export const ContactFlow: React.FC<ContactFlowProps> = ({
     }
 
     setContact(contact);
+    setSelectedAppealStatus(newAppealStatus);
 
     switch (newAppealStatus) {
       case AppealStatusEnum.Excluded:
@@ -166,40 +170,15 @@ export const ContactFlow: React.FC<ContactFlowProps> = ({
               const newStatus =
                 data.data?.updateAccountListPledge?.pledge.status;
 
-              if (
-                newStatus === PledgeStatusEnum.NotReceived &&
-                newAppealStatus === AppealStatusEnum.ReceivedNotProcessed
-              ) {
-                enqueueSnackbar(
-                  t(
-                    'Unable to move contact here as gift has not been received by Cru.',
-                  ),
-                  {
-                    variant: 'warning',
-                  },
-                );
-              } else if (
-                newStatus === PledgeStatusEnum.Processed &&
-                (newAppealStatus === AppealStatusEnum.ReceivedNotProcessed ||
-                  newAppealStatus === AppealStatusEnum.NotReceived)
-              ) {
-                enqueueSnackbar(
-                  t(
-                    'Unable to move contact here as this gift is already processed.',
-                  ),
-                  {
-                    variant: 'warning',
-                  },
-                );
-              } else {
-                enqueueSnackbar(
-                  t(
-                    'Unable to move contact to Committed as part of the pledge has been Received.',
-                  ),
-                  {
-                    variant: 'warning',
-                  },
-                );
+              const { message, snackbarOptions } =
+                handleReceivedSnackBarNotifications({
+                  dbStatus: newStatus,
+                  selectedAppealStatus: newAppealStatus,
+                  t,
+                });
+
+              if (message) {
+                enqueueSnackbar(message, snackbarOptions);
               }
             },
           });
@@ -275,6 +254,7 @@ export const ContactFlow: React.FC<ContactFlowProps> = ({
         <DynamicPledgeModal
           contact={contact}
           pledge={contact.pledge}
+          selectedAppealStatus={selectedAppealStatus}
           handleClose={() => setPledgeModalOpen(false)}
         />
       )}

--- a/src/components/Tool/Appeal/Modals/PledgeModal/ContactPledge.graphql
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/ContactPledge.graphql
@@ -6,6 +6,7 @@ mutation CreateAccountListPledge(
       id
       amount
       amountCurrency
+      status
     }
   }
 }

--- a/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
@@ -33,10 +33,12 @@ import { requiredDateTime } from 'src/lib/formikHelpers';
 import { getPledgeCurrencyOptions } from 'src/lib/getCurrencyOptions';
 import i18n from 'src/lib/i18n';
 import {
+  AppealStatusEnum,
   AppealsContext,
   AppealsType,
 } from '../../AppealsContext/AppealsContext';
 import { AppealContactInfoFragment } from '../../AppealsContext/contacts.generated';
+import handleReceivedSnackBarNotifications from '../../Shared/handleReceivedSnackBarNotifications/handleReceivedSnackBarNotifications';
 import {
   useCreateAccountListPledgeMutation,
   useUpdateAccountListPledgeMutation,
@@ -49,6 +51,7 @@ interface PledgeModalProps {
     name: string;
   };
   pledge?: AppealContactInfoFragment['pledges'][0];
+  selectedAppealStatus?: AppealStatusEnum | null;
 }
 
 const CreatePledgeSchema = yup.object({
@@ -77,6 +80,7 @@ export const PledgeModal: React.FC<PledgeModalProps> = ({
   contact,
   pledge,
   handleClose,
+  selectedAppealStatus,
 }) => {
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
@@ -114,6 +118,22 @@ export const PledgeModal: React.FC<PledgeModalProps> = ({
           },
         },
         refetchQueries: ['Contacts', 'Appeal'],
+        update: (_, data) => {
+          const newStatus = data.data?.createAccountListPledge?.pledge.status;
+
+          if (selectedAppealStatus) {
+            const { message, snackbarOptions } =
+              handleReceivedSnackBarNotifications({
+                dbStatus: newStatus,
+                selectedAppealStatus,
+                t,
+              });
+
+            if (message) {
+              enqueueSnackbar(message, snackbarOptions);
+            }
+          }
+        },
         onCompleted: () => {
           enqueueSnackbar(t('Successfully added commitment to appeal'), {
             variant: 'success',
@@ -143,6 +163,22 @@ export const PledgeModal: React.FC<PledgeModalProps> = ({
           },
         },
         refetchQueries: ['Contacts', 'Appeal'],
+        update: (_, data) => {
+          const newStatus = data.data?.updateAccountListPledge?.pledge.status;
+
+          if (selectedAppealStatus) {
+            const { message, snackbarOptions } =
+              handleReceivedSnackBarNotifications({
+                dbStatus: newStatus,
+                selectedAppealStatus,
+                t,
+              });
+
+            if (message) {
+              enqueueSnackbar(message, snackbarOptions);
+            }
+          }
+        },
         onCompleted: () => {
           enqueueSnackbar(t('Successfully edited commitment'), {
             variant: 'success',

--- a/src/components/Tool/Appeal/Shared/handleReceivedSnackBarNotifications/handleReceivedSnackBarNotifications.ts
+++ b/src/components/Tool/Appeal/Shared/handleReceivedSnackBarNotifications/handleReceivedSnackBarNotifications.ts
@@ -1,0 +1,49 @@
+import { TFunction } from 'i18next';
+import { OptionsObject } from 'notistack';
+import { Maybe, PledgeStatusEnum } from 'src/graphql/types.generated';
+import { AppealStatusEnum } from '../../AppealsContext/AppealsContext';
+
+interface HandleReceivedSnackBarNotificationsProps {
+  dbStatus: Maybe<PledgeStatusEnum> | undefined;
+  selectedAppealStatus: AppealStatusEnum;
+  t: TFunction;
+}
+const handleReceivedSnackBarNotifications = ({
+  dbStatus,
+  selectedAppealStatus,
+  t,
+}: HandleReceivedSnackBarNotificationsProps) => {
+  let message = '';
+  const snackbarOptions: OptionsObject = {
+    variant: 'warning',
+  };
+  if (
+    dbStatus === PledgeStatusEnum.NotReceived &&
+    selectedAppealStatus === AppealStatusEnum.ReceivedNotProcessed
+  ) {
+    message = t(
+      'Unable to move contact to the "Received" column as gift has not been received by Cru. Status set to "Committed".',
+    );
+  } else if (
+    dbStatus === PledgeStatusEnum.Processed &&
+    (selectedAppealStatus === AppealStatusEnum.ReceivedNotProcessed ||
+      selectedAppealStatus === AppealStatusEnum.NotReceived)
+  ) {
+    message = t(
+      'Unable to move contact here as this gift is already processed.',
+    );
+  } else if (
+    dbStatus === PledgeStatusEnum.ReceivedNotProcessed &&
+    selectedAppealStatus === AppealStatusEnum.NotReceived
+  ) {
+    message = t(
+      'Unable to move contact to the "Committed" column as part of the pledge has been Received.',
+    );
+  }
+  return {
+    message,
+    snackbarOptions,
+  };
+};
+
+export default handleReceivedSnackBarNotifications;


### PR DESCRIPTION
## Description
My aim with this PR was top add clarity to the user's actions. Users have for sometime expressed how the received column is confusing and how when they drag a contact to received, it disappears and nothing happens.

With these changes, I plan to fix that by adding more warning messages, alerting the user that their desired outcome has not worked.

To make it easier, I have created a help function that I use in multiple places, so we only have to update the wording of these alerts in one place.

1. A warning message when moving a contact from "Asked" or "Committed" to "Received"
2. A warning message when moving a contact from "Received" to "Committed"
3. A warning message when moving a contact from "Processed" to "Committed" or "Received" 

https://jira.cru.org/browse/MPDX-8187
https://jira.cru.org/browse/MPDX-8188


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
