### PR TITLE
MPDX-8491 - Fix Activity Type Case-Sensitivity Issue in Google Calendar Integration

### DIFF
--- a/pages/api/graphql-rest.page.ts
+++ b/pages/api/graphql-rest.page.ts
@@ -993,10 +993,22 @@ class MpdxRestApi extends RESTDataSource {
     googleIntegrationId,
     googleIntegration,
   ) {
-    const attributes = {};
+    interface GoogleIntegrationAttributes {
+      overwrite?: boolean;
+      calendar_id?: string;
+      calendar_integrations?: string[];
+    }
+    const attributes: GoogleIntegrationAttributes = {};
     Object.keys(googleIntegration).map((key) => {
       attributes[camelToSnake(key)] = googleIntegration[key];
     });
+    if (attributes?.calendar_integrations) {
+      // Convert to lowercase since we convert them from lowercase to Uppercase
+      // when we fetch initially from  pages/api/Schema/Settings/Integrations/Google/parse.ts
+      attributes.calendar_integrations = attributes?.calendar_integrations.map(
+        (integration) => integration.toLowerCase(),
+      );
+    }
 
     const { data }: { data: GoogleIntegrationResponse } = await this.put(
       `user/google_accounts/${googleAccountId}/google_integrations/${googleIntegrationId}`,


### PR DESCRIPTION
## Description
This PR resolves an issue where activity types were not being correctly updated in the Google Calendar integration. The root cause was identified in the handling of a proxy GraphQL query used to fetch the current calendar integration. During this process, lowercase values were converted to uppercase to align with the rest of the website's standards.

However, when sending the calendar integrations back to the REST API, the values needed to be reverted to lowercase. This discrepancy caused issues since the API correctly treats `APPOINTMENT_PHONE_CALL` and `appointment_phone_call` as distinct values. This fix ensures proper conversion and resolves the integration issue.

[Jira Task](https://jira.cru.org/secure/RapidBoard.jspa?rapidView=3&view=detail&selectedIssue=MPDX-8491)
[HelpScout Ticket](https://secure.helpscout.net/conversation/2750763969/1252356?viewId=7296147)

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
