### PR TITLE
[MPDX-8405] Fix filtering the map by selected contacts

### DIFF
--- a/src/components/Contacts/ContactsContext/ContactsContext.tsx
+++ b/src/components/Contacts/ContactsContext/ContactsContext.tsx
@@ -150,16 +150,16 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
     [activeFilters],
   );
 
-  const [contactsView, updateOptions, { loading: userOptionsLoading }] =
+  const [contactsView, saveContactsView, { loading: userOptionsLoading }] =
     useUserPreference({
       key: 'contacts_view',
       defaultValue: TableViewModeEnum.List,
     });
   useEffect(() => {
-    if (contactsView && !userOptionsLoading) {
+    if (contactsView) {
       setViewMode(contactsView);
     }
-  }, [contactsView, userOptionsLoading]);
+  }, [contactsView]);
 
   const contactsFilters = useMemo(() => {
     // Remove filters in the map view
@@ -257,8 +257,15 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
     _: React.MouseEvent<HTMLElement>,
     view: string,
   ) => {
-    setViewMode(view as TableViewModeEnum);
-    updateOptions(view as TableViewModeEnum);
+    const newViewMode = view as TableViewModeEnum;
+    saveContactsView(newViewMode);
+    if (newViewMode === TableViewModeEnum.Map) {
+      // When switching to the map, make the filter only show the selected contacts, if any
+      setActiveFilters({ ids });
+    } else if (viewMode === TableViewModeEnum.Map) {
+      // When switching away from the map, reset the filter to show all contacts
+      setActiveFilters({});
+    }
   };
   //#endregion
 


### PR DESCRIPTION
## Description

* Support filtering the contacts map by the selected contacts.
* Refactor `ContactsContext` tests to use a reusable wrapper.

## Testing

* Case 1
  * Go to the contacts list and select a few contacts
  * Switch to the map view
  * Verify that only the selected contacts show up on the map
  * Switch back to the list view
  * Verify that all contacts show up in the list view (i.e. the list is not filtered by contact ids like the map was)
* Case 2
  * Go to the contacts list (**do not** select any contacts)
  * Switch to the map view
  * Verify that all contacts show up on the map (after they finish loading)

[MPDX-8405](https://jira.cru.org/browse/MPDX-8405)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
