### PR TITLE
[no-Jira] Give bundle-analyzer permission to comment on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
 
   bundle-analyzer:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## Description

Currently, Dependabot PRs fail in the `bundle-analzyer` step because the default GitHub token doesn't have permission to create a comment on the PR ([example run](https://github.com/CruGlobal/mpdx-react/actions/runs/11895982183/job/33146819121?pr=1200)). It appears that the fix is to give additional permissions to that workflow step ([docs](https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/)).

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
