### PR TITLE
[MPDX-8418] Add UTF-8 BOM to CSV exports

### DIFF
--- a/src/components/Reports/FinancialAccountsReport/AccountTransactions/AccountTransactions.tsx
+++ b/src/components/Reports/FinancialAccountsReport/AccountTransactions/AccountTransactions.tsx
@@ -3,6 +3,7 @@ import React, { useContext, useEffect, useMemo } from 'react';
 import { Box, CircularProgress } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { DateTime } from 'luxon';
+import { buildURI } from 'react-csv/lib/core';
 import { useTranslation } from 'react-i18next';
 import { Panel } from 'pages/accountLists/[accountListId]/reports/helpers';
 import { headerHeight } from 'src/components/Shared/Header/ListHeader';
@@ -115,10 +116,10 @@ export const AccountTransactions: React.FC = () => {
       t('Outflow'),
       t('Inflow'),
     ];
-    const convertDataToArray = data.financialAccountEntries.entries.reduce(
-      (array, entry) => {
+    const csvLines = data.financialAccountEntries.entries.reduce(
+      (csvLines, entry) => {
         return [
-          ...array,
+          ...csvLines,
           [
             entry.entryDate
               ? dateFormatShort(DateTime.fromISO(entry.entryDate), locale)
@@ -138,20 +139,11 @@ export const AccountTransactions: React.FC = () => {
     );
 
     // Convert Array to CSV format
-    const csvContent =
-      'data:text/csv;charset=utf-8,' +
-      convertDataToArray
-        .map((row) =>
-          row
-            .map((field) => `"${String(field).replace(/"/g, '""')}"`)
-            .join(','),
-        )
-        .join('\n');
+    const csvBlob = buildURI(csvLines, true);
 
     // Create a link and trigger download
-    const encodedUri = encodeURI(csvContent);
     const link = document.createElement('a');
-    link.setAttribute('href', encodedUri);
+    link.setAttribute('href', csvBlob);
     link.setAttribute('download', `${appName}-entries-export${dateRange}.csv`);
     document.body.appendChild(link);
     link.click();

--- a/src/components/Reports/FourteenMonthReports/Layout/Header/Actions/Actions.test.tsx
+++ b/src/components/Reports/FourteenMonthReports/Layout/Header/Actions/Actions.test.tsx
@@ -31,7 +31,7 @@ describe('FourteenMonthReportActions', () => {
     userEvent.click(getByRole('button', { name: 'Print' }));
     expect(getByRole('link', { name: 'Export' })).toHaveAttribute(
       'href',
-      'data:text/csv;charset=utf-8,',
+      'data:text/csv;charset=utf-8,\uFEFF',
     );
   });
 

--- a/src/components/Reports/FourteenMonthReports/Layout/Header/Actions/Actions.tsx
+++ b/src/components/Reports/FourteenMonthReports/Layout/Header/Actions/Actions.tsx
@@ -34,7 +34,7 @@ export const FourteenMonthReportActions: React.FC<
   // This has to be a useEffect instead of a useMemo to prevent hydration errors because the
   // server isn't able to calculate a blob URL.
   useEffect(() => {
-    const csvBlob = buildURI(csvData);
+    const csvBlob = buildURI(csvData, true);
     setCsvBlob(csvBlob);
 
     return () => URL.revokeObjectURL(csvBlob);


### PR DESCRIPTION
## Description

Excel does not interpret UTF-8 encoded CSV files correctly. For example, exports contain characters like this instead of Russian characters: `"–ï–¥–∞/–ø–æ–¥–∞—Ä–∫–∏ –¥–ª—è –≤—Å—Ç—Ä–µ—á
–£–∂–∏–Ω –° –∫–æ–º–∞–Ω–¥–æ–π –∏ —Å —Å—Ç—É–¥–µ–Ω—Ç–∞–º–∏"`. To fix this, we need to add the [Byte Order Mark](https://en.wikipedia.org/wiki/Byte_order_mark) to hint to Excel that it needs to interpret the file as UTF-8 instead of as ASCII. Fortunately, `react-csv` has an option for this. We just have to pass `true` as the second argument to `buildURI`.

I also migrated the account transactions CSV download from a handrolled CSV export to use `react-csv`.

Note that the API already adds the byte order mark to server-generated CSV exports.

## Testing

* 14 Month Reports
  * Create or edit a contact to have a non-ASCII character in its name, like Á.
  * Go to a 14 month report and export it
  * Check in Excel (if available) and macOS Numbers that the CSV file is rendered correctly
  * Alternatively, open the CSV file in VS Code and check that it says "UTF-8 with BOM" in the status bar at the bottom of the window
* Transactions Report
  * Impersonate Toncho's account
  * Go to a responsibility centers transactions page with transactions (I had to push the start date back to see transactions)
  * Click Export CSV button
  * Check in Excel (if available) and macOS Numbers that the CSV file is rendered correctly
  * Alternatively, open the CSV file in VS Code and check that it says "UTF-8 with BOM" in the status bar at the bottom of the window

[MPDX-8418](https://jira.cru.org/browse/MPDX-8418)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
