### PR TITLE
[no-Jira] Fix disabled tooltip button warning

### DIFF
--- a/src/components/Shared/Filters/FilterListItemMultiselect.tsx
+++ b/src/components/Shared/Filters/FilterListItemMultiselect.tsx
@@ -71,15 +71,17 @@ export const FilterListItemMultiselect: React.FC<
           reverseFiltersMap.get(filter.filterKey) &&
           onReverseFilter && (
             <Tooltip title={t('Reverse Filter')}>
-              <IconButton
-                edge="end"
-                aria-label={t('Reverse Filter')}
-                color={reverseSelected ? 'error' : 'default'}
-                disabled={!selected}
-                onClick={onReverseFilter}
-              >
-                <SyncAltIcon />
-              </IconButton>
+              <span>
+                <IconButton
+                  edge="end"
+                  aria-label={t('Reverse Filter')}
+                  color={reverseSelected ? 'error' : 'default'}
+                  disabled={!selected}
+                  onClick={onReverseFilter}
+                >
+                  <SyncAltIcon />
+                </IconButton>
+              </span>
             </Tooltip>
           )
         }


### PR DESCRIPTION
## Description

Fix MUI warning:

```
You are providing a disabled button child to the Tooltip component.
A disabled element does not fire events.
Tooltip needs to listen to the child element's events to display the title.
```

I went with the simple fix, but I could see a case for hiding the reverse button entirely instead of disabling it to reduce some clutter. This could be good since there are already so many different elements in the filter panel. Let me know your thoughts.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
