### PR TITLE
[MPDX-8538] Default to calculated goal on accounts list page

### DIFF
--- a/pages/GetAccountLists.graphql
+++ b/pages/GetAccountLists.graphql
@@ -11,6 +11,11 @@ query GetAccountLists {
       receivedPledges
       totalPledges
       currency
+      healthIndicatorData {
+        id
+        machineCalculatedGoal
+        machineCalculatedGoalCurrency
+      }
     }
   }
 }

--- a/src/components/AccountLists/AccountLists.test.tsx
+++ b/src/components/AccountLists/AccountLists.test.tsx
@@ -1,53 +1,140 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
-import { render } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
+import { gqlMock } from '__tests__/util/graphqlMocking';
+import {
+  GetAccountListsDocument,
+  GetAccountListsQuery,
+} from 'pages/GetAccountLists.generated';
 import theme from '../../theme';
 import AccountLists from '.';
 
 describe('AccountLists', () => {
   it('has correct defaults', () => {
+    const data = gqlMock<GetAccountListsQuery>(GetAccountListsDocument, {
+      mocks: {
+        accountLists: {
+          nodes: [
+            { id: '1', name: 'My Personal Staff Account' },
+            { id: '2', name: 'My Ministry Account' },
+            { id: '3', name: "My Friend's Staff Account" },
+          ],
+        },
+      },
+    });
+
     const { getByTestId } = render(
       <ThemeProvider theme={theme}>
-        <AccountLists
-          data={{
-            user: {
-              id: 'user-1',
-              setup: null,
-            },
-            accountLists: {
-              nodes: [
-                {
-                  id: 'abc',
-                  name: 'My Personal Staff Account',
-                  monthlyGoal: 100,
-                  receivedPledges: 10,
-                  totalPledges: 20,
-                  currency: 'USD',
-                },
-                {
-                  id: 'def',
-                  name: 'My Ministry Account',
-                  monthlyGoal: null,
-                  receivedPledges: 10,
-                  totalPledges: 20,
-                  currency: 'USD',
-                },
-                {
-                  id: 'ghi',
-                  name: "My Friend's Staff Account",
-                  monthlyGoal: 100,
-                  receivedPledges: 0,
-                  totalPledges: 0,
-                  currency: 'USD',
-                },
-              ],
-            },
-          }}
-        />
+        <AccountLists data={data} />
       </ThemeProvider>,
     );
-    expect(getByTestId('abc')).toHaveTextContent('My Personal Staff Account');
-    expect(getByTestId('def')).toHaveTextContent('My Ministry Account');
-    expect(getByTestId('ghi')).toHaveTextContent("My Friend's Staff Account");
+    expect(
+      within(getByTestId('account-list-1')).getByRole('heading', {
+        name: 'My Personal Staff Account',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(getByTestId('account-list-2')).getByRole('heading', {
+        name: 'My Ministry Account',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(getByTestId('account-list-3')).getByRole('heading', {
+        name: "My Friend's Staff Account",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('ignores machine calculated goal when monthly goal is set', () => {
+    const data = gqlMock<GetAccountListsQuery>(GetAccountListsDocument, {
+      mocks: {
+        accountLists: {
+          nodes: [
+            {
+              name: 'Account',
+              monthlyGoal: 1000,
+              receivedPledges: 600,
+              totalPledges: 800,
+              healthIndicatorData: {
+                machineCalculatedGoal: 2000,
+                machineCalculatedGoalCurrency: 'USD',
+              },
+              currency: 'USD',
+            },
+          ],
+        },
+      },
+    });
+
+    const { getByRole } = render(
+      <ThemeProvider theme={theme}>
+        <AccountLists data={data} />
+      </ThemeProvider>,
+    );
+    expect(getByRole('link')).toHaveTextContent(
+      'AccountGoal$1,000Gifts Started60%Committed80%',
+    );
+  });
+
+  it('uses machine calculated goal when goal is not set', () => {
+    const data = gqlMock<GetAccountListsQuery>(GetAccountListsDocument, {
+      mocks: {
+        accountLists: {
+          nodes: [
+            {
+              name: 'Account',
+              monthlyGoal: null,
+              receivedPledges: 600,
+              totalPledges: 800,
+              healthIndicatorData: {
+                machineCalculatedGoal: 2000,
+                machineCalculatedGoalCurrency: 'USD',
+              },
+              currency: 'USD',
+            },
+          ],
+        },
+      },
+    });
+
+    const { getByRole } = render(
+      <ThemeProvider theme={theme}>
+        <AccountLists data={data} />
+      </ThemeProvider>,
+    );
+    expect(getByRole('link')).toHaveTextContent(
+      'AccountGoal$2,000Gifts Started30%Committed40%',
+    );
+  });
+
+  it("hides percentages when machine calculated goal currency differs from user's currency", () => {
+    const data = gqlMock<GetAccountListsQuery>(GetAccountListsDocument, {
+      mocks: {
+        accountLists: {
+          nodes: [
+            {
+              name: 'Account',
+              monthlyGoal: null,
+              receivedPledges: 600,
+              totalPledges: 800,
+              healthIndicatorData: {
+                machineCalculatedGoal: 2000,
+                machineCalculatedGoalCurrency: 'EUR',
+              },
+              currency: 'USD',
+            },
+          ],
+        },
+      },
+    });
+
+    const { getByRole } = render(
+      <ThemeProvider theme={theme}>
+        <AccountLists data={data} />
+      </ThemeProvider>,
+    );
+    expect(getByRole('link')).toHaveTextContent(
+      'AccountGoal€2,000Gifts Started-Committed-',
+    );
   });
 });

--- a/src/components/AccountLists/AccountLists.tsx
+++ b/src/components/AccountLists/AccountLists.tsx
@@ -82,24 +82,25 @@ const AccountLists = ({ data }: Props): ReactElement => {
                 currency: preferencesCurrency,
                 healthIndicatorData,
               }) => {
-                const monthlyGoal =
-                  preferencesGoal ?? healthIndicatorData?.machineCalculatedGoal;
-                const currency =
-                  typeof preferencesGoal === 'number'
-                    ? preferencesCurrency
-                    : healthIndicatorData?.machineCalculatedGoalCurrency;
+                const hasPreferencesGoal = typeof preferencesGoal === 'number';
+                const monthlyGoal = hasPreferencesGoal
+                  ? preferencesGoal
+                  : healthIndicatorData?.machineCalculatedGoal;
+                const currency = hasPreferencesGoal
+                  ? preferencesCurrency
+                  : healthIndicatorData?.machineCalculatedGoalCurrency;
 
                 // If the currency comes from the machine calculated goal and is different from the
                 // user's currency preference, we can't calculate the received or total percentages
                 // because the numbers are in different currencies
-                const receivedPercentage =
-                  currency === preferencesCurrency && monthlyGoal
-                    ? receivedPledges / monthlyGoal
-                    : NaN;
-                const totalPercentage =
-                  currency === preferencesCurrency && monthlyGoal
-                    ? totalPledges / monthlyGoal
-                    : NaN;
+                const hasValidGoal =
+                  currency === preferencesCurrency && !!monthlyGoal;
+                const receivedPercentage = hasValidGoal
+                  ? receivedPledges / monthlyGoal
+                  : NaN;
+                const totalPercentage = hasValidGoal
+                  ? totalPledges / monthlyGoal
+                  : NaN;
 
                 return (
                   <Grid key={id} item xs={12} sm={4}>

--- a/src/components/AccountLists/AccountLists.tsx
+++ b/src/components/AccountLists/AccountLists.tsx
@@ -76,18 +76,37 @@ const AccountLists = ({ data }: Props): ReactElement => {
               ({
                 id,
                 name,
-                monthlyGoal,
+                monthlyGoal: preferencesGoal,
                 receivedPledges,
                 totalPledges,
-                currency,
+                currency: preferencesCurrency,
+                healthIndicatorData,
               }) => {
+                const monthlyGoal =
+                  preferencesGoal ?? healthIndicatorData?.machineCalculatedGoal;
+                const currency =
+                  typeof preferencesGoal === 'number'
+                    ? preferencesCurrency
+                    : healthIndicatorData?.machineCalculatedGoalCurrency;
+
+                // If the currency comes from the machine calculated goal and is different from the
+                // user's currency preference, we can't calculate the received or total percentages
+                // because the numbers are in different currencies
                 const receivedPercentage =
-                  receivedPledges / (monthlyGoal ?? NaN);
-                const totalPercentage = totalPledges / (monthlyGoal ?? NaN);
+                  currency === preferencesCurrency && monthlyGoal
+                    ? receivedPledges / monthlyGoal
+                    : NaN;
+                const totalPercentage =
+                  currency === preferencesCurrency && monthlyGoal
+                    ? totalPledges / monthlyGoal
+                    : NaN;
 
                 return (
                   <Grid key={id} item xs={12} sm={4}>
-                    <AnimatedCard elevation={3}>
+                    <AnimatedCard
+                      elevation={3}
+                      data-testid={`account-list-${id}`}
+                    >
                       <Link
                         component={NextLink}
                         href={`/accountLists/${id}`}
@@ -97,7 +116,7 @@ const AccountLists = ({ data }: Props): ReactElement => {
                         <CardActionArea>
                           <CardContent className={classes.cardContent}>
                             <Box flex={1}>
-                              <Typography variant="h5" data-testid={id} noWrap>
+                              <Typography variant="h5" noWrap>
                                 {name}
                               </Typography>
                             </Box>


### PR DESCRIPTION
## Description

When the user hasn't set a monthly goal, use the machine calculated goal on the accounts list page.

*Caveat*: If the user's default currency is different from their organization's default, we aren't able to calculate percentages because the goal amount is in one currency and their received and committed amounts are in a different currency.

[MPDX-8538](https://jira.cru.org/browse/MPDX-8538)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
