### PR TITLE
[MPDX-8204] Only show the setup tour if setup_position matches the current page

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ Note: there is a test account you can use. Get this from another developer if yo
 - `HELP_URL_SETUP_FIND_ORGANIZATION` - Link to an article explaining how to find an organization
 - `PRIVACY_POLICY_URL` - URL of the privacy policy
 - `TERMS_OF_USE_URL` - URL of the terms of use
-- `DISABLE_SETUP_TOUR` - Set to `true` to disable starting users on the welcome tour. This should be removed from the codebase once tools are live.
 
 #### Auth provider
 

--- a/next.config.js
+++ b/next.config.js
@@ -86,7 +86,6 @@ const config = {
     PRIVACY_POLICY_URL: process.env.PRIVACY_POLICY_URL,
     TERMS_OF_USE_URL: process.env.TERMS_OF_USE_URL,
     DD_ENV: process.env.DD_ENV ?? 'development',
-    DISABLE_SETUP_TOUR: process.env.DISABLE_SETUP_TOUR,
   },
   experimental: {
     modularizeImports: {

--- a/pages/accountLists.page.test.tsx
+++ b/pages/accountLists.page.test.tsx
@@ -43,8 +43,6 @@ describe('Account Lists page', () => {
 
   describe('NextAuth authorized', () => {
     beforeEach(() => {
-      process.env.DISABLE_SETUP_TOUR = undefined;
-
       (getSession as jest.Mock).mockResolvedValue(session);
     });
 
@@ -60,27 +58,6 @@ describe('Account Lists page', () => {
 
       const result = await getServerSideProps(context);
       expect(result).toEqual({
-        redirect: {
-          destination: '/setup/start',
-          permanent: false,
-        },
-      });
-    });
-
-    it('does not redirect to the setup tour when DISABLE_SETUP_TOUR is true', async () => {
-      process.env.DISABLE_SETUP_TOUR = 'true';
-
-      (makeSsrClient as jest.Mock).mockReturnValue({
-        query: jest.fn().mockResolvedValue({
-          data: {
-            user: { id: 'user-1', setup: UserSetupStageEnum.NoAccountLists },
-            accountLists: { nodes: [] },
-          },
-        }),
-      });
-
-      const result = await getServerSideProps(context);
-      expect(result).not.toEqual({
         redirect: {
           destination: '/setup/start',
           permanent: false,

--- a/pages/accountLists.page.tsx
+++ b/pages/accountLists.page.tsx
@@ -45,7 +45,7 @@ export const getServerSideProps = makeGetServerSideProps(async (session) => {
       query: GetAccountListsDocument,
     });
 
-    if (data.user.setup && process.env.DISABLE_SETUP_TOUR !== 'true') {
+    if (data.user.setup) {
       // The user has not finished setting up, so start them on the tour
       return {
         redirect: {

--- a/src/components/Setup/SetupProvider.test.tsx
+++ b/src/components/Setup/SetupProvider.test.tsx
@@ -111,12 +111,26 @@ describe('SetupProvider', () => {
       expect(getByTestId('setting-up')).toHaveTextContent('undefined');
     });
 
-    it('is true when setup is set on a tour page', async () => {
+    it('is true when setup is set on a dedicated tour page', async () => {
       const { getByTestId } = render(
         <TestComponent
           setup={UserSetupStageEnum.NoDefaultAccountList}
           setupPosition=""
           pathname="/setup/start"
+        />,
+      );
+
+      await waitFor(() =>
+        expect(getByTestId('setting-up')).toHaveTextContent('true'),
+      );
+    });
+
+    it('is true when setup_position matches the current page', async () => {
+      const { getByTestId } = render(
+        <TestComponent
+          setup={null}
+          setupPosition="preferences.personal"
+          pathname="/accountLists/[accountListId]/settings/preferences"
         />,
       );
 
@@ -152,6 +166,20 @@ describe('SetupProvider', () => {
     it('is false when setup_position is not set', async () => {
       const { getByTestId } = render(
         <TestComponent setup={null} setupPosition="" />,
+      );
+
+      await waitFor(() =>
+        expect(getByTestId('setting-up')).toHaveTextContent('false'),
+      );
+    });
+
+    it('is false when setup_position does not match the current page', async () => {
+      const { getByTestId } = render(
+        <TestComponent
+          setup={null}
+          setupPosition="preferences.personal"
+          pathname="/accountLists/[accountListId]/settings/notifications"
+        />,
       );
 
       await waitFor(() =>

--- a/src/components/Setup/SetupProvider.test.tsx
+++ b/src/components/Setup/SetupProvider.test.tsx
@@ -55,10 +55,6 @@ const TestComponent: React.FC<TestComponentProps> = ({
 );
 
 describe('SetupProvider', () => {
-  beforeEach(() => {
-    process.env.DISABLE_SETUP_TOUR = undefined;
-  });
-
   it('renders child content', () => {
     const { getByText } = render(
       <TestComponent setup={UserSetupStageEnum.NoAccountLists} />,
@@ -180,18 +176,6 @@ describe('SetupProvider', () => {
           setupPosition="preferences.personal"
           pathname="/accountLists/[accountListId]/settings/notifications"
         />,
-      );
-
-      await waitFor(() =>
-        expect(getByTestId('setting-up')).toHaveTextContent('false'),
-      );
-    });
-
-    it('is false when DISABLE_SETUP_TOUR is true', async () => {
-      process.env.DISABLE_SETUP_TOUR = 'true';
-
-      const { getByTestId } = render(
-        <TestComponent setup={null} setupPosition="start" />,
       );
 
       await waitFor(() =>

--- a/src/components/Setup/SetupProvider.tsx
+++ b/src/components/Setup/SetupProvider.tsx
@@ -43,11 +43,7 @@ export const SetupProvider: React.FC<SetupProviderProps> = ({ children }) => {
   const { push, pathname } = useRouter();
 
   useEffect(() => {
-    if (
-      !data ||
-      pathname === '/setup/start' ||
-      process.env.DISABLE_SETUP_TOUR === 'true'
-    ) {
+    if (!data || pathname === '/setup/start') {
       return;
     }
 
@@ -74,10 +70,6 @@ export const SetupProvider: React.FC<SetupProviderProps> = ({ children }) => {
 
     if (!data) {
       return undefined;
-    }
-
-    if (process.env.DISABLE_SETUP_TOUR === 'true') {
-      return false;
     }
 
     const setupPosition = data.userOptions.find(

--- a/src/components/Setup/SetupProvider.tsx
+++ b/src/components/Setup/SetupProvider.tsx
@@ -24,14 +24,11 @@ const SetupContext = createContext<SetupContext>({ onSetupTour: undefined });
 
 export const useSetupContext = (): SetupContext => useContext(SetupContext);
 
-// The list of page pathnames that are part of the setup tour
+// The list of page pathnames that are dedicated setup pages
 const setupPages = new Set([
   '/setup/start',
   '/setup/connect',
   '/setup/account',
-  '/accountLists/[accountListId]/settings/preferences',
-  '/accountLists/[accountListId]/settings/notifications',
-  '/accountLists/[accountListId]/settings/integrations',
   '/accountLists/[accountListId]/setup/finish',
 ]);
 
@@ -69,6 +66,12 @@ export const SetupProvider: React.FC<SetupProviderProps> = ({ children }) => {
   }, [data]);
 
   const onSetupTour = useMemo(() => {
+    // If the user is on a dedicated setup page (i.e. not a preferences page),
+    // then they are on the setup tour regardless of their setup_position
+    if (setupPages.has(pathname)) {
+      return true;
+    }
+
     if (!data) {
       return undefined;
     }
@@ -77,12 +80,19 @@ export const SetupProvider: React.FC<SetupProviderProps> = ({ children }) => {
       return false;
     }
 
-    const onSetupPage = setupPages.has(pathname);
-    const settingUp =
-      data.userOptions.some(
-        (option) => option.key === 'setup_position' && option.value !== '',
-      ) || data.user.setup !== null;
-    return onSetupPage && settingUp;
+    const setupPosition = data.userOptions.find(
+      (option) => option.key === 'setup_position',
+    )?.value;
+
+    // The user is on the setup tour if the setup position matches their current page
+    return (
+      (setupPosition === 'preferences.personal' &&
+        pathname === '/accountLists/[accountListId]/settings/preferences') ||
+      (setupPosition === 'preferences.notifications' &&
+        pathname === '/accountLists/[accountListId]/settings/notifications') ||
+      (setupPosition === 'preferences.integrations' &&
+        pathname === '/accountLists/[accountListId]/settings/integrations')
+    );
   }, [data, pathname]);
 
   return (


### PR DESCRIPTION
## Description

* Instead of showing the setup tour on multiple preferences pages if the user was in the middle of a tour, only show the setup tour if their current page matches their setup_position option.
* Also, remove the `DISABLE_SETUP_TOUR` feature flag now that tools is live.

[MPDX-8204](https://jira.cru.org/browse/MPDX-8204)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
