### PR TITLE
MPDX-8506 - Prevent hydration errors being sent to RollBar

### DIFF
--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -85,7 +85,7 @@ const App = ({
   const { session } = pageProps;
   const rollbarConfig: Rollbar.Configuration = {
     accessToken: process.env.ROLLBAR_ACCESS_TOKEN,
-    environment: 'react_' + process.env.NODE_ENV,
+    environment: `react_${process.env.NODE_ENV}`,
     codeVersion: React.version,
     captureUncaught: true,
     captureUnhandledRejections: true,
@@ -96,8 +96,16 @@ const App = ({
         },
       },
     },
-    enabled: !!process.env.ROLLBAR_ACCESS_TOKEN,
+    enabled: Boolean(process.env.ROLLBAR_ACCESS_TOKEN),
+    checkIgnore: (_, args) =>
+      // Ignore React hydration warnings
+      [
+        'Minified React error #418',
+        'Minified React error #423',
+        'Minified React error #425',
+      ].some((error) => typeof args[0] === 'string' && args[0].includes(error)),
   };
+
   const emotionCache = createEmotionCache({ key: 'css' });
 
   if (!session && !nonAuthenticatedPages.has(router.pathname)) {


### PR DESCRIPTION
## Description
Due to the amount of errors being sent to RollBar regarding hydration and it maxing out our log rate limit, we need to prevent them from being sent to Rollbar.

In this PR, I add a check to prevent any logs regarding hydration from being sent to Rollbar.


![Screenshot 2024-12-19 at 8 31 13 AM](https://github.com/user-attachments/assets/3b7bd19c-7a69-469e-95ed-5facbf8272ec)

We might just be able to get away with ignoring `Minified React error` and not have to worry about `Expected server HTML` since that only shows locally.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
