### PR TITLE
[MPDX-8204] Refresh setup position

### DIFF
--- a/pages/accountLists/[accountListId]/setup/finish.page.tsx
+++ b/pages/accountLists/[accountListId]/setup/finish.page.tsx
@@ -51,9 +51,9 @@ const FinishPage: React.FC = () => {
       <SetupPage
         title={
           <Trans>
-            Congratulations!
+            {t('Congratulations!')}
             <br />
-            You&apos;re all set!
+            {t("You're all set!")}
           </Trans>
         }
       >

--- a/src/components/Contacts/ContactFlow/ContactFlowSetup/UpdateUserOptions.graphql
+++ b/src/components/Contacts/ContactFlow/ContactFlowSetup/UpdateUserOptions.graphql
@@ -2,6 +2,7 @@ mutation UpdateUserOptions($key: String!, $value: String!) {
   createOrUpdateUserOption(input: { key: $key, value: $value }) {
     option {
       id
+      value
     }
   }
 }


### PR DESCRIPTION
## Description

* After setting `setup_position` to `''` to end the tour, the new value wasn't being updated in the Apollo cache, and the tour banner was still being shown. This change reloads the `setup_position` after saving the new value.
* Also localize a couple of labels.

Completes part of [MPDX-8204](https://jira.cru.org/browse/MPDX-8204)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
