### PR TITLE
MPDX-8511 - Restoring the Relationship Code field on contacts

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -8314,7 +8314,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],\
       ["@surma/rollup-plugin-off-main-thread", [\
         ["npm:2.2.3", {\
-          "packageLocation": "./.yarn/unplugged/@surma-rollup-plugin-off-main-thread-npm-2.2.3-1f57d3eded/node_modules/@surma/rollup-plugin-off-main-thread/",\
+          "packageLocation": "./.yarn/cache/@surma-rollup-plugin-off-main-thread-npm-2.2.3-1f57d3eded-2c02134944.zip/node_modules/@surma/rollup-plugin-off-main-thread/",\
           "packageDependencies": [\
             ["@surma/rollup-plugin-off-main-thread", "npm:2.2.3"],\
             ["ejs", "npm:3.1.10"],\

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/ContactDonationsTab.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/ContactDonationsTab.graphql
@@ -25,6 +25,7 @@ fragment ContactDonorAccounts on Contact {
   source
   likelyToGive
   name
+  relationshipCode
   primaryPerson {
     id
   }

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.graphql
@@ -36,6 +36,7 @@ mutation UpdateContactPartnership(
         }
       }
       likelyToGive
+      relationshipCode
     }
   }
 }

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.test.tsx
@@ -18,6 +18,11 @@ import {
   ContactDonorAccountsFragment,
   ContactDonorAccountsFragmentDoc,
 } from '../../ContactDonationsTab.generated';
+import { UserOrganizationAccountsQuery } from '../PartnershipInfo.generated';
+import {
+  organizationAccountsMock,
+  organizationAccountsWithCruSwitzerlandMock,
+} from '../PartnershipInfoMocks';
 import { EditPartnershipInfoModal } from './EditPartnershipInfoModal';
 
 jest.mock('notistack', () => ({
@@ -115,21 +120,29 @@ const newContactMock = gqlMock<ContactDonorAccountsFragment>(
 
 interface ComponentsProps {
   isNewContact?: boolean;
-  showRelationshipCode?: boolean;
+  includeCruSwitzerland?: boolean;
 }
 
 const Components = ({
   isNewContact = false,
-  showRelationshipCode = false,
+  includeCruSwitzerland = false,
 }: ComponentsProps) => (
   <LocalizationProvider dateAdapter={AdapterLuxon}>
     <TestRouter>
       <SnackbarProvider>
         <ThemeProvider theme={theme}>
-          <GqlMockedProvider onCall={mutationSpy}>
+          <GqlMockedProvider<{
+            UserOrganizationAccounts: UserOrganizationAccountsQuery;
+          }>
+            mocks={{
+              UserOrganizationAccounts: includeCruSwitzerland
+                ? organizationAccountsWithCruSwitzerlandMock
+                : organizationAccountsMock,
+            }}
+            onCall={mutationSpy}
+          >
             <EditPartnershipInfoModal
               contact={isNewContact ? newContactMock : contactMock}
-              showRelationshipCode={showRelationshipCode}
               handleClose={handleClose}
             />
           </GqlMockedProvider>
@@ -559,11 +572,11 @@ describe('EditPartnershipInfoModal', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('should render relationshipCode', () => {
-      const { getByRole } = render(<Components showRelationshipCode />);
+    it('should render relationshipCode', async () => {
+      const { findByRole } = render(<Components includeCruSwitzerland />);
 
       expect(
-        getByRole('textbox', {
+        await findByRole('textbox', {
           name: 'Relationship Code',
         }),
       ).toBeInTheDocument();

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
@@ -102,18 +102,20 @@ const contactPartnershipSchema = yup.object({
     .nullable(),
   pledgeFrequency: yup.mixed<PledgeFrequencyEnum>().nullable(),
   likelyToGive: yup.mixed<LikelyToGiveEnum>().nullable(),
+  relationshipCode: yup.string().nullable(),
 });
 
 type Attributes = yup.InferType<typeof contactPartnershipSchema>;
 
 interface EditPartnershipInfoModalProps {
   contact: ContactDonorAccountsFragment;
+  showRelationshipCode: boolean;
   handleClose: () => void;
 }
 
 export const EditPartnershipInfoModal: React.FC<
   EditPartnershipInfoModalProps
-> = ({ contact, handleClose }) => {
+> = ({ contact, showRelationshipCode, handleClose }) => {
   const { t } = useTranslation();
   const { appName } = useGetAppSettings();
   const accountListId = useAccountListId();
@@ -198,6 +200,7 @@ export const EditPartnershipInfoModal: React.FC<
           likelyToGive: contact.likelyToGive,
           name: contact.name,
           primaryPersonId: contact?.primaryPerson?.id ?? '',
+          relationshipCode: contact.relationshipCode ?? '',
         }}
         validationSchema={contactPartnershipSchema}
         onSubmit={onSubmit}
@@ -216,6 +219,7 @@ export const EditPartnershipInfoModal: React.FC<
             likelyToGive,
             name,
             primaryPersonId,
+            relationshipCode,
           },
           handleSubmit,
           handleChange,
@@ -543,7 +547,23 @@ export const EditPartnershipInfoModal: React.FC<
                     />
                   </ContactInputWrapper>
                 </Grid>
+                {showRelationshipCode && (
+                  <Grid item xs={12} sm={6}>
+                    <ContactInputWrapper>
+                      <TextField
+                        name="relationshipCode"
+                        label={t('Relationship Code')}
+                        value={relationshipCode}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        inputProps={{ 'aria-label': t('Relationship Code') }}
+                        fullWidth
+                      />
+                    </ContactInputWrapper>
+                  </Grid>
+                )}
               </Grid>
+
               <ContactInputWrapper>
                 <CheckboxLabel
                   control={

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/PartnershipInfo.graphql
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/PartnershipInfo.graphql
@@ -1,0 +1,9 @@
+query UserOrganizationAccounts {
+  userOrganizationAccounts {
+    id
+    organization {
+      id
+      name
+    }
+  }
+}

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/PartnershipInfo.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/PartnershipInfo.test.tsx
@@ -1,124 +1,95 @@
 import React from 'react';
-import { MockedProvider } from '@apollo/client/testing';
 import { ThemeProvider } from '@mui/material/styles';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import userEvent from '@testing-library/user-event';
-import { DateTime } from 'luxon';
 import { SnackbarProvider } from 'notistack';
-import { gqlMock } from '__tests__/util/graphqlMocking';
+import TestRouter from '__tests__/util/TestRouter';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { render, waitFor } from '__tests__/util/testingLibraryReactMock';
-import { PledgeFrequencyEnum, StatusEnum } from 'src/graphql/types.generated';
 import theme from '../../../../../theme';
-import {
-  ContactDonorAccountsFragment,
-  ContactDonorAccountsFragmentDoc,
-} from '../ContactDonationsTab.generated';
 import { PartnershipInfo } from './PartnershipInfo';
+import { UserOrganizationAccountsQuery } from './PartnershipInfo.generated';
+import {
+  contactEmptyMock,
+  contactMock,
+  organizationAccountsMock,
+  organizationAccountsWithCruSwitzerlandMock,
+} from './PartnershipInfoMocks';
 
-const mock = gqlMock<ContactDonorAccountsFragment>(
-  ContactDonorAccountsFragmentDoc,
-  {
-    mocks: {
-      status: StatusEnum.PartnerFinancial,
-      nextAsk: DateTime.local().plus({ month: 3 }).toISO(),
-      pledgeCurrency: 'CAD',
-      pledgeStartDate: DateTime.local().toISO(),
-      pledgeFrequency: PledgeFrequencyEnum.Annual,
-      pledgeAmount: 55,
-      lastDonation: {
-        donationDate: DateTime.local().toISO(),
-        amount: {
-          currency: 'CAD',
-        },
-      },
-    },
-  },
+const mutationSpy = jest.fn();
+
+interface ComponentsProps {
+  useEmptyMock?: boolean;
+  includeCruSwitzerland?: boolean;
+}
+
+const Components = ({
+  useEmptyMock = false,
+  includeCruSwitzerland = false,
+}: ComponentsProps) => (
+  <SnackbarProvider>
+    <TestRouter>
+      <ThemeProvider theme={theme}>
+        <LocalizationProvider dateAdapter={AdapterLuxon}>
+          <GqlMockedProvider<{
+            UserOrganizationAccounts: UserOrganizationAccountsQuery;
+          }>
+            mocks={{
+              UserOrganizationAccounts: includeCruSwitzerland
+                ? organizationAccountsWithCruSwitzerlandMock
+                : organizationAccountsMock,
+            }}
+            onCall={mutationSpy}
+          >
+            <PartnershipInfo
+              contact={useEmptyMock ? contactEmptyMock : contactMock}
+            />
+          </GqlMockedProvider>
+        </LocalizationProvider>
+      </ThemeProvider>
+    </TestRouter>
+  </SnackbarProvider>
 );
-
-const emptyMock = gqlMock<ContactDonorAccountsFragment>(
-  ContactDonorAccountsFragmentDoc,
-  {
-    mocks: {
-      status: null,
-    },
-  },
-);
-
-jest.mock('next/router', () => ({
-  useRouter: () => {
-    return {
-      query: { accountListId: 'abc' },
-      isReady: true,
-    };
-  },
-}));
 
 describe('PartnershipInfo', () => {
-  it('test renderer', async () => {
-    const { getByText, findByText } = render(
-      <SnackbarProvider>
-        <ThemeProvider theme={theme}>
-          <LocalizationProvider dateAdapter={AdapterLuxon}>
-            <MockedProvider>
-              <PartnershipInfo contact={mock} />
-            </MockedProvider>
-          </LocalizationProvider>
-        </ThemeProvider>
-      </SnackbarProvider>,
-    );
+  it('test renderer', () => {
+    const { getByText } = render(<Components />);
 
-    await waitFor(() => {
-      expect(getByText('CA$55 - Annual')).toBeInTheDocument();
-    });
-    expect(await findByText('Partner - Financial')).toBeInTheDocument();
+    expect(getByText('CA$55 - Annual')).toBeInTheDocument();
+    expect(getByText('Partner - Financial')).toBeInTheDocument();
   });
 
-  it('renders No Status', async () => {
-    const { findByText } = render(
-      <SnackbarProvider>
-        <ThemeProvider theme={theme}>
-          <LocalizationProvider dateAdapter={AdapterLuxon}>
-            <MockedProvider>
-              <PartnershipInfo contact={emptyMock} />
-            </MockedProvider>
-          </LocalizationProvider>
-        </ThemeProvider>
-      </SnackbarProvider>,
-    );
+  it('renders No Status', () => {
+    const { getByText } = render(<Components useEmptyMock />);
 
-    expect(await findByText('No Status')).toBeInTheDocument();
+    expect(getByText('No Status')).toBeInTheDocument();
+  });
+
+  it('should not render relationship code', async () => {
+    const { queryByText } = render(<Components />);
+
+    await waitFor(() => {
+      expect(mutationSpy).toHaveGraphqlOperation('UserOrganizationAccounts');
+    });
+    expect(queryByText('Relationship Code')).not.toBeInTheDocument();
+  });
+
+  it('should render relationship code', async () => {
+    const { findByText } = render(<Components includeCruSwitzerland />);
+
+    expect(await findByText('Relationship Code')).toBeInTheDocument();
   });
 
   it('should open edit partnership information modal', () => {
-    const { getByText, getByLabelText } = render(
-      <SnackbarProvider>
-        <ThemeProvider theme={theme}>
-          <LocalizationProvider dateAdapter={AdapterLuxon}>
-            <MockedProvider>
-              <PartnershipInfo contact={mock} />
-            </MockedProvider>
-          </LocalizationProvider>
-        </ThemeProvider>
-      </SnackbarProvider>,
-    );
+    const { getByText, getByLabelText } = render(<Components />);
 
     userEvent.click(getByLabelText('Edit Icon'));
     expect(getByText('Edit Partnership')).toBeInTheDocument();
   });
 
   it('should close edit partnership information modal', async () => {
-    const { getByText, getByLabelText, queryByText } = render(
-      <SnackbarProvider>
-        <ThemeProvider theme={theme}>
-          <LocalizationProvider dateAdapter={AdapterLuxon}>
-            <MockedProvider>
-              <PartnershipInfo contact={mock} />
-            </MockedProvider>
-          </LocalizationProvider>
-        </ThemeProvider>
-      </SnackbarProvider>,
-    );
+    const { getByText, getByLabelText, queryByText } = render(<Components />);
 
     userEvent.click(getByLabelText('Edit Icon'));
     expect(getByText('Edit Partnership')).toBeInTheDocument();

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/PartnershipInfo.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/PartnershipInfo.tsx
@@ -16,7 +16,10 @@ import { currencyFormat } from '../../../../../lib/intlFormat';
 import { HandshakeIcon } from '../../ContactDetailsHeader/ContactHeaderSection/HandshakeIcon';
 import { ContactDonorAccountsFragment } from '../ContactDonationsTab.generated';
 import { EditPartnershipInfoModal } from './EditPartnershipInfoModal/EditPartnershipInfoModal';
-import { useUserOrganizationAccountsQuery } from './PartnershipInfo.generated';
+import {
+  UserOrganizationAccountsQuery,
+  useUserOrganizationAccountsQuery,
+} from './PartnershipInfo.generated';
 
 export const SwitzerlandOrganizationName = 'Campus fuer Christus Switzerland';
 
@@ -68,6 +71,17 @@ interface PartnershipInfoProp {
   contact: ContactDonorAccountsFragment | null;
 }
 
+export const isApartOfSwitzerlandOrganization = (
+  userOrganizationAccounts?: UserOrganizationAccountsQuery['userOrganizationAccounts'],
+) => {
+  return (
+    userOrganizationAccounts?.some(
+      (organizationAccount) =>
+        organizationAccount.organization.name === SwitzerlandOrganizationName,
+    ) ?? false
+  );
+};
+
 export const PartnershipInfo: React.FC<PartnershipInfoProp> = ({ contact }) => {
   const { t } = useTranslation();
   const locale = useLocale();
@@ -81,11 +95,7 @@ export const PartnershipInfo: React.FC<PartnershipInfoProp> = ({ contact }) => {
   const userOrganizationAccounts = data?.userOrganizationAccounts;
 
   const showRelationshipCode = useMemo(
-    () =>
-      userOrganizationAccounts?.some(
-        (organizationAccount) =>
-          organizationAccount.organization.name === SwitzerlandOrganizationName,
-      ) ?? false,
+    () => isApartOfSwitzerlandOrganization(userOrganizationAccounts),
     [userOrganizationAccounts],
   );
 
@@ -269,7 +279,6 @@ export const PartnershipInfo: React.FC<PartnershipInfoProp> = ({ contact }) => {
       {contact && editPartnershipModalOpen ? (
         <EditPartnershipInfoModal
           handleClose={() => setEditPartnershipModalOpen(false)}
-          showRelationshipCode={showRelationshipCode}
           contact={contact}
         />
       ) : null}

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/PartnershipInfo.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/PartnershipInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import CheckCircleOutline from '@mui/icons-material/CheckCircleOutline';
 import Clear from '@mui/icons-material/Clear';
 import CreateIcon from '@mui/icons-material/Create';
@@ -16,6 +16,9 @@ import { currencyFormat } from '../../../../../lib/intlFormat';
 import { HandshakeIcon } from '../../ContactDetailsHeader/ContactHeaderSection/HandshakeIcon';
 import { ContactDonorAccountsFragment } from '../ContactDonationsTab.generated';
 import { EditPartnershipInfoModal } from './EditPartnershipInfoModal/EditPartnershipInfoModal';
+import { useUserOrganizationAccountsQuery } from './PartnershipInfo.generated';
+
+export const SwitzerlandOrganizationName = 'Campus fuer Christus Switzerland';
 
 const IconAndTextContainer = styled(Box)(({ theme }) => ({
   margin: theme.spacing(0, 4),
@@ -73,6 +76,18 @@ export const PartnershipInfo: React.FC<PartnershipInfoProp> = ({ contact }) => {
 
   const [editPartnershipModalOpen, setEditPartnershipModalOpen] =
     useState(false);
+
+  const { data } = useUserOrganizationAccountsQuery();
+  const userOrganizationAccounts = data?.userOrganizationAccounts;
+
+  const showRelationshipCode = useMemo(
+    () =>
+      userOrganizationAccounts?.some(
+        (organizationAccount) =>
+          organizationAccount.organization.name === SwitzerlandOrganizationName,
+      ) ?? false,
+    [userOrganizationAccounts],
+  );
 
   return (
     <PartnershipInfoContainer>
@@ -196,6 +211,21 @@ export const PartnershipInfo: React.FC<PartnershipInfoProp> = ({ contact }) => {
           )}
         </LabelsAndText>
       </IconAndTextContainerCenter>
+
+      {showRelationshipCode && (
+        <IconAndTextContainerCenter>
+          <IconContainer>
+            <ClearIcon />
+          </IconContainer>
+          <LabelsAndText variant="subtitle1" color="textSecondary">
+            {t('Relationship Code')}
+          </LabelsAndText>
+          <LabelsAndText variant="subtitle1">
+            {contact?.relationshipCode}
+          </LabelsAndText>
+        </IconAndTextContainerCenter>
+      )}
+
       <IconAndTextContainerCenter>
         <IconContainer>
           <ClearIcon />
@@ -239,6 +269,7 @@ export const PartnershipInfo: React.FC<PartnershipInfoProp> = ({ contact }) => {
       {contact && editPartnershipModalOpen ? (
         <EditPartnershipInfoModal
           handleClose={() => setEditPartnershipModalOpen(false)}
+          showRelationshipCode={showRelationshipCode}
           contact={contact}
         />
       ) : null}

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/PartnershipInfoMocks.ts
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/PartnershipInfoMocks.ts
@@ -1,0 +1,65 @@
+import { DateTime } from 'luxon';
+import { gqlMock } from '__tests__/util/graphqlMocking';
+import { PledgeFrequencyEnum, StatusEnum } from 'src/graphql/types.generated';
+import {
+  ContactDonorAccountsFragment,
+  ContactDonorAccountsFragmentDoc,
+} from '../ContactDonationsTab.generated';
+import { SwitzerlandOrganizationName } from './PartnershipInfo';
+
+export const contactMock = gqlMock<ContactDonorAccountsFragment>(
+  ContactDonorAccountsFragmentDoc,
+  {
+    mocks: {
+      status: StatusEnum.PartnerFinancial,
+      nextAsk: DateTime.local().plus({ month: 3 }).toISO(),
+      pledgeCurrency: 'CAD',
+      pledgeStartDate: DateTime.local().toISO(),
+      pledgeFrequency: PledgeFrequencyEnum.Annual,
+      pledgeAmount: 55,
+      lastDonation: {
+        donationDate: DateTime.local().toISO(),
+        amount: {
+          currency: 'CAD',
+        },
+      },
+    },
+  },
+);
+
+export const contactEmptyMock = gqlMock<ContactDonorAccountsFragment>(
+  ContactDonorAccountsFragmentDoc,
+  {
+    mocks: {
+      status: null,
+    },
+  },
+);
+
+export const organizationAccountsMock = {
+  userOrganizationAccounts: [
+    {
+      organization: {
+        name: 'Cru - New Staff',
+      },
+      id: '123',
+    },
+  ],
+};
+
+export const organizationAccountsWithCruSwitzerlandMock = {
+  userOrganizationAccounts: [
+    {
+      organization: {
+        name: 'Cru - New Staff',
+      },
+      id: '123',
+    },
+    {
+      organization: {
+        name: SwitzerlandOrganizationName,
+      },
+      id: '456',
+    },
+  ],
+};


### PR DESCRIPTION
## Description
In 2020, we added custom code to the contact details tab for the Switzland Cru. View the [old MPDX Web PR](https://github.com/CruGlobal/mpdx_web/pull/1822/files#diff-e2732a893ad00c26aec49567ffee02a6464e866cb51fb77ddc7e3c82a3397d7d) 
This code only allowed the Switzland Cru organization members to view and edit the "Relationship Code" field since they use this with their MailChimp integration.

In this PR, I have added the field back to the contacts page under the partnership info.


### Blocked:
In order for this PR to be deployed, we need some GraphQL work completed. We need to add the field `relationshipCode` as an input under `attributes` on the `updateContact` mutation.
In our code, I have commented out code which is needed, but would break the site otherwise.

### Links
**HelpScout**: https://secure.helpscout.net/conversation/2768772103/1262455?viewId=7296147
**Jira**: https://jira.cru.org/browse/MPDX-8511

## Test

1. impersonate Swiss staff member [tim.hopcraft@campus-d.de](mailto:tim.hopcraft@campus-d.de)
2. go to contact
3. on the details tab, under partnership info, there should be a `relationship code` field (In german "Beziehungsart")
4. Click the edit partnershipInfo button to view the modal
5. You can view the partnershipInfo modal at the top of the contact

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
