### PR TITLE
[HS-1243276] Prepopulate donation designation account with only option

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/PartnerAccounts/ContactPartnerAccounts.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/PartnerAccounts/ContactPartnerAccounts.graphql
@@ -24,6 +24,7 @@ fragment ContactPartnerAccounts on Contact {
 
 query GetAccountListSalaryOrganization($accountListId: ID!) {
   accountList(id: $accountListId) {
+    id
     salaryOrganizationId
   }
 }

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/AddDonation/AddDonation.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/AddDonation/AddDonation.test.tsx
@@ -5,6 +5,7 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { GetDesignationAccountsQuery } from 'src/components/EditDonationModal/EditDonationModal.generated';
 import theme from '../../../../../../../../theme';
 import { AddDonation } from './AddDonation';
 import { AddDonationMutation } from './AddDonation.generated';
@@ -149,4 +150,44 @@ describe('AddDonation', () => {
       }),
     );
   }, 20000);
+
+  it('auto fills designation account when there is only one option', async () => {
+    const { getByRole } = render(
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <ThemeProvider theme={theme}>
+          <SnackbarProvider>
+            <GqlMockedProvider<{
+              GetDesignationAccounts: GetDesignationAccountsQuery;
+            }>
+              mocks={{
+                GetDesignationAccounts: {
+                  designationAccounts: [
+                    {
+                      designationAccounts: [
+                        {
+                          id: '321',
+                          name: 'Cool Designation Account',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              }}
+            >
+              <AddDonation
+                accountListId={accountListId}
+                handleClose={handleClose}
+              />
+            </GqlMockedProvider>
+          </SnackbarProvider>
+        </ThemeProvider>
+      </LocalizationProvider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        getByRole('combobox', { name: 'Designation Account' }),
+      ).toHaveValue('Cool Designation Account (321)'),
+    );
+  });
 });

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/AddDonation/AddDonation.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/AddDonation/AddDonation.tsx
@@ -126,7 +126,8 @@ export const AddDonation = ({
     appealAmount: null,
     appealId: null,
     currency: accountListData?.accountList.currency ?? '',
-    designationAccountId: '',
+    designationAccountId:
+      designationAccounts?.length === 1 ? designationAccounts[0].id : '',
     donationDate: DateTime.local().startOf('day'),
     donorAccountId: '',
     memo: null,
@@ -411,7 +412,7 @@ export const AddDonation = ({
                                 ({ id }) => id === accountId,
                               );
                               return account
-                                ? `${account?.name} (${account.id}) `
+                                ? `${account?.name} (${account.id})`
                                 : '';
                             }}
                             renderInput={(params): ReactElement => (


### PR DESCRIPTION
## Description

In the Add Donation modal when there is only one designation account, preselect it.

https://secure.helpscout.net/conversation/2734816905/1243276?viewId=320673

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
