### PR TITLE
[MPDX-8393] Make the Helpjuice beacon dismissable

### DIFF
--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -110,6 +110,7 @@ const App = ({
     <TaskModalProvider>
       <Layout>
         <SnackbarUtilsConfigurator />
+        <Helpjuice />
         <Box
           sx={(theme) => ({
             fontFamily: theme.typography.fontFamily,
@@ -191,10 +192,7 @@ const App = ({
                             pageContent
                           ) : (
                             <RouterGuard>
-                              <GraphQLProviders>
-                                {pageContent}
-                                <Helpjuice />
-                              </GraphQLProviders>
+                              <GraphQLProviders>{pageContent}</GraphQLProviders>
                             </RouterGuard>
                           )}
                           <Loading />

--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -191,7 +191,10 @@ const App = ({
                             pageContent
                           ) : (
                             <RouterGuard>
-                              <GraphQLProviders>{pageContent}</GraphQLProviders>
+                              <GraphQLProviders>
+                                {pageContent}
+                                <Helpjuice />
+                              </GraphQLProviders>
                             </RouterGuard>
                           )}
                           <Loading />
@@ -202,7 +205,6 @@ const App = ({
                 </StyledEngineProvider>
               </I18nextProvider>
               <DataDog />
-              <Helpjuice />
             </SessionProvider>
             {process.env.ALERT_MESSAGE ? (
               <AlertBanner

--- a/pages/helpjuice.css
+++ b/pages/helpjuice.css
@@ -4,12 +4,13 @@
 }
 
 /*
- * The default height of #helpjuice-widget-expanded is 620px and #helpjuice-widget-content is 500px. It fits well when
- * the screen is 800px. Therefore, the widget content height should be 300px less than the screen height, while keeping
- * its height between 300px and 500px. And the widget itself should be 120px taller than the content.
+ * The default height of #helpjuice-widget-expanded is 620px and #helpjuice-widget-content is 500px.
+ * It fits well when the screen is 800px. However, on smaller screens, the widget content height
+ * should be be 300px less than the screen height. And the widget itself should be 120px taller than
+ * the content.
  */
 #helpjuice-widget #helpjuice-widget-expanded {
-  --content-height: clamp(100vh - 300px, 300px, 500px);
+  --content-height: min(100vh - 300px, 500px);
   height: calc(var(--content-height) + 120px) !important;
 }
 

--- a/pages/helpjuice.css
+++ b/pages/helpjuice.css
@@ -1,3 +1,7 @@
+#helpjuice-widget {
+  --right-position: 80px;
+}
+
 #helpjuice-widget .article .footer {
   /* Hide the estimated reading time and last updated time in search results */
   display: none !important;
@@ -18,30 +22,36 @@
   height: var(--content-height) !important;
 }
 
+#dismiss-beacon {
+  cursor: pointer;
+}
+
 #helpjuice-widget.bottomRight {
-  right: 130px !important;
+  right: 10px !important;
+  transition: right 0.3s ease;
 }
 
-/* Move the beacon higher from the bottom when it is not expanded */
-#helpjuice-widget.bottomRight:has(#helpjuice-widget-expanded:not(.hj-shown)) {
-  bottom: 170px !important;
+#helpjuice-widget.bottomRight.visible,
+#helpjuice-widget.bottomRight:hover {
+  right: 80px !important;
 }
 
-/* If the browser doesn't support :has and :not selectors, always move the beacon higher. */
-@supports not selector(:has(*):not(*)) {
-  #helpjuice-widget.bottomRight {
-    bottom: 170px !important;
-  }
+/*
+ * Expand the hover hitbox to be 20px above and below the button, extend to the right edge of the
+ * screen and be 20px past the left edge of the button.
+ */
+#helpjuice-widget.bottomRight::before {
+  content: '';
+  position: absolute;
+  height: calc(var(--right-position) + 40px);
+  top: -20px;
+  right: calc(var(--right-position) * -1);
+  left: -20px;
+  z-index: -1;
 }
 
-@media (max-width: 900px) {
-  #helpjuice-widget.bottomRight {
-    right: 100px !important;
-  }
-}
-
-@media (max-width: 600px) {
-  #helpjuice-widget.bottomRight {
-    right: 90px !important;
-  }
+/* Hide the popup when the beacon is dismissed and not being hovered. */
+#helpjuice-widget.bottomRight:not(.visible):not(:hover)
+  #helpjuice-widget-expanded.hj-shown {
+  display: none !important;
 }

