### PR TITLE
Fix Late Commitments

### DIFF
--- a/src/components/Dashboard/ThisWeek/GetThisWeek.graphql
+++ b/src/components/Dashboard/ThisWeek/GetThisWeek.graphql
@@ -1,7 +1,7 @@
 query GetThisWeek(
   $accountListId: ID!
   $endOfDay: ISO8601DateTime!
-  $today: ISO8601Date!
+  $thirtyDaysAgo: ISO8601Date!
   $threeWeeksFromNow: ISO8601Date!
   $twoWeeksAgo: ISO8601Date!
 ) {
@@ -60,7 +60,7 @@ query GetThisWeek(
     accountListId: $accountListId
     first: 3
     contactsFilter: {
-      lateAt: { max: $today }
+      lateAt: { max: $thirtyDaysAgo }
       status: PARTNER_FINANCIAL
       pledgeReceived: RECEIVED
     }

--- a/src/components/Dashboard/ThisWeek/LateCommitments/LateCommitments.test.tsx
+++ b/src/components/Dashboard/ThisWeek/LateCommitments/LateCommitments.test.tsx
@@ -89,40 +89,6 @@ describe('LateCommitments', () => {
     );
   });
 
-  it('should not show a late commitment that is less than 7 days late', () => {
-    const latePledgeContacts = {
-      nodes: [
-        {
-          id: 'contact1',
-          name: 'Smith, Sarah',
-          lateAt: '2019-12-31',
-        },
-        {
-          id: 'contact2',
-          name: 'Smith, John',
-          lateAt: '2015-12-01',
-        },
-      ],
-      totalCount: 2,
-    };
-    const { getByTestId, queryByTestId } = render(
-      <GqlMockedProvider>
-        <LateCommitments latePledgeContacts={latePledgeContacts} />
-      </GqlMockedProvider>,
-    );
-    const contact1Element = queryByTestId(
-      'LateCommitmentsListItemContact-contact1',
-    );
-    expect(contact1Element).not.toBeInTheDocument();
-
-    const contact2Element = getByTestId(
-      'LateCommitmentsListItemContact-contact2',
-    );
-    expect(contact2Element.textContent).toEqual(
-      'Smith, JohnTheir gift is 1,492 days late.',
-    );
-  });
-
   it('should not show a late commitment if it has no lateAt property', () => {
     const latePledgeContacts = {
       nodes: [

--- a/src/components/Dashboard/ThisWeek/LateCommitments/LateCommitments.test.tsx
+++ b/src/components/Dashboard/ThisWeek/LateCommitments/LateCommitments.test.tsx
@@ -38,29 +38,6 @@ describe('LateCommitments', () => {
       nodes: [],
       totalCount: 0,
     };
-    emptyCheck(latePledgeContacts);
-  });
-
-  it('should show empty if all of the late pledges are under 7 days late', () => {
-    const latePledgeContacts = {
-      nodes: [
-        {
-          id: 'contact1',
-          name: 'Smith, Sarah',
-          lateAt: '2019-12-31',
-        },
-        {
-          id: 'contact2',
-          name: 'Smith, John',
-          lateAt: '2019-12-30',
-        },
-      ],
-      totalCount: 2,
-    };
-    emptyCheck(latePledgeContacts);
-  });
-
-  const emptyCheck = (latePledgeContacts: any) => {
     const { getByTestId, queryByTestId } = render(
       <LateCommitments latePledgeContacts={latePledgeContacts} />,
     );
@@ -69,7 +46,7 @@ describe('LateCommitments', () => {
     expect(
       queryByTestId('LateCommitmentsListContacts'),
     ).not.toBeInTheDocument();
-  };
+  });
 
   it('props', () => {
     const latePledgeContacts = {

--- a/src/components/Dashboard/ThisWeek/ThisWeek.mock.ts
+++ b/src/components/Dashboard/ThisWeek/ThisWeek.mock.ts
@@ -146,7 +146,7 @@ export const GetThisWeekDefaultMocks = (): MockedResponse[] => {
         variables: {
           accountListId: 'abc',
           endOfDay: endOfDay.toISO(),
-          today: endOfDay.toISODate(),
+          thirtyDaysAgo: endOfDay.minus({ days: 30 }).toISODate(),
           threeWeeksFromNow: endOfDay.plus({ weeks: 3 }).toISODate(),
           twoWeeksAgo: endOfDay.minus({ weeks: 2 }).toISODate(),
         },
@@ -181,7 +181,7 @@ export const GetThisWeekEmptyMocks = (): MockedResponse[] => {
         variables: {
           accountListId: 'abc',
           endOfDay: endOfDay.toISO(),
-          today: endOfDay.toISODate(),
+          thirtyDaysAgo: endOfDay.minus({ days: 30 }).toISODate(),
           threeWeeksFromNow: endOfDay.plus({ weeks: 3 }).toISODate(),
           twoWeeksAgo: endOfDay.minus({ weeks: 2 }).toISODate(),
         },

--- a/src/components/Dashboard/ThisWeek/ThisWeek.tsx
+++ b/src/components/Dashboard/ThisWeek/ThisWeek.tsx
@@ -25,7 +25,7 @@ const ThisWeek = ({ accountListId }: Props): ReactElement => {
     variables: {
       accountListId,
       endOfDay: endOfDay.toISO(),
-      today: endOfDay.toISODate(),
+      thirtyDaysAgo: endOfDay.minus({ days: 30 }).toISODate(),
       threeWeeksFromNow: endOfDay.plus({ weeks: 3 }).toISODate(),
       twoWeeksAgo: endOfDay.minus({ weeks: 2 }).toISODate(),
     },


### PR DESCRIPTION
## Description
https://secure.helpscout.net/mailbox/2c1fe7d687998a44/7669074/
https://secure.helpscout.net/conversation/2725829190/1238582?folderId=7669074

Issue: 
Right now the API returns the first 3 late commitments (anything that is even 1 day late). Then the FE hides late commitments that are less than 7 days late. So sometimes those 3 late commitments get filtered out and it shows that there are no late commitments.

Fix:
- Remove front-end filtering
- Make the API only get commitments that are at least 30 days late. (This is how angular did it)

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
