### PR TITLE
[no-Jira] Disable Dependabot PRs for non-security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,5 @@ updates:
       interval: daily
     reviewers:
       - CruGlobal/web-engineering-js
-    pull-request-branch-name:
-      separator: '-'
     # Disable version updates while still allowing security updates
     open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
       - CruGlobal/web-engineering-js
     pull-request-branch-name:
       separator: '-'
+    # Disable version updates while still allowing security updates
+    open-pull-requests-limit: 0

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,7 +22,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_GITHUB_ACTIONS_ROLE }}
           output-credentials: true
       - name: deploy PR preview
-        uses: CruGlobal/amplify-preview-actions@handle-existing-branches
+        uses: CruGlobal/amplify-preview-actions@sed-replace-all
         with:
           branch_name: ${{ github.head_ref }}
           amplify_command: deploy


### PR DESCRIPTION
## Description

* Prevent Dependabot from creating PRs for package updates that aren't vulnerable. This config would have prevented PRs like #1235, #1236, #1237, #1238 from being created.
* Update the GitHub workflow to replace all instances of invalid URL characters with dashes in the Amplify Preview URL comment instead of just the first.

@dr-bizz Let me know if you like those PRs, but I was thinking that we ignore them so they don't add noise and we can focus on Dependabot updates that resolve security vulnerabilities.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
