### PR TITLE
MPDX 8403 - Fix email exports to export the correct emails

### DIFF
--- a/src/components/Contacts/MassActions/Exports/Emails/GetEmailsForExporting.graphql
+++ b/src/components/Contacts/MassActions/Exports/Emails/GetEmailsForExporting.graphql
@@ -12,6 +12,8 @@ query GetEmailsForExporting(
       id
       people(first: 25) {
         nodes {
+          id
+          optoutEnewsletter
           primaryEmailAddress {
             id
             email

--- a/src/components/Contacts/MassActions/Exports/Emails/MassActionsExportEmailsModal.test.tsx
+++ b/src/components/Contacts/MassActions/Exports/Emails/MassActionsExportEmailsModal.test.tsx
@@ -6,43 +6,20 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import {
+  correctEmailsForExport,
+  getEmailNewsletterContactsMocks as getEmailsForExportingMocks,
+} from 'src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/ExportEmailMocks';
 import theme from 'src/theme';
 import { GetEmailsForExportingQuery } from './GetEmailsForExporting.generated';
 import { MassActionsExportEmailsModal } from './MassActionsExportEmailsModal';
 
 const mockEnqueue = jest.fn();
 const selectedIds: string[] = ['abc'];
-const accountListId = '123456789';
+const accountListId = 'accountListId';
 const handleClose = jest.fn();
 const mocks = {
-  GetEmailsForExporting: {
-    contacts: {
-      nodes: [
-        {
-          people: {
-            nodes: [
-              {
-                primaryEmailAddress: {
-                  email: 'testEmailOne@cru.org',
-                },
-              },
-            ],
-          },
-        },
-        {
-          people: {
-            nodes: [
-              {
-                primaryEmailAddress: {
-                  email: 'testEmailTwo@cru.org',
-                },
-              },
-            ],
-          },
-        },
-      ],
-    },
-  },
+  GetEmailsForExporting: getEmailsForExportingMocks,
 };
 
 jest.mock('notistack', () => ({
@@ -96,7 +73,7 @@ describe('MassActionsExportEmailsModal', () => {
     userEvent.click(queryAllByText('Copy All')[0]);
     await waitFor(() =>
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        'testEmailOne@cru.org,testEmailTwo@cru.org',
+        correctEmailsForExport,
       ),
     );
     // Export Outlook emails
@@ -114,7 +91,7 @@ describe('MassActionsExportEmailsModal', () => {
     userEvent.click(queryAllByText('Copy All')[1]);
     await waitFor(() =>
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        'testEmailOne@cru.org;testEmailTwo@cru.org',
+        correctEmailsForExport,
       ),
     );
     // Exit

--- a/src/components/Contacts/MassActions/Exports/Emails/MassActionsExportEmailsModal.tsx
+++ b/src/components/Contacts/MassActions/Exports/Emails/MassActionsExportEmailsModal.tsx
@@ -48,10 +48,14 @@ export const MassActionsExportEmailsModal: React.FC<
     },
   });
 
+  // Contact Query filters "optOut" removes any contacts that one of their people has opted out of the digital newsletter.
+  // So we have to filter out contacts that have opted out of the digital newsletter from the people nodes.
   const contactPrimaryEmails =
     contactData?.contacts.nodes
       .flatMap((contact) => contact.people.nodes)
-      .filter((person) => person.primaryEmailAddress)
+      .filter(
+        (person) => person.primaryEmailAddress && !person.optoutEnewsletter,
+      )
       .map((person) => person.primaryEmailAddress?.email) ?? [];
 
   const regularFormat = contactPrimaryEmails.join(',');

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/ExportEmail.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/ExportEmail.tsx
@@ -57,14 +57,18 @@ const ExportEmail = ({
     pageInfo: data?.contacts.pageInfo,
   });
 
-  const emailList = useMemo(
-    () =>
-      data?.contacts?.nodes
-        .map((contact) => contact.primaryPerson?.primaryEmailAddress?.email)
-        .filter(Boolean)
-        .join(','),
-    [data],
-  );
+  const emailList = useMemo(() => {
+    if (!data) {
+      return '';
+    }
+    return data.contacts.nodes
+      .flatMap((contact) => contact.people.nodes)
+      .filter(
+        (person) => person.primaryEmailAddress && !person.optoutEnewsletter,
+      )
+      .map((person) => person.primaryEmailAddress?.email)
+      .join(',');
+  }, [data]);
 
   return (
     <>

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/ExportEmailMocks.ts
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/ExportEmailMocks.ts
@@ -1,0 +1,71 @@
+export const correctEmailsForExport = 'email1,email3,email4,email7';
+
+export const getEmailNewsletterContactsMocks = {
+  contacts: {
+    nodes: [
+      {
+        people: {
+          nodes: [
+            {
+              optoutEnewsletter: false,
+              primaryEmailAddress: {
+                email: 'email1',
+              },
+            },
+            {
+              optoutEnewsletter: true,
+              primaryEmailAddress: {
+                email: 'email2',
+              },
+            },
+            {
+              optoutEnewsletter: false,
+              primaryEmailAddress: {
+                email: 'email3',
+              },
+            },
+          ],
+        },
+      },
+      {
+        people: {
+          nodes: [
+            {
+              optoutEnewsletter: false,
+              primaryEmailAddress: {
+                email: 'email4',
+              },
+            },
+          ],
+        },
+      },
+      {
+        people: {
+          nodes: [
+            {
+              optoutEnewsletter: true,
+              primaryEmailAddress: {
+                email: 'email5',
+              },
+            },
+            {
+              optoutEnewsletter: true,
+              primaryEmailAddress: {
+                email: 'email6',
+              },
+            },
+            {
+              optoutEnewsletter: false,
+              primaryEmailAddress: {
+                email: 'email7',
+              },
+            },
+          ],
+        },
+      },
+    ],
+    pageInfo: {
+      hasNextPage: false,
+    },
+  },
+};

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/GetNewsletterContacts.graphql
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportEmail/GetNewsletterContacts.graphql
@@ -7,11 +7,14 @@ query GetEmailNewsletterContacts($accountListId: ID!, $after: String) {
   ) {
     nodes {
       id
-      primaryPerson {
-        id
-        primaryEmailAddress {
+      people {
+        nodes {
           id
-          email
+          optoutEnewsletter
+          primaryEmailAddress {
+            id
+            email
+          }
         }
       }
     }


### PR DESCRIPTION
## Description
A user pointed out that we aren't exporting all the people's emails under each contact when exporting the newsletter email list on the dashboard.
Upon investigating, Scott Michell found that in addition to the above, when you export emails using the bulk action, it includes all the people's emails even if they have opted out.

HelpScout: https://secure.helpscout.net/conversation/2740763718/1246535/
Jira: https://jira.cru.org/browse/MPDX-8403

## Changes
1.  On the export email bulk action on the contacts page, we only include people's email addresses who have not opted out of the digital newsletter.
2. The e-mail Newsletter list now pulls all the people under each contact, as long as they haven't asked to be opted out of the digital newsletter.


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
