### PR TITLE
Setting the result based on the displayResults and the default to com…

### DIFF
--- a/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.tsx
+++ b/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.tsx
@@ -190,10 +190,11 @@ const TaskModalLogForm = ({
         attributes.displayResult,
         attributes.activityType || undefined,
       );
+    } else if (!attributes.result) {
+      attributes.result = ResultEnum.Completed;
     }
+    // Remove taskPhase from attributes as we don't save it on the DB
     delete attributes.taskPhase;
-    // TODO - remove this when NewResultEnum are added
-    attributes.result = ResultEnum.Completed;
 
     const updatingContactStatus =
       changeContactStatus && !!suggestedPartnerStatus;


### PR DESCRIPTION
## Description
In this PR, If the result is left blank on the log task modal form, it defaults it to `COMPLETED`.

I'm unsure if this is the correct functionality, as it's been some time since I edited this and I can't find anywhere that mentions what we should o in this case. the other option is that it always runs the getDatabaseValueFromResult, so if there is not a result selected, it defaults to `NONE`.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
