### PR TITLE
HS-1278785 Stop filtering out contacts who have their primary person deceased

### DIFF
--- a/src/components/Tool/FixSendNewsletter/FixSendNewsletter.test.tsx
+++ b/src/components/Tool/FixSendNewsletter/FixSendNewsletter.test.tsx
@@ -67,7 +67,6 @@ const TestComponent = ({
 describe('FixSendNewsletter', () => {
   const contacts =
     mockInvalidNewslettersResponse.InvalidNewsletter.contacts.nodes;
-  const deceasedName = contacts[2].name;
   const firstContactName = contacts[0].name;
   const secondContactName = contacts[1].name;
   const initialNewsletterValue = 'None';
@@ -118,26 +117,7 @@ describe('FixSendNewsletter', () => {
       );
 
       await waitFor(() => {
-        expect(getByRole('button', { name: 'Confirm All (2)' })).toBeVisible();
-      });
-    });
-
-    it('should not show deceased contacts', async () => {
-      const { queryByRole, queryByText } = render(
-        <TestComponent
-          mocks={{
-            InvalidNewsletter: {
-              ...mockInvalidNewslettersResponse.InvalidNewsletter,
-            },
-          }}
-        />,
-      );
-
-      await waitFor(() =>
-        expect(queryByRole('progressbar')).not.toBeInTheDocument(),
-      );
-      await waitFor(() => {
-        expect(queryByText(deceasedName)).not.toBeInTheDocument();
+        expect(getByRole('button', { name: 'Confirm All (3)' })).toBeVisible();
       });
     });
   });
@@ -224,33 +204,6 @@ describe('FixSendNewsletter', () => {
         );
       });
     });
