### PR TITLE
[MDPX-8385] Preserve previous task name

### DIFF
--- a/src/components/Task/Modal/Form/Complete/TaskModalCompleteForm.test.tsx
+++ b/src/components/Task/Modal/Form/Complete/TaskModalCompleteForm.test.tsx
@@ -372,6 +372,7 @@ describe('TaskModalCompleteForm', () => {
       expect(openTaskModal).toHaveBeenCalledWith({
         view: TaskModalEnum.Add,
         defaultValues: {
+          subject: task.subject,
           activityType: ActivityTypeEnum.PartnerCareThank,
           contactIds: ['contact-1', 'contact-2'],
           userId: 'user-1',
@@ -411,6 +412,7 @@ describe('TaskModalCompleteForm', () => {
       expect(openTaskModal).toHaveBeenCalledWith({
         view: 'add',
         defaultValues: {
+          subject: task.subject,
           activityType: ActivityTypeEnum.PartnerCareThank,
           contactIds: ['contact-1'],
           userId: 'user-1',

--- a/src/components/Task/Modal/Form/Complete/TaskModalCompleteForm.tsx
+++ b/src/components/Task/Modal/Form/Complete/TaskModalCompleteForm.tsx
@@ -55,6 +55,7 @@ import { useUpdateContactStatusMutation } from '../TaskModal.generated';
 import {
   extractSuggestedTags,
   getDatabaseValueFromResult,
+  getDefaultTaskName,
 } from '../TaskModalHelper';
 import { possibleNextActions } from '../possibleNextActions';
 import { possiblePartnerStatus } from '../possiblePartnerStatus';
@@ -219,9 +220,17 @@ const TaskModalCompleteForm = ({
     }
     onClose();
     if (attributes.nextAction) {
+      const defaultSubject = getDefaultTaskName(
+        task.activityType ?? null,
+        activityTypes,
+      );
+
       openTaskModal({
         view: TaskModalEnum.Add,
         defaultValues: {
+          // If the user changed the task subject from the default, use their customized task
+          // subject in the new task
+          subject: task.subject === defaultSubject ? undefined : task.subject,
           activityType: attributes.nextAction,
           // TODO: Use fragments to ensure all required fields are loaded
           contactIds: task.contacts.nodes.map((contact) => contact.id),

--- a/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.test.tsx
+++ b/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.test.tsx
@@ -8,7 +8,6 @@ import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { AssigneeOptionsQuery } from 'src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOther.generated';
-import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import { ActivityTypeEnum } from 'src/graphql/types.generated';
 import useTaskModal from 'src/hooks/useTaskModal';
 import { dispatch } from 'src/lib/analytics';
@@ -283,10 +282,7 @@ describe('TaskModalLogForm', () => {
     const { findByRole, getByRole } = render(
       <LocalizationProvider dateAdapter={AdapterLuxon}>
         <SnackbarProvider>
-          <GqlMockedProvider<{
-            AssigneeOptions: AssigneeOptionsQuery;
-            GetUser: GetUserQuery;
-          }>
+          <GqlMockedProvider<{ AssigneeOptions: AssigneeOptionsQuery }>
             mocks={{
               AssigneeOptions: {
                 accountListUsers: {
@@ -295,11 +291,6 @@ describe('TaskModalLogForm', () => {
                       user: { id: 'user-1', firstName: 'User', lastName: '1' },
                     },
                   ],
-                },
-              },
-              GetUser: {
-                user: {
-                  id: 'user-1',
                 },
               },
             }}

--- a/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.tsx
+++ b/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.tsx
@@ -121,7 +121,6 @@ const TaskModalLogForm = ({
   const {
     phaseData,
     setPhaseId,
-    constants,
     taskPhases,
     activityTypes,
     activitiesByPhase,
@@ -365,7 +364,7 @@ const TaskModalLogForm = ({
                           activities,
                           focusActivity,
                           activityType,
-                          constants,
+                          activityTypes,
                           setFieldTouched,
                         });
                       }}
@@ -388,7 +387,7 @@ const TaskModalLogForm = ({
                           setFieldValue,
                           setFieldTouched,
                           setActionSelected,
-                          constants,
+                          activityTypes,
                         });
                       }}
                       inputRef={activityRef}

--- a/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.tsx
+++ b/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.tsx
@@ -63,6 +63,7 @@ import {
 import {
   extractSuggestedTags,
   getDatabaseValueFromResult,
+  getDefaultTaskName,
   handleTaskActionChange,
   handleTaskPhaseChange,
 } from '../TaskModalHelper';
@@ -245,9 +246,20 @@ const TaskModalLogForm = ({
     enqueueSnackbar(t('Task(s) logged successfully'), { variant: 'success' });
     onClose();
     if (attributes.nextAction) {
+      const defaultSubject = getDefaultTaskName(
+        attributes.activityType,
+        activityTypes,
+      );
+
       openTaskModal({
         view: TaskModalEnum.Add,
         defaultValues: {
+          // If the user changed the task subject from the default, use their customized task
+          // subject in the new task
+          subject:
+            attributes.subject === defaultSubject
+              ? undefined
+              : attributes.subject,
           activityType: attributes.nextAction,
           // TODO: Use fragments to ensure all required fields are loaded
           contactIds: attributes.contactIds,

--- a/src/components/Task/Modal/Form/TaskModalForm.test.tsx
+++ b/src/components/Task/Modal/Form/TaskModalForm.test.tsx
@@ -5,7 +5,7 @@ import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { DateTime, Settings } from 'luxon';
+import { DateTime } from 'luxon';
 import { SnackbarProvider } from 'notistack';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import LoadConstantsMock from 'src/components/Constants/LoadConstantsMock';
@@ -90,12 +90,6 @@ describe('TaskModalForm', () => {
       id: 'userId',
     },
   };
-
-  beforeEach(() => {
-    // Create a stable time so that the "now" in the component will match "now" in the mocks
-    const now = Date.now();
-    Settings.now = () => now;
-  });
 
   it('Modal should close', async () => {
     const { getByText } = render(<Components />);

--- a/src/components/Task/Modal/Form/TaskModalForm.test.tsx
+++ b/src/components/Task/Modal/Form/TaskModalForm.test.tsx
@@ -365,6 +365,55 @@ describe('TaskModalForm', () => {
     );
   });
 
+  it('defaults the subject to the defaultValues subject', () => {
+    const { getByRole } = render(
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <SnackbarProvider>
+          <GqlMockedProvider>
+            <TaskModalForm
+              defaultValues={{
+                taskPhase: PhaseEnum.PartnerCare,
+                activityType: ActivityTypeEnum.PartnerCareTextMessage,
+                subject: 'Do something',
+              }}
+              accountListId={accountListId}
+              onClose={onClose}
+              task={null}
+            />
+          </GqlMockedProvider>
+        </SnackbarProvider>
+      </LocalizationProvider>,
+    );
+
+    expect(getByRole('textbox', { name: 'Subject' })).toHaveValue(
+      'Do something',
+    );
+  });
+
+  it('defaults the subject to the name based on phase and action', () => {
+    const { getByRole } = render(
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <SnackbarProvider>
+          <GqlMockedProvider>
+            <TaskModalForm
+              defaultValues={{
+                taskPhase: PhaseEnum.PartnerCare,
+                activityType: ActivityTypeEnum.PartnerCareTextMessage,
+              }}
+              accountListId={accountListId}
+              onClose={onClose}
+              task={null}
+            />
+          </GqlMockedProvider>
+        </SnackbarProvider>
+      </LocalizationProvider>,
+    );
+
+    expect(getByRole('textbox', { name: 'Subject' })).toHaveValue(
+      'Text Message Partner For Cultivation',
+    );
+  });
+
   it('renders fields for completed task', async () => {
     const { getByRole, findByRole, queryByText } = render(
       <ThemeProvider theme={theme}>

--- a/src/components/Task/Modal/Form/TaskModalForm.test.tsx
+++ b/src/components/Task/Modal/Form/TaskModalForm.test.tsx
@@ -10,7 +10,6 @@ import { SnackbarProvider } from 'notistack';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import LoadConstantsMock from 'src/components/Constants/LoadConstantsMock';
 import { AssigneeOptionsQuery } from 'src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOther.generated';
-import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import { ActivityTypeEnum, PhaseEnum } from 'src/graphql/types.generated';
 import useTaskModal from 'src/hooks/useTaskModal';
 import theme from 'src/theme';
@@ -337,10 +336,7 @@ describe('TaskModalForm', () => {
     const { getByRole } = render(
       <LocalizationProvider dateAdapter={AdapterLuxon}>
         <SnackbarProvider>
-          <GqlMockedProvider<{
-            AssigneeOptions: AssigneeOptionsQuery;
-            GetUser: GetUserQuery;
-          }>
+          <GqlMockedProvider<{ AssigneeOptions: AssigneeOptionsQuery }>
             mocks={{
               AssigneeOptions: {
                 accountListUsers: {
@@ -349,11 +345,6 @@ describe('TaskModalForm', () => {
                       user: { id: 'user-1', firstName: 'User', lastName: '1' },
                     },
                   ],
-                },
-              },
-              GetUser: {
-                user: {
-                  id: 'user-1',
                 },
               },
             }}

--- a/src/components/Task/Modal/Form/TaskModalForm.tsx
+++ b/src/components/Task/Modal/Form/TaskModalForm.tsx
@@ -248,7 +248,7 @@ const TaskModalForm = ({
         taskPhase: taskPhase as PhaseEnum,
         activityType: (defaultValues?.activityType ?? null) as ActivityTypeEnum,
         location: '',
-        subject: taskSubject ?? '',
+        subject: defaultValues?.subject ?? taskSubject ?? '',
         startAt: DateTime.local(),
         completedAt: null,
         displayResult: null,

--- a/src/hooks/usePhaseData.ts
+++ b/src/hooks/usePhaseData.ts
@@ -26,8 +26,15 @@ export type ActivityData = {
   name: string;
   phaseId: PhaseEnum;
   phase: string;
+  subject?: string;
   title?: string;
 };
+
+const capitalizeWords = (sentence: string): string =>
+  sentence
+    .split(' ')
+    .map((word) => word[0].toUpperCase() + word.substring(1))
+    .join(' ');
 
 const phaseFromActivity = (
   activity: PhaseEnum | null,
@@ -112,12 +119,14 @@ export const usePhaseData = (phaseEnum?: PhaseEnum | null): GetPhaseData => {
   //   name: 'Special Gift Appeal',
   //   phase: 'Initiation',
   //   phaseId: 'INITIATION',
+  //   subject: 'Special Gift Appeal',
   //   title: 'Initiation - Special Gift Appeal',
   // },
   // FOLLOW_UP_TEXT_MESSAGE: {
   //   name: 'Text Message',
   //   phase: 'Follow-Up',
   //   phaseId: 'FOLLOW_UP',
+  //   subject: 'Text Message To Follow Up',
   //   title: 'Follow Up - Text Message',
   // },}
 
@@ -125,13 +134,16 @@ export const usePhaseData = (phaseEnum?: PhaseEnum | null): GetPhaseData => {
     const activitiesMap = new Map();
 
     constants?.phases?.forEach((phase) => {
-      phase?.tasks?.forEach((task) => {
-        activitiesMap.set(task, {
-          name: getLocalizedTaskType(t, task),
+      phase?.tasks?.forEach((activityType) => {
+        const activity = constants?.activities?.find(
+          (activity) => activity.id === activityType,
+        );
+        activitiesMap.set(activityType, {
+          name: getLocalizedTaskType(t, activityType),
           phaseId: phase.id,
           phase: getLocalizedPhase(t, phase.id),
-          title: constants?.activities?.find((activity) => activity.id === task)
-            ?.value,
+          subject: activity?.name && capitalizeWords(activity.name),
+          title: activity?.value,
         });
       });
     });


### PR DESCRIPTION
## Description

* When creating a new task after completing a different task, default the task name to the previous task name.
* If the user changes the new task's task phase or activity type, the task name will be overridden, which I believe is what we want.
* ~~If the user had a customized task name for a text message task, for example, and they make the next action a phone call, we just use the autogenerated task name. This is to prevent someone who didn't customize their task name from getting "Call to Initiate Appointment" as the initial task name for a text message task. I think this is a reasonable tradeoff, but feel free to discuss.~~ **EDIT**: Now I'm just comparing the task subject with the default task subject. If they differ, this means that the user customized the task subject. This logic will break if the server changes the default task subjects, but this should be rare, so I think this is acceptable.

## Testing

* Case 1
  * Create a new task and customize the name
  * Complete the task and make sure that the next action is set
  * Check that the task name in the Add Task modal is the customized task name
* Case 2
  * Log a new task and customize the name
  * Complete the task and make sure that the next action is set
  * Check that the task name in the Add Task modal is the customized task name
* Case 3
  * Create a new task
  * Check that change the phase and activity type changes the task subject

[MPDX-8385](https://jira.cru.org/browse/MPDX-8385)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
