### PR TITLE
MPDX-8511 - Allowing users to edit the relationship_code field

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.test.tsx
@@ -582,8 +582,7 @@ describe('EditPartnershipInfoModal', () => {
       ).toBeInTheDocument();
     });
 
-    // Remove skip this when the UpdateContact mutation operation is updated to include the relationshipCode
-    it.skip('should update relationshipCode', async () => {
+    it('should update relationshipCode', async () => {
       const { findByRole, getByText } = render(
         <Components includeCruSwitzerland />,
       );

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
@@ -142,13 +142,11 @@ export const EditPartnershipInfoModal: React.FC<
   const pledgeCurrencies = constants?.pledgeCurrency;
 
   const onSubmit = async (attributes: Attributes) => {
-    // Remove and just use "attributes" when the UpdateContact mutation operation is updated to include the relationshipCode
-    const { relationshipCode: _, ...newAttributes } = attributes;
     await updateContactPartnership({
       variables: {
         accountListId: accountListId ?? '',
         attributes: {
-          ...newAttributes,
+          ...attributes,
           pledgeStartDate: attributes.pledgeStartDate?.toISODate() ?? null,
           nextAsk: attributes.nextAsk?.toISODate() ?? null,
           primaryPersonId: attributes.primaryPersonId,


### PR DESCRIPTION
## Description
In this PR, I allow the user to edit the `relationship_code` field.

In this PR https://github.com/CruGlobal/mpdx-react/pull/1250, I add the field for only certain users in the Switzerland Cru organization. However, I didn't allow the users to edit the field until the API PR https://github.com/CruGlobal/mpdx_api/pull/2901 was merged.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
