### PR TITLE
[MPDX-8446] Automate translation download and extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
         run: yarn install --immutable --immutable-cache
+      - name: 🌐 Extract Translations
+        run: yarn extract
       - name: ⛅🔼 OneSky Upload
         env:
           ONESKY_API_KEY: ${{ secrets.ONESKY_API_KEY }}

--- a/.github/workflows/onesky.yml
+++ b/.github/workflows/onesky.yml
@@ -1,0 +1,46 @@
+name: OneSky Translation PR
+
+on:
+  schedule:
+    # Run every day at 10:50am UTC (5:50am EST). To avoid delays and possibly dropped jobs GitHub
+    # recommends not scheduling jobs at the top of the hour.
+    - cron: '50 10 * * *'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .tool-versions
+      - name: 📦 Install Dependencies
+        run: yarn install --immutable --immutable-cache
+      - name: 🌐 Extract Translations
+        run: yarn extract
+      - name: ⛅🔽 OneSky Download
+        env:
+          ONESKY_API_KEY: ${{ secrets.ONESKY_API_KEY }}
+          ONESKY_API_SECRET: ${{ secrets.ONESKY_API_SECRET }}
+          ONESKY_PROJECT_ID: ${{ secrets.ONESKY_PROJECT_ID }}
+        run: yarn onesky:download
+      - name: 🔀 Create PR
+        uses: peter-evans/create-pull-request@v7
+        env:
+          # Disable git hooks because we are only modifying translation files
+          HUSKY: 0
+        with:
+          branch: bot-update-translations
+          add-paths: |
+            public/locales/
+          # Sign commits so that the author is a bot
+          sign-commits: true
+          commit-message: Run `yarn extract` and `yarn onesky:download`
+          title: '[no-Jira] Update translations'
+          body: Update translations with the latest labels extracted from the components and downloaded from OneSky.

--- a/amplify.yml
+++ b/amplify.yml
@@ -19,6 +19,7 @@ frontend:
         - yarn
         - yarn disable-telemetry
         - yarn gql
+        - yarn onesky:download
     build:
       commands:
         - yarn build:amplify

--- a/amplify.yml
+++ b/amplify.yml
@@ -19,7 +19,7 @@ frontend:
         - yarn
         - yarn disable-telemetry
         - yarn gql
-        - yarn onesky:download
+        - timeout 1m yarn onesky:download || echo "yarn onesky:download timed out after 1 minute or failed with an error"
     build:
       commands:
         - yarn build:amplify

--- a/src/components/Tool/Appeal/InitialPage/AddAppealForm/AddAppealForm.test.tsx
+++ b/src/components/Tool/Appeal/InitialPage/AddAppealForm/AddAppealForm.test.tsx
@@ -203,7 +203,7 @@ describe('AddAppealForm', () => {
       expect(
         await findByText(/must use a positive whole number for admin cost/i),
       ).toBeInTheDocument();
-    }, 6000);
+    }, 10000);
 
     it('should calculate the Goal amount correctly', async () => {
       const { getByRole } = render(<Components />);


### PR DESCRIPTION
## Description

* On every commit to main run `yarn extract` before uploading labels to OneSky. That way translation can begin immediately on any new labels instead of needing to wait for `public/locales/en/translation.json` to be updated. (The extracted labels are not committed and are discarded when the action terminates)
* During deployment to Amplify, run `yarn onesky:download` to deploy the app with the latest labels from OneSky. I tested that if that command fails for any reason, the deployment will still continue successfully.
  * I added the `ONESKY_*` environment variables to Amplify.
* Add a new workflow that runs daily to create a PR with any new labels from `yarn extract` or `yarn onesky:download`. Here is an example from my fork of the PR that will be created: https://github.com/canac/mpdx-react/pull/5. If the PR hasn't merged, the action will rebase and force-push any new labels to the branch.

[MPDX-8446](https://jira.cru.org/browse/MPDX-8446)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
