### PR TITLE
[MPDX-8350] Fix missing outstanding special needs

### DIFF
--- a/src/components/Coaching/CoachingDetail/OutstandingNeeds/OutstandingNeeds.graphql
+++ b/src/components/Coaching/CoachingDetail/OutstandingNeeds/OutstandingNeeds.graphql
@@ -1,49 +1,45 @@
 query LoadCoachingNeeds($coachingAccountListId: ID!, $after: String) {
-  coachingAccountList(id: $coachingAccountListId) {
-    id
-    primaryAppeal {
+  # Coached account lists intentionally cannot see or filter by pledge statuses
+  coachingAccountListPledges(
+    accountListId: $coachingAccountListId
+    after: $after
+  ) {
+    nodes {
       id
-      pledges(first: 8, after: $after) {
-        nodes {
-          id
-          amount
-          amountCurrency
-          expectedDate
-          contact {
-            id
-            name
-          }
-        }
-        pageInfo {
-          endCursor
-          hasNextPage
-        }
+      amount
+      amountCurrency
+      expectedDate
+      contact {
+        id
+        name
       }
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
     }
   }
 }
 
 query LoadAccountListCoachingNeeds($accountListId: ID!, $after: String) {
-  accountList(id: $accountListId) {
-    id
-    primaryAppeal {
+  accountListPledges(
+    accountListId: $accountListId
+    after: $after
+    status: NOT_RECEIVED
+  ) {
+    nodes {
       id
-      pledges(first: 8, after: $after) {
-        nodes {
-          id
-          amount
-          amountCurrency
-          expectedDate
-          contact {
-            id
-            name
-          }
-        }
-        pageInfo {
-          endCursor
-          hasNextPage
-        }
+      amount
+      amountCurrency
+      expectedDate
+      contact {
+        id
+        name
       }
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
     }
   }
 }

--- a/src/components/Coaching/CoachingDetail/OutstandingNeeds/OutstandingNeeds.test.tsx
+++ b/src/components/Coaching/CoachingDetail/OutstandingNeeds/OutstandingNeeds.test.tsx
@@ -19,17 +19,12 @@ describe('OutstandingNeeds', () => {
       }>
         mocks={{
           LoadAccountListCoachingNeeds: {
-            accountList: {
-              id: accountListId,
-              primaryAppeal: {
-                pledges: {
-                  nodes: [
-                    {
-                      amountCurrency: 'USD',
-                    },
-                  ],
+            accountListPledges: {
+              nodes: [
+                {
+                  amountCurrency: 'USD',
                 },
-              },
+              ],
             },
           },
         }}
@@ -51,22 +46,17 @@ describe('OutstandingNeeds', () => {
       }>
         mocks={{
           LoadAccountListCoachingNeeds: {
-            accountList: {
-              id: accountListId,
-              primaryAppeal: {
-                pledges: {
-                  nodes: [
-                    {
-                      amount: 32.29,
-                      amountCurrency: 'USD',
-                      expectedDate: '2017-02-15',
-                      contact: {
-                        name: 'Dennis Reynolds',
-                      },
-                    },
-                  ],
+            accountListPledges: {
+              nodes: [
+                {
+                  amount: 32.29,
+                  amountCurrency: 'USD',
+                  expectedDate: '2017-02-15',
+                  contact: {
+                    name: 'Dennis Reynolds',
+                  },
                 },
-              },
+              ],
             },
           },
         }}
@@ -94,22 +84,17 @@ describe('OutstandingNeeds', () => {
       }>
         mocks={{
           LoadAccountListCoachingNeeds: {
-            accountList: {
-              id: accountListId,
-              primaryAppeal: {
-                pledges: {
-                  nodes: [
-                    {
-                      amount: 32.29,
-                      amountCurrency: 'USD',
-                      expectedDate: '2019-02-15',
-                      contact: {
-                        name: 'Dennis Reynolds',
-                      },
-                    },
-                  ],
+            accountListPledges: {
+              nodes: [
+                {
+                  amount: 32.29,
+                  amountCurrency: 'USD',
+                  expectedDate: '2019-02-15',
+                  contact: {
+                    name: 'Dennis Reynolds',
+                  },
                 },
-              },
+              ],
             },
           },
         }}
@@ -137,22 +122,17 @@ describe('OutstandingNeeds', () => {
       }>
         mocks={{
           LoadCoachingNeeds: {
-            coachingAccountList: {
-              id: accountListId,
-              primaryAppeal: {
-                pledges: {
-                  nodes: [
-                    {
-                      amount: 0,
-                      amountCurrency: null,
-                      expectedDate: '',
-                      contact: {
-                        name: 'Charlie Kelly',
-                      },
-                    },
-                  ],
+            coachingAccountListPledges: {
+              nodes: [
+                {
+                  amount: 0,
+                  amountCurrency: null,
+                  expectedDate: '',
+                  contact: {
+                    name: 'Charlie Kelly',
+                  },
                 },
-              },
+              ],
             },
           },
         }}
@@ -180,23 +160,18 @@ describe('OutstandingNeeds', () => {
       }>
         mocks={{
           LoadCoachingNeeds: {
-            coachingAccountList: {
-              id: accountListId,
-              primaryAppeal: {
-                pledges: {
-                  nodes: [...Array(15)].map((x, i) => {
-                    return {
-                      expectedDate: DateTime.local()
-                        .minus({ month: i })
-                        .toISO()
-                        .toString(),
-                      amountCurrency: 'USD',
-                    };
-                  }),
-                  pageInfo: {
-                    hasNextPage: true,
-                  },
-                },
+            coachingAccountListPledges: {
+              nodes: [...Array(15)].map((x, i) => {
+                return {
+                  expectedDate: DateTime.local()
+                    .minus({ month: i })
+                    .toISO()
+                    .toString(),
+                  amountCurrency: 'USD',
+                };
+              }),
+              pageInfo: {
+                hasNextPage: true,
               },
             },
           },

--- a/src/components/Coaching/CoachingDetail/OutstandingNeeds/OutstandingNeeds.tsx
+++ b/src/components/Coaching/CoachingDetail/OutstandingNeeds/OutstandingNeeds.tsx
@@ -78,10 +78,10 @@ export const OutstandingNeeds: React.FC<OutstandingNeedsProps> = ({
     accountListType === AccountListTypeEnum.Own
       ? ownFetchMore
       : coachingFetchMore;
-  const accountListData =
+  const pledges =
     accountListType === AccountListTypeEnum.Own
-      ? ownData?.accountList
-      : coachingData?.coachingAccountList;
+      ? ownData?.accountListPledges
+      : coachingData?.coachingAccountListPledges;
 
   const checkDueDate = (
     expectedDate: string | null | undefined,
@@ -124,16 +124,14 @@ export const OutstandingNeeds: React.FC<OutstandingNeedsProps> = ({
         title={
           <Box display="flex" alignItems="center">
             <Box flex={1}>{t('Outstanding Special Needs')}</Box>
-            {accountListData?.primaryAppeal?.pledges.pageInfo.hasNextPage && (
+            {pledges?.pageInfo.hasNextPage && (
               <LoadMoreButton
                 role="button"
                 variant="outlined"
                 onClick={() =>
                   fetchMore({
                     variables: {
-                      after:
-                        accountListData?.primaryAppeal?.pledges.pageInfo
-                          .endCursor,
+                      after: pledges?.pageInfo.endCursor,
                     },
                   })
                 }
@@ -145,7 +143,7 @@ export const OutstandingNeeds: React.FC<OutstandingNeedsProps> = ({
         }
       />
       <ContentContainer>
-        {loading && !accountListData ? (
+        {loading && !pledges ? (
           <MultilineSkeleton lines={8} />
         ) : (
           <TableContainer sx={{ minWidth: 600 }}>
@@ -158,7 +156,7 @@ export const OutstandingNeeds: React.FC<OutstandingNeedsProps> = ({
                 </TableRow>
               </TableHead>
               <TableBody>
-                {accountListData?.primaryAppeal?.pledges.nodes.map((need) => (
+                {pledges?.nodes.map((need) => (
                   <TableRow role="row" key={need.id}>
                     <AlignedTableCell>{need.contact.name}</AlignedTableCell>
                     <AlignedTableCell>

--- a/src/components/Coaching/CoachingDetail/OutstandingNeeds/OutstandingNeeds.tsx
+++ b/src/components/Coaching/CoachingDetail/OutstandingNeeds/OutstandingNeeds.tsx
@@ -170,17 +170,15 @@ export const OutstandingNeeds: React.FC<OutstandingNeedsProps> = ({
                     </AlignedTableCell>
                     <AlignedTableCell
                       sx={{
-                        color: checkDueDate(need.expectedDate)['color'],
+                        color: checkDueDate(need.expectedDate).color,
                       }}
                     >
-                      {`${
-                        need.expectedDate
-                          ? dateFormatShort(
-                              DateTime.fromISO(need.expectedDate),
-                              locale,
-                            )
-                          : ''
-                      } ${checkDueDate(need.expectedDate)['overdue']}`}
+                      {need.expectedDate &&
+                        dateFormatShort(
+                          DateTime.fromISO(need.expectedDate),
+                          locale,
+                        )}{' '}
+                      {checkDueDate(need.expectedDate).overdue}
                     </AlignedTableCell>
                   </TableRow>
                 ))}

--- a/src/lib/apollo/cache.ts
+++ b/src/lib/apollo/cache.ts
@@ -72,6 +72,8 @@ export const createCache = () =>
       Tag: { keyFields: false },
       Query: {
         fields: {
+          accountListPledges: paginationFieldPolicy,
+          coachingAccountListPledges: paginationFieldPolicy,
           contacts: paginationFieldPolicy,
           donations: paginationFieldPolicy,
           financialAccounts: paginationFieldPolicy,


### PR DESCRIPTION
## Description

Angular and React were showing different numbers of outstanding special needs. This is because React was showing all pledges on the primary appeal, but Angular was showing not received pledges from any appeal. They are now consistent again.

Note that in both REST and GraphQL, coaches cannot filter pledges by status. See this method that ignores all filters besides `contact_id` for coaches: https://github.com/CruGlobal/mpdx_api/blob/f6b0395b143a8dc104ba016eae26b832ad3a8995/app/controllers/api/v2/account_lists/pledges_controller.rb#L97-L105

[MPDX-8350](https://jira.cru.org/browse/MPDX-8350)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
