### PR TITLE
MPDX-8362 - Move Google map under navigation

### DIFF
--- a/src/components/Contacts/ContactsMap/ContactsMap.tsx
+++ b/src/components/Contacts/ContactsMap/ContactsMap.tsx
@@ -35,7 +35,7 @@ const MapLoading = styled(CircularProgress)(() => ({
 const mapContainerStyle = {
   height: '100%',
   width: '100%',
-  zIndex: 2000,
+  zIndex: 1000,
 };
 
 const options = {


### PR DESCRIPTION
## Description
In this PR, I change the z-index of the Google map so it appears below the site's navigation and still above the HelpDuck's beacon, as that has a z-index of `2147483647` 😂


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
