### PR TITLE
[MPDX-8330] Fix Google Calendar integration activity type checkboxes

### DIFF
--- a/pages/api/Schema/Settings/Integrations/Google/createGoogleIntegration/datahandler.ts
+++ b/pages/api/Schema/Settings/Integrations/Google/createGoogleIntegration/datahandler.ts
@@ -1,3 +1,4 @@
+import { ActivityTypeEnum } from 'pages/api/graphql-rest.page.generated';
 import { snakeToCamel } from 'src/lib/snakeToCamel';
 
 export interface CreateGoogleIntegrationResponse {
@@ -27,7 +28,7 @@ export interface CreateGoogleIntegrationAttributes {
 interface CreateGoogleIntegrationAttributesCamel {
   calendarId: string;
   calendarIntegration: boolean;
-  calendarIntegrations: string[];
+  calendarIntegrations: ActivityTypeEnum[];
   calendarName: string;
   calendars: Calendar[];
   createdAt: string;
@@ -47,6 +48,10 @@ export const CreateGoogleIntegration = (
   Object.keys(data.attributes).forEach((key) => {
     attributes[snakeToCamel(key)] = data.attributes[key];
   });
+  // Convert REST activity type enums which are lowercase to GraphQL activity type enums, which are uppercase
+  attributes.calendarIntegrations = data.attributes.calendar_integrations.map(
+    (integration) => integration.toUpperCase() as ActivityTypeEnum,
+  );
 
   return {
     id: data.id,

--- a/pages/api/Schema/Settings/Integrations/Google/createGoogleIntegration/datahandler.ts
+++ b/pages/api/Schema/Settings/Integrations/Google/createGoogleIntegration/datahandler.ts
@@ -1,60 +1,9 @@
-import { ActivityTypeEnum } from 'pages/api/graphql-rest.page.generated';
-import { snakeToCamel } from 'src/lib/snakeToCamel';
-
-export interface CreateGoogleIntegrationResponse {
-  id: string;
-  type: string;
-  attributes: Omit<CreateGoogleIntegrationAttributes, 'id'>;
-  relationships: Relationships;
-}
-
-type Relationships = {
-  account_list: object[];
-  google_account: object[];
-};
-
-export interface CreateGoogleIntegrationAttributes {
-  calendar_id: string;
-  calendar_integration: boolean;
-  calendar_integrations: string[];
-  calendar_name: string;
-  calendars: Calendar[];
-  created_at: string;
-  updated_at: string;
-  id: string;
-  updated_in_db_at: string;
-}
-
-interface CreateGoogleIntegrationAttributesCamel {
-  calendarId: string;
-  calendarIntegration: boolean;
-  calendarIntegrations: ActivityTypeEnum[];
-  calendarName: string;
-  calendars: Calendar[];
-  createdAt: string;
-  updatedAt: string;
-  id: string;
-  updatedInDbAt: string;
-}
-type Calendar = {
-  id: string;
-  name: string;
-};
+import {
+  GoogleIntegrationAttributesCamel,
+  GoogleIntegrationResponse,
+  parseGoogleIntegrationResponse,
+} from '../parse';
 
 export const CreateGoogleIntegration = (
-  data: CreateGoogleIntegrationResponse,
-): CreateGoogleIntegrationAttributesCamel => {
-  const attributes = {} as Omit<CreateGoogleIntegrationAttributesCamel, 'id'>;
-  Object.keys(data.attributes).forEach((key) => {
-    attributes[snakeToCamel(key)] = data.attributes[key];
-  });
-  // Convert REST activity type enums which are lowercase to GraphQL activity type enums, which are uppercase
-  attributes.calendarIntegrations = data.attributes.calendar_integrations.map(
-    (integration) => integration.toUpperCase() as ActivityTypeEnum,
-  );
-
-  return {
-    id: data.id,
-    ...attributes,
-  };
-};
+  data: GoogleIntegrationResponse,
+): GoogleIntegrationAttributesCamel => parseGoogleIntegrationResponse(data);

--- a/pages/api/Schema/Settings/Integrations/Google/googleAccountIntegrations/datahandler.ts
+++ b/pages/api/Schema/Settings/Integrations/Google/googleAccountIntegrations/datahandler.ts
@@ -1,59 +1,10 @@
-import { ActivityTypeEnum } from 'pages/api/graphql-rest.page.generated';
-import { snakeToCamel } from 'src/lib/snakeToCamel';
-
-export interface GoogleAccountIntegrationsResponse {
-  id: string;
-  type: string;
-  attributes: Omit<GoogleAccountIntegrationAttributes, 'id'>;
-  relationships: Relationships;
-}
-type Relationships = {
-  account_list: object[];
-  google_account: object[];
-};
-export interface GoogleAccountIntegrationAttributes {
-  calendar_id: string;
-  calendar_integration: boolean;
-  calendar_integrations: string[];
-  calendar_name: string;
-  calendars: Calendar[];
-  created_at: string;
-  updated_at: string;
-  id: string;
-  updated_in_db_at: string;
-}
-interface GoogleAccountIntegrationAttributesCamel {
-  calendarId: string;
-  calendarIntegration: boolean;
-  calendarIntegrations: ActivityTypeEnum[];
-  calendarName: string;
-  calendars: Calendar[];
-  createdAt: string;
-  updatedAt: string;
-  id: string;
-  updatedInDbAt: string;
-}
-type Calendar = {
-  id: string;
-  name: string;
-};
+import {
+  GoogleIntegrationAttributesCamel,
+  GoogleIntegrationResponse,
+  parseGoogleIntegrationResponse,
+} from '../parse';
 
 export const GoogleAccountIntegrations = (
-  data: GoogleAccountIntegrationsResponse[],
-): GoogleAccountIntegrationAttributesCamel[] => {
-  return data.map((integrations) => {
-    const attributes = {} as Omit<
-      GoogleAccountIntegrationAttributesCamel,
-      'id'
-    >;
-    Object.keys(integrations.attributes).forEach((key) => {
-      attributes[snakeToCamel(key)] = integrations.attributes[key];
-    });
-    // Convert REST activity type enums which are lowercase to GraphQL activity type enums, which are uppercase
-    attributes.calendarIntegrations =
-      integrations.attributes.calendar_integrations.map(
-        (integration) => integration.toUpperCase() as ActivityTypeEnum,
-      );
-    return { id: integrations.id, ...attributes };
-  });
-};
+  data: GoogleIntegrationResponse[],
+): GoogleIntegrationAttributesCamel[] =>
+  data.map((integration) => parseGoogleIntegrationResponse(integration));

--- a/pages/api/Schema/Settings/Integrations/Google/googleAccountIntegrations/datahandler.ts
+++ b/pages/api/Schema/Settings/Integrations/Google/googleAccountIntegrations/datahandler.ts
@@ -1,3 +1,4 @@
+import { ActivityTypeEnum } from 'pages/api/graphql-rest.page.generated';
 import { snakeToCamel } from 'src/lib/snakeToCamel';
 
 export interface GoogleAccountIntegrationsResponse {
@@ -24,7 +25,7 @@ export interface GoogleAccountIntegrationAttributes {
 interface GoogleAccountIntegrationAttributesCamel {
   calendarId: string;
   calendarIntegration: boolean;
-  calendarIntegrations: string[];
+  calendarIntegrations: ActivityTypeEnum[];
   calendarName: string;
   calendars: Calendar[];
   createdAt: string;
@@ -48,6 +49,11 @@ export const GoogleAccountIntegrations = (
     Object.keys(integrations.attributes).forEach((key) => {
       attributes[snakeToCamel(key)] = integrations.attributes[key];
     });
+    // Convert REST activity type enums which are lowercase to GraphQL activity type enums, which are uppercase
+    attributes.calendarIntegrations =
+      integrations.attributes.calendar_integrations.map(
+        (integration) => integration.toUpperCase() as ActivityTypeEnum,
+      );
     return { id: integrations.id, ...attributes };
   });
 };

--- a/pages/api/Schema/Settings/Integrations/Google/googleAccountIntegrations/googleAccountIntegrations.graphql
+++ b/pages/api/Schema/Settings/Integrations/Google/googleAccountIntegrations/googleAccountIntegrations.graphql
@@ -1,3 +1,37 @@
+enum ActivityTypeEnum {
+  APPOINTMENT_IN_PERSON
+  APPOINTMENT_PHONE_CALL
+  APPOINTMENT_VIDEO_CALL
+  FOLLOW_UP_EMAIL
+  FOLLOW_UP_IN_PERSON
+  FOLLOW_UP_PHONE_CALL
+  FOLLOW_UP_SOCIAL_MEDIA
+  FOLLOW_UP_TEXT_MESSAGE
+  INITIATION_EMAIL
+  INITIATION_IN_PERSON
+  INITIATION_LETTER
+  INITIATION_PHONE_CALL
+  INITIATION_SOCIAL_MEDIA
+  INITIATION_SPECIAL_GIFT_APPEAL
+  INITIATION_TEXT_MESSAGE
+
+  """
+  special type when filtered by will return any task with no activityType
+  """
+  NONE
+  PARTNER_CARE_DIGITAL_NEWSLETTER
+  PARTNER_CARE_EMAIL
+  PARTNER_CARE_IN_PERSON
+  PARTNER_CARE_PHONE_CALL
+  PARTNER_CARE_PHYSICAL_NEWSLETTER
+  PARTNER_CARE_PRAYER_REQUEST
+  PARTNER_CARE_SOCIAL_MEDIA
+  PARTNER_CARE_TEXT_MESSAGE
+  PARTNER_CARE_THANK
+  PARTNER_CARE_TO_DO
+  PARTNER_CARE_UPDATE_INFORMATION
+}
+
 extend type Query {
   googleAccountIntegrations(
     input: GoogleAccountIntegrationsInput!
@@ -12,7 +46,7 @@ input GoogleAccountIntegrationsInput {
 type GoogleAccountIntegration {
   calendarId: String
   calendarIntegration: Boolean
-  calendarIntegrations: [String]!
+  calendarIntegrations: [ActivityTypeEnum!]!
   calendarName: String
   calendars: [GoogleAccountIntegrationCalendars]!
   createdAt: String!

--- a/pages/api/Schema/Settings/Integrations/Google/parse.ts
+++ b/pages/api/Schema/Settings/Integrations/Google/parse.ts
@@ -1,0 +1,69 @@
+import { ActivityTypeEnum } from 'src/graphql/types.generated';
+import { snakeToCamel } from 'src/lib/snakeToCamel';
+
+export interface GoogleIntegrationResponse {
+  id: string;
+  type: string;
+  attributes: Omit<GoogleIntegrationAttributes, 'id'>;
+  relationships: Relationships;
+}
+
+type Relationships = {
+  account_list: object[];
+  google_account: object[];
+};
+
+interface Calendar {
+  id: string;
+  name: string;
+}
+
+interface GoogleIntegrationAttributes {
+  calendar_id: string;
+  calendar_integration: boolean;
+  calendar_integrations: string[];
+  calendar_name: string;
+  calendars: Calendar[];
+  created_at: string;
+  updated_at: string;
+  id: string;
+  updated_in_db_at: string;
+}
+
+export interface GoogleIntegrationAttributesCamel {
+  calendarId: string;
+  calendarIntegration: boolean;
+  calendarIntegrations: ActivityTypeEnum[];
+  calendarName: string;
+  calendars: Calendar[];
+  createdAt: string;
+  updatedAt: string;
+  id: string;
+  updatedInDbAt: string;
+}
+
+/*
+ * Convert a Google Integration object received from the REST API into the format
+ * expected by GraphQL.
+ */
+export const parseGoogleIntegrationResponse = (
+  data: GoogleIntegrationResponse,
+): GoogleIntegrationAttributesCamel => {
+  // Convert keys from snake case to camel case, keeping values the same
+  const attributes = Object.fromEntries(
+    Object.entries(data.attributes).map(([key, value]) => [
+      snakeToCamel(key),
+      value,
+    ]),
+  ) as Omit<GoogleIntegrationAttributesCamel, 'id'>;
+
+  // Convert REST activity type enums which are lowercase to GraphQL activity type enums, which are uppercase
+  attributes.calendarIntegrations = data.attributes.calendar_integrations.map(
+    (integration) => integration.toUpperCase() as ActivityTypeEnum,
+  );
+
+  return {
+    id: data.id,
+    ...attributes,
+  };
+};

--- a/pages/api/Schema/Settings/Integrations/Google/updateGoogleIntegration/datahandler.ts
+++ b/pages/api/Schema/Settings/Integrations/Google/updateGoogleIntegration/datahandler.ts
@@ -1,63 +1,9 @@
-import { ActivityTypeEnum } from 'src/graphql/types.generated';
-import { snakeToCamel } from 'src/lib/snakeToCamel';
-
-export interface UpdateGoogleIntegrationResponse {
-  id: string;
-  type: string;
-  attributes: Omit<SaveGoogleIntegrationAttributes, 'id'>;
-  relationships: Relationships;
-}
-
-type Relationships = {
-  account_list: object[];
-  google_account: object[];
-};
-
-export interface SaveGoogleIntegrationAttributes {
-  calendar_id: string;
-  calendar_integration: boolean;
-  calendar_integrations: string[];
-  calendar_name: string;
-  calendars: Calendar[];
-  created_at: string;
-  updated_at: string;
-  id: string;
-  updated_in_db_at: string;
-}
-
-interface GetGoogleAccountIntegrationAttributesCamel {
-  calendarId: string;
-  calendarIntegration: boolean;
-  calendarIntegrations: ActivityTypeEnum[];
-  calendarName: string;
-  calendars: Calendar[];
-  createdAt: string;
-  updatedAt: string;
-  id: string;
-  updatedInDbAt: string;
-}
-type Calendar = {
-  id: string;
-  name: string;
-};
+import {
+  GoogleIntegrationAttributesCamel,
+  GoogleIntegrationResponse,
+  parseGoogleIntegrationResponse,
+} from '../parse';
 
 export const UpdateGoogleIntegration = (
-  data: UpdateGoogleIntegrationResponse,
-): GetGoogleAccountIntegrationAttributesCamel => {
-  const attributes = {} as Omit<
-    GetGoogleAccountIntegrationAttributesCamel,
-    'id'
-  >;
-  Object.keys(data.attributes).forEach((key) => {
-    attributes[snakeToCamel(key)] = data.attributes[key];
-  });
-  // Convert REST activity type enums which are lowercase to GraphQL activity type enums, which are uppercase
-  attributes.calendarIntegrations = data.attributes.calendar_integrations.map(
-    (integration) => integration.toUpperCase() as ActivityTypeEnum,
-  );
-
-  return {
-    id: data.id,
-    ...attributes,
-  };
-};
+  data: GoogleIntegrationResponse,
+): GoogleIntegrationAttributesCamel => parseGoogleIntegrationResponse(data);

--- a/pages/api/Schema/Settings/Integrations/Google/updateGoogleIntegration/datahandler.ts
+++ b/pages/api/Schema/Settings/Integrations/Google/updateGoogleIntegration/datahandler.ts
@@ -1,3 +1,4 @@
+import { ActivityTypeEnum } from 'src/graphql/types.generated';
 import { snakeToCamel } from 'src/lib/snakeToCamel';
 
 export interface UpdateGoogleIntegrationResponse {
@@ -27,7 +28,7 @@ export interface SaveGoogleIntegrationAttributes {
 interface GetGoogleAccountIntegrationAttributesCamel {
   calendarId: string;
   calendarIntegration: boolean;
-  calendarIntegrations: string[];
+  calendarIntegrations: ActivityTypeEnum[];
   calendarName: string;
   calendars: Calendar[];
   createdAt: string;
@@ -50,6 +51,10 @@ export const UpdateGoogleIntegration = (
   Object.keys(data.attributes).forEach((key) => {
     attributes[snakeToCamel(key)] = data.attributes[key];
   });
+  // Convert REST activity type enums which are lowercase to GraphQL activity type enums, which are uppercase
+  attributes.calendarIntegrations = data.attributes.calendar_integrations.map(
+    (integration) => integration.toUpperCase() as ActivityTypeEnum,
+  );
 
   return {
     id: data.id,

--- a/pages/api/graphql-rest.page.ts
+++ b/pages/api/graphql-rest.page.ts
@@ -31,23 +31,15 @@ import {
   DestroyDonorAccountResponse,
 } from './Schema/Contacts/DonorAccounts/Destroy/datahander';
 import { SendToChalkline } from './Schema/Settings/Integrations/Chalkine/sendToChalkline/datahandler';
-import {
-  CreateGoogleIntegration,
-  CreateGoogleIntegrationResponse,
-} from './Schema/Settings/Integrations/Google/createGoogleIntegration/datahandler';
-import {
-  GoogleAccountIntegrations,
-  GoogleAccountIntegrationsResponse,
-} from './Schema/Settings/Integrations/Google/googleAccountIntegrations/datahandler';
+import { CreateGoogleIntegration } from './Schema/Settings/Integrations/Google/createGoogleIntegration/datahandler';
+import { GoogleAccountIntegrations } from './Schema/Settings/Integrations/Google/googleAccountIntegrations/datahandler';
 import {
   GoogleAccounts,
   GoogleAccountsResponse,
 } from './Schema/Settings/Integrations/Google/googleAccounts/datahandler';
+import { GoogleIntegrationResponse } from './Schema/Settings/Integrations/Google/parse';
 import { SyncGoogleIntegration } from './Schema/Settings/Integrations/Google/syncGoogleIntegration/datahandler';
-import {
-  UpdateGoogleIntegration,
-  UpdateGoogleIntegrationResponse,
-} from './Schema/Settings/Integrations/Google/updateGoogleIntegration/datahandler';
+import { UpdateGoogleIntegration } from './Schema/Settings/Integrations/Google/updateGoogleIntegration/datahandler';
 import {
   MailchimpAccount,
   MailchimpAccountResponse,
@@ -902,12 +894,11 @@ class MpdxRestApi extends RESTDataSource {
     googleAccountId: string,
     accountListId: string,
   ) {
-    const { data }: { data: GoogleAccountIntegrationsResponse[] } =
-      await this.get(
-        `user/google_accounts/${googleAccountId}/google_integrations?${encodeURI(
-          `filter[account_list_id]=${accountListId}`,
-        )}`,
-      );
+    const { data }: { data: GoogleIntegrationResponse[] } = await this.get(
+      `user/google_accounts/${googleAccountId}/google_integrations?${encodeURI(
+        `filter[account_list_id]=${accountListId}`,
+      )}`,
+    );
     return GoogleAccountIntegrations(data);
   }
 
@@ -931,13 +922,11 @@ class MpdxRestApi extends RESTDataSource {
     Object.keys(googleIntegration).forEach((key) => {
       attributes[camelToSnake(key)] = googleIntegration[key];
     });
-    const { data }: { data: CreateGoogleIntegrationResponse } = await this.post(
+    const { data }: { data: GoogleIntegrationResponse } = await this.post(
       `user/google_accounts/${googleAccountId}/google_integrations`,
       {
         data: {
-          attributes: {
-            ...attributes,
-          },
+          attributes,
           relationships: {
             account_list: {
               data: {
@@ -963,13 +952,11 @@ class MpdxRestApi extends RESTDataSource {
       attributes[camelToSnake(key)] = googleIntegration[key];
     });
 
-    const { data }: { data: UpdateGoogleIntegrationResponse } = await this.put(
+    const { data }: { data: GoogleIntegrationResponse } = await this.put(
       `user/google_accounts/${googleAccountId}/google_integrations/${googleIntegrationId}`,
       {
         data: {
-          attributes: {
-            ...attributes,
-          },
+          attributes,
           id: googleIntegrationId,
           type: 'google_integrations',
         },

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
@@ -257,7 +257,9 @@ describe('EditGoogleAccountModal', () => {
     await waitFor(() =>
       expect(queryByRole(/this field is required/i)).not.toBeInTheDocument(),
     );
-
+    await waitFor(() =>
+      expect(getByRole('button', { name: /update/i })).not.toBeDisabled(),
+    );
     userEvent.click(getByRole('button', { name: /update/i }));
 
     await waitFor(() =>

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
@@ -191,7 +191,7 @@ describe('EditGoogleAccountModal', () => {
 
   it('should update Integrations calendar', async () => {
     const mutationSpy = jest.fn();
-    const { getByText, getByRole, queryByRole } = render(
+    const { getByText, getByRole, findByRole, queryByRole } = render(
       <Components>
         <GqlMockedProvider<{
           LoadConstants: LoadConstantsQuery;
@@ -242,11 +242,11 @@ describe('EditGoogleAccountModal', () => {
       expect(getByText(/this field is required/i)).toBeInTheDocument(),
     );
     userEvent.click(getByRole('combobox'));
-    const calendarOption = getByRole('option', {
-      name: /calendarsName@cru\.org/i,
-    });
-    await waitFor(() => expect(calendarOption).toBeInTheDocument());
-    userEvent.click(calendarOption);
+    userEvent.click(
+      await findByRole('option', {
+        name: /calendarsName@cru\.org/i,
+      }),
+    );
 
     await waitFor(() =>
       expect(queryByRole(/this field is required/i)).not.toBeInTheDocument(),

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
 import { ThemeProvider } from '@mui/material/styles';
-import { act, render, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
@@ -237,22 +237,16 @@ describe('EditGoogleAccountModal', () => {
       ).toBeInTheDocument(),
     );
 
-    await act(async () => {
-      userEvent.click(getByRole('button', { name: /update/i }));
-    });
+    userEvent.click(getByRole('button', { name: /update/i }));
     await waitFor(() =>
       expect(getByText(/this field is required/i)).toBeInTheDocument(),
     );
-    await act(async () => {
-      userEvent.click(getByRole('combobox'));
-    });
+    userEvent.click(getByRole('combobox'));
     const calendarOption = getByRole('option', {
       name: /calendarsName@cru\.org/i,
     });
     await waitFor(() => expect(calendarOption).toBeInTheDocument());
-    await act(async () => {
-      userEvent.click(calendarOption);
-    });
+    userEvent.click(calendarOption);
 
     await waitFor(() =>
       expect(queryByRole(/this field is required/i)).not.toBeInTheDocument(),

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
@@ -5,13 +5,11 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { LoadConstantsQuery } from 'src/components/Constants/LoadConstants.generated';
 import * as Types from 'src/graphql/types.generated';
 import theme from '../../../../../theme';
 import { EditGoogleAccountModal } from './EditGoogleAccountModal';
-import {
-  GetIntegrationActivitiesQuery,
-  GoogleAccountIntegrationsQuery,
-} from './googleIntegrations.generated';
+import { GoogleAccountIntegrationsQuery } from './googleIntegrations.generated';
 
 jest.mock('next-auth/react');
 
@@ -191,14 +189,14 @@ describe('EditGoogleAccountModal', () => {
     const { getByText, getByRole, queryByRole } = render(
       <Components>
         <GqlMockedProvider<{
-          GetIntegrationActivities: GetIntegrationActivitiesQuery;
+          LoadConstants: LoadConstantsQuery;
           GoogleAccountIntegrations: GoogleAccountIntegrationsQuery;
         }>
           mocks={{
             GoogleAccountIntegrations: {
               googleAccountIntegrations: [googleIntegration],
             },
-            GetIntegrationActivities: {
+            LoadConstants: {
               constant: {
                 activities: [
                   {
@@ -289,13 +287,13 @@ describe('EditGoogleAccountModal', () => {
       <Components>
         <GqlMockedProvider<{
           GoogleAccountIntegrations: GoogleAccountIntegrationsQuery;
-          GetIntegrationActivities: GetIntegrationActivitiesQuery;
+          LoadConstants: LoadConstantsQuery;
         }>
           mocks={{
             GoogleAccountIntegrations: {
               googleAccountIntegrations: [googleIntegration],
             },
-            GetIntegrationActivities: {
+            LoadConstants: {
               constant: {
                 activities: [
                   {

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleIntegrationForm.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleIntegrationForm.tsx
@@ -20,7 +20,10 @@ import {
   DeleteButton,
   SubmitButton,
 } from 'src/components/common/Modal/ActionButtons/ActionButtons';
-import { GoogleAccountIntegration } from 'src/graphql/types.generated';
+import {
+  ActivityTypeEnum,
+  GoogleAccountIntegration,
+} from 'src/graphql/types.generated';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
 import { GoogleAccountAttributesSlimmed } from '../GoogleAccordion';
@@ -39,7 +42,7 @@ interface EditGoogleIntegrationFormProps {
   googleAccountDetails: GoogleAccountIntegrationSlimmed;
   loading: boolean;
   setIsSubmitting: (isSubmitting: boolean) => void;
-  handleToggleCalendarIntegration: (enableIntegration: boolean) => void;
+  handleToggleCalendarIntegration: (isSubmitting: boolean) => void;
   handleClose: () => void;
 }
 
@@ -61,7 +64,15 @@ const integrationSchema: yup.SchemaOf<GoogleAccountIntegrationSlimmed> =
   yup.object({
     id: yup.string().required(),
     calendarId: yup.string().required(),
-    calendarIntegrations: yup.array().of(yup.string().required()).required(),
+    calendarIntegrations: yup
+      .array()
+      .of(
+        yup
+          .mixed<ActivityTypeEnum>()
+          .oneOf(Object.values(ActivityTypeEnum))
+          .required(),
+      )
+      .required(),
     calendars: yup
       .array()
       .of(
@@ -216,12 +227,12 @@ export const EditGoogleIntegrationForm: React.FC<
                             name={activityId}
                             checked={isChecked}
                             onChange={(_, value) => {
-                              let newCalendarIntegrations;
+                              let newCalendarIntegrations: ActivityTypeEnum[];
                               if (value) {
                                 // Add to calendarIntegrations
                                 newCalendarIntegrations = [
                                   ...calendarIntegrations,
-                                  activity.value,
+                                  activity.id,
                                 ];
                               } else {
                                 // Remove from calendarIntegrations
@@ -231,7 +242,7 @@ export const EditGoogleIntegrationForm: React.FC<
                                   );
                               }
                               setFieldValue(
-                                `calendarIntegrations`,
+                                'calendarIntegrations',
                                 newCalendarIntegrations,
                               );
                             }}

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleIntegrationForm.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleIntegrationForm.tsx
@@ -15,6 +15,7 @@ import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { useApiConstants } from 'src/components/Constants/UseApiConstants';
 import {
   DeleteButton,
   SubmitButton,
@@ -26,7 +27,6 @@ import { GoogleAccountAttributesSlimmed } from '../GoogleAccordion';
 import {
   GoogleAccountIntegrationsDocument,
   GoogleAccountIntegrationsQuery,
-  useGetIntegrationActivitiesQuery,
 } from './googleIntegrations.generated';
 import { useUpdateGoogleIntegrationMutation } from './updateGoogleIntegration.generated';
 
@@ -73,8 +73,7 @@ export const EditGoogleIntegrationForm: React.FC<
   const { appName } = useGetAppSettings();
   const [updateGoogleIntegration] = useUpdateGoogleIntegrationMutation();
 
-  const { data: actvitiesData } = useGetIntegrationActivitiesQuery();
-  const actvities = actvitiesData?.constant?.activities;
+  const activities = useApiConstants()?.activities;
 
   const IntegrationSchema: yup.SchemaOf<GoogleAccountIntegrationSlimmed> =
     yup.object({
@@ -200,7 +199,7 @@ export const EditGoogleIntegrationForm: React.FC<
                 </Box>
 
                 <StyledBox>
-                  {actvities?.map((activity) => {
+                  {activities?.map((activity) => {
                     if (!activity?.id || !activity?.value) {
                       return null;
                     }

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleIntegrationForm.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleIntegrationForm.tsx
@@ -38,8 +38,8 @@ interface EditGoogleIntegrationFormProps {
   account: GoogleAccountAttributesSlimmed;
   googleAccountDetails: GoogleAccountIntegrationSlimmed;
   loading: boolean;
-  setIsSubmitting: (boolean) => void;
-  handleToggleCalendarIntegration: (boolean) => void;
+  setIsSubmitting: (isSubmitting: boolean) => void;
+  handleToggleCalendarIntegration: (enableIntegration: boolean) => void;
   handleClose: () => void;
 }
 

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleIntegrationForm.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleIntegrationForm.tsx
@@ -57,6 +57,25 @@ const StyledFormControlLabel = styled(FormControlLabel)(() => ({
   margin: '0 0 0 -11px',
 }));
 
+const integrationSchema: yup.SchemaOf<GoogleAccountIntegrationSlimmed> =
+  yup.object({
+    id: yup.string().required(),
+    calendarId: yup.string().required(),
+    calendarIntegrations: yup.array().of(yup.string().required()).required(),
+    calendars: yup
+      .array()
+      .of(
+        yup.object({
+          __typename: yup
+            .string()
+            .equals(['GoogleAccountIntegrationCalendars']),
+          id: yup.string().required(),
+          name: yup.string().required(),
+        }),
+      )
+      .required(),
+  });
+
 export const EditGoogleIntegrationForm: React.FC<
   EditGoogleIntegrationFormProps
 > = ({
@@ -74,25 +93,6 @@ export const EditGoogleIntegrationForm: React.FC<
   const [updateGoogleIntegration] = useUpdateGoogleIntegrationMutation();
 
   const activities = useApiConstants()?.activities;
-
-  const IntegrationSchema: yup.SchemaOf<GoogleAccountIntegrationSlimmed> =
-    yup.object({
-      id: yup.string().required(),
-      calendarId: yup.string().required(),
-      calendarIntegrations: yup.array().of(yup.string().required()).required(),
-      calendars: yup
-        .array()
-        .of(
-          yup.object({
-            __typename: yup
-              .string()
-              .equals(['GoogleAccountIntegrationCalendars']),
-            id: yup.string().required(),
-            name: yup.string().required(),
-          }),
-        )
-        .required(),
-    });
 
   const onSubmit = async (attributes: GoogleAccountIntegrationSlimmed) => {
     setIsSubmitting(true);
@@ -163,7 +163,7 @@ export const EditGoogleIntegrationForm: React.FC<
               calendarIntegrations: googleAccountDetails.calendarIntegrations,
               calendars: googleAccountDetails.calendars,
             }}
-            validationSchema={IntegrationSchema}
+            validationSchema={integrationSchema}
             onSubmit={onSubmit}
           >
             {({

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleIntegrationForm.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleIntegrationForm.tsx
@@ -37,6 +37,7 @@ type GoogleAccountIntegrationSlimmed = Pick<
   GoogleAccountIntegration,
   'calendarId' | 'id' | 'calendarIntegrations' | 'calendars'
 >;
+
 interface EditGoogleIntegrationFormProps {
   account: GoogleAccountAttributesSlimmed;
   googleAccountDetails: GoogleAccountIntegrationSlimmed;
@@ -60,32 +61,30 @@ const StyledFormControlLabel = styled(FormControlLabel)(() => ({
   margin: '0 0 0 -11px',
 }));
 
-const integrationSchema: yup.SchemaOf<GoogleAccountIntegrationSlimmed> =
-  yup.object({
-    id: yup.string().required(),
-    calendarId: yup.string().required(),
-    calendarIntegrations: yup
-      .array()
-      .of(
-        yup
-          .mixed<ActivityTypeEnum>()
-          .oneOf(Object.values(ActivityTypeEnum))
-          .required(),
-      )
-      .required(),
-    calendars: yup
-      .array()
-      .of(
-        yup.object({
-          __typename: yup
-            .string()
-            .equals(['GoogleAccountIntegrationCalendars']),
+const integrationSchema = yup.object({
+  id: yup.string().required(),
+  calendarId: yup.string().required(),
+  calendarIntegrations: yup
+    .array()
+    .of(
+      yup
+        .mixed<ActivityTypeEnum>()
+        .oneOf(Object.values(ActivityTypeEnum))
+        .required(),
+    )
+    .required(),
+  calendars: yup
+    .array()
+    .of(
+      yup
+        .object({
           id: yup.string().required(),
           name: yup.string().required(),
-        }),
-      )
-      .required(),
-  });
+        })
+        .nullable(),
+    )
+    .required(),
+});
 
 export const EditGoogleIntegrationForm: React.FC<
   EditGoogleIntegrationFormProps
@@ -105,7 +104,9 @@ export const EditGoogleIntegrationForm: React.FC<
 
   const activities = useApiConstants()?.activities;
 
-  const onSubmit = async (attributes: GoogleAccountIntegrationSlimmed) => {
+  const onSubmit = async (
+    attributes: yup.InferType<typeof integrationSchema>,
+  ) => {
     setIsSubmitting(true);
     const googleIntegration = {
       calendarId: attributes.calendarId,
@@ -169,7 +170,7 @@ export const EditGoogleIntegrationForm: React.FC<
 
           <Formik
             initialValues={{
-              calendarId: googleAccountDetails.calendarId,
+              calendarId: googleAccountDetails.calendarId ?? '',
               id: googleAccountDetails.id,
               calendarIntegrations: googleAccountDetails.calendarIntegrations,
               calendars: googleAccountDetails.calendars,

--- a/src/components/Settings/integrations/Google/Modals/googleIntegrations.graphql
+++ b/src/components/Settings/integrations/Google/Modals/googleIntegrations.graphql
@@ -15,15 +15,6 @@ query GoogleAccountIntegrations($input: GoogleAccountIntegrationsInput!) {
   }
 }
 
-query GetIntegrationActivities {
-  constant {
-    activities {
-      id
-      value
-    }
-  }
-}
-
 mutation CreateGoogleIntegration($input: CreateGoogleIntegrationInput!) {
   createGoogleIntegration(input: $input) {
     calendarId


### PR DESCRIPTION
## Description

The Google Calendar integration activity type checkboxes were using the translated names. This PR switches them to use `ActivityTypeEnum` values. This PR also contains some general cleanup and improvements to `EditGoogleIntegrationForm`.

[MPDX-8330](https://jira.cru.org/browse/MPDX-8330)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
