### PR TITLE
[MPDX-8221] Convert contact statuses correctly

### DIFF
--- a/pages/api/Schema/reports/fourteenMonth/datahandler.ts
+++ b/pages/api/Schema/reports/fourteenMonth/datahandler.ts
@@ -69,6 +69,61 @@ export interface FourteenMonthReportResponse {
   };
 }
 
+// Convert a status string into a StatusEnum
+const convertStatus = (
+  status: string | null | undefined,
+): StatusEnum | null => {
+  // Statuses will be lowercase and underscored (i.e. "never_contacted") after task phases lands
+  // Statuses will be sentence case with spaces (i.e. "Never Contacted") before task phases lands
+  switch (status) {
+    case 'never_contacted':
+    case 'Never Contacted':
+      return StatusEnum.NeverContacted;
+    case 'ask_in_future':
+    case 'Ask in Future':
+      return StatusEnum.AskInFuture;
+    case 'cultivate_relationship':
+    case 'Cultivate Relationship':
+      return StatusEnum.CultivateRelationship;
+    case 'contact_for_appointment':
+    case 'Contact for Appointment':
+      return StatusEnum.ContactForAppointment;
+    case 'appointment_scheduled':
+    case 'Appointment Scheduled':
+      return StatusEnum.AppointmentScheduled;
+    case 'call_for_decision':
+    case 'Call for Decision':
+      return StatusEnum.CallForDecision;
+    case 'partner_financial':
+    case 'Partner - Financial':
+      return StatusEnum.PartnerFinancial;
+    case 'partner_special':
+    case 'Partner - Special':
+      return StatusEnum.PartnerSpecial;
+    case 'partner_pray':
+    case 'Partner - Pray':
+      return StatusEnum.PartnerPray;
+    case 'not_interested':
+    case 'Not Interested':
+      return StatusEnum.NotInterested;
+    case 'unresponsive':
+    case 'Unresponsive':
+      return StatusEnum.Unresponsive;
+    case 'never_ask':
+    case 'Never Ask':
+      return StatusEnum.NeverAsk;
+    case 'research_abandoned':
+    case 'Research Abandoned':
+      return StatusEnum.ResearchAbandoned;
+    case 'expired_referral':
+    case 'Expired Referral':
+      return StatusEnum.ExpiredReferral;
+
+    default:
+      return null;
+  }
+};
+
 export const mapFourteenMonthReport = (
   data: FourteenMonthReportResponse,
   currencyType: FourteenMonthReportCurrencyType,
@@ -140,10 +195,7 @@ export const mapFourteenMonthReport = (
                 : null,
               pledgeCurrency: contact?.pledge_currency,
               pledgeFrequency: contact?.pledge_frequency,
-              status: contact?.status?.toUpperCase() as
-                | StatusEnum
-                | null
-                | undefined,
+              status: convertStatus(contact?.status),
             };
           })
           .sort((a, b) => a.name.localeCompare(b.name)),


### PR DESCRIPTION
## Description

In production, the 14 month partner reports were giving GraphQL errors like `Enum "StatusEnum" cannot represent value: "PARTNER - FINANCIAL"`. That is because in production, partner statuses are still strings like "Partner - Financial" (not "partner_financial") until the task phases API changes merge into production.

## Testing

To test that this change fixes the issue, run `REST_API_URL=https://api.mpdx.org/api/v2/ yarn start` on `main` (to temporarily point the REST API at production) and go to a 14 month report page to see the issue. Then run `REST_API_URL=https://api.mpdx.org/api/v2/ yarn start` on this branch and go to a 14 month report to see the issue resolved.

Follow up to #1080

[MPDX-8221](https://jira.cru.org/browse/MPDX-8221)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
