### PR TITLE
[MPDX-8539] Show calculated goal in preferences goal accordion

### DIFF
--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.test.tsx
@@ -100,7 +100,7 @@ describe('MonthlyGoalAccordion', () => {
       />,
     );
 
-    expect(await findByText('€1,000')).toBeInTheDocument();
+    expect(await findByText('€1,000 (estimated)')).toBeInTheDocument();
     expect(queryByRole('textbox')).not.toBeInTheDocument();
   });
 

--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.test.tsx
@@ -80,6 +80,7 @@ describe('MonthlyGoalAccordion', () => {
   afterEach(() => {
     mutationSpy.mockClear();
   });
+
   it('should render accordion closed', () => {
     const { getByText, queryByRole } = render(
       <Components monthlyGoal={100} expandedPanel="" />,
@@ -88,6 +89,21 @@ describe('MonthlyGoalAccordion', () => {
     expect(getByText(label)).toBeInTheDocument();
     expect(queryByRole('textbox')).not.toBeInTheDocument();
   });
+
+  it('should render accordion closed with calculated goal', async () => {
+    const { findByText, queryByRole } = render(
+      <Components
+        monthlyGoal={null}
+        machineCalculatedGoal={1000}
+        machineCalculatedGoalCurrency="EUR"
+        expandedPanel=""
+      />,
+    );
+
+    expect(await findByText('€1,000')).toBeInTheDocument();
+    expect(queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
   it('should render accordion open and textfield should have a value', () => {
     const { getByRole } = render(
       <Components monthlyGoal={20000} expandedPanel={label} />,

--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
@@ -135,7 +135,7 @@ export const MonthlyGoalAccordion: React.FC<MonthlyGoalAccordionProps> = ({
       onAccordionChange={handleAccordionChange}
       expandedPanel={expandedPanel}
       label={label}
-      value={formattedMonthlyGoal}
+      value={formattedMonthlyGoal || formattedCalculatedGoal}
       fullWidth
       disabled={disabled}
     >

--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
@@ -135,7 +135,9 @@ export const MonthlyGoalAccordion: React.FC<MonthlyGoalAccordionProps> = ({
       onAccordionChange={handleAccordionChange}
       expandedPanel={expandedPanel}
       label={label}
-      value={formattedMonthlyGoal || formattedCalculatedGoal}
+      value={
+        formattedMonthlyGoal || `${formattedCalculatedGoal} (${t('estimated')})`
+      }
       fullWidth
       disabled={disabled}
     >


### PR DESCRIPTION
## Description

On the preferences page, if the goal isn't set, show the calculated goal in the monthly accordion when the accordion is closed.

[MPDX-8539](https://jira.cru.org/browse/MPDX-8539)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