--- a/pages/helpjuice.css
+++ b/pages/helpjuice.css
@@ -2,6 +2,16 @@
   --right-position: 80px;
 }
 
+/* Hide the life preserver SVG path when the widget is open and show our injected close path */
+#helpjuice-widget:has(#helpjuice-widget-expanded.hj-shown) svg .st0 {
+  display: none;
+}
+
+/* Hide our injected close path when the widget is closed */
+#helpjuice-widget:has(#helpjuice-widget-expanded:not(.hj-shown)) svg .close {
+  display: none;
+}
+
 #helpjuice-widget .article .footer {
   /* Hide the estimated reading time and last updated time in search results */
   display: none !important;

--- a/src/components/Helpjuice/DismissableBeacon.test.tsx
+++ b/src/components/Helpjuice/DismissableBeacon.test.tsx
@@ -1,0 +1,53 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DismissableBeacon } from './DismissableBeacon';
+
+const setDismissed = jest.fn();
+
+describe('DismissableBeacon', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `<div id="helpjuice-widget">
+  <a id="helpjuice-widget-trigger" />
+  <div id="helpjuice-widget-expanded" />
+    <div id="helpjuice-widget-content" />
+    <div id="helpjuice-widget-contact" />
+  </div>
+</div>`;
+  });
+
+  it('toggles visible class to widget', () => {
+    const { rerender } = render(
+      <DismissableBeacon dismissed={false} setDismissed={setDismissed} />,
+    );
+    expect(document.getElementById('helpjuice-widget')).toHaveClass('visible');
+
+    rerender(
+      <DismissableBeacon dismissed={true} setDismissed={setDismissed} />,
+    );
+    expect(document.getElementById('helpjuice-widget')).not.toHaveClass(
+      'visible',
+    );
+  });
+
+  it('creates Hide Beacon link that hides the popup and removes the visible class from the widget', () => {
+    render(<DismissableBeacon dismissed={false} setDismissed={setDismissed} />);
+
+    expect(document.getElementById('helpjuice-widget')).toHaveClass('visible');
+
+    // Simulating expanding the widget
+    const expandedWidget = document.getElementById('helpjuice-widget-expanded');
+    expandedWidget?.classList.add('hj-shown');
+
+    userEvent.click(document.getElementById('dismiss-beacon')!);
+
+    expect(setDismissed).toHaveBeenCalledWith(true);
+    expect(expandedWidget).not.toHaveClass('hj-shown');
+  });
+
+  it('undismisses the beacon when the trigger is clicked', () => {
+    render(<DismissableBeacon dismissed={true} setDismissed={setDismissed} />);
+
+    userEvent.click(document.getElementById('helpjuice-widget-trigger')!);
+    expect(setDismissed).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/Helpjuice/DismissableBeacon.test.tsx
+++ b/src/components/Helpjuice/DismissableBeacon.test.tsx
@@ -1,18 +1,13 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DismissableBeacon } from './DismissableBeacon';
+import { widgetHTML } from './widget.mock';
 
 const setDismissed = jest.fn();
 
 describe('DismissableBeacon', () => {
   beforeEach(() => {
-    document.body.innerHTML = `<div id="helpjuice-widget">
-  <a id="helpjuice-widget-trigger" />
-  <div id="helpjuice-widget-expanded" />
-    <div id="helpjuice-widget-content" />
-    <div id="helpjuice-widget-contact" />
-  </div>
-</div>`;
+    document.body.innerHTML = widgetHTML;
   });
 
   it('toggles visible class to widget', () => {

--- a/src/components/Helpjuice/DismissableBeacon.tsx
+++ b/src/components/Helpjuice/DismissableBeacon.tsx
@@ -1,0 +1,73 @@
+import { useEffect } from 'react';
+
+interface DismissableBeaconProps {
+  dismissed: boolean;
+  setDismissed: (dismissed: boolean) => void;
+}
+
+/**
+ * Like <Helpjuice>, this component doesn't render anything, but it enhances the existing Helpjuice
+ * beacon in the DOM by making it dismissable.
+ */
+export const DismissableBeacon: React.FC<DismissableBeaconProps> = ({
+  dismissed,
+  setDismissed,
+}) => {
+  // Sync the #helpjuice-widget .visible classname with the dismissed state
+  useEffect(() => {
+    const widget = document.getElementById('helpjuice-widget');
+    if (dismissed) {
+      widget?.classList.remove('visible');
+    } else {
+      widget?.classList.add('visible');
+    }
+  }, [dismissed]);
+
+  // Add a Hide Beacon link to the bottom of the popup
+  useEffect(() => {
+    const dismissLink = document.createElement('a');
+    dismissLink.id = 'dismiss-beacon';
+    dismissLink.textContent = 'Hide Beacon';
+    dismissLink.tabIndex = 0;
+    document
+      .getElementById('helpjuice-widget-contact')
+      ?.appendChild(dismissLink);
+
+    return () => {
+      dismissLink?.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    // Dismiss the beacon when the Hide Beacon link is clicked
+    document.getElementById('dismiss-beacon')?.addEventListener(
+      'click',
+      () => {
+        // Hide the popup
+        document
+          .getElementById('helpjuice-widget-expanded')
+          ?.classList.remove('hj-shown');
+
+        setDismissed(true);
+      },
+      { signal: abortController.signal },
+    );
+
+    // Undismiss the beacon when it is clicked
+    document.getElementById('helpjuice-widget-trigger')?.addEventListener(
+      'click',
+      () => {
+        setDismissed(false);
+      },
+      { signal: abortController.signal },
+    );
+
+    // Remove all event listeners on unmount
+    return () => {
+      abortController.abort();
+    };
+  }, [setDismissed]);
+
+  return null;
+};

--- a/src/components/Helpjuice/Helpjuice.test.tsx
+++ b/src/components/Helpjuice/Helpjuice.test.tsx
@@ -4,15 +4,21 @@ import { session } from '__tests__/fixtures/session';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { UserOptionQuery } from 'src/hooks/UserPreference.generated';
 import { Helpjuice } from './Helpjuice';
+import { widgetHTML } from './widget.mock';
 
 describe('Helpjuice', () => {
   beforeEach(() => {
     process.env.HELPJUICE_ORIGIN = 'https://domain.helpjuice.com';
     process.env.HELPJUICE_KNOWLEDGE_BASE_URL =
       'https://domain.helpjuice.com/kb';
-    document.body.innerHTML =
-      '<a id="helpjuice-contact-link">Contact Us</a><a class="knowledge-base-link">Visit Knowledge Base</a>';
+    document.body.innerHTML = widgetHTML;
     location.href = 'https://example.com/';
+  });
+
+  it('adds close icon svg path', () => {
+    render(<Helpjuice />);
+
+    expect(document.querySelector('path.close')).toBeInTheDocument();
   });
 
   it('does nothing if the element is missing', () => {

--- a/src/components/Helpjuice/Helpjuice.test.tsx
+++ b/src/components/Helpjuice/Helpjuice.test.tsx
@@ -1,6 +1,8 @@
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { useSession } from 'next-auth/react';
 import { session } from '__tests__/fixtures/session';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { UserOptionQuery } from 'src/hooks/UserPreference.generated';
 import { Helpjuice } from './Helpjuice';
 
 describe('Helpjuice', () => {
@@ -95,6 +97,29 @@ describe('Helpjuice', () => {
     expect(document.querySelector('a.knowledge-base-link')).toHaveProperty(
       'href',
       'https://domain.helpjuice.com/kb',
+    );
+  });
+
+  it('uses the Apollo client when available', async () => {
+    const mutationSpy = jest.fn();
+    render(
+      <GqlMockedProvider<{ UserOption: UserOptionQuery }>
+        mocks={{
+          UserOption: {
+            userOption: {
+              key: 'dismissed',
+              value: 'false',
+            },
+          },
+        }}
+        onCall={mutationSpy}
+      >
+        <Helpjuice />
+      </GqlMockedProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('UserOption'),
     );
   });
 });

--- a/src/components/Helpjuice/Helpjuice.tsx
+++ b/src/components/Helpjuice/Helpjuice.tsx
@@ -53,13 +53,16 @@ export const Helpjuice: React.FC = () => {
  * It can only be used on pages with an <ApolloProvider>.
  */
 const ApolloBeacon: React.FC = () => {
-  const [dismissed, setDismissed] = useUserPreference({
+  const [dismissed, setDismissed, { loading }] = useUserPreference({
     key: 'beacon_dismissed',
     defaultValue: false,
   });
 
   return (
-    <DismissableBeacon dismissed={dismissed} setDismissed={setDismissed} />
+    <DismissableBeacon
+      dismissed={dismissed || loading}
+      setDismissed={setDismissed}
+    />
   );
 };
 

--- a/src/components/Helpjuice/Helpjuice.tsx
+++ b/src/components/Helpjuice/Helpjuice.tsx
@@ -16,6 +16,26 @@ export const Helpjuice: React.FC = () => {
   const { data: session } = useSession();
   const href = useLocation();
 
+  // Add a white x that is shown using CSS when the panel is open
+  useEffect(() => {
+    const closeImage = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'path',
+    );
+    closeImage.classList.add('close');
+    closeImage.setAttributeNS(null, 'd', 'M20,20L88,88M88,20L20,88');
+    closeImage.setAttributeNS(null, 'stroke', 'white');
+    closeImage.setAttributeNS(null, 'stroke-linecap', 'round');
+    closeImage.setAttributeNS(null, 'stroke-width', '8');
+    closeImage.setAttributeNS(null, 'fill', 'none');
+
+    document
+      .querySelector('#helpjuice-widget #helpjuice-widget-trigger svg g')
+      ?.appendChild(closeImage);
+
+    return () => closeImage.remove();
+  });
+
   useEffect(() => {
     if (!process.env.HELPJUICE_ORIGIN) {
       return;

--- a/src/components/Helpjuice/widget.mock.ts
+++ b/src/components/Helpjuice/widget.mock.ts
@@ -1,0 +1,13 @@
+export const widgetHTML = `<div id="helpjuice-widget">
+  <a id="helpjuice-widget-trigger">
+    <svg>
+     <g />
+    </svg>
+  </a>
+  <div id="helpjuice-widget-expanded" />
+    <div id="helpjuice-widget-contact">
+      <a id="helpjuice-contact-link">Contact Us</a>
+      <a class="knowledge-base-link">Visit Knowledge Base</a>
+    </div>
+  </div>
+</div>`;


### PR DESCRIPTION
## Description

Make the Helpjuice beacon dismissable. There is a new Hide Beacon link in the beacon widget that dismisses the beacon. Once dismissed, the beacon peeks just barely out from the right side of the screen. Hovering over it causes it to slide out, and clicking on it makes it no longer dismissed.

On most pages, the dismissed preference is saved to a persistent user preference. On login and error pages, we don't have an Apollo client, so the preference can't be persisted, but the beacon can still be temporarily dismissed until the next page load.

I had to jump through some hoops to get this to work, but the complexity is abstracted away into the `Helpjuice` component, and the comments for `ApolloBeacon` and `NoApolloBeacon` should describe what is going on. I chose not to do something like this because although it might technically work, it violates React's rules of hooks that hooks must not be conditionally called.

```tsx
const hasApolloClient = !useContext(getApolloContext());
const [dismissed, setDismissed] = hasApolloClient
  ? useUserPreference({
      key: 'beacon_dismissed',
      defaultValue: false,
    })
  : useState(false);
  return <DismissableBeacon dismissed={dismissed} setDismissed={setDismissed} />;
```

[MPDX-8393](https://jira.cru.org/browse/MPDX-8393)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
