### PR TITLE
Print - Remove help juice beacon to not block content on page.

### DIFF
--- a/pages/print.css
+++ b/pages/print.css
@@ -18,4 +18,8 @@
   header {
     display: none !important;
   }
+
+  #helpjuice-widget {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Description
I hide the Help Juice beacon as it blocks content when user's print out reports.

This was added to the old BEason, but looks like it was removed in the migration to Help Juice. - https://github.com/CruGlobal/mpdx-react/pull/1019/files#diff-e98282886594b0fe4dec5aac96decb88fe7efba8d4b06283027b6a1be41c3c0a


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
