### PR TITLE
MPDX-8492 - Enhance loadSession to Redirect Placeholder _ to Default Account List

### DIFF
--- a/pages/acceptInvite.page.tsx
+++ b/pages/acceptInvite.page.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { SetupPage } from 'src/components/Setup/SetupPage';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
 import { useRequiredSession } from 'src/hooks/useRequiredSession';
-import { loadSession } from './api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from './api/utils/pagePropsHelpers';
 
 interface FetchAcceptInviteProps {
   apiToken: string;
@@ -149,6 +149,6 @@ const AcceptInvitePage = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default AcceptInvitePage;

--- a/pages/accountLists/[accountListId].page.tsx
+++ b/pages/accountLists/[accountListId].page.tsx
@@ -5,7 +5,10 @@ import {
   GetDefaultAccountDocument,
   GetDefaultAccountQuery,
 } from 'pages/api/getDefaultAccount.generated';
-import { makeGetServerSideProps } from 'pages/api/utils/pagePropsHelpers';
+import {
+  handleUnderscoreAccountListRedirect,
+  makeGetServerSideProps,
+} from 'pages/api/utils/pagePropsHelpers';
 import { logErrorOnRollbar } from 'pages/api/utils/rollBar';
 import Dashboard from 'src/components/Dashboard';
 import {
@@ -81,6 +84,14 @@ const AccountListIdPage = ({
 
 export const getServerSideProps = makeGetServerSideProps(
   async (session, { query, req }) => {
+    const underscoreRedirect = await handleUnderscoreAccountListRedirect(
+      session,
+      req.url,
+    );
+    if (underscoreRedirect) {
+      return underscoreRedirect;
+    }
+
     const ssrClient = makeSsrClient(session.user.apiToken);
 
     try {

--- a/pages/accountLists/[accountListId]/coaching.page.tsx
+++ b/pages/accountLists/[accountListId]/coaching.page.tsx
@@ -1,7 +1,7 @@
 import Head from 'next/head';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { CoachingList } from 'src/components/Coaching/CoachingList';
 import Loading from 'src/components/Loading';
 import { useAccountListId } from 'src/hooks/useAccountListId';
@@ -26,6 +26,6 @@ const CoachingPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default CoachingPage;

--- a/pages/accountLists/[accountListId]/coaching/[coachingId].page.tsx
+++ b/pages/accountLists/[accountListId]/coaching/[coachingId].page.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import {
   AccountListTypeEnum,
   CoachingDetail,
@@ -35,6 +35,6 @@ const CoachingPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default CoachingPage;

--- a/pages/accountLists/[accountListId]/contacts/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/contacts/[[...contactId]].page.tsx
@@ -1,7 +1,7 @@
 import Head from 'next/head';
 import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import {
   ContactsContext,
   ContactsType,
@@ -72,4 +72,4 @@ const ContactsPage: React.FC = () => (
 
 export default ContactsPage;
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;

--- a/pages/accountLists/[accountListId]/contacts/flows/setup.page.tsx
+++ b/pages/accountLists/[accountListId]/contacts/flows/setup.page.tsx
@@ -8,7 +8,7 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { useTranslation } from 'react-i18next';
 import { v4 as uuidv4 } from 'uuid';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { colorMap } from 'src/components/Contacts/ContactFlow/ContactFlow';
 import { ContactFlowSetupColumn } from 'src/components/Contacts/ContactFlow/ContactFlowSetup/Column/ContactFlowSetupColumn';
 import { UnusedStatusesColumn } from 'src/components/Contacts/ContactFlow/ContactFlowSetup/Column/UnusedStatusesColumn';
@@ -228,6 +228,6 @@ const ContactFlowSetupPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default ContactFlowSetupPage;

--- a/pages/accountLists/[accountListId]/reports/coaching.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/coaching.page.tsx
@@ -1,7 +1,7 @@
 import Head from 'next/head';
 import React, { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import {
   AccountListTypeEnum,
   CoachingDetail,
@@ -32,6 +32,6 @@ const CoachingReportPage = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default CoachingReportPage;

--- a/pages/accountLists/[accountListId]/reports/designationAccounts.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/designationAccounts.page.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Box } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
 import Loading from 'src/components/Loading';
 import { DesignationAccountsReport } from 'src/components/Reports/DesignationAccountsReport/DesignationAccountsReport';
@@ -67,6 +67,6 @@ const DesignationAccountsReportPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default DesignationAccountsReportPage;

--- a/pages/accountLists/[accountListId]/reports/donations/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/donations/[[...contactId]].page.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { Box } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { DynamicContactsRightPanel } from 'src/components/Contacts/ContactsRightPanel/DynamicContactsRightPanel';
 import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
 import Loading from 'src/components/Loading';
@@ -89,6 +89,6 @@ const DonationsReportPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default DonationsReportPage;

--- a/pages/accountLists/[accountListId]/reports/expectedMonthlyTotal/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/expectedMonthlyTotal/[[...contactId]].page.tsx
@@ -4,7 +4,7 @@ import React, { ReactElement, useState } from 'react';
 import { Box } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { DynamicContactsRightPanel } from 'src/components/Contacts/ContactsRightPanel/DynamicContactsRightPanel';
 import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
 import Loading from 'src/components/Loading';
@@ -101,6 +101,6 @@ const ExpectedMonthlyTotalReportPage = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default ExpectedMonthlyTotalReportPage;

--- a/pages/accountLists/[accountListId]/reports/financialAccounts/[financialAccountId].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/financialAccounts/[financialAccountId].page.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import React, { useState } from 'react';
 import { Box } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
 import Loading from 'src/components/Loading';
 import { AccountSummary } from 'src/components/Reports/FinancialAccountsReport/AccountSummary/AccountSummary';
@@ -61,6 +61,6 @@ const FinancialAccountSummaryPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default FinancialAccountSummaryPage;

--- a/pages/accountLists/[accountListId]/reports/financialAccounts/[financialAccountId]/entries.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/financialAccounts/[financialAccountId]/entries.page.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import React, { ReactElement, useContext, useMemo } from 'react';
 import { Box } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
 import Loading from 'src/components/Loading';
 import { AccountTransactions } from 'src/components/Reports/FinancialAccountsReport/AccountTransactions/AccountTransactions';
@@ -168,6 +168,6 @@ const FinancialAccountsPage: React.FC = () => (
   </FinancialAccountsWrapper>
 );
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default FinancialAccountsPage;

--- a/pages/accountLists/[accountListId]/reports/financialAccounts/index.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/financialAccounts/index.page.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import React, { useState } from 'react';
 import { Box } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
 import Loading from 'src/components/Loading';
 import { FinancialAccounts } from 'src/components/Reports/FinancialAccountsReport/FinancialAccounts/FinancialAccounts';
@@ -64,6 +64,6 @@ const FinancialAccountsPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default FinancialAccountsPage;

--- a/pages/accountLists/[accountListId]/reports/partnerCurrency/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/partnerCurrency/[[...contactId]].page.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { Box } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { DynamicContactsRightPanel } from 'src/components/Contacts/ContactsRightPanel/DynamicContactsRightPanel';
 import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
 import Loading from 'src/components/Loading';
@@ -90,6 +90,6 @@ const PartnerCurrencyReportPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default PartnerCurrencyReportPage;

--- a/pages/accountLists/[accountListId]/reports/partnerGivingAnalysis/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/partnerGivingAnalysis/[[...contactId]].page.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useRef, useState } from 'react';
 import { sortBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { ReportContactFilterSetInput } from 'pages/api/graphql-rest.page.generated';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { ContactsProvider } from 'src/components/Contacts/ContactsContext/ContactsContext';
 import { DynamicContactsRightPanel } from 'src/components/Contacts/ContactsRightPanel/DynamicContactsRightPanel';
 import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
@@ -174,6 +174,6 @@ const PartnerGivingAnalysisReportPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default PartnerGivingAnalysisReportPage;

--- a/pages/accountLists/[accountListId]/reports/salaryCurrency/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/salaryCurrency/[[...contactId]].page.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { Box } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { DynamicContactsRightPanel } from 'src/components/Contacts/ContactsRightPanel/DynamicContactsRightPanel';
 import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
 import Loading from 'src/components/Loading';
@@ -90,6 +90,6 @@ const SalaryCurrencyReportPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default SalaryCurrencyReportPage;

--- a/pages/accountLists/[accountListId]/settings/integrations/index.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/integrations/index.page.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import { Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { ChalklineAccordion } from 'src/components/Settings/integrations/Chalkline/ChalklineAccordion';
 import { GoogleAccordion } from 'src/components/Settings/integrations/Google/GoogleAccordion';
 import { TheKeyAccordion } from 'src/components/Settings/integrations/Key/TheKeyAccordion';
@@ -120,6 +120,6 @@ const Integrations: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default Integrations;

--- a/pages/accountLists/[accountListId]/settings/manageAccounts.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/manageAccounts.page.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import React, { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { ManageAccountAccessAccordion } from 'src/components/Settings/Accounts/ManageAccountAccess/ManageAccountAccessAccordion';
 import { MergeAccountsAccordion } from 'src/components/Settings/Accounts/MergeAccounts/MergeAccountsAccordion';
 import { MergeSpouseAccountsAccordion } from 'src/components/Settings/Accounts/MergeSpouseAccounts/MergeSpouseAccountsAccordion';
@@ -50,6 +50,6 @@ const ManageAccounts = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default ManageAccounts;

--- a/pages/accountLists/[accountListId]/settings/manageCoaches.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/manageCoaches.page.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import React, { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { ManageCoachesAccessAccordion } from 'src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion';
 import { AccordionGroup } from 'src/components/Shared/Forms/Accordions/AccordionGroup';
 import { SettingsWrapper } from './Wrapper';
@@ -36,6 +36,6 @@ const ManageCoaching = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default ManageCoaching;

--- a/pages/accountLists/[accountListId]/settings/notifications.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/notifications.page.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import React from 'react';
 import { Box, Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { NotificationsTable } from 'src/components/Settings/notifications/NotificationsTable';
 import { SetupBanner } from 'src/components/Settings/preferences/SetupBanner';
 import { useSetupContext } from 'src/components/Setup/SetupProvider';
@@ -78,6 +78,6 @@ const Notifications: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default Notifications;

--- a/pages/accountLists/[accountListId]/settings/organizations.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/organizations.page.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, useEffect, useState } from 'react';
 import { Autocomplete, Box, Skeleton, TextField } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { ImpersonateUserAccordion } from 'src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion';
 import { ManageOrganizationAccessAccordion } from 'src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion';
 import { AccordionGroup } from 'src/components/Shared/Forms/Accordions/AccordionGroup';
@@ -139,6 +139,6 @@ const Organizations = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default Organizations;

--- a/pages/accountLists/[accountListId]/settings/organizations/accountLists.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/organizations/accountLists.page.tsx
@@ -11,7 +11,7 @@ import {
 import { styled } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { AccountLists } from 'src/components/Settings/Organization/AccountLists/AccountLists';
 import { useDebouncedValue } from 'src/hooks/useDebounce';
 import { SettingsWrapper } from '../Wrapper';
@@ -143,6 +143,6 @@ const AccountListsOrganizations = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default AccountListsOrganizations;

--- a/pages/accountLists/[accountListId]/settings/organizations/contacts.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/organizations/contacts.page.tsx
@@ -11,7 +11,7 @@ import {
 import { styled } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { Contacts } from 'src/components/Settings/Organization/Contacts/Contacts';
 import { useDebouncedValue } from 'src/hooks/useDebounce';
 import { SettingsWrapper } from '../Wrapper';
@@ -130,6 +130,6 @@ const OrganizationsContacts = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default OrganizationsContacts;

--- a/pages/accountLists/[accountListId]/settings/preferences.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/preferences.page.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { Box, Button, Skeleton } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { useGetUsersOrganizationsAccountsQuery } from 'src/components/Settings/integrations/Organization/Organizations.generated';
 import {
   useCanUserExportDataQuery,
@@ -343,6 +343,6 @@ const Preferences: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default Preferences;

--- a/pages/accountLists/[accountListId]/setup/finish.page.tsx
+++ b/pages/accountLists/[accountListId]/setup/finish.page.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
 import { Button } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { SetupPage } from 'src/components/Setup/SetupPage';
 import { LargeButton } from 'src/components/Setup/styledComponents';
 import { useAccountListId } from 'src/hooks/useAccountListId';
@@ -73,6 +73,6 @@ You can import from software like TntConnect, Google Contacts or a Spreadsheet.`
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default FinishPage;

--- a/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
@@ -7,7 +7,7 @@ import { Box, Button, ButtonGroup, Hidden } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { DateTime } from 'luxon';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { ContactsProvider } from 'src/components/Contacts/ContactsContext/ContactsContext';
 import { DynamicContactsRightPanel } from 'src/components/Contacts/ContactsRightPanel/DynamicContactsRightPanel';
 import { InfiniteList } from 'src/components/InfiniteList/InfiniteList';
@@ -411,6 +411,6 @@ const TasksPage: React.FC = () => {
   //#endregion
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default TasksPage;

--- a/pages/accountLists/[accountListId]/tools.page.tsx
+++ b/pages/accountLists/[accountListId]/tools.page.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import React, { ReactElement } from 'react';
 import { Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { SetupBanner } from 'src/components/Settings/preferences/SetupBanner';
 import { StickyBox } from 'src/components/Shared/Header/styledComponents';
 import ToolsHome from 'src/components/Tool/Home/ToolsHome';
@@ -43,6 +43,6 @@ const ToolsPage = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default ToolsPage;

--- a/pages/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]].page.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import AppealsDetailsPage from 'src/components/Tool/Appeal/AppealDetails/AppealsDetailsPage';
 import { ToolsWrapper } from '../../ToolsWrapper';
 import { AppealsWrapper } from '../AppealsWrapper';
@@ -29,4 +29,4 @@ const AppealsPage: React.FC = () => (
 
 export default AppealsPage;
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;

--- a/pages/accountLists/[accountListId]/tools/appeals/index.page.tsx
+++ b/pages/accountLists/[accountListId]/tools/appeals/index.page.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import AppealsInitialPage from 'src/components/Tool/Appeal/InitialPage/AppealsInitialPage';
 import { ToolsWrapper } from '../ToolsWrapper';
 
@@ -21,4 +21,4 @@ const AppealsPage = (): ReactElement => {
 
 export default AppealsPage;
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;

--- a/pages/accountLists/[accountListId]/tools/fix/commitmentInfo/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/commitmentInfo/[[...contactId]].page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import FixCommitmentInfo from 'src/components/Tool/FixCommitmentInfo/FixCommitmentInfo';
 import { ToolsWrapper } from '../../ToolsWrapper';
 import { useToolsHelper } from '../../useToolsHelper';
@@ -21,6 +21,6 @@ const FixCommitmentInfoPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default FixCommitmentInfoPage;

--- a/pages/accountLists/[accountListId]/tools/fix/emailAddresses/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/emailAddresses/[[...contactId]].page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { FixEmailAddresses } from 'src/components/Tool/FixEmailAddresses/FixEmailAddresses';
 import { ToolsWrapper } from '../../ToolsWrapper';
 import { useToolsHelper } from '../../useToolsHelper';
@@ -21,6 +21,6 @@ const FixEmailAddressesPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default FixEmailAddressesPage;

--- a/pages/accountLists/[accountListId]/tools/fix/mailingAddresses/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/mailingAddresses/[[...contactId]].page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import FixMailingAddresses from 'src/components/Tool/FixMailingAddresses/FixMailingAddresses';
 import { ToolsWrapper } from '../../ToolsWrapper';
 import { useToolsHelper } from '../../useToolsHelper';
@@ -21,6 +21,6 @@ const FixMailingAddressesPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default FixMailingAddressesPage;

--- a/pages/accountLists/[accountListId]/tools/fix/phoneNumbers/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/phoneNumbers/[[...contactId]].page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import FixPhoneNumbers from 'src/components/Tool/FixPhoneNumbers/FixPhoneNumbers';
 import { ToolsWrapper } from '../../ToolsWrapper';
 import { useToolsHelper } from '../../useToolsHelper';
@@ -21,6 +21,6 @@ const FixPhoneNumbersPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default FixPhoneNumbersPage;

--- a/pages/accountLists/[accountListId]/tools/fix/sendNewsletter/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/sendNewsletter/[[...contactId]].page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import FixSendNewsletter from 'src/components/Tool/FixSendNewsletter/FixSendNewsletter';
 import { ToolsWrapper } from '../../ToolsWrapper';
 import { useToolsHelper } from '../../useToolsHelper';
@@ -21,6 +21,6 @@ const FixSendNewsletterPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default FixSendNewsletterPage;

--- a/pages/accountLists/[accountListId]/tools/import/csv.page.tsx
+++ b/pages/accountLists/[accountListId]/tools/import/csv.page.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import {
   CsvImportProvider,
   CsvImportViewStepEnum,
@@ -78,6 +78,6 @@ const CsvHome: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default CsvHome;

--- a/pages/accountLists/[accountListId]/tools/import/google.page.tsx
+++ b/pages/accountLists/[accountListId]/tools/import/google.page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import Loading from 'src/components/Loading';
 import GoogleImport from 'src/components/Tool/GoogleImport/GoogleImport';
 import { useAccountListId } from 'src/hooks/useAccountListId';
@@ -26,6 +26,6 @@ const GoogleImportPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default GoogleImportPage;

--- a/pages/accountLists/[accountListId]/tools/import/tnt.page.tsx
+++ b/pages/accountLists/[accountListId]/tools/import/tnt.page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import Loading from 'src/components/Loading';
 import TntConnect from 'src/components/Tool/TntConnect/TntConnect';
 import { useAccountListId } from 'src/hooks/useAccountListId';
@@ -26,6 +26,6 @@ const TntConnectPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default TntConnectPage;

--- a/pages/accountLists/[accountListId]/tools/merge/contacts/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/merge/contacts/[[...contactId]].page.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import MergeContacts from 'src/components/Tool/MergeContacts/MergeContacts';
 import { ToolsWrapper } from '../../ToolsWrapper';
 import { useToolsHelper } from '../../useToolsHelper';
@@ -28,6 +28,6 @@ const MergeContactsPage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default MergeContactsPage;

--- a/pages/accountLists/[accountListId]/tools/merge/people/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/merge/people/[[...contactId]].page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { loadSession } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import MergePeople from 'src/components/Tool/MergePeople/MergePeople';
 import { ToolsWrapper } from '../../ToolsWrapper';
 import { useToolsHelper } from '../../useToolsHelper';
@@ -21,6 +21,6 @@ const MergePeoplePage: React.FC = () => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default MergePeoplePage;

--- a/pages/api/utils/pagePropsHelpers.test.ts
+++ b/pages/api/utils/pagePropsHelpers.test.ts
@@ -1,140 +1,192 @@
 import { GetServerSidePropsContext } from 'next';
 import { getSession } from 'next-auth/react';
 import { session } from '__tests__/fixtures/session';
+import makeSsrClient from 'src/lib/apollo/ssrClient';
 import {
   enforceAdmin,
-  loadSession,
+  ensureSessionAndAccountList,
   loginRedirect,
   makeGetServerSideProps,
 } from './pagePropsHelpers';
 
 jest.mock('next-auth/react');
+jest.mock('src/lib/apollo/ssrClient', () => jest.fn());
 
 const context = {
+  req: {},
   query: { accountListId: 'account-list-1' },
   resolvedUrl: '/page?param=value',
 } as unknown as GetServerSidePropsContext;
 
-describe('loginRedirect', () => {
-  it('returns redirect with current URL', () => {
-    expect(loginRedirect(context)).toEqual({
-      redirect: {
-        destination: '/login?redirect=%2Fpage%3Fparam%3Dvalue',
-        permanent: false,
-      },
-    });
-  });
-});
-
-describe('enforceAdmin', () => {
-  it('does not return a redirect if the user is an admin', async () => {
-    (getSession as jest.Mock).mockResolvedValue({ user: { admin: true } });
-
-    await expect(enforceAdmin(context)).resolves.not.toMatchObject({
-      redirect: {},
+describe('pagePropsHelpers', () => {
+  describe('loginRedirect', () => {
+    it('returns redirect with current URL', () => {
+      expect(loginRedirect(context)).toEqual({
+        redirect: {
+          destination: '/login?redirect=%2Fpage%3Fparam%3Dvalue',
+          permanent: false,
+        },
+      });
     });
   });
 
-  it('returns a redirect if the user is not an admin', async () => {
-    (getSession as jest.Mock).mockResolvedValue({ user: { admin: false } });
+  describe('enforceAdmin', () => {
+    it('does not return a redirect if the user is an admin', async () => {
+      (getSession as jest.Mock).mockResolvedValue({ user: { admin: true } });
 
-    await expect(enforceAdmin(context)).resolves.toMatchObject({
-      redirect: {
-        destination: '/accountLists/account-list-1',
-      },
+      await expect(enforceAdmin(context)).resolves.not.toMatchObject({
+        redirect: {},
+      });
     });
-  });
-});
 
-describe('loadSession', () => {
-  it('does not return a redirect if the user is logged in', async () => {
-    const user = { apiToken: 'token' };
-    (getSession as jest.Mock).mockResolvedValue({ user });
+    it('returns a redirect if the user is not an admin', async () => {
+      (getSession as jest.Mock).mockResolvedValue({ user: { admin: false } });
 
-    await expect(loadSession(context)).resolves.toMatchObject({
-      props: {
-        session: { user },
-      },
+      await expect(enforceAdmin(context)).resolves.toMatchObject({
+        redirect: {
+          destination: '/accountLists/account-list-1',
+        },
+      });
     });
   });
 
-  it('returns a redirect if the user is not logged in', async () => {
-    (getSession as jest.Mock).mockResolvedValue(null);
+  describe('ensureSessionAndAccountList', () => {
+    it('does not return a redirect if the user is logged in', async () => {
+      const user = { apiToken: 'token' };
+      (getSession as jest.Mock).mockResolvedValue({ user });
 
-    await expect(loadSession(context)).resolves.toMatchObject({
-      redirect: {
-        destination: '/login?redirect=%2Fpage%3Fparam%3Dvalue',
-      },
+      await expect(ensureSessionAndAccountList(context)).resolves.toMatchObject(
+        {
+          props: {
+            session: { user },
+          },
+        },
+      );
+    });
+
+    it('returns a redirect if the user is not logged in', async () => {
+      (getSession as jest.Mock).mockResolvedValue(null);
+
+      await expect(ensureSessionAndAccountList(context)).resolves.toMatchObject(
+        {
+          redirect: {
+            destination: '/login?redirect=%2Fpage%3Fparam%3Dvalue',
+          },
+        },
+      );
+    });
+
+    describe('redirects to the default account list if the URL contains "_"', () => {
+      const context = {
+        req: { url: '/accountLists/_/contacts' },
+        resolvedUrl: '/filters?param=value',
+      } as unknown as GetServerSidePropsContext;
+      beforeEach(() => {
+        const user = { apiToken: 'token' };
+        (getSession as jest.Mock).mockResolvedValue({ user });
+        const query = jest.fn().mockResolvedValueOnce({
+          data: {
+            user: {
+              defaultAccountList: 'defaultAccountList',
+            },
+          },
+        });
+        (makeSsrClient as jest.Mock).mockReturnValue({
+          query: query,
+        });
+      });
+
+      it('redirects to the contacts page with default account list', async () => {
+        await expect(
+          ensureSessionAndAccountList(context),
+        ).resolves.toMatchObject({
+          redirect: {
+            destination: '/accountLists/defaultAccountList/contacts',
+          },
+        });
+      });
+
+      it('redirects to dashboard with default account list"', async () => {
+        await expect(
+          ensureSessionAndAccountList({
+            req: { url: '/accountLists/_' },
+          } as unknown as GetServerSidePropsContext),
+        ).resolves.toMatchObject({
+          redirect: {
+            destination: '/accountLists/defaultAccountList',
+          },
+        });
+      });
     });
   });
-});
 
-describe('makeGetServerSideProps', () => {
-  it('redirects to the login page if the session is missing', async () => {
-    (getSession as jest.Mock).mockResolvedValue(null);
+  describe('makeGetServerSideProps', () => {
+    it('redirects to the login page if the session is missing', async () => {
+      (getSession as jest.Mock).mockResolvedValue(null);
 
-    const getServerSidePropsFromSession = jest.fn();
-    const getServerSideProps = makeGetServerSideProps(
-      getServerSidePropsFromSession,
-    );
+      const getServerSidePropsFromSession = jest.fn();
+      const getServerSideProps = makeGetServerSideProps(
+        getServerSidePropsFromSession,
+      );
 
-    await expect(getServerSideProps(context)).resolves.toEqual({
-      redirect: {
-        destination: '/login?redirect=%2Fpage%3Fparam%3Dvalue',
-        permanent: false,
-      },
+      await expect(getServerSideProps(context)).resolves.toEqual({
+        redirect: {
+          destination: '/login?redirect=%2Fpage%3Fparam%3Dvalue',
+          permanent: false,
+        },
+      });
+      expect(getServerSidePropsFromSession).not.toHaveBeenCalled();
     });
-    expect(getServerSidePropsFromSession).not.toHaveBeenCalled();
-  });
 
-  it('calls the custom function and adds the session to the returned props', async () => {
-    (getSession as jest.Mock).mockResolvedValue(session);
+    it('calls the custom function and adds the session to the returned props', async () => {
+      (getSession as jest.Mock).mockResolvedValue(session);
 
-    const getServerSidePropsFromSession = jest.fn().mockResolvedValue({
-      props: {
-        data1: 1,
-        dataA: 'A',
-      },
-    });
-    const getServerSideProps = makeGetServerSideProps(
-      getServerSidePropsFromSession,
-    );
+      const getServerSidePropsFromSession = jest.fn().mockResolvedValue({
+        props: {
+          data1: 1,
+          dataA: 'A',
+        },
+      });
+      const getServerSideProps = makeGetServerSideProps(
+        getServerSidePropsFromSession,
+      );
 
-    await expect(getServerSideProps(context)).resolves.toEqual({
-      props: {
+      await expect(getServerSideProps(context)).resolves.toEqual({
+        props: {
+          session,
+          data1: 1,
+          dataA: 'A',
+        },
+      });
+      expect(getServerSidePropsFromSession).toHaveBeenCalledWith(
         session,
-        data1: 1,
-        dataA: 'A',
-      },
+        context,
+      );
     });
-    expect(getServerSidePropsFromSession).toHaveBeenCalledWith(
-      session,
-      context,
-    );
-  });
 
-  it('calls the custom function and passes through redirects', async () => {
-    (getSession as jest.Mock).mockResolvedValue(session);
+    it('calls the custom function and passes through redirects', async () => {
+      (getSession as jest.Mock).mockResolvedValue(session);
 
-    const getServerSidePropsFromSession = jest.fn().mockResolvedValue({
-      redirect: {
-        destination: '/new/url',
-        permanent: false,
-      },
+      const getServerSidePropsFromSession = jest.fn().mockResolvedValue({
+        redirect: {
+          destination: '/new/url',
+          permanent: false,
+        },
+      });
+      const getServerSideProps = makeGetServerSideProps(
+        getServerSidePropsFromSession,
+      );
+
+      await expect(getServerSideProps(context)).resolves.toEqual({
+        redirect: {
+          destination: '/new/url',
+          permanent: false,
+        },
+      });
+      expect(getServerSidePropsFromSession).toHaveBeenCalledWith(
+        session,
+        context,
+      );
     });
-    const getServerSideProps = makeGetServerSideProps(
-      getServerSidePropsFromSession,
-    );
-
-    await expect(getServerSideProps(context)).resolves.toEqual({
-      redirect: {
-        destination: '/new/url',
-        permanent: false,
-      },
-    });
-    expect(getServerSidePropsFromSession).toHaveBeenCalledWith(
-      session,
-      context,
-    );
   });
 });

--- a/pages/logout.page.tsx
+++ b/pages/logout.page.tsx
@@ -8,7 +8,7 @@ import { signOut } from 'next-auth/react';
 import { useTranslation } from 'react-i18next';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
 import { clearDataDogUser } from 'src/lib/dataDog';
-import { loadSession } from './api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from './api/utils/pagePropsHelpers';
 
 const BoxWrapper = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.cruGrayLight.main,
@@ -51,6 +51,6 @@ const LogoutPage = ({}): ReactElement => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default LogoutPage;

--- a/pages/setup/connect.page.tsx
+++ b/pages/setup/connect.page.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Connect } from 'src/components/Setup/Connect';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
-import { loadSession } from '../api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from '../api/utils/pagePropsHelpers';
 
 // This is the second page of the setup tour. It lets users connect to
 // organizations. It will be shown if the user doesn't have any organization
@@ -22,6 +22,6 @@ const ConnectPage = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default ConnectPage;

--- a/pages/setup/start.page.tsx
+++ b/pages/setup/start.page.tsx
@@ -12,7 +12,7 @@ import {
 } from 'src/components/Shared/Links/Links';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
 import { formatLanguage, languages } from 'src/lib/data/languages';
-import { loadSession } from '../api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from '../api/utils/pagePropsHelpers';
 
 // This is the first page of the tour, and it lets users choose their language. It is always shown.
 const StartPage = (): ReactElement => {
@@ -92,6 +92,6 @@ const StartPage = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = loadSession;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default StartPage;


### PR DESCRIPTION
## Description

The `loadSession` function has been updated to automatically redirect users to their default `accountListID` when the placeholder `_` is detected.

This enhancement enables the sharing of links with users without requiring knowledge of their specific `accountListID`.

For example, a link like `https://mpdx.org/accountLists/_/reports/salaryCurrency` will seamlessly redirect the user to the correct account list context.


Test:
https://salary-page-error.d3dytjb8adxkk5.amplifyapp.com/accountLists/_/contacts?filters=%257B%2522status%2522%253A%255B%2522NEVER_CONTACTED%2522%255D%257D

https://salary-page-error.d3dytjb8adxkk5.amplifyapp.com/accountLists/_/settings/preferences

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
