### PR TITLE
[MPDX-8416] Turn article name into a link that opens in a new tab

### DIFF
--- a/pages/helpjuice.css
+++ b/pages/helpjuice.css
@@ -13,9 +13,15 @@
   display: none;
 }
 
+/* Hide the estimated reading time and last updated time in search results */
 #helpjuice-widget .article .footer {
-  /* Hide the estimated reading time and last updated time in search results */
   display: none !important;
+}
+
+/* Style the header link to still look like a header instead of like a link in the article content */
+#helpjuice-widget #article-content-name a {
+  font-size: unset;
+  text-decoration: none;
 }
 
 /*

--- a/src/components/Helpjuice/Helpjuice.test.tsx
+++ b/src/components/Helpjuice/Helpjuice.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { useSession } from 'next-auth/react';
 import { session } from '__tests__/fixtures/session';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
@@ -19,6 +19,27 @@ describe('Helpjuice', () => {
     render(<Helpjuice />);
 
     expect(document.querySelector('path.close')).toBeInTheDocument();
+  });
+
+  it('turns header into a link', async () => {
+    render(<Helpjuice />);
+
+    document
+      .getElementsByClassName('hj-swifty')[0]
+      .setAttribute('data-current-question-id', 'article-1');
+    expect(
+      await screen.findByRole('link', { name: 'Article Name' }),
+    ).toHaveAttribute('href', 'https://domain.helpjuice.com/article-1');
+
+    // Simulate clicking on another article, which will replace #article-content-name and change data-current-question-id
+    document.getElementById('article-content-name')!.textContent =
+      'Another Article Name';
+    document
+      .getElementsByClassName('hj-swifty')[0]
+      .setAttribute('data-current-question-id', 'article-2');
+    expect(
+      await screen.findByRole('link', { name: 'Another Article Name' }),
+    ).toHaveAttribute('href', 'https://domain.helpjuice.com/article-2');
   });
 
   it('does nothing if the element is missing', () => {

--- a/src/components/Helpjuice/Helpjuice.tsx
+++ b/src/components/Helpjuice/Helpjuice.tsx
@@ -36,6 +36,36 @@ export const Helpjuice: React.FC = () => {
     return () => closeImage.remove();
   });
 
+  // When a user clicks on an article in the beacon, make the title link to the article in a new
+  // tab on Helpjuice
+  useEffect(() => {
+    const helpJuiceOrigin = process.env.HELPJUICE_ORIGIN;
+    const swiftyContainer = document.getElementsByClassName('hj-swifty')[0];
+    if (!helpJuiceOrigin || !(swiftyContainer instanceof HTMLElement)) {
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      const questionId = swiftyContainer.dataset.currentQuestionId;
+      const nameHeader = document.getElementById('article-content-name');
+      if (!questionId || !nameHeader) {
+        return;
+      }
+
+      // Turn the title into a link when the selected question id changes
+      const link = document.createElement('a');
+      link.setAttribute('href', `${helpJuiceOrigin}/${questionId}`);
+      link.setAttribute('target', '_blank');
+      link.textContent = nameHeader.textContent;
+      nameHeader.replaceChildren(link);
+    });
+    // Watch for changes to the selected question
+    observer.observe(swiftyContainer, {
+      attributeFilter: ['data-current-question-id'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
   useEffect(() => {
     if (!process.env.HELPJUICE_ORIGIN) {
       return;

--- a/src/components/Helpjuice/widget.mock.ts
+++ b/src/components/Helpjuice/widget.mock.ts
@@ -1,13 +1,21 @@
-export const widgetHTML = `<div id="helpjuice-widget">
-  <a id="helpjuice-widget-trigger">
-    <svg>
-     <g />
-    </svg>
-  </a>
-  <div id="helpjuice-widget-expanded" />
-    <div id="helpjuice-widget-contact">
-      <a id="helpjuice-contact-link">Contact Us</a>
-      <a class="knowledge-base-link">Visit Knowledge Base</a>
+export const widgetHTML = `<div class="hj-swifty">
+  <div id="helpjuice-widget">
+    <a id="helpjuice-widget-trigger">
+      <svg>
+        <g />
+      </svg>
+    </a>
+    <div id="helpjuice-widget-expanded" />
+    <div id="helpjuice-widget-article-content" class="active">
+      <div class="content">
+        <div class="header">
+          <h1 id="article-content-name" class="name">Article Name</h1>
+        </div>
+      </div>
+      <div id="helpjuice-widget-contact">
+        <a id="helpjuice-contact-link">Contact Us</a>
+        <a class="knowledge-base-link">Visit Knowledge Base</a>
+      </div>
     </div>
   </div>
 </div>`;


### PR DESCRIPTION
## Description

In the Helpjuice beacon, make the article header a link that opens the article in a new tab on Helpjuice.

## Testing

* Search for an article and click on it or click on a suggested article
* Verify that the article header is a link that opens the article in a new tab

<img width="202" alt="Screenshot 2024-11-05 at 3 13 09 PM" src="https://github.com/user-attachments/assets/4a2b7afb-970f-43bc-9c3d-3f175b3bf113">

[MPDX-8416](https://jira.cru.org/browse/MPDX-8416)

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
