### PR TITLE
[no-Jira] Refresh 14 month report after account list redirect

### DIFF
--- a/src/components/Reports/FourteenMonthReports/FourteenMonthReport.tsx
+++ b/src/components/Reports/FourteenMonthReports/FourteenMonthReport.tsx
@@ -69,6 +69,7 @@ export const FourteenMonthReport: React.FC<Props> = ({
   useEffect(() => {
     (async () => {
       try {
+        setFourteenMonthReportError('');
         const designationAccountFilter = designationAccounts?.length
           ? `&filter[designation_account_id]=${designationAccounts.join(',')}`
           : '';
@@ -101,7 +102,7 @@ export const FourteenMonthReport: React.FC<Props> = ({
         }
       }
     })();
-  }, [designationAccounts, currencyType]);
+  }, [accountListId, designationAccounts, currencyType]);
 
   // Generate a table for each currency group in the report
   const currencyTables = useMemo<CurrencyTable[]>(


### PR DESCRIPTION
## Description

When an invalid account list id is passed to the 14 month report, the application would redirect to the user's default account list, but the report would be stuck showing an error message. This PR resets the error message and refetches the report data when the account list id changes.

## Testing

To see the bug, go to https://mpdx.org/accountLists/_/reports/salaryCurrency and see the account list id change in the URL but the report still render an error message.

To see the fix, go to https://fourteen-month-report-redirect.d3dytjb8adxkk5.amplifyapp.com/accountLists/_/reports/salaryCurrency and verify that the reports renders after the account list id changes in the URL.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
