### PR TITLE
Fix login loop from logout redirect

### DIFF
--- a/pages/api/utils/pagePropsHelpers.test.ts
+++ b/pages/api/utils/pagePropsHelpers.test.ts
@@ -27,6 +27,15 @@ describe('pagePropsHelpers', () => {
         },
       });
     });
+
+    it("doesn't redirect to logout", () => {
+      expect(loginRedirect({ ...context, resolvedUrl: '/logout' })).toEqual({
+        redirect: {
+          destination: '/login',
+          permanent: false,
+        },
+      });
+    });
   });
 
   describe('enforceAdmin', () => {

--- a/pages/api/utils/pagePropsHelpers.ts
+++ b/pages/api/utils/pagePropsHelpers.ts
@@ -21,7 +21,11 @@ export const loginRedirect = (
   context: GetServerSidePropsContext,
 ): { redirect: Redirect } => ({
   redirect: {
-    destination: `/login?redirect=${encodeURIComponent(context.resolvedUrl)}`,
+    destination: `/login${
+      context.resolvedUrl !== '/logout'
+        ? `?redirect=${encodeURIComponent(context.resolvedUrl)}`
+        : ''
+    }`,
     permanent: false,
   },
 });


### PR DESCRIPTION
## Description
This PR fixes the error where users find themselves in an endless loop on the login screen. When you are logged out after a certain amount of time, you are redirected to the homepage with the redirect of `/logout`, which, once you log in, you will be automatically logged out.

This PR prevents the redirect for the logout page from being added to the login redirect.


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
