### PR TITLE
MPDX-8515 - Fetching all pages on the coaches page

### DIFF
--- a/src/components/Coaching/CoachingList.test.tsx
+++ b/src/components/Coaching/CoachingList.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { render } from '@testing-library/react';
+import { ErgonoMockShape } from 'graphql-ergonomock';
+import TestRouter from '__tests__/util/TestRouter';
+import TestWrapper from '__tests__/util/TestWrapper';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import theme from 'src/theme';
+import { CoachingList } from './CoachingList';
+import { LoadCoachingListQuery } from './LoadCoachingList.generated';
+
+const accountListId = 'accountListId';
+const mutationSpy = jest.fn();
+
+const coachingAccountListsMock = [
+  {
+    id: '1',
+    name: 'Account 1',
+  },
+  {
+    id: '2',
+    name: 'Account 2',
+  },
+];
+const router = {
+  query: { accountListId: accountListId },
+  push: jest.fn(),
+};
+
+interface ComponentsProps {
+  mockNodes?: ErgonoMockShape[];
+}
+const Components = ({
+  mockNodes = coachingAccountListsMock,
+}: ComponentsProps) => (
+  <ThemeProvider theme={theme}>
+    <TestRouter router={router}>
+      <TestWrapper>
+        <GqlMockedProvider<{
+          coachingAccountLists: LoadCoachingListQuery;
+        }>
+          mocks={{
+            LoadCoachingList: {
+              coachingAccountLists: {
+                nodes: mockNodes,
+                totalCount: 2,
+              },
+            },
+          }}
+          onCall={mutationSpy}
+        >
+          <CoachingList accountListId={accountListId} />
+        </GqlMockedProvider>
+      </TestWrapper>
+    </TestRouter>
+  </ThemeProvider>
+);
+
+describe('CoachingList', () => {
+  it('should render loading state', () => {
+    const { getAllByTestId } = render(<Components />);
+
+    expect(getAllByTestId('loading-coaches')[0]).toBeInTheDocument();
+  });
+
+  it('should render coaching accounts', async () => {
+    const { findByText, getByText } = render(<Components />);
+
+    expect(await findByText('Account 1')).toBeInTheDocument();
+    expect(getByText('Account 2')).toBeInTheDocument();
+  });
+});

--- a/src/components/Coaching/CoachingList.tsx
+++ b/src/components/Coaching/CoachingList.tsx
@@ -3,12 +3,15 @@ import { Spa } from '@mui/icons-material';
 import { Box, Divider, Skeleton, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
-import { CoachingRow } from './CoachingRow/CoachingRow';
+import { useFetchAllPages } from 'src/hooks/useFetchAllPages';
+import { CoachingRow, CoachingRowWrapper } from './CoachingRow/CoachingRow';
 import { useLoadCoachingListQuery } from './LoadCoachingList.generated';
 
-interface CoachingListProps {
-  accountListId: string;
-}
+const LoadingCoach: React.FC = () => (
+  <CoachingRowWrapper>
+    <CoachingLoading role="listitem" data-testid="loading-coaches" />
+  </CoachingRowWrapper>
+);
 
 const CoachingListWrapper = styled(Box)(({ theme }) => ({
   width: '100%',
@@ -32,18 +35,26 @@ const CoachingListTitle = styled(Typography)(({ theme }) => ({
 }));
 
 const CoachingLoading = styled(Skeleton)(() => ({
-  width: '75%',
-  height: '50px',
+  height: '100px',
 }));
 
+interface CoachingListProps {
+  accountListId: string;
+}
 export const CoachingList: React.FC<CoachingListProps> = ({
   accountListId,
 }) => {
   // This needs to become a infinite scroll query
-  const { data, loading } = useLoadCoachingListQuery();
+  const { data, fetchMore, error } = useLoadCoachingListQuery();
   const { t } = useTranslation();
 
   const coachingAccounts = data?.coachingAccountLists;
+
+  useFetchAllPages({
+    fetchMore,
+    error,
+    pageInfo: coachingAccounts?.pageInfo,
+  });
 
   return (
     <CoachingListWrapper>
@@ -55,11 +66,11 @@ export const CoachingList: React.FC<CoachingListProps> = ({
       </CoachingTitleWrapper>
       <Divider />
       <Box>
-        {loading ? (
+        {!data && !error ? (
           <>
-            <CoachingLoading role="listitem" />
-            <CoachingLoading role="listitem" />
-            <CoachingLoading role="listitem" />
+            <LoadingCoach />
+            <LoadingCoach />
+            <LoadingCoach />
           </>
         ) : (
           coachingAccounts?.nodes.map((coachingAccount, _index) => {

--- a/src/components/Coaching/CoachingRow/CoachingRow.tsx
+++ b/src/components/Coaching/CoachingRow/CoachingRow.tsx
@@ -17,7 +17,7 @@ interface Props {
   accountListId: string;
 }
 
-const CoachingRowWrapper = styled(Box)(({ theme }) => ({
+export const CoachingRowWrapper = styled(Box)(({ theme }) => ({
   width: '100%',
   maxWidth: '950px',
   margin: 'auto',

--- a/src/components/Coaching/LoadCoachingList.graphql
+++ b/src/components/Coaching/LoadCoachingList.graphql
@@ -1,5 +1,5 @@
-query LoadCoachingList {
-  coachingAccountLists(first: 100) {
+query LoadCoachingList($after: String) {
+  coachingAccountLists(first: 25, after: $after) {
     nodes {
       ...CoachedPerson
     }

--- a/src/lib/apollo/cache.ts
+++ b/src/lib/apollo/cache.ts
@@ -77,6 +77,7 @@ export const createCache = () =>
           accountListPledges: paginationFieldPolicy,
           appeals: paginationFieldPolicy,
           coachingAccountListPledges: paginationFieldPolicy,
+          coachingAccountLists: paginationFieldPolicy,
           contacts: paginationFieldPolicy,
           donations: paginationFieldPolicy,
           financialAccounts: paginationFieldPolicy,


### PR DESCRIPTION
## Description
As there was a limit on the number of coaches we could grab at one time from the GraphQL, I've implemented the `useFetchAllPages` functionality into the coaches page to ensure all coaches are rendered and not just the first 25.

This PR continues the work done on PR https://github.com/CruGlobal/mpdx-react/pull/1257 Where I adjusted the number of coaches to be fetched from 25 to 100. However, the server limits us to only fetch 50 at a time.

To Test, please impersonate Shelley and navigate to her coaches page. You can find Shelley's email address from this [HelpScout ticket](https://secure.helpscout.net/conversation/2817301546/1288380?viewId=7296147)

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