-
-    it('should filter out deceased', async () => {
-      const { getAllByRole, queryByText, queryByRole, getByText } = render(
-        <TestComponent
-          mocks={{
-            InvalidNewsletter: {
-              ...mockInvalidNewslettersResponse.InvalidNewsletter,
-            },
-            UpdateContactNewsletter: {
-              ...mockUploadNewsletterChange.UpdateContactNewsletter,
-            },
-          }}
-        />,
-      );
-      await waitFor(() =>
-        expect(queryByRole('progressbar')).not.toBeInTheDocument(),
-      );
-
-      const newsletterDropdown = getAllByRole('combobox')[0];
-      userEvent.click(newsletterDropdown);
-      userEvent.click(getByText(newNewsletterValue));
-      userEvent.click(getAllByRole('button', { name: 'Confirm' })[0]);
-      await waitFor(() => {
-        expect(queryByText(deceasedName)).not.toBeInTheDocument();
-        expect(queryByText(secondContactName)).toBeInTheDocument();
-      });
-    });
   });
 
   describe('bulk confirm', () => {
@@ -287,7 +240,7 @@ describe('FixSendNewsletter', () => {
       userEvent.click(
         getByRole('option', { name: secondContactNewNewsletterValue }),
       );
-      userEvent.click(getByText('Confirm All (2)'));
+      userEvent.click(getByText('Confirm All (3)'));
       userEvent.click(getByRole('button', { name: 'Yes' }));
     };
 
@@ -309,7 +262,7 @@ describe('FixSendNewsletter', () => {
         expect(queryByRole('progressbar')).not.toBeInTheDocument(),
       );
 
-      userEvent.click(getByRole('button', { name: 'Confirm All (2)' }));
+      userEvent.click(getByRole('button', { name: 'Confirm All (3)' }));
 
       await waitFor(() => {
         expect(
@@ -372,12 +325,17 @@ describe('FixSendNewsletter', () => {
               accountListId: 'account-id',
               attributes: [
                 {
-                  id: 'contactId2',
-                  sendNewsletter: SendNewsletterEnum.Both,
+                  id: 'contactId3',
+                  sendNewsletter: SendNewsletterEnum.None,
                 },
+
                 {
                   id: 'contactId1',
                   sendNewsletter: SendNewsletterEnum.Physical,
+                },
+                {
+                  id: 'contactId2',
+                  sendNewsletter: SendNewsletterEnum.Both,
                 },
               ],
             },

--- a/src/components/Tool/FixSendNewsletter/FixSendNewsletter.test.tsx
+++ b/src/components/Tool/FixSendNewsletter/FixSendNewsletter.test.tsx
@@ -328,7 +328,6 @@ describe('FixSendNewsletter', () => {
                   id: 'contactId3',
                   sendNewsletter: SendNewsletterEnum.None,
                 },
-
                 {
                   id: 'contactId1',
                   sendNewsletter: SendNewsletterEnum.Physical,

--- a/src/components/Tool/FixSendNewsletter/FixSendNewsletter.tsx
+++ b/src/components/Tool/FixSendNewsletter/FixSendNewsletter.tsx
@@ -156,7 +156,7 @@ const FixSendNewsletter: React.FC<Props> = ({ accountListId }: Props) => {
                     defaults="<i>Showing <bold>{{numberOfContacts}}</bold> of <bold>{{totalCount}}</bold></i>"
                     shouldUnescape
                     values={{
-                      numberOfContactsShowing,
+                      numberOfContacts: numberOfContactsShowing,
                       totalCount,
                     }}
                     components={{ bold: <strong />, i: <i /> }}

--- a/src/components/Tool/FixSendNewsletter/FixSendNewsletter.tsx
+++ b/src/components/Tool/FixSendNewsletter/FixSendNewsletter.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { Box, Button, Grid, Typography } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import { Trans, useTranslation } from 'react-i18next';
@@ -55,18 +55,9 @@ const FixSendNewsletter: React.FC<Props> = ({ accountListId }: Props) => {
     variables: { accountListId },
   });
   const totalCount = data?.contacts.totalCount;
-  let numberOfContacts = data?.contacts.nodes?.length ?? 0;
+  const contactsToFix = data?.contacts.nodes;
+  const numberOfContactsShowing = contactsToFix?.length ?? 0;
 
-  const contactsToFix = useMemo(
-    () =>
-      data?.contacts?.nodes.filter(
-        (contact) => !contact?.primaryPerson?.deceased,
-      ),
-    [data],
-  );
-  if (contactsToFix) {
-    numberOfContacts = contactsToFix?.length;
-  }
   const [updateNewsletter, { loading: updating }] =
     useUpdateContactNewsletterMutation();
   const [contactUpdates, setContactUpdates] = useState<ContactUpdateData[]>([]);
@@ -156,7 +147,7 @@ const FixSendNewsletter: React.FC<Props> = ({ accountListId }: Props) => {
             </Typography>
           </Box>
         </Grid>
-        {!loading && data && !!numberOfContacts ? (
+        {!loading && data && !!numberOfContactsShowing ? (
           <>
             <StickyButtonHeaderBox mb={0}>
               <Box>
@@ -165,7 +156,7 @@ const FixSendNewsletter: React.FC<Props> = ({ accountListId }: Props) => {
                     defaults="<i>Showing <bold>{{numberOfContacts}}</bold> of <bold>{{totalCount}}</bold></i>"
                     shouldUnescape
                     values={{
-                      numberOfContacts,
+                      numberOfContactsShowing,
                       totalCount,
                     }}
                     components={{ bold: <strong />, i: <i /> }}
@@ -177,14 +168,14 @@ const FixSendNewsletter: React.FC<Props> = ({ accountListId }: Props) => {
                 <Button
                   variant="contained"
                   onClick={() => setShowBulkConfirmModal(true)}
-                  disabled={updating || !numberOfContacts}
+                  disabled={updating || !numberOfContactsShowing}
                   sx={{ mr: 2 }}
                 >
                   {
                     <Trans
                       defaults="Confirm All ({{value}})"
                       values={{
-                        value: numberOfContacts,
+                        value: numberOfContactsShowing,
                       }}
                     />
                   }


### PR DESCRIPTION
## Description
https://secure.helpscout.net/conversation/2799104265/1278785?viewId=7669074

Problem:
- The user had a contact with a primary person who was deceased. The Fix Send Newsletter page is incorrectly filtering out contacts based on the primary person's deceased status. Contacts should only be hidden if all people in the contact are deceased. When all people are set to deceased, MPDX will automatically update their status to "Never Ask" and then those contacts won't be shown on any "Fix" pages.

Solution: 
- Stop filtering out contacts who have their primary person deceased

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
