### PR TITLE
Show Received on pledge modal to avoid confusion

### DIFF
--- a/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.test.tsx
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.test.tsx
@@ -410,7 +410,7 @@ describe('PledgeModal', () => {
     );
   });
 
-  it('can not select the status given or received if the pledge does not have one of those statuses already', async () => {
+  it('can not select the status given if the pledge does not have the status "given"', async () => {
     const { getByRole, queryByRole } = render(
       <Components
         pledge={{
@@ -429,7 +429,7 @@ describe('PledgeModal', () => {
     userEvent.click(getByRole('combobox', { name: 'Status' }));
 
     expect(getByRole('option', { name: 'Committed' })).toBeInTheDocument();
-    expect(queryByRole('option', { name: 'Received' })).not.toBeInTheDocument();
+    expect(getByRole('option', { name: 'Received' })).toBeInTheDocument();
     expect(queryByRole('option', { name: 'Given' })).not.toBeInTheDocument();
   });
 });

--- a/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
@@ -410,14 +410,11 @@ export const PledgeModal: React.FC<PledgeModalProps> = ({
                             <MenuItem value={PledgeStatusEnum.NotReceived}>
                               {t('Committed')}
                             </MenuItem>
-                            {pledge?.status ===
-                              PledgeStatusEnum.ReceivedNotProcessed && (
-                              <MenuItem
-                                value={PledgeStatusEnum.ReceivedNotProcessed}
-                              >
-                                {t('Received')}
-                              </MenuItem>
-                            )}
+                            <MenuItem
+                              value={PledgeStatusEnum.ReceivedNotProcessed}
+                            >
+                              {t('Received')}
+                            </MenuItem>
                             {pledge?.status === PledgeStatusEnum.Processed && (
                               <MenuItem value={PledgeStatusEnum.Processed}>
                                 {t('Given')}


### PR DESCRIPTION
## Description
I have added the "Received" option back onto the pledge modal. Looking back at previous messages, it looks like users can try to put the contact into "Received", ost of the time the server will override their choice but not always.

Putting it back this way will make it simplier for users until we overhaul the appeals Committed->Given process.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
