### PR TITLE
MPDX-8521 - Formatting subpremise for US and Singapore addresses

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/AddAddressModal/AddAddressModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/AddAddressModal/AddAddressModal.test.tsx
@@ -204,7 +204,7 @@ describe('AddAddressModal', () => {
     userEvent.click(
       getByRole('option', { name: '100 Lake Hart Dr, Orlando, FL 32832, USA' }),
     );
-    expect(addressAutocomplete).toHaveValue('A/100 Lake Hart Drive');
+    expect(addressAutocomplete).toHaveValue('100 Lake Hart Drive A');
     expect(getByRole('textbox', { name: 'City' })).toHaveValue('Orlando');
     expect(getByRole('textbox', { name: 'State' })).toHaveValue('FL');
     expect(getByRole('textbox', { name: 'Zip' })).toHaveValue('32832');

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/EditContactAddressModal/EditContactAddressModal.test.tsx
@@ -257,7 +257,7 @@ describe('EditContactAddressModal', () => {
     userEvent.click(
       getByRole('option', { name: '100 Lake Hart Dr, Orlando, FL 32832, USA' }),
     );
-    expect(addressAutocomplete).toHaveValue('A/100 Lake Hart Drive');
+    expect(addressAutocomplete).toHaveValue('100 Lake Hart Drive A');
     expect(getByRole('textbox', { name: 'City' })).toHaveValue('Orlando');
     expect(getByRole('textbox', { name: 'State' })).toHaveValue('FL');
     expect(getByRole('textbox', { name: 'Zip' })).toHaveValue('32832');

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/StreetAutocomplete/StreetAutocomplete.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/StreetAutocomplete/StreetAutocomplete.test.tsx
@@ -95,7 +95,7 @@ describe('StreetAutocomplete', () => {
       postalCode: '32832',
       region: 'Orange County',
       state: 'FL',
-      street: 'A/100 Lake Hart Drive',
+      street: '100 Lake Hart Drive A',
     });
   });
 
@@ -136,12 +136,40 @@ describe('StreetAutocomplete', () => {
   describe('parsePlace', () => {
     it('parses places', () => {
       expect(parsePlace(place)).toEqual({
-        street: 'A/100 Lake Hart Drive',
+        street: '100 Lake Hart Drive A',
         city: 'Orlando',
         region: 'Orange County',
         metroArea: 'Orlando',
         state: 'FL',
         country: 'United States',
+        postalCode: '32832',
+      });
+    });
+
+    it('parses Singapore places', () => {
+      place.address_components[7].long_name = 'Singapore';
+      place.address_components[7].short_name = 'SG';
+      expect(parsePlace(place)).toEqual({
+        street: '100 Lake Hart Drive #A',
+        city: 'Orlando',
+        region: 'Orange County',
+        metroArea: 'Orlando',
+        state: 'FL',
+        country: 'Singapore',
+        postalCode: '32832',
+      });
+    });
+
+    it('parses CA/UK or other countries', () => {
+      place.address_components[7].long_name = 'Canada';
+      place.address_components[7].short_name = 'CA';
+      expect(parsePlace(place)).toEqual({
+        street: 'A/100 Lake Hart Drive',
+        city: 'Orlando',
+        region: 'Orange County',
+        metroArea: 'Orlando',
+        state: 'FL',
+        country: 'Canada',
         postalCode: '32832',
       });
     });

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/StreetAutocomplete/StreetAutocomplete.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/StreetAutocomplete/StreetAutocomplete.tsx
@@ -36,11 +36,13 @@ export const parsePlace = (
     metroArea: '',
   };
 
+  // Unit, apartment, or suite number
+  let subpremise = '';
   place.address_components?.forEach((addressComponent) => {
     const { long_name: longName, short_name: shortName } = addressComponent;
     switch (addressComponent.types[0]) {
       case 'subpremise':
-        updatedFields.street += longName + '/';
+        subpremise = longName;
         break;
       case 'street_number':
         updatedFields.street += longName + ' ';
@@ -68,6 +70,25 @@ export const parsePlace = (
         break;
     }
   });
+
+  // TODO - Replace this manual formatting with a library that can handle all edge cases
+  // We should use Google Places API to format the address.
+  if (subpremise) {
+    if (
+      updatedFields.country === 'United States' ||
+      updatedFields.country === 'Singapore'
+    ) {
+      // Adding subpremise to the end of street as this is preferred by USPS and other mail carriers
+      // Singapore prefers subpremise to be at the end of the street with a "#" prefix
+      updatedFields.street +=
+        updatedFields.country === 'United States'
+          ? ` ${subpremise}`
+          : ` #${subpremise}`;
+    } else {
+      // Adding subpremise to the end of street as this is preferred by USPS and other mail carriers
+      updatedFields.street = `${subpremise}/${updatedFields.street}`;
+    }
+  }
 
   return updatedFields;
 };

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateMultipleContacts/CreateMultipleContacts.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateMultipleContacts/CreateMultipleContacts.test.tsx
@@ -401,7 +401,7 @@ describe('CreateMultipleContacts', () => {
           name: '100 Lake Hart Dr, Orlando, FL 32832, USA',
         }),
       );
-      expect(addressAutocomplete).toHaveValue('A/100 Lake Hart Drive');
+      expect(addressAutocomplete).toHaveValue('100 Lake Hart Drive A');
       userEvent.click(getByRole('button', { name: 'Save' }));
 
       await waitFor(() => expect(mutationSpy).toHaveBeenCalled());
@@ -410,7 +410,7 @@ describe('CreateMultipleContacts', () => {
         expect(mutationSpy).toHaveGraphqlOperation('CreateContactAddress', {
           accountListId,
           attributes: {
-            street: 'A/100 Lake Hart Drive',
+            street: '100 Lake Hart Drive A',
             city: 'Orlando',
             region: 'Orange County',
             metroArea: 'Orlando',


### PR DESCRIPTION
## Description
In this PR, I changed how we format the `subpremise` (Apt, Unit or Suite number) on an address.
Before, we always put it in front of the street address formatted like `Apt 100/Street Address`. This is the correct format for the UK, CA and many other countries, but the US and Singapore prefer that `subpremise` be used at the end of the address.

[USPS stated the `subpremise` should be after the street address](https://pe.usps.com/text/pub28/28c2_003.htm)
[Singapore stated the `subpresmise` should be after the address prefixed with a hashtag.](https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/sgpEn.pdf)

[Helpscout](https://secure.helpscout.net/conversation/2827220856/1294018?viewId=7296147)
Jira: [MPDX-8521](https://jira.cru.org/browse/MPDX-8521)

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
