### PR TITLE
[HS-1284159] Fix accept invite redirect

### DIFF
--- a/pages/acceptInvite.page.tsx
+++ b/pages/acceptInvite.page.tsx
@@ -121,9 +121,7 @@ const AcceptInvitePage = (): ReactElement => {
       hasFetchedRef.current = true;
     } else {
       enqueueSnackbar(
-        t(
-          'Invalid invite URL. Try asking the the inviter to resend the invite.',
-        ),
+        t('Invalid invite URL. Try asking the inviter to resend the invite.'),
         {
           variant: 'error',
         },

--- a/pages/acceptInvite.page.tsx
+++ b/pages/acceptInvite.page.tsx
@@ -72,35 +72,16 @@ const AcceptInvitePage = (): ReactElement => {
         ? 'organization_invites'
         : 'account_list_invites';
 
-      try {
-        const apiToken = session.apiToken;
+      const apiToken = session.apiToken;
+      const response = await fetchAcceptInvite({
+        apiToken,
+        url,
+        inviteType,
+        id,
+        code,
+      });
 
-        const response = await fetchAcceptInvite({
-          apiToken,
-          url,
-          inviteType,
-          id,
-          code,
-        });
-
-        if (!response.ok) {
-          throw new Error('Network response was not ok');
-        }
-        if (url.includes('organizations')) {
-          enqueueSnackbar(t('Accepted invite successfully.'), {
-            variant: 'success',
-          });
-
-          router.push(
-            dashboardLink + 'settings/integrations?selectedTab=organization',
-          );
-        } else {
-          enqueueSnackbar(t('Accepted invite successfully.'), {
-            variant: 'success',
-          });
-          router.push(dashboardLink);
-        }
-      } catch (err) {
+      if (!response.ok) {
         const inviter = url.includes('organizations')
           ? t('organization admin')
           : t('account holder');
@@ -113,6 +94,19 @@ const AcceptInvitePage = (): ReactElement => {
             variant: 'error',
           },
         );
+        return;
+      }
+
+      enqueueSnackbar(t('Accepted invite successfully.'), {
+        variant: 'success',
+      });
+
+      if (url.includes('organizations')) {
+        router.push(
+          dashboardLink + 'settings/integrations?selectedTab=organization',
+        );
+      } else {
+        router.push(dashboardLink);
       }
     };
 

--- a/pages/acceptInvite.page.tsx
+++ b/pages/acceptInvite.page.tsx
@@ -52,6 +52,49 @@ const AcceptInvitePage = (): ReactElement => {
   // Since we don't have the user's accountListId, use an invalid accountListId so the page redirects on it's own.
   const dashboardLink = '/accountLists/_/';
 
+  const acceptInvite = async (id: string, code: string, url: string) => {
+    const inviteType = url.includes('organizations')
+      ? 'organization_invites'
+      : 'account_list_invites';
+
+    const apiToken = session.apiToken;
+    const response = await fetchAcceptInvite({
+      apiToken,
+      url,
+      inviteType,
+      id,
+      code,
+    });
+
+    if (!response.ok) {
+      const inviter = url.includes('organizations')
+        ? t('organization admin')
+        : t('account holder');
+      enqueueSnackbar(
+        t(
+          'Unable to accept invite. Try asking the {{inviter}} to resend the invite.',
+          { inviter },
+        ),
+        {
+          variant: 'error',
+        },
+      );
+      return;
+    }
+
+    enqueueSnackbar(t('Accepted invite successfully.'), {
+      variant: 'success',
+    });
+
+    if (url.includes('organizations')) {
+      router.push(
+        dashboardLink + 'settings/integrations?selectedTab=organization',
+      );
+    } else {
+      router.push(dashboardLink);
+    }
+  };
+
   useEffect(() => {
     if (!router.isReady || hasFetchedRef.current) {
       return;
@@ -67,48 +110,6 @@ const AcceptInvitePage = (): ReactElement => {
       typeof query.inviteCode === 'string' ? query.inviteCode : undefined;
 
     const inviterAccountListId = router.query.accountListId || undefined;
-    const acceptInvite = async (id: string, code: string, url: string) => {
-      const inviteType = url.includes('organizations')
-        ? 'organization_invites'
-        : 'account_list_invites';
-
-      const apiToken = session.apiToken;
-      const response = await fetchAcceptInvite({
-        apiToken,
-        url,
-        inviteType,
-        id,
-        code,
-      });
-
-      if (!response.ok) {
-        const inviter = url.includes('organizations')
-          ? t('organization admin')
-          : t('account holder');
-        enqueueSnackbar(
-          t(
-            'Unable to accept invite. Try asking the {{inviter}} to resend the invite.',
-            { inviter },
-          ),
-          {
-            variant: 'error',
-          },
-        );
-        return;
-      }
-
-      enqueueSnackbar(t('Accepted invite successfully.'), {
-        variant: 'success',
-      });
-
-      if (url.includes('organizations')) {
-        router.push(
-          dashboardLink + 'settings/integrations?selectedTab=organization',
-        );
-      } else {
-        router.push(dashboardLink);
-      }
-    };
 
     if (accountInviteId && inviteCode && inviterAccountListId) {
       const url = `account_lists/${inviterAccountListId}/invites/${accountInviteId}/accept`;

--- a/pages/acceptInvite.test.tsx
+++ b/pages/acceptInvite.test.tsx
@@ -175,7 +175,7 @@ describe('AcceptInvitePage', () => {
 
     await waitFor(() => {
       expect(mockEnqueue).toHaveBeenCalledWith(
-        'Invalid invite URL. Try asking the the inviter to resend the invite.',
+        'Invalid invite URL. Try asking the inviter to resend the invite.',
         { variant: 'error' },
       );
     });

--- a/pages/accountLists/[accountListId].page.test.tsx
+++ b/pages/accountLists/[accountListId].page.test.tsx
@@ -24,7 +24,6 @@ interface GetServerSidePropsReturn {
 
 describe('AccountListsId page', () => {
   const context = {
-    req: {},
     query: {
       accountListId: 'account-list-1',
     },
@@ -52,7 +51,7 @@ describe('AccountListsId page', () => {
       (makeSsrClient as jest.Mock).mockReturnValue({
         query: jest
           .fn()
-          .mockRejectedValueOnce(new Error('GraphQL Authentication error')),
+          .mockRejectedValue(new Error('GraphQL Authentication error')),
       });
 
       const { props, redirect } = (await getServerSideProps(
@@ -61,7 +60,7 @@ describe('AccountListsId page', () => {
 
       expect(props).toBeUndefined();
       expect(redirect).toEqual({
-        destination: '/',
+        destination: '/accountLists',
         permanent: false,
       });
     });
@@ -110,13 +109,13 @@ describe('AccountListsId page', () => {
     const restApiNotFoundErrorMessage = "Resource 'AccountList' is not valid";
 
     const makeContext = (
-      url: string = '/accountLists/[accountListId]/contacts',
+      resolvedUrl = '/accountLists/[accountListId]/contacts',
     ) => {
       return {
-        req: { url: url },
         query: {
           accountListId: 'account-list-1',
         },
+        resolvedUrl,
       } as unknown as GetServerSidePropsContext;
     };
 

--- a/pages/accountLists/[accountListId].page.tsx
+++ b/pages/accountLists/[accountListId].page.tsx
@@ -83,10 +83,10 @@ const AccountListIdPage = ({
 };
 
 export const getServerSideProps = makeGetServerSideProps(
-  async (session, { query, req }) => {
+  async (session, { query, resolvedUrl }) => {
     const underscoreRedirect = await handleUnderscoreAccountListRedirect(
       session,
-      req.url,
+      resolvedUrl,
     );
     if (underscoreRedirect) {
       return underscoreRedirect;
@@ -132,7 +132,7 @@ export const getServerSideProps = makeGetServerSideProps(
         error.graphQLErrors.every(
           (error) => !isAccountListNotFoundError(error),
         );
-      if (!req.url || nonAccountListError) {
+      if (nonAccountListError) {
         return {
           redirect: {
             destination: '/',
@@ -149,7 +149,7 @@ export const getServerSideProps = makeGetServerSideProps(
         return {
           redirect: {
             destination: replaceUrlAccountList(
-              req.url,
+              resolvedUrl,
               data.user.defaultAccountList,
             ),
             permanent: false,

--- a/pages/api/utils/pagePropsHelpers.test.ts
+++ b/pages/api/utils/pagePropsHelpers.test.ts
@@ -13,7 +13,6 @@ jest.mock('next-auth/react');
 jest.mock('src/lib/apollo/ssrClient', () => jest.fn());
 
 const context = {
-  req: {},
   query: { accountListId: 'account-list-1' },
   resolvedUrl: '/page?param=value',
 } as unknown as GetServerSidePropsContext;
@@ -78,9 +77,9 @@ describe('pagePropsHelpers', () => {
 
     describe('redirects to the default account list if the URL contains "_"', () => {
       const context = {
-        req: { url: '/accountLists/_/contacts' },
-        resolvedUrl: '/filters?param=value',
+        resolvedUrl: '/accountLists/_/contacts',
       } as unknown as GetServerSidePropsContext;
+
       beforeEach(() => {
         const user = { apiToken: 'token' };
         (getSession as jest.Mock).mockResolvedValue({ user });
@@ -109,7 +108,7 @@ describe('pagePropsHelpers', () => {
       it('redirects to dashboard with default account list"', async () => {
         await expect(
           ensureSessionAndAccountList({
-            req: { url: '/accountLists/_' },
+            resolvedUrl: '/accountLists/_',
           } as unknown as GetServerSidePropsContext),
         ).resolves.toMatchObject({
           redirect: {

--- a/pages/api/utils/pagePropsHelpers.ts
+++ b/pages/api/utils/pagePropsHelpers.ts
@@ -2,6 +2,7 @@ import {
   GetServerSideProps,
   GetServerSidePropsContext,
   GetServerSidePropsResult,
+  Redirect,
 } from 'next';
 import { Session } from 'next-auth';
 import { getSession } from 'next-auth/react';
@@ -18,7 +19,7 @@ interface PagePropsWithSession {
 // Return a redirect to the login page
 export const loginRedirect = (
   context: GetServerSidePropsContext,
-): GetServerSidePropsResult<never> => ({
+): { redirect: Redirect } => ({
   redirect: {
     destination: `/login?redirect=${encodeURIComponent(context.resolvedUrl)}`,
     permanent: false,
@@ -26,9 +27,9 @@ export const loginRedirect = (
 });
 
 // Redirect back to the dashboard if the user isn't an admin
-export const enforceAdmin = async (
+export const enforceAdmin: GetServerSideProps<PagePropsWithSession> = async (
   context,
-): Promise<GetServerSideProps | GetServerSidePropsResult<unknown>> => {
+) => {
   const session = await getSession(context);
   if (!session?.user.admin) {
     return {
@@ -55,14 +56,12 @@ export const enforceAdmin = async (
 };
 
 // Redirect back to login screen if user isn't logged in
-export const ensureSessionAndAccountList = async (
-  context,
-): Promise<GetServerSideProps | GetServerSidePropsResult<unknown>> => {
+export const ensureSessionAndAccountList: GetServerSideProps<
+  PagePropsWithSession
+> = async (context) => {
   const session = await getSession(context);
   if (!session?.user.apiToken) {
-    return {
-      ...loginRedirect(context),
-    };
+    return loginRedirect(context);
   }
 
   const underscoreRedirect = await handleUnderscoreAccountListRedirect(
@@ -83,8 +82,8 @@ export const ensureSessionAndAccountList = async (
 export const handleUnderscoreAccountListRedirect = async (
   session: Session,
   url?: string,
-): Promise<GetServerSidePropsResult<unknown> | undefined> => {
-  if (url?.includes('/accountLists/_')) {
+): Promise<{ redirect: Redirect } | undefined> => {
+  if (url?.startsWith('/accountLists/_')) {
     // Redirect to the default account list if the "_" is where the account list ID would be in the URL
     // This is a common pattern in our app, so we handle it here to avoid repeating
     const ssrClient = makeSsrClient(session.user.apiToken);

--- a/pages/api/utils/pagePropsHelpers.ts
+++ b/pages/api/utils/pagePropsHelpers.ts
@@ -42,7 +42,7 @@ export const enforceAdmin: GetServerSideProps<PagePropsWithSession> = async (
 
   const underscoreRedirect = await handleUnderscoreAccountListRedirect(
     session,
-    context.req.url,
+    context.resolvedUrl,
   );
   if (underscoreRedirect) {
     return underscoreRedirect;
@@ -66,7 +66,7 @@ export const ensureSessionAndAccountList: GetServerSideProps<
 
   const underscoreRedirect = await handleUnderscoreAccountListRedirect(
     session,
-    context.req.url,
+    context.resolvedUrl,
   );
   if (underscoreRedirect) {
     return underscoreRedirect;
@@ -81,9 +81,9 @@ export const ensureSessionAndAccountList: GetServerSideProps<
 
 export const handleUnderscoreAccountListRedirect = async (
   session: Session,
-  url?: string,
+  url: string,
 ): Promise<{ redirect: Redirect } | undefined> => {
-  if (url?.startsWith('/accountLists/_')) {
+  if (url.startsWith('/accountLists/_')) {
     // Redirect to the default account list if the "_" is where the account list ID would be in the URL
     // This is a common pattern in our app, so we handle it here to avoid repeating
     const ssrClient = makeSsrClient(session.user.apiToken);


### PR DESCRIPTION
## Description

The core bug is that `context.req.url` can be `/_next/data/development/accountLists/_.json?accountListId=_` when pushing `/accountLists/_` like the accept invite page does. This is because instead of doing a normal GET request, Next.js loads the props for the new page and rerenders without doing a full-page refresh.

When encountering those props requests, the underscore redirect logic was naively replacing the account list id and returning to a redirect. The fix is to use `context.resolvedUrl` because it gives urls like `/accountLists/_` even during a props request.

I also did some cleanup in the accept invite page and page props helpers.

* `acceptInvite` was treating `!res.ok` from `fetch` as a network error instead of an API error.
* Moved a helper method outside of the `useEffect`.
* Add back more robust type checking to the page props helpers.

https://secure.helpscout.net/conversation/2809610238/1284159/

## Testing

* Navigate to `/acceptInvite` (you don't need any of the query parameters)
* Check that it shows the error toast and navigates to the dashboard of the default account list instead of the JSON page shown in the Help Scout ticket

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
