### PR TITLE
MPDX-8274 Pointing GH CI to use new domain after we switch react MPDX to production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   # Use production API for codegen to make sure production is compatible with the code to be merged
   API_URL: 'https://api.mpdx.org/graphql'
-  SITE_URL: 'http://next-stage.mpdx.org'
+  SITE_URL: 'http://stage.mpdx.org'
 
 jobs:
   test:

--- a/lighthouse/lighthouse-origin.js
+++ b/lighthouse/lighthouse-origin.js
@@ -16,8 +16,8 @@ module.exports = {
 
 function getPushOrigin() {
   if (process.env.GITHUB_REF_NAME === 'staging') {
-    return 'https://next-stage.mpdx.org';
+    return 'https://stage.mpdx.org';
   } else if (process.env.GITHUB_REF_NAME === 'main') {
-    return 'https://next.mpdx.org';
+    return 'https://mpdx.org';
   }
 }


### PR DESCRIPTION
## Description
In this PR, I update the GitHub Actions to use the new domains

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
