### PR TITLE
MPDX-8496 - Replace hard coded emails with env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Note: there is a test account you can use. Get this from another developer if yo
 - `HELP_URL_SETUP_FIND_ORGANIZATION` - Link to an article explaining how to find an organization
 - `PRIVACY_POLICY_URL` - URL of the privacy policy
 - `TERMS_OF_USE_URL` - URL of the terms of use
+- `DATA_PRIVACY_EMAIL` - Email address for requesting data privacy actions, such as the removal of anonymized contact data across all systems.
+- `DONATION_SERVICES_EMAIL` - Email address for contacting Donation Services.
 
 #### Auth provider
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -86,7 +86,7 @@ const config: NextConfig = {
     PRIVACY_POLICY_URL: process.env.PRIVACY_POLICY_URL,
     TERMS_OF_USE_URL: process.env.TERMS_OF_USE_URL,
     DD_ENV: process.env.DD_ENV ?? 'development',
-    SERVICE_SUPPORT_EMAIL: process.env.SERVICE_SUPPORT_EMAIL ?? 'dsar@cru.org',
+    DATA_PRIVACY_EMAIL: process.env.DATA_PRIVACY_EMAIL ?? 'dsar@cru.org',
     DONATION_SERVICES_EMAIL:
       process.env.DONATION_SERVICES_EMAIL ?? 'donation.services@cru.org',
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -86,6 +86,9 @@ const config: NextConfig = {
     PRIVACY_POLICY_URL: process.env.PRIVACY_POLICY_URL,
     TERMS_OF_USE_URL: process.env.TERMS_OF_USE_URL,
     DD_ENV: process.env.DD_ENV ?? 'development',
+    SERVICE_SUPPORT_EMAIL: process.env.SERVICE_SUPPORT_EMAIL ?? 'dsar@cru.org',
+    DONATION_SERVICES_EMAIL:
+      process.env.DONATION_SERVICES_EMAIL ?? 'donation.services@cru.org',
   },
   // Force .page prefix on page files (ex. index.page.tsx) so generated files can be included in /pages directory without Next.js throwing build errors
   pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/ContactSource.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/ContactSource.graphql
@@ -1,7 +1,8 @@
-query ContactSource($accountListId: ID!, $contactId: ID!) {
+query Contact($accountListId: ID!, $contactId: ID!) {
   contact(accountListId: $accountListId, id: $contactId) {
     id
     name
+    donorAccountIds
     source
     addresses {
       nodes {

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/ContactSource.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/ContactSource.graphql
@@ -1,6 +1,7 @@
 query ContactSource($accountListId: ID!, $contactId: ID!) {
   contact(accountListId: $accountListId, id: $contactId) {
     id
+    name
     source
     addresses {
       nodes {

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/ContactSource.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/ContactSource.graphql
@@ -2,7 +2,15 @@ query Contact($accountListId: ID!, $contactId: ID!) {
   contact(accountListId: $accountListId, id: $contactId) {
     id
     name
-    donorAccountIds
+    contactDonorAccounts(first: 25) {
+      nodes {
+        id
+        donorAccount {
+          id
+          accountNumber
+        }
+      }
+    }
     source
     addresses {
       nodes {

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/DeleteContactModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/DeleteContactModal.test.tsx
@@ -8,7 +8,7 @@ import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { ContactSourceEnum } from 'src/graphql/types.generated';
 import theme from 'src/theme';
-import { ContactSourceQuery } from './ContactSource.generated';
+import { ContactQuery } from './ContactSource.generated';
 import { DeleteContactModal } from './DeleteContactModal';
 
 const contactId = 'contact-id';
@@ -38,10 +38,10 @@ const TestComponent: React.FC<TestComponentProps> = ({
       <TestRouter router={{ query: { accountListId: 'accountListId' } }}>
         <ThemeProvider theme={theme}>
           <GqlMockedProvider<{
-            ContactSource: ContactSourceQuery;
+            Contact: ContactQuery;
           }>
             mocks={{
-              ContactSource: {
+              Contact: {
                 contact: {
                   id: contactId,
                   source: contactSource,
@@ -100,7 +100,7 @@ describe('DeleteContactModal', () => {
     const { getByText, getByRole } = render(<TestComponent />);
 
     await waitFor(() => {
-      expect(mutationSpy).toHaveGraphqlOperation('ContactSource');
+      expect(mutationSpy).toHaveGraphqlOperation('Contact');
     });
 
     expect(
@@ -114,7 +114,7 @@ describe('DeleteContactModal', () => {
     const { getByRole } = render(<TestComponent deleting={true} />);
 
     await waitFor(() => {
-      expect(mutationSpy).toHaveGraphqlOperation('ContactSource');
+      expect(mutationSpy).toHaveGraphqlOperation('Contact');
     });
 
     expect(getByRole('button', { name: 'delete contact' })).toBeDisabled();
@@ -204,7 +204,7 @@ describe('DeleteContactModal', () => {
       );
 
       await waitFor(() => {
-        expect(mutationSpy).toHaveGraphqlOperation('ContactSource');
+        expect(mutationSpy).toHaveGraphqlOperation('Contact');
       });
 
       expect(

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/DeleteContactModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/DeleteContactModal.tsx
@@ -26,12 +26,31 @@ const LoadingIndicator = styled(CircularProgress)(({ theme }) => ({
   margin: theme.spacing(0, 1, 0, 0),
 }));
 
+interface CreateEmailLinkProps {
+  partnerAccountNumbers: string[];
+  contactName: string;
+}
+export const createEmailLink = ({
+  partnerAccountNumbers,
+  contactName,
+}: CreateEmailLinkProps) => {
+  return `mailto:${
+    process.env.DONATION_SERVICES_EMAIL
+  }?subject=Request+contact+deletion&body=${encodeURIComponent(
+    'Dear Donation Services,\nPlease could you remove the following contact:' +
+      `\n\nContact name: ${contactName}` +
+      `\nContact's partner numbers: ${partnerAccountNumbers.join(', ')}` +
+      '\n\nThanks,\n\n',
+  )}`;
+};
+
 interface DataInfo {
   canDeleteWithoutIssues: boolean;
   contactSource: string;
   addressSources: string[];
   emailSources: string[];
   phoneSources: string[];
+  emailLink: string;
 }
 interface DeleteContactModalProps {
   open: boolean;
@@ -65,6 +84,7 @@ export const DeleteContactModal: React.FC<DeleteContactModalProps> = ({
         addressSources: [],
         emailSources: [],
         phoneSources: [],
+        emailLink: '',
       };
     }
 
@@ -95,6 +115,9 @@ export const DeleteContactModal: React.FC<DeleteContactModalProps> = ({
         }
       });
     });
+    const partnerAccountNumbers = contact.contactDonorAccounts.nodes.map(
+      ({ donorAccount }) => donorAccount.accountNumber,
+    );
 
     return {
       canDeleteWithoutIssues:
@@ -108,6 +131,10 @@ export const DeleteContactModal: React.FC<DeleteContactModalProps> = ({
       ),
       emailSources: [...emailSources].map((source) => sourceToStr(t, source)),
       phoneSources: [...phoneSources].map((source) => sourceToStr(t, source)),
+      emailLink: createEmailLink({
+        partnerAccountNumbers,
+        contactName: contact.name,
+      }),
     };
   }, [contact]);
 
@@ -135,19 +162,7 @@ export const DeleteContactModal: React.FC<DeleteContactModalProps> = ({
               {t(
                 `For contacts originating from Donation Services or DonorHub, `,
               )}
-              <Link
-                href={`mailto:${
-                  process.env.DONATION_SERVICES_EMAIL
-                }?subject=Request+contact+deletion&body=${encodeURIComponent(
-                  'Dear Donation Services,\nPlease could you remove the following contact:' +
-                    `\n\nContact name: ${contact?.name}` +
-                    `\nContact's partner numbers': ${contact?.donorAccountIds?.join(
-                      ', ',
-                    )}` +
-                    '\n\nThanks,\n\n',
-                )}`}
-                sx={{ fontWeight: 'bold' }}
-              >
+              <Link href={dataInfo.emailLink} sx={{ fontWeight: 'bold' }}>
                 {t('email Donation Services to request deletion.')}
               </Link>
             </Typography>

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/DeleteContactModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/DeleteContactModal.tsx
@@ -4,6 +4,7 @@ import {
   CircularProgress,
   DialogActions,
   DialogContent,
+  Link,
   List,
   ListItem,
   ListItemIcon,
@@ -55,6 +56,7 @@ export const DeleteContactModal: React.FC<DeleteContactModalProps> = ({
     skip: !open && !contactId,
   });
   const contactSources = data?.contact;
+  const contactName = data?.contact?.name;
 
   const dataInfo: DataInfo = useMemo(() => {
     if (!contactSources) {
@@ -136,7 +138,6 @@ export const DeleteContactModal: React.FC<DeleteContactModalProps> = ({
               )}
             </Typography>
             <br />
-            <br />
             <Typography variant="h6">{t('Data sources:')}</Typography>
             <List dense={true}>
               {!!dataInfo.contactSource && (
@@ -187,6 +188,21 @@ export const DeleteContactModal: React.FC<DeleteContactModalProps> = ({
                 </ListItem>
               )}
             </List>
+            <br />
+            <Typography>
+              <Link
+                href={`mailto:${
+                  process.env.DONATION_SERVICES_EMAIL
+                }?subject=Request+contact+deletion&body=${encodeURIComponent(
+                  `Dear Donation Services,\n\Please could you remove the following contact: ${contactName} ` +
+                    '\n\nThanks,\n\n',
+                )}`}
+                underline="hover"
+                sx={{ fontWeight: 'bold' }}
+              >
+                {t('Email Donation Services here')}
+              </Link>
+            </Typography>
           </>
         )}
       </DialogContent>

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.tsx
@@ -236,7 +236,9 @@ export const EditContactAddressModal: React.FC<
                         {emailData && (
                           <p>
                             <Link
-                              href={`mailto:donation.services@cru.org?subject=Donor+address+change&body=${encodeURIComponent(
+                              href={`mailto:${
+                                process.env.DONATION_SERVICES_EMAIL
+                              }?subject=Donor+address+change&body=${encodeURIComponent(
                                 generateEmailBody(emailData, address),
                               )}`}
                               underline="hover"

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.tsx
@@ -241,7 +241,6 @@ export const EditContactAddressModal: React.FC<
                               }?subject=Donor+address+change&body=${encodeURIComponent(
                                 generateEmailBody(emailData, address),
                               )}`}
-                              underline="hover"
                               sx={{ fontWeight: 'bold' }}
                             >
                               {t('Email Donation Services here')}

--- a/src/components/Settings/Organization/Contacts/ContactRow/ContactRow.tsx
+++ b/src/components/Settings/Organization/Contacts/ContactRow/ContactRow.tsx
@@ -238,7 +238,7 @@ export const ContactRow: React.FC<Props> = ({ contact }) => {
             defaults="<p>This contact will be anonymized in your {{appName}} organization. This is permanent and can't be recovered. Only anonymize if you are 100% confident that you are looking at the correct contact.</p><br /><p>A contact placeholder will remain with a name like “DataPrivacy, Deleted”. Gift data will remain. Other data such as notes and tasks will be removed. Status will be set as “Never Ask”. Newsletter set to 'N/A'. You can request removal across all other systems at {{serviceSupportEmail}}.</p>"
             values={{
               appName,
-              serviceSupportEmail: process.env.SERVICE_SUPPORT_EMAIL,
+              serviceSupportEmail: process.env.DATA_PRIVACY_EMAIL,
             }}
             shouldUnescape={true}
           />

--- a/src/components/Settings/Organization/Contacts/ContactRow/ContactRow.tsx
+++ b/src/components/Settings/Organization/Contacts/ContactRow/ContactRow.tsx
@@ -235,9 +235,10 @@ export const ContactRow: React.FC<Props> = ({ contact }) => {
         message={
           <Trans
             t={t}
-            defaults="<p>This contact will be anonymized in your {{appName}} organization. This is permanent and can't be recovered. Only anonymize if you are 100% confident that you are looking at the correct contact.</p><br /><p>A contact placeholder will remain with a name like “DataPrivacy, Deleted”. Gift data will remain. Other data such as notes and tasks will be removed. Status will be set as “Never Ask”. Newsletter set to 'N/A'. You can request removal across all other systems at dsar@cru.org.</p>"
+            defaults="<p>This contact will be anonymized in your {{appName}} organization. This is permanent and can't be recovered. Only anonymize if you are 100% confident that you are looking at the correct contact.</p><br /><p>A contact placeholder will remain with a name like “DataPrivacy, Deleted”. Gift data will remain. Other data such as notes and tasks will be removed. Status will be set as “Never Ask”. Newsletter set to 'N/A'. You can request removal across all other systems at {{serviceSupportEmail}}.</p>"
             values={{
               appName,
+              serviceSupportEmail: process.env.SERVICE_SUPPORT_EMAIL,
             }}
             shouldUnescape={true}
           />


### PR DESCRIPTION
## Description
Remove all hardcoded emails from MPDX and replace them with variables so non-Cru organisations can use their emails without editing the source code.

We don't need to add any new variables to our Amplify as the default values are the ones we use.

This was spotted on Jira task [MPDX-8492](https://jira.cru.org/browse/MPDX-8492) and PR https://github.com/CruGlobal/mpdx-react/pull/1216



## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
