### PR TITLE
[no-Jira] Use a dash in dependabot branch names

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,0 @@
-{
-  "extends": ["config:base", ":preserveSemverRanges"],
-  "ignorePaths": [".yarn/sdks/"],
-  "labels": ["dependencies"],
-  "prConcurrentLimit": 8,
-  "prHourlyLimit": 2
-}

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    pull-request-branch-name:
+      separator: '-'


### PR DESCRIPTION
## Description

Use a dash in dependabot branch names. This will make preview environments work on dependabot PRs because the default / separator isn't a valid character in a domain name.

[Docs link](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#pull-request-branch-nameseparator)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
