### PR TITLE
Fixing issue with error when deleting contact from appeal.

### DIFF
--- a/src/components/Tool/Appeal/Modals/DeleteAppealContact/DeleteAppealContactModal.test.tsx
+++ b/src/components/Tool/Appeal/Modals/DeleteAppealContact/DeleteAppealContactModal.test.tsx
@@ -33,7 +33,6 @@ jest.mock('notistack', () => ({
 const accountListId = 'abc';
 const appealId = 'appealId';
 const contactId = 'contact-1';
-const appealContactId = 'appealContactId';
 const router = {
   query: { accountListId },
   isReady: true,
@@ -46,7 +45,6 @@ interface ComponentsProps {
 }
 
 const Components = ({ viewMode = TableViewModeEnum.List }: ComponentsProps) => {
-  let requestCount = 0;
   return (
     <I18nextProvider i18n={i18n}>
       <SnackbarProvider>
@@ -56,70 +54,6 @@ const Components = ({ viewMode = TableViewModeEnum.List }: ComponentsProps) => {
               <TestRouter router={router}>
                 <GqlMockedProvider
                   mocks={{
-                    AppealContacts: () => {
-                      let mutationResponse;
-                      if (requestCount < 3) {
-                        mutationResponse = {
-                          appealContacts: {
-                            nodes: [
-                              {
-                                id: `id1${requestCount}`,
-                                contact: {
-                                  id: `contactId1${requestCount}`,
-                                },
-                              },
-                              {
-                                id: `id2${requestCount}`,
-                                contact: {
-                                  id: `contactId2${requestCount}`,
-                                },
-                              },
-                              {
-                                id: `id3${requestCount}`,
-                                contact: {
-                                  id: `contactId3${requestCount}`,
-                                },
-                              },
-                            ],
-                            pageInfo: {
-                              hasNextPage: true,
-                              endCursor: `endCursor${requestCount}`,
-                            },
-                          },
-                        };
-                      } else {
-                        mutationResponse = {
-                          appealContacts: {
-                            nodes: [
-                              {
-                                id: appealContactId,
-                                contact: {
-                                  id: contactId,
-                                },
-                              },
-                              {
-                                id: `id5${requestCount}`,
-                                contact: {
-                                  id: `contactId5${requestCount}`,
-                                },
-                              },
-                              {
-                                id: `id6${requestCount}`,
-                                contact: {
-                                  id: `contactId6${requestCount}`,
-                                },
-                              },
-                            ],
-                            pageInfo: {
-                              hasNextPage: false,
-                              endCursor: 'endCursor3',
-                            },
-                          },
-                        };
-                      }
-                      requestCount++;
-                      return mutationResponse;
-                    },
                     GetContactIdsForMassSelection: {
                       contacts: {
                         nodes: [
@@ -191,22 +125,6 @@ describe('DeleteAppealContactModal', () => {
   it('fetches all the appealContacts and matches up the correct ID to send to the API', async () => {
     const { getByRole } = render(<Components />);
 
-    // Call AppealContacts 3 times getting all contacts.
-    await waitFor(() =>
-      expect(mutationSpy).toHaveGraphqlOperation('AppealContacts', {
-        after: 'endCursor2',
-        appealId: 'appealId',
-      }),
-    );
-    expect(mutationSpy).toHaveGraphqlOperation('AppealContacts', {
-      after: null,
-      appealId: 'appealId',
-    });
-    expect(mutationSpy).toHaveGraphqlOperation('AppealContacts', {
-      after: 'endCursor1',
-      appealId: 'appealId',
-    });
-
     userEvent.click(getByRole('button', { name: 'Yes' }));
 
     await waitFor(() => {
@@ -221,7 +139,7 @@ describe('DeleteAppealContactModal', () => {
     await waitFor(() => {
       expect(mutationSpy).toHaveGraphqlOperation('DeleteAppealContact', {
         input: {
-          id: 'appealContactId',
+          id: contactId,
         },
       });
     });

--- a/src/components/Tool/Appeal/Modals/DeleteAppealContact/DeleteAppealContactModal.tsx
+++ b/src/components/Tool/Appeal/Modals/DeleteAppealContact/DeleteAppealContactModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import {
   Box,
   CircularProgress,
@@ -19,11 +19,7 @@ import {
   AppealsType,
   TableViewModeEnum,
 } from '../../AppealsContext/AppealsContext';
-import {
-  AppealContactsInfoFragment,
-  useAppealContactsQuery,
-  useDeleteAppealContactMutation,
-} from './DeleteAppealContact.generated';
+import { useDeleteAppealContactMutation } from './DeleteAppealContact.generated';
 
 const LoadingIndicator = styled(CircularProgress)(({ theme }) => ({
   margin: theme.spacing(0, 1, 0, 0),
@@ -39,62 +35,15 @@ export const DeleteAppealContactModal: React.FC<
 > = ({ contactId, handleClose }) => {
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
-  const { appealId, viewMode } = React.useContext(
-    AppealsContext,
-  ) as AppealsType;
+  const { viewMode } = React.useContext(AppealsContext) as AppealsType;
   const [deleteAppealContact, { loading: mutating }] =
     useDeleteAppealContactMutation();
-  const { data, fetchMore } = useAppealContactsQuery({
-    variables: {
-      appealId: appealId ?? '',
-    },
-  });
-  const [loading, setLoading] = useState(false);
-  const [appealContactsIds, setAppealContactsIds] = useState<
-    AppealContactsInfoFragment[]
-  >([]);
-
-  const loadAllAppealContacts = async () => {
-    let allContacts = data?.appealContacts.nodes ?? [];
-    let hasNextPage = true;
-    let cursor: string | null = null;
-
-    while (hasNextPage) {
-      const response = await fetchMore({
-        variables: {
-          after: cursor,
-        },
-      });
-
-      const newContacts = response.data.appealContacts.nodes;
-      allContacts = [...allContacts, ...newContacts];
-      hasNextPage = response.data.appealContacts.pageInfo.hasNextPage;
-      cursor = response.data.appealContacts.pageInfo.endCursor ?? null;
-    }
-
-    setAppealContactsIds(allContacts);
-    setLoading(false);
-    return allContacts;
-  };
-
-  useEffect(() => {
-    loadAllAppealContacts();
-  }, []);
 
   const handleRemoveContact = async () => {
-    const appealContactId = appealContactsIds.find(
-      (appealContact) => appealContact.contact.id === contactId,
-    )?.id;
-    if (!appealContactId) {
-      enqueueSnackbar('Error while removing contact from appeal.', {
-        variant: 'error',
-      });
-      return;
-    }
     await deleteAppealContact({
       variables: {
         input: {
-          id: appealContactId,
+          id: contactId,
         },
       },
       update: (cache) => {
@@ -136,13 +85,13 @@ export const DeleteAppealContactModal: React.FC<
         )}
       </DialogContent>
       <DialogActions>
-        <CancelButton onClick={onClickDecline} disabled={mutating || loading}>
+        <CancelButton onClick={onClickDecline} disabled={mutating}>
           {t('No')}
         </CancelButton>
         <SubmitButton
           type="button"
           onClick={handleRemoveContact}
-          disabled={mutating || loading}
+          disabled={mutating}
         >
           {t('Yes')}
         </SubmitButton>


### PR DESCRIPTION
## Description
On appeals, when deleting a contact from an appeal, it would sometimes error. This PR fixes this bug.

The issue arose as I added functionality that tested the contact in question is on the appeal. However, since it meant we had to load all the contacts before we deleted it, if the user clicks the "Remove" button before it all loads, it would cause this error.
I could have prevented the "Remove" button from being selected until all contacts were loaded or removed the functionality and let the server check and produce the error. I opted to remove it as it adds a better UX, and as a bonus, there's less code to manage.


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
