### PR TITLE
[no-Jira] Fix currency preference help text

### DIFF
--- a/src/components/Settings/preferences/accordions/CurrencyAccordion/CurrencyAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/CurrencyAccordion/CurrencyAccordion.tsx
@@ -99,7 +99,7 @@ export const CurrencyAccordion: React.FC<CurrencyAccordionProps> = ({
           >
             <FieldWrapper
               helperText={t(
-                'This should be the place from which you are living and sending out physical communications. This will be used in exports for mailing address information.',
+                'This should be the currency that you receive your paychecks in. This will be used when converting donations in other currencies.',
               )}
             >
               <Autocomplete


### PR DESCRIPTION
## Description

The currency preference help text was a copy/paste of the home country preference.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
