### PR TITLE
[MPDX-8341] Fix coaching Connections Remaining link filter

### DIFF
--- a/src/components/Coaching/CoachingDetail/Activity/Activity.test.tsx
+++ b/src/components/Coaching/CoachingDetail/Activity/Activity.test.tsx
@@ -304,21 +304,27 @@ describe('Activity', () => {
   });
 
   describe('links', () => {
+    const connectionsRemainingLinkText =
+      mocks.CoachingDetailActivity.accountListAnalytics.contactsByStatus.connectionsRemaining.toString();
+
     it('are hidden when viewing coaching account list', async () => {
       const { findByTestId, queryByRole } = render(<TestComponent />);
 
       expect(
         await findByTestId('CurrentRealityConnections'),
       ).toBeInTheDocument();
-      expect(queryByRole('link')).not.toBeInTheDocument();
+      expect(
+        queryByRole('link', { name: connectionsRemainingLinkText }),
+      ).not.toBeInTheDocument();
     });
 
     it('are shown when viewing own account list', async () => {
-      const { findAllByRole } = render(
+      const { findByRole } = render(
         <TestComponent accountListType={AccountListTypeEnum.Own} />,
       );
-
-      expect((await findAllByRole('link')).length).toBeGreaterThan(0);
+      expect(
+        await findByRole('link', { name: connectionsRemainingLinkText }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/components/Coaching/CoachingDetail/Activity/Activity.tsx
+++ b/src/components/Coaching/CoachingDetail/Activity/Activity.tsx
@@ -259,7 +259,6 @@ export const Activity: React.FC<ActivityProps> = ({
             <Link
               href={contactsLink({
                 status: [
-                  ContactFilterStatusEnum.Null,
                   ContactFilterStatusEnum.NeverContacted,
                   ContactFilterStatusEnum.AskInFuture,
                   ContactFilterStatusEnum.CultivateRelationship,


### PR DESCRIPTION
## Description

* Remove `status === null` filter from the Connections Remaining link on the coaching report page.
* Fix tests that will fail if you have HELP_URL_* environment variables set locally.

To test, go to Reports > Coaching, then click on the Connections Remaining link. Verify that the number on the coaching report matches the number of contacts showing on the contacts page. Before, too many contacts were showing because it was including contacts with a null status.

[MPDX-8341](https://jira.cru.org/browse/MPDX-8341)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
