### PR TITLE
MPDX-8515 -  Increase # of coaches fetched

### DIFF
--- a/src/components/Coaching/CoachingList.tsx
+++ b/src/components/Coaching/CoachingList.tsx
@@ -39,6 +39,7 @@ const CoachingLoading = styled(Skeleton)(() => ({
 export const CoachingList: React.FC<CoachingListProps> = ({
   accountListId,
 }) => {
+  // This needs to become a infinite scroll query
   const { data, loading } = useLoadCoachingListQuery();
   const { t } = useTranslation();
 

--- a/src/components/Coaching/LoadCoachingList.graphql
+++ b/src/components/Coaching/LoadCoachingList.graphql
@@ -1,5 +1,5 @@
 query LoadCoachingList {
-  coachingAccountLists(first: 25) {
+  coachingAccountLists(first: 100) {
     nodes {
       ...CoachedPerson
     }


### PR DESCRIPTION
## Description
In this PR, I increased the limit of the amount of coaches we fetch on the coaches page from `25` to `100`.

This is only a quick fix. The longer fix would be to make the coaches list into an infinite scroll to ensure all coaches are loaded.

HelpScout Ticket: https://secure.helpscout.net/conversation/2817301546/1288380/


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
