### PR TITLE
[no-Jira] Remove Amplify caching

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -26,4 +26,4 @@ frontend:
       - '**/*'
   cache:
     paths:
-      - '.next/cache/**/*'
+      - node_modules/**/*


### PR DESCRIPTION
## Description

Recent PRs (likely since the Next.js 13 upgrade and the migrating to Amplify Web Compute) are deploying in preview but the changes aren't showing up in production or staging. I'm trying removing caching of `.next/cache` and adding caching of `node_modules` to match the Amplify configuration in the [Next.js SSR docs](https://docs.aws.amazon.com/amplify/latest/userguide/deploy-nextjs-app.html#build-setting-detection).

## Testing

* Go to staging and check whether the Contact Us beacon link opens in a new tab or not. If it opens in a new tab, the latest code from staging successfully deployed.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
