### PR TITLE
[no-Jira] Fix PREVIEW_URL in Dependabot preview environments

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -9,7 +9,8 @@ frontend:
         - node -v
         - |
           if [[ "${AWS_BRANCH}" != "main" && "${AWS_BRANCH}" != "staging" ]]; then
-            PREVIEW_URL="https://${AWS_BRANCH}.${AWS_APP_ID}.amplifyapp.com";
+            SUBDOMAIN="$(echo $AWS_BRANCH | sed 's/[^a-zA-Z0-9-]/-/g')"
+            PREVIEW_URL="https://${SUBDOMAIN}.${AWS_APP_ID}.amplifyapp.com";
             NEXTAUTH_URL=$PREVIEW_URL;
             echo "PREVIEW_URL=$PREVIEW_URL" >> .env;
           fi


### PR DESCRIPTION
## Description

Strip invalid characters like `/` from the `PREVIEW_URL` when creating preview environments. We're doing this because dependabot creates branches containing slashes. We're using the same logic as the amplify-preview-actions action: https://github.com/CruGlobal/amplify-preview-actions/blob/ba8e23fa3e14151058ba488a9754e154bd1d60ac/entrypoint.sh#L91

These changes successfully created a working preview environment from a branch with slashes in the name: #1264.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
