### PR TITLE
HS-1258682 Appeals Loading Fix

### DIFF
--- a/src/lib/apollo/cache.ts
+++ b/src/lib/apollo/cache.ts
@@ -75,6 +75,7 @@ export const createCache = () =>
       Query: {
         fields: {
           accountListPledges: paginationFieldPolicy,
+          appeals: paginationFieldPolicy,
           coachingAccountListPledges: paginationFieldPolicy,
           contacts: paginationFieldPolicy,
           donations: paginationFieldPolicy,


### PR DESCRIPTION
## Description
https://secure.helpscout.net/conversation/2761477377/1258682?folderId=7669074
Users with over 50 appeals were not able to see their appeals because Apollo was not merging the results from `useFetchAllPages` back into the result from the initial query.
Fix: Set the field policy of the field `appeals` to `paginationFieldPolicy`

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
