### PR TITLE
[MPDX-8540] Use enums to identify accordions

### DIFF
--- a/pages/acceptInvite.page.tsx
+++ b/pages/acceptInvite.page.tsx
@@ -4,6 +4,7 @@ import React, { ReactElement, useEffect, useRef } from 'react';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { SetupPage } from 'src/components/Setup/SetupPage';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
 import { useRequiredSession } from 'src/hooks/useRequiredSession';
 import { ensureSessionAndAccountList } from './api/utils/pagePropsHelpers';
@@ -88,7 +89,9 @@ const AcceptInvitePage = (): ReactElement => {
 
     if (url.includes('organizations')) {
       router.push(
-        dashboardLink + 'settings/integrations?selectedTab=organization',
+        dashboardLink +
+          'settings/integrations?selectedTab=' +
+          IntegrationAccordion.Organization,
       );
     } else {
       router.push(dashboardLink);

--- a/pages/accountLists/[accountListId]/settings/admin.page.test.tsx
+++ b/pages/accountLists/[accountListId]/settings/admin.page.test.tsx
@@ -1,19 +1,14 @@
-import { useRouter } from 'next/router';
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
-import { getSession } from 'next-auth/react';
 import { SnackbarProvider } from 'notistack';
 import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { AdminAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import Admin from './admin.page';
 
-jest.mock('next-auth/react');
-jest.mock('next/router', () => ({
-  useRouter: jest.fn(),
-}));
 jest.mock('notistack', () => ({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -25,19 +20,13 @@ jest.mock('notistack', () => ({
   },
 }));
 
-const session = {
-  expires: '2021-10-28T14:48:20.897Z',
-  user: {
-    email: 'Chair Library Bed',
-    image: null,
-    name: 'Dung Tapestry',
-    token: 'superLongJwtString',
-  },
-};
+interface ComponentsProps {
+  selectedTab?: string;
+}
 
-const Components = () => (
+const Components: React.FC<ComponentsProps> = ({ selectedTab }) => (
   <ThemeProvider theme={theme}>
-    <TestRouter>
+    <TestRouter router={{ query: { selectedTab } }}>
       <GqlMockedProvider>
         <I18nextProvider i18n={i18n}>
           <SnackbarProvider>
@@ -50,14 +39,6 @@ const Components = () => (
 );
 
 describe('Admin', () => {
-  beforeEach(() => {
-    (getSession as jest.Mock).mockResolvedValue(session);
-    (useRouter as jest.Mock).mockReturnValue({
-      query: {},
-      isReady: true,
-    });
-  });
-
   it('should keep impersonate user accordion close', async () => {
     const { getAllByText } = render(<Components />);
     await waitFor(() => {
@@ -67,13 +48,9 @@ describe('Admin', () => {
   });
 
   it('should open impersonate user accordion', async () => {
-    (useRouter as jest.Mock).mockReturnValue({
-      query: {
-        selectedTab: 'Reset Account',
-      },
-      isReady: true,
-    });
-    const { getAllByText } = render(<Components />);
+    const { getAllByText } = render(
+      <Components selectedTab={AdminAccordion.ResetAccount} />,
+    );
     await waitFor(() => {
       expect(getAllByText('Impersonate User').length).toEqual(1);
       expect(getAllByText('Reset Account').length).toEqual(3);

--- a/pages/accountLists/[accountListId]/settings/admin.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/admin.page.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { enforceAdmin } from 'pages/api/utils/pagePropsHelpers';
 import { ImpersonateUserAccordion } from 'src/components/Settings/Admin/ImpersonateUser/ImpersonateUserAccordion';
 import { ResetAccountAccordion } from 'src/components/Settings/Admin/ResetAccount/ResetAccountAccordion';
+import { AdminAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionGroup } from 'src/components/Shared/Forms/Accordions/AccordionGroup';
 import { SettingsWrapper } from './Wrapper';
 
@@ -12,16 +13,12 @@ export const suggestedArticles = 'HS_SETTINGS_SERVICES_SUGGESTIONS';
 const Admin = (): ReactElement => {
   const { t } = useTranslation();
   const { query } = useRouter();
-  const [expandedPanel, setExpandedPanel] = useState(
-    typeof query.selectedTab === 'string'
-      ? query.selectedTab
-      : 'Impersonate User',
-  );
-
-  const handleAccordionChange = (panel: string) => {
-    const panelLowercase = panel.toLowerCase();
-    setExpandedPanel(expandedPanel === panelLowercase ? '' : panelLowercase);
-  };
+  const [expandedAccordion, setExpandedAccordion] =
+    useState<AdminAccordion | null>(
+      typeof query.selectedTab === 'string'
+        ? (query.selectedTab as AdminAccordion)
+        : AdminAccordion.ImpersonateUser,
+    );
 
   return (
     <SettingsWrapper
@@ -31,13 +28,13 @@ const Admin = (): ReactElement => {
     >
       <AccordionGroup title="">
         <ImpersonateUserAccordion
-          handleAccordionChange={handleAccordionChange}
-          expandedPanel={expandedPanel}
+          handleAccordionChange={setExpandedAccordion}
+          expandedAccordion={expandedAccordion}
         />
 
         <ResetAccountAccordion
-          handleAccordionChange={handleAccordionChange}
-          expandedPanel={expandedPanel}
+          handleAccordionChange={setExpandedAccordion}
+          expandedAccordion={expandedAccordion}
         />
       </AccordionGroup>
     </SettingsWrapper>

--- a/pages/accountLists/[accountListId]/settings/integrations/index.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/integrations/index.page.tsx
@@ -11,6 +11,7 @@ import { OrganizationAccordion } from 'src/components/Settings/integrations/Orga
 import { PrayerlettersAccordion } from 'src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion';
 import { SetupBanner } from 'src/components/Settings/preferences/SetupBanner';
 import { useSetupContext } from 'src/components/Setup/SetupProvider';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionGroup } from 'src/components/Shared/Forms/Accordions/AccordionGroup';
 import { StickyBox } from 'src/components/Shared/Header/styledComponents';
 import { useAccountListId } from 'src/hooks/useAccountListId';
@@ -21,15 +22,21 @@ import { SettingsWrapper } from '../Wrapper';
 const Integrations: React.FC = () => {
   const { t } = useTranslation();
   const { push, query } = useRouter();
-  const [expandedPanel, setExpandedPanel] = useState(
-    (query?.selectedTab as string | undefined) || '',
+  const [expandedAccordion, setExpandedAccordion] = useState(
+    typeof query.selectedTab === 'string'
+      ? (query.selectedTab as IntegrationAccordion)
+      : null,
   );
   const accountListId = useAccountListId() || '';
   const { appName } = useGetAppSettings();
   const { onSetupTour } = useSetupContext();
   const [setup, setSetup] = useState(0);
 
-  const setupAccordions = ['google', 'mailchimp', 'prayerletters.com'];
+  const setupAccordions = [
+    IntegrationAccordion.Google,
+    IntegrationAccordion.Mailchimp,
+    IntegrationAccordion.Prayerletters,
+  ];
 
   const [_, setSetupPosition] = useUserPreference({
     key: 'setup_position',
@@ -47,18 +54,13 @@ const Integrations: React.FC = () => {
       push(`/accountLists/${accountListId}/setup/finish`);
     } else {
       setSetup(nextNav);
-      setExpandedPanel(setupAccordions[nextNav]);
+      setExpandedAccordion(setupAccordions[nextNav]);
     }
-  };
-
-  const handleAccordionChange = (panel: string) => {
-    const panelLowercase = panel.toLowerCase();
-    setExpandedPanel(expandedPanel === panelLowercase ? '' : panelLowercase);
   };
 
   useEffect(() => {
     if (onSetupTour) {
-      setExpandedPanel(setupAccordions[0]);
+      setExpandedAccordion(setupAccordions[0]);
     }
   }, [onSetupTour]);
 
@@ -84,35 +86,35 @@ const Integrations: React.FC = () => {
       )}
       <AccordionGroup title="">
         <OktaAccordion
-          handleAccordionChange={handleAccordionChange}
-          expandedPanel={expandedPanel}
+          handleAccordionChange={setExpandedAccordion}
+          expandedAccordion={expandedAccordion}
           disabled={onSetupTour}
         />
         <OrganizationAccordion
-          handleAccordionChange={handleAccordionChange}
-          expandedPanel={expandedPanel}
+          handleAccordionChange={setExpandedAccordion}
+          expandedAccordion={expandedAccordion}
           disabled={onSetupTour}
         />
       </AccordionGroup>
       <AccordionGroup title={t('External Services')}>
         <GoogleAccordion
-          handleAccordionChange={handleAccordionChange}
-          expandedPanel={expandedPanel}
+          handleAccordionChange={setExpandedAccordion}
+          expandedAccordion={expandedAccordion}
           disabled={onSetupTour && setup !== 0}
         />
         <MailchimpAccordion
-          handleAccordionChange={handleAccordionChange}
-          expandedPanel={expandedPanel}
+          handleAccordionChange={setExpandedAccordion}
+          expandedAccordion={expandedAccordion}
           disabled={onSetupTour && setup !== 1}
         />
         <PrayerlettersAccordion
-          handleAccordionChange={handleAccordionChange}
-          expandedPanel={expandedPanel}
+          handleAccordionChange={setExpandedAccordion}
+          expandedAccordion={expandedAccordion}
           disabled={onSetupTour && setup !== 2}
         />
         <ChalklineAccordion
-          handleAccordionChange={handleAccordionChange}
-          expandedPanel={expandedPanel}
+          handleAccordionChange={setExpandedAccordion}
+          expandedAccordion={expandedAccordion}
           disabled={onSetupTour}
         />
       </AccordionGroup>

--- a/pages/accountLists/[accountListId]/settings/manageAccounts.page.test.tsx
+++ b/pages/accountLists/[accountListId]/settings/manageAccounts.page.test.tsx
@@ -1,17 +1,14 @@
-import { useRouter } from 'next/router';
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
 import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { AccountAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import ManageAccounts from './manageAccounts.page';
 
-jest.mock('next/router', () => ({
-  useRouter: jest.fn(),
-}));
 jest.mock('notistack', () => ({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -23,9 +20,13 @@ jest.mock('notistack', () => ({
   },
 }));
 
-const Components = () => (
+interface ComponentsProps {
+  selectedTab?: string;
+}
+
+const Components: React.FC<ComponentsProps> = ({ selectedTab }) => (
   <ThemeProvider theme={theme}>
-    <TestRouter>
+    <TestRouter router={{ query: { selectedTab } }}>
       <GqlMockedProvider>
         <I18nextProvider i18n={i18n}>
           <SnackbarProvider>
@@ -38,13 +39,6 @@ const Components = () => (
 );
 
 describe('ManageAccounts', () => {
-  beforeEach(() => {
-    (useRouter as jest.Mock).mockReturnValue({
-      query: {},
-      isReady: true,
-    });
-  });
-
   it('should open `Manage Account Access` accordion', async () => {
     const { getAllByText } = render(<Components />);
     await waitFor(() => {
@@ -53,13 +47,9 @@ describe('ManageAccounts', () => {
   });
 
   it('should open `Merge Your Accounts` accordion', async () => {
-    (useRouter as jest.Mock).mockReturnValue({
-      query: {
-        selectedTab: 'Merge Your Accounts',
-      },
-      isReady: true,
-    });
-    const { getAllByText } = render(<Components />);
+    const { getAllByText } = render(
+      <Components selectedTab={AccountAccordion.MergeAccounts} />,
+    );
     await waitFor(() => {
       expect(getAllByText('Manage Account Access').length).toEqual(1);
       expect(getAllByText('Merge Your Accounts').length).toEqual(2);

--- a/pages/accountLists/[accountListId]/settings/manageAccounts.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/manageAccounts.page.tsx
@@ -5,6 +5,7 @@ import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { ManageAccountAccessAccordion } from 'src/components/Settings/Accounts/ManageAccountAccess/ManageAccountAccessAccordion';
 import { MergeAccountsAccordion } from 'src/components/Settings/Accounts/MergeAccounts/MergeAccountsAccordion';
 import { MergeSpouseAccountsAccordion } from 'src/components/Settings/Accounts/MergeSpouseAccounts/MergeSpouseAccountsAccordion';
+import { AccountAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionGroup } from 'src/components/Shared/Forms/Accordions/AccordionGroup';
 import { SettingsWrapper } from './Wrapper';
 
@@ -13,16 +14,12 @@ export const suggestedArticles = 'HS_SETTINGS_SERVICES_SUGGESTIONS';
 const ManageAccounts = (): ReactElement => {
   const { t } = useTranslation();
   const { query } = useRouter();
-  const [expandedPanel, setExpandedPanel] = useState(
-    typeof query.selectedTab === 'string'
-      ? query.selectedTab
-      : 'Manage Account Access',
-  );
-
-  const handleAccordionChange = (panel: string) => {
-    const panelLowercase = panel.toLowerCase();
-    setExpandedPanel(expandedPanel === panelLowercase ? '' : panelLowercase);
-  };
+  const [expandedAccordion, setExpandedAccordion] =
+    useState<AccountAccordion | null>(
+      typeof query.selectedTab === 'string'
+        ? (query.selectedTab as AccountAccordion)
+        : AccountAccordion.ManageAccountAccess,
+    );
 
   return (
     <SettingsWrapper
@@ -32,18 +29,18 @@ const ManageAccounts = (): ReactElement => {
     >
       <AccordionGroup title="">
         <ManageAccountAccessAccordion
-          handleAccordionChange={handleAccordionChange}
-          expandedPanel={expandedPanel}
+          handleAccordionChange={setExpandedAccordion}
+          expandedAccordion={expandedAccordion}
         />
 
         <MergeAccountsAccordion
-          handleAccordionChange={handleAccordionChange}
-          expandedPanel={expandedPanel}
+          handleAccordionChange={setExpandedAccordion}
+          expandedAccordion={expandedAccordion}
         />
 
         <MergeSpouseAccountsAccordion
-          handleAccordionChange={handleAccordionChange}
-          expandedPanel={expandedPanel}
+          handleAccordionChange={setExpandedAccordion}
+          expandedAccordion={expandedAccordion}
         />
       </AccordionGroup>
     </SettingsWrapper>

--- a/pages/accountLists/[accountListId]/settings/manageCoaches.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/manageCoaches.page.tsx
@@ -3,22 +3,19 @@ import React, { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { ManageCoachesAccessAccordion } from 'src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion';
+import { CoachAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionGroup } from 'src/components/Shared/Forms/Accordions/AccordionGroup';
 import { SettingsWrapper } from './Wrapper';
 
 const ManageCoaching = (): ReactElement => {
   const { t } = useTranslation();
   const { query } = useRouter();
-  const [expandedPanel, setExpandedPanel] = useState(
-    typeof query.selectedTab === 'string'
-      ? query.selectedTab
-      : 'Manage Account Coaching Access',
-  );
-
-  const handleAccordionChange = (panel: string) => {
-    const panelLowercase = panel.toLowerCase();
-    setExpandedPanel(expandedPanel === panelLowercase ? '' : panelLowercase);
-  };
+  const [expandedAccordion, setExpandedAccordion] =
+    useState<CoachAccordion | null>(
+      typeof query.selectedTab === 'string'
+        ? (query.selectedTab as CoachAccordion)
+        : CoachAccordion.ManageCoachesAccess,
+    );
 
   return (
     <SettingsWrapper
@@ -28,8 +25,8 @@ const ManageCoaching = (): ReactElement => {
     >
       <AccordionGroup title="">
         <ManageCoachesAccessAccordion
-          handleAccordionChange={handleAccordionChange}
-          expandedPanel={expandedPanel}
+          handleAccordionChange={setExpandedAccordion}
+          expandedAccordion={expandedAccordion}
         />
       </AccordionGroup>
     </SettingsWrapper>

--- a/pages/accountLists/[accountListId]/settings/organizations.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/organizations.page.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { ImpersonateUserAccordion } from 'src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion';
 import { ManageOrganizationAccessAccordion } from 'src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion';
+import { OrganizationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionGroup } from 'src/components/Shared/Forms/Accordions/AccordionGroup';
 import { SettingsWrapper } from './Wrapper';
 import {
@@ -43,11 +44,12 @@ const HeaderAndDropdown = styled(Box)(() => ({
 const Organizations = (): ReactElement => {
   const { t } = useTranslation();
   const { query } = useRouter();
-  const [expandedPanel, setExpandedPanel] = useState(
-    typeof query.selectedTab === 'string'
-      ? query.selectedTab
-      : 'Impersonate User',
-  );
+  const [expandedAccordion, setExpandedAccordion] =
+    useState<OrganizationAccordion | null>(
+      typeof query.selectedTab === 'string'
+        ? (query.selectedTab as OrganizationAccordion)
+        : OrganizationAccordion.ImpersonateUser,
+    );
 
   const [selectedOrganization, setSelectedOrganization] = useState<
     SettingsOrganizationFragment | null | undefined
@@ -59,11 +61,6 @@ const Organizations = (): ReactElement => {
   useEffect(() => {
     setSelectedOrganization(organizations?.[0]);
   }, [organizations]);
-
-  const handleAccordionChange = (panel: string) => {
-    const panelLowercase = panel.toLowerCase();
-    setExpandedPanel(expandedPanel === panelLowercase ? '' : panelLowercase);
-  };
 
   return (
     <OrganizationsContextProvider
@@ -125,13 +122,13 @@ const Organizations = (): ReactElement => {
         )}
         <AccordionGroup title={t('External Services')}>
           <ImpersonateUserAccordion
-            handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            handleAccordionChange={setExpandedAccordion}
+            expandedAccordion={expandedAccordion}
           />
 
           <ManageOrganizationAccessAccordion
-            handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            handleAccordionChange={setExpandedAccordion}
+            expandedAccordion={expandedAccordion}
           />
         </AccordionGroup>
       </SettingsWrapper>

--- a/pages/accountLists/[accountListId]/settings/preferences.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/preferences.page.tsx
@@ -26,6 +26,7 @@ import { PrimaryOrgAccordion } from 'src/components/Settings/preferences/accordi
 import { TimeZoneAccordion } from 'src/components/Settings/preferences/accordions/TimeZoneAccordion/TimeZoneAccordion';
 import { ProfileInfo } from 'src/components/Settings/preferences/info/ProfileInfo';
 import { useSetupContext } from 'src/components/Setup/SetupProvider';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionGroup } from 'src/components/Shared/Forms/Accordions/AccordionGroup';
 import { StickyBox } from 'src/components/Shared/Header/styledComponents';
 import { useAccountListId } from 'src/hooks/useAccountListId';
@@ -47,11 +48,18 @@ const Preferences: React.FC = () => {
   const { onSetupTour } = useSetupContext();
   const session = useRequiredSession();
 
-  const setupAccordions = ['locale', 'monthly goal', 'home country'];
+  const setupAccordions = [
+    PreferenceAccordion.Locale,
+    PreferenceAccordion.MonthlyGoal,
+    PreferenceAccordion.HomeCountry,
+  ];
   const [setup, setSetup] = useState(0);
-  const [expandedPanel, setExpandedPanel] = useState(
-    typeof query.selectedTab === 'string' ? query.selectedTab : '',
-  );
+  const [expandedAccordion, setExpandedAccordion] =
+    useState<PreferenceAccordion | null>(
+      typeof query.selectedTab === 'string'
+        ? (query.selectedTab as PreferenceAccordion)
+        : null,
+    );
   const countries = getCountries();
   const timeZones = useGetTimezones();
 
@@ -100,14 +108,9 @@ const Preferences: React.FC = () => {
 
   useEffect(() => {
     if (onSetupTour) {
-      setExpandedPanel(setupAccordions[0]);
+      setExpandedAccordion(setupAccordions[0]);
     }
   }, [onSetupTour]);
-
-  const handleAccordionChange = (panel: string) => {
-    const panelLowercase = panel.toLowerCase();
-    setExpandedPanel(expandedPanel === panelLowercase ? '' : panelLowercase);
-  };
 
   const resetWelcomeTour = async () => {
     setSetupPosition('start');
@@ -125,7 +128,7 @@ const Preferences: React.FC = () => {
       push(`/accountLists/${accountListId}/settings/notifications`);
     } else {
       setSetup(nextNav);
-      setExpandedPanel(setupAccordions[nextNav]);
+      setExpandedAccordion(setupAccordions[nextNav]);
     }
   };
 
@@ -174,14 +177,14 @@ const Preferences: React.FC = () => {
         {!personalPreferencesLoading && (
           <>
             <LanguageAccordion
-              handleAccordionChange={handleAccordionChange}
-              expandedPanel={expandedPanel}
+              handleAccordionChange={setExpandedAccordion}
+              expandedAccordion={expandedAccordion}
               locale={personalPreferencesData?.user?.preferences?.locale || ''}
               disabled={onSetupTour}
             />
             <LocaleAccordion
-              handleAccordionChange={handleAccordionChange}
-              expandedPanel={expandedPanel}
+              handleAccordionChange={setExpandedAccordion}
+              expandedAccordion={expandedAccordion}
               localeDisplay={
                 personalPreferencesData?.user?.preferences?.localeDisplay || ''
               }
@@ -189,8 +192,8 @@ const Preferences: React.FC = () => {
               handleSetupChange={handleSetupChange}
             />
             <DefaultAccountAccordion
-              handleAccordionChange={handleAccordionChange}
-              expandedPanel={expandedPanel}
+              handleAccordionChange={setExpandedAccordion}
+              expandedAccordion={expandedAccordion}
               data={personalPreferencesData}
               accountListId={accountListId}
               defaultAccountList={
@@ -199,8 +202,8 @@ const Preferences: React.FC = () => {
               disabled={onSetupTour}
             />
             <TimeZoneAccordion
-              handleAccordionChange={handleAccordionChange}
-              expandedPanel={expandedPanel}
+              handleAccordionChange={setExpandedAccordion}
+              expandedAccordion={expandedAccordion}
               timeZone={
                 personalPreferencesData?.user?.preferences?.timeZone || ''
               }
@@ -208,8 +211,8 @@ const Preferences: React.FC = () => {
               disabled={onSetupTour}
             />
             <HourToSendNotificationsAccordion
-              handleAccordionChange={handleAccordionChange}
-              expandedPanel={expandedPanel}
+              handleAccordionChange={setExpandedAccordion}
+              expandedAccordion={expandedAccordion}
               hourToSendNotifications={
                 personalPreferencesData?.user?.preferences
                   ?.hourToSendNotifications || null
@@ -232,15 +235,15 @@ const Preferences: React.FC = () => {
         {!accountPreferencesLoading && (
           <>
             <AccountNameAccordion
-              handleAccordionChange={handleAccordionChange}
-              expandedPanel={expandedPanel}
+              handleAccordionChange={setExpandedAccordion}
+              expandedAccordion={expandedAccordion}
               name={accountPreferencesData?.accountList?.name || ''}
               accountListId={accountListId}
               disabled={onSetupTour}
             />
             <MonthlyGoalAccordion
-              handleAccordionChange={handleAccordionChange}
-              expandedPanel={expandedPanel}
+              handleAccordionChange={setExpandedAccordion}
+              expandedAccordion={expandedAccordion}
               monthlyGoal={
                 accountPreferencesData?.accountList?.settings?.monthlyGoal ||
                 null
@@ -253,8 +256,8 @@ const Preferences: React.FC = () => {
               handleSetupChange={handleSetupChange}
             />
             <HomeCountryAccordion
-              handleAccordionChange={handleAccordionChange}
-              expandedPanel={expandedPanel}
+              handleAccordionChange={setExpandedAccordion}
+              expandedAccordion={expandedAccordion}
               homeCountry={
                 accountPreferencesData?.accountList?.settings?.homeCountry || ''
               }
@@ -264,8 +267,8 @@ const Preferences: React.FC = () => {
               handleSetupChange={handleSetupChange}
             />
             <CurrencyAccordion
-              handleAccordionChange={handleAccordionChange}
-              expandedPanel={expandedPanel}
+              handleAccordionChange={setExpandedAccordion}
+              expandedAccordion={expandedAccordion}
               currency={
                 accountPreferencesData?.accountList?.settings?.currency || ''
               }
@@ -276,8 +279,8 @@ const Preferences: React.FC = () => {
               userOrganizationAccountsData?.userOrganizationAccounts?.length >
                 1 && (
                 <PrimaryOrgAccordion
-                  handleAccordionChange={handleAccordionChange}
-                  expandedPanel={expandedPanel}
+                  handleAccordionChange={setExpandedAccordion}
+                  expandedAccordion={expandedAccordion}
                   organizations={userOrganizationAccountsData}
                   salaryOrganizationId={
                     accountPreferencesData?.accountList?.salaryOrganizationId ||
@@ -288,8 +291,8 @@ const Preferences: React.FC = () => {
                 />
               )}
             <EarlyAdopterAccordion
-              handleAccordionChange={handleAccordionChange}
-              expandedPanel={expandedPanel}
+              handleAccordionChange={setExpandedAccordion}
+              expandedAccordion={expandedAccordion}
               tester={
                 accountPreferencesData?.accountList?.settings?.tester || false
               }
@@ -297,8 +300,8 @@ const Preferences: React.FC = () => {
               disabled={onSetupTour}
             />
             <MpdInfoAccordion
-              handleAccordionChange={handleAccordionChange}
-              expandedPanel={expandedPanel}
+              handleAccordionChange={setExpandedAccordion}
+              expandedAccordion={expandedAccordion}
               activeMpdStartAt={
                 accountPreferencesData?.accountList?.activeMpdStartAt || ''
               }
@@ -317,8 +320,8 @@ const Preferences: React.FC = () => {
             />
             {canUserExportData?.canUserExportData.allowed && (
               <ExportAllDataAccordion
-                handleAccordionChange={handleAccordionChange}
-                expandedPanel={expandedPanel}
+                handleAccordionChange={setExpandedAccordion}
+                expandedAccordion={expandedAccordion}
                 exportedAt={
                   canUserExportData?.canUserExportData.exportedAt || undefined
                 }

--- a/src/components/Settings/Accounts/ManageAccountAccess/ManageAccountAccessAccordion.test.tsx
+++ b/src/components/Settings/Accounts/ManageAccountAccess/ManageAccountAccessAccordion.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { AccountAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from '../../../../theme';
 import { GetAccountsSharingWithQuery } from './ManageAccountAccess.generated';
 import { ManageAccountAccessAccordion } from './ManageAccountAccessAccordion';
@@ -47,7 +48,7 @@ describe('ManageAccountAccessAccordion', () => {
         <GqlMockedProvider>
           <ManageAccountAccessAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={''}
+            expandedAccordion={null}
           />
         </GqlMockedProvider>
       </Components>,
@@ -62,7 +63,7 @@ describe('ManageAccountAccessAccordion', () => {
         <GqlMockedProvider>
           <ManageAccountAccessAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Manage Account Access'}
+            expandedAccordion={AccountAccordion.ManageAccountAccess}
           />
         </GqlMockedProvider>
       </Components>,
@@ -107,7 +108,7 @@ describe('ManageAccountAccessAccordion', () => {
         >
           <ManageAccountAccessAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Manage Account Access'}
+            expandedAccordion={AccountAccordion.ManageAccountAccess}
           />
         </GqlMockedProvider>
       </Components>,

--- a/src/components/Settings/Accounts/ManageAccountAccess/ManageAccountAccessAccordion.tsx
+++ b/src/components/Settings/Accounts/ManageAccountAccess/ManageAccountAccessAccordion.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Alert, Typography } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
+import { AccountAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { StyledFormLabel } from 'src/components/Shared/Forms/Field';
 import { InviteTypeEnum } from 'src/graphql/types.generated';
@@ -15,10 +16,9 @@ import {
   useGetAccountsSharingWithQuery,
 } from './ManageAccountAccess.generated';
 
-export const ManageAccountAccessAccordion: React.FC<AccordionProps> = ({
-  handleAccordionChange,
-  expandedPanel,
-}) => {
+export const ManageAccountAccessAccordion: React.FC<
+  AccordionProps<AccountAccordion>
+> = ({ handleAccordionChange, expandedAccordion }) => {
   const { t } = useTranslation();
   const accordionName = t('Manage Account Access');
   const { enqueueSnackbar } = useSnackbar();
@@ -76,8 +76,9 @@ export const ManageAccountAccessAccordion: React.FC<AccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={AccountAccordion.ManageAccountAccess}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={accordionName}
       value={''}
       fullWidth={true}

--- a/src/components/Settings/Accounts/MergeAccounts/MergeAccountsAccordion.test.tsx
+++ b/src/components/Settings/Accounts/MergeAccounts/MergeAccountsAccordion.test.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { AccountAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from '../../../../theme';
 import { MergeAccountsAccordion } from './MergeAccountsAccordion';
 
@@ -45,7 +46,7 @@ describe('MergeAccountsAccordion', () => {
         <GqlMockedProvider>
           <MergeAccountsAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={''}
+            expandedAccordion={null}
           />
         </GqlMockedProvider>
       </Components>,
@@ -59,7 +60,7 @@ describe('MergeAccountsAccordion', () => {
         <GqlMockedProvider>
           <MergeAccountsAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Merge Your Accounts'}
+            expandedAccordion={AccountAccordion.MergeAccounts}
           />
         </GqlMockedProvider>
       </Components>,

--- a/src/components/Settings/Accounts/MergeAccounts/MergeAccountsAccordion.tsx
+++ b/src/components/Settings/Accounts/MergeAccounts/MergeAccountsAccordion.tsx
@@ -1,20 +1,21 @@
 import { useTranslation } from 'react-i18next';
+import { AccountAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { StyledFormLabel } from 'src/components/Shared/Forms/Field';
 import { AccordionProps } from '../../accordionHelper';
 import { MergeForm } from '../MergeForm/MergeForm';
 
-export const MergeAccountsAccordion: React.FC<AccordionProps> = ({
-  handleAccordionChange,
-  expandedPanel,
-}) => {
+export const MergeAccountsAccordion: React.FC<
+  AccordionProps<AccountAccordion>
+> = ({ handleAccordionChange, expandedAccordion }) => {
   const { t } = useTranslation();
   const accordionName = t('Merge Your Accounts');
 
   return (
     <AccordionItem
+      accordion={AccountAccordion.MergeAccounts}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={accordionName}
       value={''}
     >

--- a/src/components/Settings/Accounts/MergeSpouseAccounts/MergeSpouseAccountsAccordion.test.tsx
+++ b/src/components/Settings/Accounts/MergeSpouseAccounts/MergeSpouseAccountsAccordion.test.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { AccountAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from '../../../../theme';
 import { MergeSpouseAccountsAccordion } from './MergeSpouseAccountsAccordion';
 
@@ -45,7 +46,7 @@ describe('MergeSpouseAccountsAccordion', () => {
         <GqlMockedProvider>
           <MergeSpouseAccountsAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={''}
+            expandedAccordion={null}
           />
         </GqlMockedProvider>
       </Components>,
@@ -58,7 +59,7 @@ describe('MergeSpouseAccountsAccordion', () => {
         <GqlMockedProvider>
           <MergeSpouseAccountsAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Merge Spouse Accounts'}
+            expandedAccordion={AccountAccordion.MergeSpouseAccounts}
           />
         </GqlMockedProvider>
       </Components>,

--- a/src/components/Settings/Accounts/MergeSpouseAccounts/MergeSpouseAccountsAccordion.tsx
+++ b/src/components/Settings/Accounts/MergeSpouseAccounts/MergeSpouseAccountsAccordion.tsx
@@ -1,6 +1,7 @@
 import { Divider, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
+import { AccountAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { StyledFormLabel } from 'src/components/Shared/Forms/Field';
 import { InviteTypeEnum } from 'src/graphql/types.generated';
@@ -14,18 +15,18 @@ const DividerWithPadding = styled(Divider)(() => ({
   marginBottom: '20px',
 }));
 
-export const MergeSpouseAccountsAccordion: React.FC<AccordionProps> = ({
-  handleAccordionChange,
-  expandedPanel,
-}) => {
+export const MergeSpouseAccountsAccordion: React.FC<
+  AccordionProps<AccountAccordion>
+> = ({ handleAccordionChange, expandedAccordion }) => {
   const { t } = useTranslation();
   const { appName } = useGetAppSettings();
   const accordionName = t('Merge Spouse Accounts');
 
   return (
     <AccordionItem
+      accordion={AccountAccordion.MergeSpouseAccounts}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={accordionName}
       value={''}
       fullWidth={true}

--- a/src/components/Settings/Admin/ImpersonateUser/ImpersonateUserAccordion.test.tsx
+++ b/src/components/Settings/Admin/ImpersonateUser/ImpersonateUserAccordion.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { AdminAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from '../../../../theme';
 import { ImpersonateUserAccordion } from './ImpersonateUserAccordion';
 
@@ -31,18 +32,18 @@ jest.mock('notistack', () => ({
 const handleAccordionChange = jest.fn();
 
 interface ComponentsProps {
-  expandedPanel: string;
+  expandedAccordion: AdminAccordion | null;
   mutationSpy?: () => void;
 }
 
-const Components = ({ mutationSpy, expandedPanel }: ComponentsProps) => (
+const Components = ({ mutationSpy, expandedAccordion }: ComponentsProps) => (
   <SnackbarProvider>
     <TestRouter router={router}>
       <ThemeProvider theme={theme}>
         <GqlMockedProvider onCall={mutationSpy}>
           <ImpersonateUserAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            expandedAccordion={expandedAccordion}
           />
         </GqlMockedProvider>
       </ThemeProvider>
@@ -74,7 +75,7 @@ describe('ImpersonateUserAccordion', () => {
       const { getAllByRole, getByRole } = render(
         <Components
           mutationSpy={mutationSpy}
-          expandedPanel={'Impersonate User'}
+          expandedAccordion={AdminAccordion.ImpersonateUser}
         />,
       );
 
@@ -115,7 +116,7 @@ describe('ImpersonateUserAccordion', () => {
       const { getAllByRole, getByRole } = render(
         <Components
           mutationSpy={mutationSpy}
-          expandedPanel={'Impersonate User'}
+          expandedAccordion={AdminAccordion.ImpersonateUser}
         />,
       );
 
@@ -154,7 +155,7 @@ describe('ImpersonateUserAccordion', () => {
       const { getByText, getAllByRole, getByRole } = render(
         <Components
           mutationSpy={mutationSpy}
-          expandedPanel={'Impersonate User'}
+          expandedAccordion={AdminAccordion.ImpersonateUser}
         />,
       );
 
@@ -186,7 +187,7 @@ describe('ImpersonateUserAccordion', () => {
     });
 
     it('should render Accordion closed', async () => {
-      const { getAllByText } = render(<Components expandedPanel={''} />);
+      const { getAllByText } = render(<Components expandedAccordion={null} />);
       expect(getAllByText('Impersonate User').length).toEqual(1);
     });
 
@@ -196,7 +197,7 @@ describe('ImpersonateUserAccordion', () => {
       const { getAllByText, getAllByRole, getByRole } = render(
         <Components
           mutationSpy={mutationSpy}
-          expandedPanel={'Impersonate User'}
+          expandedAccordion={AdminAccordion.ImpersonateUser}
         />,
       );
       expect(getAllByText('Impersonate User').length).toEqual(3);

--- a/src/components/Settings/Admin/ImpersonateUser/ImpersonateUserAccordion.tsx
+++ b/src/components/Settings/Admin/ImpersonateUser/ImpersonateUserAccordion.tsx
@@ -12,6 +12,7 @@ import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { AdminAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { StyledFormLabel } from 'src/components/Shared/Forms/FieldHelper';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
@@ -35,10 +36,9 @@ const ImpersonateUserSchema: yup.ObjectSchema<ImpersonateUserFormType> =
     reason: yup.string().required(),
   });
 
-export const ImpersonateUserAccordion: React.FC<AccordionProps> = ({
-  handleAccordionChange,
-  expandedPanel,
-}) => {
+export const ImpersonateUserAccordion: React.FC<
+  AccordionProps<AdminAccordion>
+> = ({ handleAccordionChange, expandedAccordion }) => {
   const { t } = useTranslation();
   const accordionName = t('Impersonate User');
   const { enqueueSnackbar } = useSnackbar();
@@ -84,8 +84,9 @@ export const ImpersonateUserAccordion: React.FC<AccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={AdminAccordion.ImpersonateUser}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={accordionName}
       value={''}
     >

--- a/src/components/Settings/Admin/ResetAccount/ResetAccountAccordion.test.tsx
+++ b/src/components/Settings/Admin/ResetAccount/ResetAccountAccordion.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { AdminAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from '../../../../theme';
 import { ResetAccountAccordion } from './ResetAccountAccordion';
 
@@ -46,7 +47,7 @@ describe('ResetAccountAccordion', () => {
         <GqlMockedProvider>
           <ResetAccountAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={''}
+            expandedAccordion={null}
           />
         </GqlMockedProvider>
       </Components>,
@@ -61,7 +62,7 @@ describe('ResetAccountAccordion', () => {
         <GqlMockedProvider onCall={mutationSpy}>
           <ResetAccountAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Reset Account'}
+            expandedAccordion={AdminAccordion.ResetAccount}
           />
         </GqlMockedProvider>
       </Components>,
@@ -115,7 +116,7 @@ describe('ResetAccountAccordion', () => {
         <GqlMockedProvider onCall={mutationSpy}>
           <ResetAccountAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Reset Account'}
+            expandedAccordion={AdminAccordion.ResetAccount}
           />
         </GqlMockedProvider>
       </Components>,

--- a/src/components/Settings/Admin/ResetAccount/ResetAccountAccordion.tsx
+++ b/src/components/Settings/Admin/ResetAccount/ResetAccountAccordion.tsx
@@ -11,6 +11,7 @@ import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { AdminAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { StyledFormLabel } from 'src/components/Shared/Forms/FieldHelper';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
@@ -35,10 +36,9 @@ const ImpersonateUserSchema: yup.ObjectSchema<ImpersonateUserFormType> =
     reason: yup.string(),
   });
 
-export const ResetAccountAccordion: React.FC<AccordionProps> = ({
-  handleAccordionChange,
-  expandedPanel,
-}) => {
+export const ResetAccountAccordion: React.FC<
+  AccordionProps<AdminAccordion>
+> = ({ handleAccordionChange, expandedAccordion }) => {
   const { t } = useTranslation();
   const accordionName = t('Reset Account');
   const { enqueueSnackbar } = useSnackbar();
@@ -74,8 +74,9 @@ export const ResetAccountAccordion: React.FC<AccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={AdminAccordion.ResetAccount}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={accordionName}
       value={''}
     >

--- a/src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion.test.tsx
+++ b/src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { CoachAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from '../../../../theme';
 import { GetAccountListCoachesQuery } from './ManageAccountAccess.generated';
 import { ManageCoachesAccessAccordion } from './ManageCoachesAccessAccordion';
@@ -47,7 +48,7 @@ describe('ManageCoachesAccessAccordion', () => {
         <GqlMockedProvider>
           <ManageCoachesAccessAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={''}
+            expandedAccordion={null}
           />
         </GqlMockedProvider>
       </Components>,
@@ -62,7 +63,7 @@ describe('ManageCoachesAccessAccordion', () => {
         <GqlMockedProvider>
           <ManageCoachesAccessAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Manage Account Coaching Access'}
+            expandedAccordion={CoachAccordion.ManageCoachesAccess}
           />
         </GqlMockedProvider>
       </Components>,
@@ -96,7 +97,7 @@ describe('ManageCoachesAccessAccordion', () => {
         >
           <ManageCoachesAccessAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Manage Account Coaching Access'}
+            expandedAccordion={CoachAccordion.ManageCoachesAccess}
           />
         </GqlMockedProvider>
       </Components>,

--- a/src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion.tsx
+++ b/src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Alert, Typography } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
+import { CoachAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { StyledFormLabel } from 'src/components/Shared/Forms/Field';
 import { InviteTypeEnum } from 'src/graphql/types.generated';
@@ -15,10 +16,9 @@ import {
   useGetAccountListCoachesQuery,
 } from './ManageAccountAccess.generated';
 
-export const ManageCoachesAccessAccordion: React.FC<AccordionProps> = ({
-  handleAccordionChange,
-  expandedPanel,
-}) => {
+export const ManageCoachesAccessAccordion: React.FC<
+  AccordionProps<CoachAccordion>
+> = ({ handleAccordionChange, expandedAccordion }) => {
   const { t } = useTranslation();
   const accordionName = t('Manage Account Coaching Access');
   const { enqueueSnackbar } = useSnackbar();
@@ -68,8 +68,9 @@ export const ManageCoachesAccessAccordion: React.FC<AccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={CoachAccordion.ManageCoachesAccess}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={accordionName}
       value={''}
       fullWidth={true}

--- a/src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion.test.tsx
+++ b/src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion.test.tsx
@@ -6,6 +6,7 @@ import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { OrganizationsContextProvider } from 'pages/accountLists/[accountListId]/settings/organizations.page';
+import { OrganizationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from '../../../../theme';
 import { ImpersonateUserAccordion } from './ImpersonateUserAccordion';
 
@@ -59,7 +60,7 @@ describe('ImpersonateUserAccordion', () => {
         <GqlMockedProvider>
           <ImpersonateUserAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={''}
+            expandedAccordion={null}
           />
         </GqlMockedProvider>
       </Components>,
@@ -74,7 +75,7 @@ describe('ImpersonateUserAccordion', () => {
         <GqlMockedProvider onCall={mutationSpy}>
           <ImpersonateUserAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Impersonate User'}
+            expandedAccordion={OrganizationAccordion.ImpersonateUser}
           />
         </GqlMockedProvider>
       </Components>,

--- a/src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion.tsx
+++ b/src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion.tsx
@@ -16,6 +16,7 @@ import {
   OrganizationsContext,
   OrganizationsContextType,
 } from 'pages/accountLists/[accountListId]/settings/organizations.page';
+import { OrganizationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { StyledFormLabel } from 'src/components/Shared/Forms/Field';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
@@ -39,10 +40,9 @@ const impersonateUserSchema: yup.ObjectSchema<ImpersonateUserFormType> =
     reason: yup.string().required(),
   });
 
-export const ImpersonateUserAccordion: React.FC<AccordionProps> = ({
-  handleAccordionChange,
-  expandedPanel,
-}) => {
+export const ImpersonateUserAccordion: React.FC<
+  AccordionProps<OrganizationAccordion>
+> = ({ handleAccordionChange, expandedAccordion }) => {
   const { t } = useTranslation();
   const accordionName = t('Impersonate User');
   const { enqueueSnackbar } = useSnackbar();
@@ -93,8 +93,9 @@ export const ImpersonateUserAccordion: React.FC<AccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={OrganizationAccordion.ImpersonateUser}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={accordionName}
       value={''}
     >

--- a/src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion.test.tsx
+++ b/src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion.test.tsx
@@ -6,6 +6,7 @@ import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { OrganizationsContextProvider } from 'pages/accountLists/[accountListId]/settings/organizations.page';
+import { OrganizationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from '../../../../theme';
 import {
   CreateOrganizationInviteMutation,
@@ -98,7 +99,7 @@ describe('ManageOrganizationAccessAccordion', () => {
         <GqlMockedProvider>
           <ManageOrganizationAccessAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={''}
+            expandedAccordion={null}
           />
         </GqlMockedProvider>
       </Components>,
@@ -128,7 +129,7 @@ describe('ManageOrganizationAccessAccordion', () => {
         >
           <ManageOrganizationAccessAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Manage Organization Access'}
+            expandedAccordion={OrganizationAccordion.ManageOrganizationAccess}
           />
         </GqlMockedProvider>
       </Components>,
@@ -162,7 +163,7 @@ describe('ManageOrganizationAccessAccordion', () => {
         >
           <ManageOrganizationAccessAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Manage Organization Access'}
+            expandedAccordion={OrganizationAccordion.ManageOrganizationAccess}
           />
         </GqlMockedProvider>
       </Components>,
@@ -208,7 +209,7 @@ describe('ManageOrganizationAccessAccordion', () => {
         >
           <ManageOrganizationAccessAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Manage Organization Access'}
+            expandedAccordion={OrganizationAccordion.ManageOrganizationAccess}
           />
         </GqlMockedProvider>
       </Components>,
@@ -268,7 +269,7 @@ describe('ManageOrganizationAccessAccordion', () => {
         >
           <ManageOrganizationAccessAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Manage Organization Access'}
+            expandedAccordion={OrganizationAccordion.ManageOrganizationAccess}
           />
         </GqlMockedProvider>
       </Components>,

--- a/src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion.tsx
+++ b/src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion.tsx
@@ -22,6 +22,7 @@ import {
   OrganizationsContext,
   OrganizationsContextType,
 } from 'pages/accountLists/[accountListId]/settings/organizations.page';
+import { OrganizationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { SubmitButton } from 'src/components/common/Modal/ActionButtons/ActionButtons';
@@ -66,10 +67,9 @@ const impersonateUserSchema: yup.ObjectSchema<ImpersonateUserFormType> =
     username: yup.string().email().required(),
   });
 
-export const ManageOrganizationAccessAccordion: React.FC<AccordionProps> = ({
-  handleAccordionChange,
-  expandedPanel,
-}) => {
+export const ManageOrganizationAccessAccordion: React.FC<
+  AccordionProps<OrganizationAccordion>
+> = ({ handleAccordionChange, expandedAccordion }) => {
   const { t } = useTranslation();
   const accordionName = t('Manage Organization Access');
   const { enqueueSnackbar } = useSnackbar();
@@ -245,8 +245,9 @@ export const ManageOrganizationAccessAccordion: React.FC<AccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={OrganizationAccordion.ManageOrganizationAccess}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={accordionName}
       value={''}
     >

--- a/src/components/Settings/accordionHelper.ts
+++ b/src/components/Settings/accordionHelper.ts
@@ -1,4 +1,4 @@
-export interface AccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+export interface AccordionProps<AccordionEnum> {
+  handleAccordionChange: (accordion: AccordionEnum | null) => void;
+  expandedAccordion: AccordionEnum | null;
 }

--- a/src/components/Settings/integrations/Chalkline/ChalklineAccordion.test.tsx
+++ b/src/components/Settings/integrations/Chalkline/ChalklineAccordion.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from '../../../../theme';
 import { ChalklineAccordion } from './ChalklineAccordion';
 
@@ -47,7 +48,7 @@ describe('PrayerlettersAccount', () => {
         <GqlMockedProvider>
           <ChalklineAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={''}
+            expandedAccordion={null}
           />
         </GqlMockedProvider>
       </Components>,
@@ -64,7 +65,7 @@ describe('PrayerlettersAccount', () => {
         <GqlMockedProvider>
           <ChalklineAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Chalk Line'}
+            expandedAccordion={IntegrationAccordion.Chalkline}
           />
         </GqlMockedProvider>
       </Components>,
@@ -84,7 +85,7 @@ describe('PrayerlettersAccount', () => {
         <GqlMockedProvider onCall={mutationSpy}>
           <ChalklineAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Chalk Line'}
+            expandedAccordion={IntegrationAccordion.Chalkline}
           />
         </GqlMockedProvider>
       </Components>,

--- a/src/components/Settings/integrations/Chalkline/ChalklineAccordion.tsx
+++ b/src/components/Settings/integrations/Chalkline/ChalklineAccordion.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Typography } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { StyledFormLabel } from 'src/components/Shared/Forms/FieldHelper';
 import { Confirmation } from 'src/components/common/Modal/Confirmation/Confirmation';
@@ -12,7 +13,7 @@ import { useSendToChalklineMutation } from './SendToChalkline.generated';
 
 export const ChalklineAccordion: React.FC<AccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   disabled,
 }) => {
   const { t } = useTranslation();
@@ -51,8 +52,9 @@ export const ChalklineAccordion: React.FC<AccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={IntegrationAccordion.Chalkline}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={accordionName}
       value={''}
       disabled={disabled}

--- a/src/components/Settings/integrations/Google/GoogleAccordion.test.tsx
+++ b/src/components/Settings/integrations/Google/GoogleAccordion.test.tsx
@@ -125,7 +125,7 @@ describe('GoogleAccordion', () => {
 
       expect(getByText(/continue/i)).toHaveAttribute(
         'href',
-        `https://auth.mpdx.org/auth/user/google?account_list_id=account-list-1&redirect_to=https%3A%2F%2Fmpdx.org%2FaccountLists%2Faccount-list-1%2Fsettings%2Fintegrations%3FselectedTab%3DGoogle&access_token=apiToken`,
+        `https://auth.mpdx.org/auth/user/google?account_list_id=account-list-1&redirect_to=https%3A%2F%2Fmpdx.org%2FaccountLists%2Faccount-list-1%2Fsettings%2Fintegrations%3FselectedTab%3Dgoogle&access_token=apiToken`,
       );
     });
   });
@@ -224,7 +224,7 @@ describe('GoogleAccordion', () => {
 
         expect(getByText(/continue/i)).toHaveAttribute(
           'href',
-          `https://auth.mpdx.org/auth/user/google?account_list_id=account-list-1&redirect_to=https%3A%2F%2Fmpdx.org%2FaccountLists%2Faccount-list-1%2Fsettings%2Fintegrations%3FselectedTab%3DGoogle&access_token=apiToken`,
+          `https://auth.mpdx.org/auth/user/google?account_list_id=account-list-1&redirect_to=https%3A%2F%2Fmpdx.org%2FaccountLists%2Faccount-list-1%2Fsettings%2Fintegrations%3FselectedTab%3Dgoogle&access_token=apiToken`,
         );
       });
     });

--- a/src/components/Settings/integrations/Google/GoogleAccordion.test.tsx
+++ b/src/components/Settings/integrations/Google/GoogleAccordion.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from '../../../../theme';
 import { GoogleAccordion } from './GoogleAccordion';
 import { GoogleAccountsQuery } from './GoogleAccounts.generated';
@@ -58,7 +59,7 @@ describe('GoogleAccordion', () => {
         <GqlMockedProvider>
           <GoogleAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={''}
+            expandedAccordion={null}
           />
         </GqlMockedProvider>
       </Components>,
@@ -75,7 +76,7 @@ describe('GoogleAccordion', () => {
         <GqlMockedProvider>
           <GoogleAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Google'}
+            expandedAccordion={IntegrationAccordion.Google}
           />
         </GqlMockedProvider>
       </Components>,
@@ -103,7 +104,7 @@ describe('GoogleAccordion', () => {
           >
             <GoogleAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Google'}
+              expandedAccordion={IntegrationAccordion.Google}
             />
           </GqlMockedProvider>
         </Components>,
@@ -151,7 +152,7 @@ describe('GoogleAccordion', () => {
           >
             <GoogleAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Google'}
+              expandedAccordion={IntegrationAccordion.Google}
             />
           </GqlMockedProvider>
         </Components>,
@@ -207,7 +208,7 @@ describe('GoogleAccordion', () => {
           >
             <GoogleAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Google'}
+              expandedAccordion={IntegrationAccordion.Google}
             />
           </GqlMockedProvider>
         </Components>,

--- a/src/components/Settings/integrations/Google/GoogleAccordion.tsx
+++ b/src/components/Settings/integrations/Google/GoogleAccordion.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { Trans, useTranslation } from 'react-i18next';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { StyledFormLabel } from 'src/components/Shared/Forms/FieldHelper';
 import Modal from 'src/components/common/Modal/Modal';
@@ -73,7 +74,7 @@ export type GoogleAccountAttributesSlimmed = Pick<
 
 export const GoogleAccordion: React.FC<AccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   disabled,
 }) => {
   const accountListId = useAccountListId();
@@ -85,7 +86,7 @@ export const GoogleAccordion: React.FC<AccordionProps> = ({
     GoogleAccountAttributesSlimmed | undefined
   >();
   const { data, loading } = useGoogleAccountsQuery({
-    skip: !expandedPanel,
+    skip: !expandedAccordion,
   });
   const googleAccounts = data?.googleAccounts;
   const { appName } = useGetAppSettings();
@@ -102,8 +103,9 @@ export const GoogleAccordion: React.FC<AccordionProps> = ({
   return (
     <>
       <AccordionItem
+        accordion={IntegrationAccordion.Google}
         onAccordionChange={handleAccordionChange}
-        expandedPanel={expandedPanel}
+        expandedAccordion={expandedAccordion}
         label={t('Google')}
         value={''}
         disabled={disabled}
@@ -118,7 +120,7 @@ export const GoogleAccordion: React.FC<AccordionProps> = ({
         }
       >
         {loading && <Skeleton height="90px" />}
-        {!loading && !googleAccounts?.length && !!expandedPanel && (
+        {!loading && !googleAccounts?.length && !!expandedAccordion && (
           <>
             <StyledFormLabel>
               {t('Google Integration Overview')}

--- a/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.test.tsx
+++ b/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import * as Types from 'src/graphql/types.generated';
 import theme from '../../../../theme';
 import { MailchimpAccordion } from './MailchimpAccordion';
@@ -79,7 +80,7 @@ describe('MailchimpAccount', () => {
         <GqlMockedProvider>
           <MailchimpAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={''}
+            expandedAccordion={null}
           />
         </GqlMockedProvider>
       </Components>,
@@ -96,7 +97,7 @@ describe('MailchimpAccount', () => {
         <GqlMockedProvider>
           <MailchimpAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Mailchimp'}
+            expandedAccordion={IntegrationAccordion.Mailchimp}
           />
         </GqlMockedProvider>
       </Components>,
@@ -124,7 +125,7 @@ describe('MailchimpAccount', () => {
           >
             <MailchimpAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Mailchimp'}
+              expandedAccordion={IntegrationAccordion.Mailchimp}
             />
           </GqlMockedProvider>
         </Components>,
@@ -165,7 +166,7 @@ describe('MailchimpAccount', () => {
           >
             <MailchimpAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Mailchimp'}
+              expandedAccordion={IntegrationAccordion.Mailchimp}
             />
           </GqlMockedProvider>
         </Components>,
@@ -208,7 +209,7 @@ describe('MailchimpAccount', () => {
           >
             <MailchimpAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Mailchimp'}
+              expandedAccordion={IntegrationAccordion.Mailchimp}
             />
           </GqlMockedProvider>
         </Components>,
@@ -243,7 +244,7 @@ describe('MailchimpAccount', () => {
           >
             <MailchimpAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Mailchimp'}
+              expandedAccordion={IntegrationAccordion.Mailchimp}
             />
           </GqlMockedProvider>
         </Components>,
@@ -310,7 +311,7 @@ describe('MailchimpAccount', () => {
           >
             <MailchimpAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Mailchimp'}
+              expandedAccordion={IntegrationAccordion.Mailchimp}
             />
           </GqlMockedProvider>
         </Components>,
@@ -377,7 +378,7 @@ describe('MailchimpAccount', () => {
           >
             <MailchimpAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Mailchimp'}
+              expandedAccordion={IntegrationAccordion.Mailchimp}
             />
           </GqlMockedProvider>
         </Components>,
@@ -413,7 +414,7 @@ describe('MailchimpAccount', () => {
           >
             <MailchimpAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Mailchimp'}
+              expandedAccordion={IntegrationAccordion.Mailchimp}
             />
           </GqlMockedProvider>
         </Components>,
@@ -470,7 +471,7 @@ describe('MailchimpAccount', () => {
           >
             <MailchimpAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Mailchimp'}
+              expandedAccordion={IntegrationAccordion.Mailchimp}
             />
           </GqlMockedProvider>
         </Components>,

--- a/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.tsx
+++ b/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.tsx
@@ -19,6 +19,7 @@ import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { StyledFormLabel } from 'src/components/Shared/Forms/FieldHelper';
 import { SubmitButton } from 'src/components/common/Modal/ActionButtons/ActionButtons';
@@ -59,7 +60,7 @@ const StyledButton = styled(Button)(() => ({
 
 export const MailchimpAccordion: React.FC<AccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   disabled,
 }) => {
   const { t } = useTranslation();
@@ -165,8 +166,9 @@ export const MailchimpAccordion: React.FC<AccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={IntegrationAccordion.Mailchimp}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={t('MailChimp')}
       value={''}
       disabled={disabled}

--- a/src/components/Settings/integrations/Okta/OktaAccordion.tsx
+++ b/src/components/Settings/integrations/Okta/OktaAccordion.tsx
@@ -1,5 +1,6 @@
 import { Box, Skeleton, TextField } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { AccordionProps } from '../integrationsHelper';
@@ -7,7 +8,7 @@ import { useOktaAccountsQuery } from './OktaAccounts.generated';
 
 export const OktaAccordion: React.FC<AccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   disabled,
 }) => {
   const { t } = useTranslation();
@@ -15,8 +16,9 @@ export const OktaAccordion: React.FC<AccordionProps> = ({
   const oktaAccounts = data?.user?.keyAccounts;
   return (
     <AccordionItem
+      accordion={IntegrationAccordion.Okta}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={t('Okta')}
       value={''}
       disabled={disabled}

--- a/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
+++ b/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
@@ -6,6 +6,7 @@ import { cloneDeep } from 'lodash';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import * as Types from 'src/graphql/types.generated';
 import theme from '../../../../theme';
 import { OrganizationAccordion } from './OrganizationAccordion';
@@ -100,7 +101,7 @@ describe('OrganizationAccordion', () => {
         <GqlMockedProvider>
           <OrganizationAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={''}
+            expandedAccordion={null}
           />
         </GqlMockedProvider>
       </Components>,
@@ -117,7 +118,7 @@ describe('OrganizationAccordion', () => {
         <GqlMockedProvider>
           <OrganizationAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'Organization'}
+            expandedAccordion={IntegrationAccordion.Organization}
           />
         </GqlMockedProvider>
       </Components>,
@@ -147,7 +148,7 @@ describe('OrganizationAccordion', () => {
           >
             <OrganizationAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Organization'}
+              expandedAccordion={IntegrationAccordion.Organization}
             />
           </GqlMockedProvider>
         </Components>,
@@ -180,7 +181,7 @@ describe('OrganizationAccordion', () => {
           >
             <OrganizationAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Organization'}
+              expandedAccordion={IntegrationAccordion.Organization}
             />
           </GqlMockedProvider>
         </Components>,
@@ -226,7 +227,7 @@ describe('OrganizationAccordion', () => {
           >
             <OrganizationAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Organization'}
+              expandedAccordion={IntegrationAccordion.Organization}
             />
           </GqlMockedProvider>
         </Components>,
@@ -274,7 +275,7 @@ describe('OrganizationAccordion', () => {
           >
             <OrganizationAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Organization'}
+              expandedAccordion={IntegrationAccordion.Organization}
             />
           </GqlMockedProvider>
         </Components>,
@@ -309,7 +310,7 @@ describe('OrganizationAccordion', () => {
           >
             <OrganizationAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Organization'}
+              expandedAccordion={IntegrationAccordion.Organization}
             />
           </GqlMockedProvider>
         </Components>,
@@ -350,7 +351,7 @@ describe('OrganizationAccordion', () => {
           >
             <OrganizationAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Organization'}
+              expandedAccordion={IntegrationAccordion.Organization}
             />
           </GqlMockedProvider>
         </Components>,
@@ -401,7 +402,7 @@ describe('OrganizationAccordion', () => {
           >
             <OrganizationAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'Organization'}
+              expandedAccordion={IntegrationAccordion.Organization}
             />
           </GqlMockedProvider>
         </Components>,

--- a/src/components/Settings/integrations/Organization/OrganizationAccordion.tsx
+++ b/src/components/Settings/integrations/Organization/OrganizationAccordion.tsx
@@ -13,6 +13,7 @@ import { styled } from '@mui/material/styles';
 import { DateTime } from 'luxon';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { Confirmation } from 'src/components/common/Modal/Confirmation/Confirmation';
 import { useAccountListId } from 'src/hooks/useAccountListId';
@@ -80,7 +81,7 @@ export const getOrganizationType = (
 
 export const OrganizationAccordion: React.FC<AccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   disabled,
 }) => {
   const { t } = useTranslation();
@@ -175,8 +176,9 @@ export const OrganizationAccordion: React.FC<AccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={IntegrationAccordion.Organization}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={t('Organization')}
       value={''}
       disabled={disabled}

--- a/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.test.tsx
+++ b/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import * as Types from 'src/graphql/types.generated';
 import theme from 'src/theme';
 import { PrayerlettersAccordion } from './PrayerlettersAccordion';
@@ -54,7 +55,7 @@ describe('PrayerlettersAccount', () => {
         <GqlMockedProvider>
           <PrayerlettersAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={''}
+            expandedAccordion={null}
           />
         </GqlMockedProvider>
       </Components>,
@@ -71,7 +72,7 @@ describe('PrayerlettersAccount', () => {
         <GqlMockedProvider>
           <PrayerlettersAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={'prayerletters.com'}
+            expandedAccordion={IntegrationAccordion.Prayerletters}
           />
         </GqlMockedProvider>
       </Components>,
@@ -97,7 +98,7 @@ describe('PrayerlettersAccount', () => {
           >
             <PrayerlettersAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'prayerletters.com'}
+              expandedAccordion={IntegrationAccordion.Prayerletters}
             />
           </GqlMockedProvider>
         </Components>,
@@ -138,7 +139,7 @@ describe('PrayerlettersAccount', () => {
           >
             <PrayerlettersAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'prayerletters.com'}
+              expandedAccordion={IntegrationAccordion.Prayerletters}
             />
           </GqlMockedProvider>
         </Components>,
@@ -207,7 +208,7 @@ describe('PrayerlettersAccount', () => {
           >
             <PrayerlettersAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'prayerletters.com'}
+              expandedAccordion={IntegrationAccordion.Prayerletters}
             />
           </GqlMockedProvider>
         </Components>,
@@ -272,7 +273,7 @@ describe('PrayerlettersAccount', () => {
           >
             <PrayerlettersAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={'prayerletters.com'}
+              expandedAccordion={IntegrationAccordion.Prayerletters}
             />
           </GqlMockedProvider>
         </Components>,

--- a/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.tsx
+++ b/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Alert, Box, Button, Skeleton, Typography } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { StyledFormLabel } from 'src/components/Shared/Forms/FieldHelper';
 import { useAccountListId } from 'src/hooks/useAccountListId';
@@ -16,7 +17,7 @@ import {
 
 export const PrayerlettersAccordion: React.FC<AccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   disabled,
 }) => {
   const { t } = useTranslation();
@@ -39,7 +40,7 @@ export const PrayerlettersAccordion: React.FC<AccordionProps> = ({
         accountListId: accountListId ?? '',
       },
     },
-    skip: expandedPanel !== accordionName,
+    skip: expandedAccordion !== IntegrationAccordion.Prayerletters,
   });
 
   const prayerlettersAccount = data?.prayerlettersAccount
@@ -88,8 +89,9 @@ export const PrayerlettersAccordion: React.FC<AccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={IntegrationAccordion.Prayerletters}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={accordionName}
       value={''}
       disabled={disabled}

--- a/src/components/Settings/integrations/integrationsHelper.ts
+++ b/src/components/Settings/integrations/integrationsHelper.ts
@@ -1,6 +1,7 @@
 import { Button, List, ListItemText } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
+import { AccordionProps as BaseAccordionProps } from '../accordionHelper';
 
 export const StyledListItem = styled(ListItemText)(() => ({
   display: 'list-item',
@@ -15,8 +16,7 @@ export const StyledServicesButton = styled(Button)(({ theme }) => ({
   marginTop: theme.spacing(2),
 })) as typeof Button; // Type cast so that `component` prop works
 
-export interface AccordionProps {
-  handleAccordionChange: (accordion: IntegrationAccordion | null) => void;
-  expandedAccordion: IntegrationAccordion | null;
+export interface AccordionProps
+  extends BaseAccordionProps<IntegrationAccordion> {
   disabled?: boolean;
 }

--- a/src/components/Settings/integrations/integrationsHelper.ts
+++ b/src/components/Settings/integrations/integrationsHelper.ts
@@ -1,5 +1,6 @@
 import { Button, List, ListItemText } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 
 export const StyledListItem = styled(ListItemText)(() => ({
   display: 'list-item',
@@ -15,7 +16,7 @@ export const StyledServicesButton = styled(Button)(({ theme }) => ({
 })) as typeof Button; // Type cast so that `component` prop works
 
 export interface AccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: IntegrationAccordion | null) => void;
+  expandedAccordion: IntegrationAccordion | null;
   disabled?: boolean;
 }

--- a/src/components/Settings/integrations/useOauthUrl.ts
+++ b/src/components/Settings/integrations/useOauthUrl.ts
@@ -1,3 +1,4 @@
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useRequiredSession } from 'src/hooks/useRequiredSession';
 
@@ -5,33 +6,33 @@ export const useOauthUrl = () => {
   const { apiToken } = useRequiredSession();
   const accountListId = useAccountListId();
 
-  const getRedirectUrl = (tab: string) => {
+  const getRedirectUrl = (accordion: IntegrationAccordion) => {
     const domain = process.env.SITE_URL || window.location.origin;
     return encodeURIComponent(
-      `${domain}/accountLists/${accountListId}/settings/integrations?selectedTab=${tab}`,
+      `${domain}/accountLists/${accountListId}/settings/integrations?selectedTab=${accordion}`,
     );
   };
 
   return {
     getGoogleOauthUrl: () =>
       `${process.env.OAUTH_URL}/auth/user/google?account_list_id=${accountListId}` +
-      `&redirect_to=${getRedirectUrl('Google')}` +
+      `&redirect_to=${getRedirectUrl(IntegrationAccordion.Google)}` +
       `&access_token=${apiToken}`,
 
     getMailChimpOauthUrl: () =>
       `${process.env.OAUTH_URL}/auth/user/mailchimp?account_list_id=${accountListId}` +
-      `&redirect_to=${getRedirectUrl('mailchimp')}` +
+      `&redirect_to=${getRedirectUrl(IntegrationAccordion.Mailchimp)}` +
       `&access_token=${apiToken}`,
 
     getOrganizationOauthUrl: (organizationId: string) =>
       `${process.env.OAUTH_URL}/auth/user/donorhub?account_list_id=${accountListId}` +
-      `&redirect_to=${getRedirectUrl('organization')}` +
+      `&redirect_to=${getRedirectUrl(IntegrationAccordion.Organization)}` +
       `&access_token=${apiToken}` +
       `&organization_id=${organizationId}`,
 
     getPrayerlettersOauthUrl: () =>
       `${process.env.OAUTH_URL}/auth/user/prayer_letters?account_list_id=${accountListId}` +
-      `&redirect_to=${getRedirectUrl('prayerletters.com')}` +
+      `&redirect_to=${getRedirectUrl(IntegrationAccordion.Prayerletters)}` +
       `&access_token=${apiToken}`,
   };
 };

--- a/src/components/Settings/preferences/accordions/AccountNameAccordion/AccountNameAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/AccountNameAccordion/AccountNameAccordion.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from 'src/theme';
 import { UpdateAccountPreferencesDocument } from '../UpdateAccountPreferences.generated';
 import { AccountNameAccordion } from './AccountNameAccordion';
@@ -34,17 +35,17 @@ const mutationSpy = jest.fn();
 
 interface ComponentsProps {
   name: string;
-  expandedPanel: string;
+  expandedAccordion: PreferenceAccordion | null;
 }
 
-const Components: React.FC<ComponentsProps> = ({ name, expandedPanel }) => (
+const Components: React.FC<ComponentsProps> = ({ name, expandedAccordion }) => (
   <SnackbarProvider>
     <TestRouter router={router}>
       <ThemeProvider theme={theme}>
         <GqlMockedProvider onCall={mutationSpy}>
           <AccountNameAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            expandedAccordion={expandedAccordion}
             name={name}
             accountListId={accountListId}
           />
@@ -69,7 +70,7 @@ describe('AccountNameAccordion', () => {
   });
   it('should render accordion closed', () => {
     const { getByText, queryByRole } = render(
-      <Components name={"Pedro Perez's Account"} expandedPanel="" />,
+      <Components name={"Pedro Perez's Account"} expandedAccordion={null} />,
     );
 
     expect(getByText(label)).toBeInTheDocument();
@@ -80,7 +81,10 @@ describe('AccountNameAccordion', () => {
     const name = ''; //name is required
 
     const { getByRole, getByText } = render(
-      <Components name={name} expandedPanel={label} />,
+      <Components
+        name={name}
+        expandedAccordion={PreferenceAccordion.AccountName}
+      />,
     );
 
     const input = getByRole('textbox');
@@ -95,7 +99,10 @@ describe('AccountNameAccordion', () => {
 
   it('Changes and saves the input', async () => {
     const { getByRole } = render(
-      <Components name={"Pedro Perez's Account"} expandedPanel={label} />,
+      <Components
+        name={"Pedro Perez's Account"}
+        expandedAccordion={PreferenceAccordion.AccountName}
+      />,
     );
     const input = getByRole('textbox');
     const button = getByRole('button', { name: 'Save' });
@@ -135,7 +142,7 @@ describe('AccountNameAccordion', () => {
             <MockedProvider mocks={[errorMock]}>
               <AccountNameAccordion
                 handleAccordionChange={handleAccordionChange}
-                expandedPanel={label}
+                expandedAccordion={PreferenceAccordion.AccountName}
                 name={'Test Account'}
                 accountListId={accountListId}
               />

--- a/src/components/Settings/preferences/accordions/AccountNameAccordion/AccountNameAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/AccountNameAccordion/AccountNameAccordion.tsx
@@ -4,6 +4,7 @@ import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
@@ -17,8 +18,8 @@ const accountPreferencesSchema: yup.ObjectSchema<Pick<AccountList, 'name'>> =
   });
 
 interface AccountNameAccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
+  expandedAccordion: PreferenceAccordion | null;
   accountListId: string;
   name: string;
   disabled?: boolean;
@@ -26,7 +27,7 @@ interface AccountNameAccordionProps {
 
 export const AccountNameAccordion: React.FC<AccountNameAccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   name,
   accountListId,
   disabled,
@@ -52,7 +53,7 @@ export const AccountNameAccordion: React.FC<AccountNameAccordionProps> = ({
         enqueueSnackbar(t('Saved successfully.'), {
           variant: 'success',
         });
-        handleAccordionChange(label);
+        handleAccordionChange(null);
       },
       onError: () => {
         enqueueSnackbar(t('Saving failed.'), {
@@ -64,8 +65,9 @@ export const AccountNameAccordion: React.FC<AccountNameAccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={PreferenceAccordion.AccountName}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={label}
       value={name}
       fullWidth

--- a/src/components/Settings/preferences/accordions/AccountNameAccordion/AccountNameAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/AccountNameAccordion/AccountNameAccordion.tsx
@@ -10,6 +10,7 @@ import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
 import { AccountList } from 'src/graphql/types.generated';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
+import { AccordionProps } from '../../../accordionHelper';
 import { useUpdateAccountPreferencesMutation } from '../UpdateAccountPreferences.generated';
 
 const accountPreferencesSchema: yup.ObjectSchema<Pick<AccountList, 'name'>> =
@@ -17,9 +18,8 @@ const accountPreferencesSchema: yup.ObjectSchema<Pick<AccountList, 'name'>> =
     name: yup.string().required(),
   });
 
-interface AccountNameAccordionProps {
-  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
-  expandedAccordion: PreferenceAccordion | null;
+interface AccountNameAccordionProps
+  extends AccordionProps<PreferenceAccordion> {
   accountListId: string;
   name: string;
   disabled?: boolean;

--- a/src/components/Settings/preferences/accordions/CurrencyAccordion/CurrencyAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/CurrencyAccordion/CurrencyAccordion.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from 'src/theme';
 import { UpdatePersonalPreferencesDocument } from '../UpdatePersonalPreferences.generated';
 import { CurrencyAccordion } from './CurrencyAccordion';
@@ -34,17 +35,20 @@ const mutationSpy = jest.fn();
 
 interface ComponentsProps {
   currency: string;
-  expandedPanel: string;
+  expandedAccordion: PreferenceAccordion | null;
 }
 
-const Components: React.FC<ComponentsProps> = ({ currency, expandedPanel }) => (
+const Components: React.FC<ComponentsProps> = ({
+  currency,
+  expandedAccordion,
+}) => (
   <SnackbarProvider>
     <TestRouter router={router}>
       <ThemeProvider theme={theme}>
         <GqlMockedProvider onCall={mutationSpy}>
           <CurrencyAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            expandedAccordion={expandedAccordion}
             currency={currency}
             accountListId={accountListId}
           />
@@ -69,7 +73,7 @@ describe('CurrencyAccordion', () => {
   });
   it('should render accordion closed', () => {
     const { getByText, queryByRole } = render(
-      <Components currency={'USD'} expandedPanel="" />,
+      <Components currency={'USD'} expandedAccordion={null} />,
     );
 
     expect(getByText(label)).toBeInTheDocument();
@@ -80,7 +84,10 @@ describe('CurrencyAccordion', () => {
     const value = ''; //value is required
 
     const { getByRole } = render(
-      <Components currency={value} expandedPanel={label} />,
+      <Components
+        currency={value}
+        expandedAccordion={PreferenceAccordion.Currency}
+      />,
     );
 
     const button = getByRole('button', { name: 'Save' });
@@ -92,7 +99,10 @@ describe('CurrencyAccordion', () => {
 
   it('Changes and saves the input', async () => {
     const { getByRole, getByText } = render(
-      <Components currency={'USD'} expandedPanel={label} />,
+      <Components
+        currency={'USD'}
+        expandedAccordion={PreferenceAccordion.Currency}
+      />,
     );
     const input = getByRole('combobox');
     const button = getByRole('button', { name: 'Save' });
@@ -136,7 +146,7 @@ describe('CurrencyAccordion', () => {
             <MockedProvider mocks={[errorMock]}>
               <CurrencyAccordion
                 handleAccordionChange={handleAccordionChange}
-                expandedPanel={label}
+                expandedAccordion={PreferenceAccordion.Currency}
                 currency={'USD'}
                 accountListId={accountListId}
               />

--- a/src/components/Settings/preferences/accordions/CurrencyAccordion/CurrencyAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/CurrencyAccordion/CurrencyAccordion.tsx
@@ -10,6 +10,7 @@ import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionI
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
 import { AccountListSettingsInput } from 'src/graphql/types.generated';
+import { AccordionProps } from '../../../accordionHelper';
 import { useUpdateAccountPreferencesMutation } from '../UpdateAccountPreferences.generated';
 
 const preferencesSchema: yup.ObjectSchema<
@@ -18,9 +19,7 @@ const preferencesSchema: yup.ObjectSchema<
   currency: yup.string().required(),
 });
 
-interface CurrencyAccordionProps {
-  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
-  expandedAccordion: PreferenceAccordion | null;
+interface CurrencyAccordionProps extends AccordionProps<PreferenceAccordion> {
   currency: string;
   accountListId: string;
   disabled?: boolean;

--- a/src/components/Settings/preferences/accordions/CurrencyAccordion/CurrencyAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/CurrencyAccordion/CurrencyAccordion.tsx
@@ -5,6 +5,7 @@ import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 import { useApiConstants } from 'src/components/Constants/UseApiConstants';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
@@ -18,8 +19,8 @@ const preferencesSchema: yup.ObjectSchema<
 });
 
 interface CurrencyAccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
+  expandedAccordion: PreferenceAccordion | null;
   currency: string;
   accountListId: string;
   disabled?: boolean;
@@ -27,7 +28,7 @@ interface CurrencyAccordionProps {
 
 export const CurrencyAccordion: React.FC<CurrencyAccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   currency,
   accountListId,
   disabled,
@@ -58,7 +59,7 @@ export const CurrencyAccordion: React.FC<CurrencyAccordionProps> = ({
         enqueueSnackbar(t('Saved successfully.'), {
           variant: 'success',
         });
-        handleAccordionChange(label);
+        handleAccordionChange(null);
       },
       onError: () => {
         enqueueSnackbar(t('Saving failed.'), {
@@ -70,8 +71,9 @@ export const CurrencyAccordion: React.FC<CurrencyAccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={PreferenceAccordion.Currency}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={label}
       value={currency}
       fullWidth

--- a/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from 'src/theme';
 import { DefaultAccountAccordion } from './DefaultAccountAccordion';
 
@@ -62,12 +63,12 @@ const mockData = {
 
 interface ComponentsProps {
   defaultAccountList: string;
-  expandedPanel: string;
+  expandedAccordion: PreferenceAccordion | null;
 }
 
 const Components: React.FC<ComponentsProps> = ({
   defaultAccountList,
-  expandedPanel,
+  expandedAccordion,
 }) => (
   <SnackbarProvider>
     <TestRouter router={router}>
@@ -75,7 +76,7 @@ const Components: React.FC<ComponentsProps> = ({
         <GqlMockedProvider onCall={mutationSpy}>
           <DefaultAccountAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            expandedAccordion={expandedAccordion}
             data={mockData}
             accountListId={accountListId}
             defaultAccountList={defaultAccountList}
@@ -96,7 +97,7 @@ describe('Default Account Accordion', () => {
     const { getByText, queryByRole } = render(
       <Components
         defaultAccountList={'cbe2fe56-1525-4aee-8320-1ca7ccf09703'}
-        expandedPanel=""
+        expandedAccordion={null}
       />,
     );
     const input = queryByRole('combobox');
@@ -109,7 +110,10 @@ describe('Default Account Accordion', () => {
     const value = ''; //value is required
 
     const { getByRole } = render(
-      <Components defaultAccountList={value} expandedPanel={label} />,
+      <Components
+        defaultAccountList={value}
+        expandedAccordion={PreferenceAccordion.DefaultAccount}
+      />,
     );
 
     const button = getByRole('button', { name: 'Save' });
@@ -123,7 +127,7 @@ describe('Default Account Accordion', () => {
     const { getByRole, getByText } = render(
       <Components
         defaultAccountList={'cbe2fe56-1525-4aee-8320-1ca7ccf09703'}
-        expandedPanel={label}
+        expandedAccordion={PreferenceAccordion.DefaultAccount}
       />,
     );
     const input = getByRole('combobox');

--- a/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.tsx
@@ -4,6 +4,7 @@ import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
@@ -13,8 +14,8 @@ import { GetPersonalPreferencesQuery } from '../../GetPersonalPreferences.genera
 import { useUpdateUserDefaultAccountMutation } from './UpdateDefaultAccount.generated';
 
 interface DefaultAccountAccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
+  expandedAccordion: PreferenceAccordion | null;
   data: GetPersonalPreferencesQuery | undefined;
   accountListId: string;
   defaultAccountList: string;
@@ -30,7 +31,7 @@ export const DefaultAccountAccordion: React.FC<
   DefaultAccountAccordionProps
 > = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   data,
   defaultAccountList,
   disabled,
@@ -61,7 +62,7 @@ export const DefaultAccountAccordion: React.FC<
         enqueueSnackbar(t('Saved successfully.'), {
           variant: 'success',
         });
-        handleAccordionChange(label);
+        handleAccordionChange(null);
       },
       onError: () => {
         enqueueSnackbar(t('Saving failed.'), {
@@ -73,8 +74,9 @@ export const DefaultAccountAccordion: React.FC<
 
   return (
     <AccordionItem
+      accordion={PreferenceAccordion.DefaultAccount}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={label}
       value={selectedAccount}
       fullWidth

--- a/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.tsx
@@ -10,12 +10,12 @@ import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
 import { User } from 'src/graphql/types.generated';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
+import { AccordionProps } from '../../../accordionHelper';
 import { GetPersonalPreferencesQuery } from '../../GetPersonalPreferences.generated';
 import { useUpdateUserDefaultAccountMutation } from './UpdateDefaultAccount.generated';
 
-interface DefaultAccountAccordionProps {
-  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
-  expandedAccordion: PreferenceAccordion | null;
+interface DefaultAccountAccordionProps
+  extends AccordionProps<PreferenceAccordion> {
   data: GetPersonalPreferencesQuery | undefined;
   accountListId: string;
   defaultAccountList: string;

--- a/src/components/Settings/preferences/accordions/EarlyAdopterAccordion/EarlyAdopterAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/EarlyAdopterAccordion/EarlyAdopterAccordion.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { UserPreferenceContext } from 'src/components/User/Preferences/UserPreferenceProvider';
 import theme from 'src/theme';
 import { EarlyAdopterAccordion } from './EarlyAdopterAccordion';
@@ -33,9 +34,12 @@ const mutationSpy = jest.fn();
 
 interface ComponentsProps {
   tester: boolean;
-  expandedPanel: string;
+  expandedAccordion: PreferenceAccordion | null;
 }
-const Components: React.FC<ComponentsProps> = ({ tester, expandedPanel }) => (
+const Components: React.FC<ComponentsProps> = ({
+  tester,
+  expandedAccordion,
+}) => (
   <SnackbarProvider>
     <TestRouter router={router}>
       <ThemeProvider theme={theme}>
@@ -43,7 +47,7 @@ const Components: React.FC<ComponentsProps> = ({ tester, expandedPanel }) => (
           <UserPreferenceContext.Provider value={{ locale: 'en-US' }}>
             <EarlyAdopterAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={expandedPanel}
+              expandedAccordion={expandedAccordion}
               tester={tester}
               accountListId={accountListId}
             />
@@ -62,7 +66,7 @@ describe('EarlyAdopterAccordion', () => {
   });
   it('should render accordion closed', () => {
     const { getByText, queryByRole } = render(
-      <Components tester={true} expandedPanel="" />,
+      <Components tester={true} expandedAccordion={null} />,
     );
 
     expect(getByText(label)).toBeInTheDocument();
@@ -70,7 +74,10 @@ describe('EarlyAdopterAccordion', () => {
   });
   it('should render accordion open', async () => {
     const { getByRole } = render(
-      <Components tester={true} expandedPanel={label} />,
+      <Components
+        tester={true}
+        expandedAccordion={PreferenceAccordion.EarlyAdopter}
+      />,
     );
 
     expect(getByRole('checkbox')).toBeInTheDocument();
@@ -78,7 +85,10 @@ describe('EarlyAdopterAccordion', () => {
 
   it('should always have the save button enabled', async () => {
     const { getByRole } = render(
-      <Components tester={true} expandedPanel={label} />,
+      <Components
+        tester={true}
+        expandedAccordion={PreferenceAccordion.EarlyAdopter}
+      />,
     );
     const input = getByRole('checkbox');
     const button = getByRole('button', { name: 'Save' });
@@ -96,7 +106,10 @@ describe('EarlyAdopterAccordion', () => {
 
   it('Changes and saves the input', async () => {
     const { getByRole } = render(
-      <Components tester={false} expandedPanel={label} />,
+      <Components
+        tester={false}
+        expandedAccordion={PreferenceAccordion.EarlyAdopter}
+      />,
     );
     const button = getByRole('button', { name: 'Save' });
     userEvent.click(getByRole('checkbox'));
@@ -127,7 +140,10 @@ describe('EarlyAdopterAccordion', () => {
   describe('onSubmit()', () => {
     it('sets early adopter to true', async () => {
       const { getByRole } = render(
-        <Components tester={false} expandedPanel={label} />,
+        <Components
+          tester={false}
+          expandedAccordion={PreferenceAccordion.EarlyAdopter}
+        />,
       );
       const button = getByRole('button', { name: 'Save' });
       userEvent.click(getByRole('checkbox'));
@@ -142,7 +158,10 @@ describe('EarlyAdopterAccordion', () => {
 
     it('sets early adopter to false', async () => {
       const { getByRole } = render(
-        <Components tester={true} expandedPanel={label} />,
+        <Components
+          tester={true}
+          expandedAccordion={PreferenceAccordion.EarlyAdopter}
+        />,
       );
       const button = getByRole('button', { name: 'Save' });
       userEvent.click(getByRole('checkbox'));

--- a/src/components/Settings/preferences/accordions/EarlyAdopterAccordion/EarlyAdopterAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/EarlyAdopterAccordion/EarlyAdopterAccordion.tsx
@@ -4,6 +4,7 @@ import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
@@ -18,8 +19,8 @@ const accountPreferencesSchema: yup.ObjectSchema<
 });
 
 interface EarlyAdopterAccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
+  expandedAccordion: PreferenceAccordion | null;
   tester: boolean;
   accountListId: string;
   disabled?: boolean;
@@ -27,7 +28,7 @@ interface EarlyAdopterAccordionProps {
 
 export const EarlyAdopterAccordion: React.FC<EarlyAdopterAccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   tester,
   accountListId,
   disabled,
@@ -55,7 +56,7 @@ export const EarlyAdopterAccordion: React.FC<EarlyAdopterAccordionProps> = ({
         enqueueSnackbar(t('Saved successfully.'), {
           variant: 'success',
         });
-        handleAccordionChange(label);
+        handleAccordionChange(null);
       },
       onError: () => {
         enqueueSnackbar(t('Saving failed.'), {
@@ -67,8 +68,9 @@ export const EarlyAdopterAccordion: React.FC<EarlyAdopterAccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={PreferenceAccordion.EarlyAdopter}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={label}
       value={tester ? t('Yes') : t('No')}
       fullWidth

--- a/src/components/Settings/preferences/accordions/EarlyAdopterAccordion/EarlyAdopterAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/EarlyAdopterAccordion/EarlyAdopterAccordion.tsx
@@ -10,6 +10,7 @@ import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
 import { AccountListSettingsInput } from 'src/graphql/types.generated';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
+import { AccordionProps } from '../../../accordionHelper';
 import { useUpdateAccountPreferencesMutation } from '../UpdateAccountPreferences.generated';
 
 const accountPreferencesSchema: yup.ObjectSchema<
@@ -18,9 +19,8 @@ const accountPreferencesSchema: yup.ObjectSchema<
   tester: yup.boolean().required(),
 });
 
-interface EarlyAdopterAccordionProps {
-  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
-  expandedAccordion: PreferenceAccordion | null;
+interface EarlyAdopterAccordionProps
+  extends AccordionProps<PreferenceAccordion> {
   tester: boolean;
   accountListId: string;
   disabled?: boolean;

--- a/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.test.tsx
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from 'src/theme';
 import { ExportDataMutation } from '../../GetAccountPreferences.generated';
 import { ExportAllDataAccordion } from './ExportAllDataAccordion';
@@ -33,12 +34,12 @@ const handleAccordionChange = jest.fn();
 const mutationSpy = jest.fn();
 
 interface ComponentsProps {
-  expandedPanel: string;
+  expandedAccordion: PreferenceAccordion | null;
   exportedAt?: string;
 }
 
 const Components: React.FC<ComponentsProps> = ({
-  expandedPanel,
+  expandedAccordion,
   exportedAt,
 }) => (
   <SnackbarProvider>
@@ -56,7 +57,7 @@ const Components: React.FC<ComponentsProps> = ({
         >
           <ExportAllDataAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            expandedAccordion={expandedAccordion}
             exportedAt={exportedAt || ''}
             accountListId={accountListId}
           />
@@ -75,7 +76,9 @@ describe('Export All Data Accordion', () => {
     mutationSpy.mockClear();
   });
   it('should render accordion closed', () => {
-    const { getByText, queryByText } = render(<Components expandedPanel="" />);
+    const { getByText, queryByText } = render(
+      <Components expandedAccordion={null} />,
+    );
 
     expect(getByText(label)).toBeInTheDocument();
     expect(queryByText(descriptionText)).not.toBeInTheDocument();
@@ -83,7 +86,7 @@ describe('Export All Data Accordion', () => {
   it('should render accordion open and show the last exported date', async () => {
     const { getByText, queryByRole } = render(
       <Components
-        expandedPanel={label}
+        expandedAccordion={PreferenceAccordion.ExportAllData}
         exportedAt={DateTime.local(2024, 1, 16, 18, 34, 12).toISO() ?? ''}
       />,
     );
@@ -94,7 +97,7 @@ describe('Export All Data Accordion', () => {
 
   it('should default the submit button to disabled unless the box is checked', async () => {
     const { getAllByRole, queryByRole } = render(
-      <Components expandedPanel={label} />,
+      <Components expandedAccordion={PreferenceAccordion.ExportAllData} />,
     );
     const button = getAllByRole('button', {
       name: 'Export All Data',
@@ -112,7 +115,7 @@ describe('Export All Data Accordion', () => {
   });
   it('should enable the submit button and call the mutation', async () => {
     const { getByRole, getAllByRole, queryByRole, getByText } = render(
-      <Components expandedPanel={label} />,
+      <Components expandedAccordion={PreferenceAccordion.ExportAllData} />,
     );
     const input = getByRole('checkbox');
     const button = getAllByRole('button', { name: 'Export All Data' })[1];

--- a/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.tsx
@@ -12,6 +12,7 @@ import { useTheme } from '@mui/material/styles';
 import { DateTime } from 'luxon';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
@@ -21,8 +22,8 @@ import { useExportDataMutation } from '../../GetAccountPreferences.generated';
 import { GetPersonalPreferencesQuery } from '../../GetPersonalPreferences.generated';
 
 interface ExportAllDataAccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
+  expandedAccordion: PreferenceAccordion | null;
   exportedAt?: string;
   accountListId: string;
   data?: GetPersonalPreferencesQuery | undefined;
@@ -31,7 +32,7 @@ interface ExportAllDataAccordionProps {
 
 export const ExportAllDataAccordion: React.FC<ExportAllDataAccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   exportedAt,
   accountListId,
   disabled,
@@ -78,8 +79,9 @@ export const ExportAllDataAccordion: React.FC<ExportAllDataAccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={PreferenceAccordion.ExportAllData}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={label}
       value={''}
       fullWidth

--- a/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.tsx
@@ -66,7 +66,7 @@ export const ExportAllDataAccordion: React.FC<ExportAllDataAccordionProps> = ({
         setConfirmation(true);
       },
       onError: () => {
-        enqueueSnackbar(t('And error occured.'), {
+        enqueueSnackbar(t('An error occurred.'), {
           variant: 'error',
         });
       },

--- a/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.tsx
@@ -18,12 +18,12 @@ import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
 import { useLocale } from 'src/hooks/useLocale';
 import { dateTimeFormat } from 'src/lib/intlFormat';
+import { AccordionProps } from '../../../accordionHelper';
 import { useExportDataMutation } from '../../GetAccountPreferences.generated';
 import { GetPersonalPreferencesQuery } from '../../GetPersonalPreferences.generated';
 
-interface ExportAllDataAccordionProps {
-  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
-  expandedAccordion: PreferenceAccordion | null;
+interface ExportAllDataAccordionProps
+  extends AccordionProps<PreferenceAccordion> {
   exportedAt?: string;
   accountListId: string;
   data?: GetPersonalPreferencesQuery | undefined;

--- a/src/components/Settings/preferences/accordions/HomeCountryAccordion/HomeCountryAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/HomeCountryAccordion/HomeCountryAccordion.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from 'src/theme';
 import { UpdatePersonalPreferencesDocument } from '../UpdatePersonalPreferences.generated';
 import { HomeCountryAccordion } from './HomeCountryAccordion';
@@ -40,12 +41,12 @@ const countries = [
 
 interface ComponentsProps {
   homeCountry: string;
-  expandedPanel: string;
+  expandedAccordion: PreferenceAccordion | null;
 }
 
 const Components: React.FC<ComponentsProps> = ({
   homeCountry,
-  expandedPanel,
+  expandedAccordion,
 }) => (
   <SnackbarProvider>
     <TestRouter router={router}>
@@ -53,7 +54,7 @@ const Components: React.FC<ComponentsProps> = ({
         <GqlMockedProvider onCall={mutationSpy}>
           <HomeCountryAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            expandedAccordion={expandedAccordion}
             homeCountry={homeCountry}
             accountListId={accountListId}
             countries={countries}
@@ -80,7 +81,7 @@ describe('HomeCountryAccordion', () => {
   });
   it('should render accordion closed', () => {
     const { getByText, queryByRole } = render(
-      <Components homeCountry={'US'} expandedPanel="" />,
+      <Components homeCountry={'US'} expandedAccordion={null} />,
     );
 
     expect(getByText(label)).toBeInTheDocument();
@@ -91,7 +92,10 @@ describe('HomeCountryAccordion', () => {
     const value = ''; //value is not required
 
     const { getByRole } = render(
-      <Components homeCountry={value} expandedPanel={label} />,
+      <Components
+        homeCountry={value}
+        expandedAccordion={PreferenceAccordion.HomeCountry}
+      />,
     );
 
     const button = getByRole('button', { name: 'Save' });
@@ -103,7 +107,10 @@ describe('HomeCountryAccordion', () => {
 
   it('Changes and saves the input', async () => {
     const { getByRole, getByText } = render(
-      <Components homeCountry={'US'} expandedPanel={label} />,
+      <Components
+        homeCountry={'US'}
+        expandedAccordion={PreferenceAccordion.HomeCountry}
+      />,
     );
     const button = getByRole('button', { name: 'Save' });
     const input = getByRole('combobox');
@@ -144,7 +151,7 @@ describe('HomeCountryAccordion', () => {
             <MockedProvider mocks={[errorMock]}>
               <HomeCountryAccordion
                 handleAccordionChange={handleAccordionChange}
-                expandedPanel={label}
+                expandedAccordion={PreferenceAccordion.HomeCountry}
                 homeCountry={'USA'}
                 accountListId={accountListId}
                 countries={countries}

--- a/src/components/Settings/preferences/accordions/HomeCountryAccordion/HomeCountryAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/HomeCountryAccordion/HomeCountryAccordion.tsx
@@ -9,6 +9,7 @@ import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionI
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
 import { AccountListSettingsInput } from 'src/graphql/types.generated';
+import { AccordionProps } from '../../../accordionHelper';
 import { useUpdateAccountPreferencesMutation } from '../UpdateAccountPreferences.generated';
 
 const preferencesSchema: yup.ObjectSchema<
@@ -17,9 +18,8 @@ const preferencesSchema: yup.ObjectSchema<
   homeCountry: yup.string(),
 });
 
-interface HomeCountryAccordionProps {
-  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
-  expandedAccordion: PreferenceAccordion | null;
+interface HomeCountryAccordionProps
+  extends AccordionProps<PreferenceAccordion> {
   homeCountry: string;
   accountListId: string;
   countries: { name: string; code: string }[];

--- a/src/components/Settings/preferences/accordions/HomeCountryAccordion/HomeCountryAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/HomeCountryAccordion/HomeCountryAccordion.tsx
@@ -4,6 +4,7 @@ import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
@@ -17,8 +18,8 @@ const preferencesSchema: yup.ObjectSchema<
 });
 
 interface HomeCountryAccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
+  expandedAccordion: PreferenceAccordion | null;
   homeCountry: string;
   accountListId: string;
   countries: { name: string; code: string }[];
@@ -28,7 +29,7 @@ interface HomeCountryAccordionProps {
 
 export const HomeCountryAccordion: React.FC<HomeCountryAccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   homeCountry,
   accountListId,
   countries,
@@ -65,7 +66,7 @@ export const HomeCountryAccordion: React.FC<HomeCountryAccordionProps> = ({
         enqueueSnackbar(t('Saved successfully.'), {
           variant: 'success',
         });
-        handleAccordionChange(label);
+        handleAccordionChange(null);
       },
       onError: () => {
         enqueueSnackbar(t('Saving failed.'), {
@@ -78,8 +79,9 @@ export const HomeCountryAccordion: React.FC<HomeCountryAccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={PreferenceAccordion.HomeCountry}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={label}
       value={selectedCountry}
       fullWidth

--- a/src/components/Settings/preferences/accordions/HourToSendNotificationsAccordion/HourToSendNotificationsAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/HourToSendNotificationsAccordion/HourToSendNotificationsAccordion.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from 'src/theme';
 import { HourToSendNotificationsAccordion } from './HourToSendNotificationsAccordion';
 
@@ -32,12 +33,12 @@ const mutationSpy = jest.fn();
 
 interface ComponentsProps {
   hourToSendNotifications: number | null;
-  expandedPanel: string;
+  expandedAccordion: PreferenceAccordion | null;
 }
 
 const Components: React.FC<ComponentsProps> = ({
   hourToSendNotifications,
-  expandedPanel,
+  expandedAccordion,
 }) => (
   <SnackbarProvider>
     <TestRouter router={router}>
@@ -45,7 +46,7 @@ const Components: React.FC<ComponentsProps> = ({
         <GqlMockedProvider onCall={mutationSpy}>
           <HourToSendNotificationsAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            expandedAccordion={expandedAccordion}
             hourToSendNotifications={hourToSendNotifications}
           />
         </GqlMockedProvider>
@@ -62,7 +63,7 @@ describe('HourToSendNotificationsAccordion', () => {
   });
   it('should render accordion closed', () => {
     const { getByText, queryByRole } = render(
-      <Components hourToSendNotifications={0} expandedPanel="" />,
+      <Components hourToSendNotifications={0} expandedAccordion={null} />,
     );
 
     expect(getByText(label)).toBeInTheDocument();
@@ -71,7 +72,10 @@ describe('HourToSendNotificationsAccordion', () => {
 
   it('should always have the save button enabled. null will set to Immediately', async () => {
     const { getByRole, getByText } = render(
-      <Components hourToSendNotifications={null} expandedPanel={label} />,
+      <Components
+        hourToSendNotifications={null}
+        expandedAccordion={PreferenceAccordion.HourToSendNotifications}
+      />,
     );
 
     const button = getByRole('button', { name: 'Save' });
@@ -84,7 +88,10 @@ describe('HourToSendNotificationsAccordion', () => {
 
   it('changes and saves the input', async () => {
     const { getByRole, getByText } = render(
-      <Components hourToSendNotifications={null} expandedPanel={label} />,
+      <Components
+        hourToSendNotifications={null}
+        expandedAccordion={PreferenceAccordion.HourToSendNotifications}
+      />,
     );
     const input = getByRole('combobox');
     const button = getByRole('button', { name: 'Save' });

--- a/src/components/Settings/preferences/accordions/HourToSendNotificationsAccordion/HourToSendNotificationsAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/HourToSendNotificationsAccordion/HourToSendNotificationsAccordion.tsx
@@ -5,6 +5,7 @@ import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 import { useApiConstants } from 'src/components/Constants/UseApiConstants';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
@@ -19,8 +20,8 @@ const preferencesSchema: yup.ObjectSchema<
 });
 
 interface HourToSendNotificationsAccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
+  expandedAccordion: PreferenceAccordion | null;
   hourToSendNotifications: number | null;
   disabled?: boolean;
 }
@@ -29,7 +30,7 @@ export const HourToSendNotificationsAccordion: React.FC<
   HourToSendNotificationsAccordionProps
 > = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   hourToSendNotifications,
   disabled,
 }) => {
@@ -66,7 +67,7 @@ export const HourToSendNotificationsAccordion: React.FC<
         enqueueSnackbar(t('Saved successfully.'), {
           variant: 'success',
         });
-        handleAccordionChange(label);
+        handleAccordionChange(null);
       },
       onError: () => {
         enqueueSnackbar(t('Saving failed.'), {
@@ -78,8 +79,9 @@ export const HourToSendNotificationsAccordion: React.FC<
 
   return (
     <AccordionItem
+      accordion={PreferenceAccordion.HourToSendNotifications}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={label}
       value={selectedHour || ''}
       fullWidth

--- a/src/components/Settings/preferences/accordions/HourToSendNotificationsAccordion/HourToSendNotificationsAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/HourToSendNotificationsAccordion/HourToSendNotificationsAccordion.tsx
@@ -11,6 +11,7 @@ import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
 import { Preference } from 'src/graphql/types.generated';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
+import { AccordionProps } from '../../../accordionHelper';
 import { useUpdatePersonalPreferencesMutation } from '../UpdatePersonalPreferences.generated';
 
 const preferencesSchema: yup.ObjectSchema<
@@ -19,9 +20,8 @@ const preferencesSchema: yup.ObjectSchema<
   hourToSendNotifications: yup.number().default(null).nullable(),
 });
 
-interface HourToSendNotificationsAccordionProps {
-  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
-  expandedAccordion: PreferenceAccordion | null;
+interface HourToSendNotificationsAccordionProps
+  extends AccordionProps<PreferenceAccordion> {
   hourToSendNotifications: number | null;
   disabled?: boolean;
 }

--- a/src/components/Settings/preferences/accordions/LanguageAccordion/LanguageAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/LanguageAccordion/LanguageAccordion.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from 'src/theme';
 import { UpdatePersonalPreferencesDocument } from '../UpdatePersonalPreferences.generated';
 import { LanguageAccordion } from './LanguageAccordion';
@@ -34,17 +35,20 @@ const mutationSpy = jest.fn();
 
 interface ComponentsProps {
   locale: string;
-  expandedPanel: string;
+  expandedAccordion: PreferenceAccordion | null;
 }
 
-const Components: React.FC<ComponentsProps> = ({ locale, expandedPanel }) => (
+const Components: React.FC<ComponentsProps> = ({
+  locale,
+  expandedAccordion,
+}) => (
   <SnackbarProvider>
     <TestRouter router={router}>
       <ThemeProvider theme={theme}>
         <GqlMockedProvider onCall={mutationSpy}>
           <LanguageAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            expandedAccordion={expandedAccordion}
             locale={locale}
           />
         </GqlMockedProvider>
@@ -68,7 +72,7 @@ describe('LanguageAccordion', () => {
   });
   it('should render accordion closed', () => {
     const { getByText, queryByRole } = render(
-      <Components locale={'de'} expandedPanel="" />,
+      <Components locale={'de'} expandedAccordion={null} />,
     );
 
     expect(getByText(label)).toBeInTheDocument();
@@ -79,7 +83,10 @@ describe('LanguageAccordion', () => {
     const value = ''; //value is required
 
     const { getByRole } = render(
-      <Components locale={value} expandedPanel={label} />,
+      <Components
+        locale={value}
+        expandedAccordion={PreferenceAccordion.Language}
+      />,
     );
 
     const button = getByRole('button', { name: 'Save' });
@@ -91,7 +98,10 @@ describe('LanguageAccordion', () => {
 
   it('should change and save the language', async () => {
     const { getByText, getByRole } = render(
-      <Components locale={'en-us'} expandedPanel={label} />,
+      <Components
+        locale={'en-us'}
+        expandedAccordion={PreferenceAccordion.Language}
+      />,
     );
 
     const input = getByRole('combobox');
@@ -130,7 +140,7 @@ describe('LanguageAccordion', () => {
             <MockedProvider mocks={[errorMock]}>
               <LanguageAccordion
                 handleAccordionChange={handleAccordionChange}
-                expandedPanel={label}
+                expandedAccordion={PreferenceAccordion.Language}
                 locale={'en-US'}
               />
             </MockedProvider>

--- a/src/components/Settings/preferences/accordions/LanguageAccordion/LanguageAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/LanguageAccordion/LanguageAccordion.tsx
@@ -11,6 +11,7 @@ import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
 import { Preference } from 'src/graphql/types.generated';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
 import { formatLanguage, languages } from 'src/lib/data/languages';
+import { AccordionProps } from '../../../accordionHelper';
 import { useUpdatePersonalPreferencesMutation } from '../UpdatePersonalPreferences.generated';
 
 const preferencesSchema: yup.ObjectSchema<Pick<Preference, 'locale'>> =
@@ -18,9 +19,7 @@ const preferencesSchema: yup.ObjectSchema<Pick<Preference, 'locale'>> =
     locale: yup.string().required(),
   });
 
-interface LanguageAccordionProps {
-  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
-  expandedAccordion: PreferenceAccordion | null;
+interface LanguageAccordionProps extends AccordionProps<PreferenceAccordion> {
   locale: string;
   disabled?: boolean;
 }

--- a/src/components/Settings/preferences/accordions/LanguageAccordion/LanguageAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/LanguageAccordion/LanguageAccordion.tsx
@@ -4,6 +4,7 @@ import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
@@ -18,15 +19,15 @@ const preferencesSchema: yup.ObjectSchema<Pick<Preference, 'locale'>> =
   });
 
 interface LanguageAccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
+  expandedAccordion: PreferenceAccordion | null;
   locale: string;
   disabled?: boolean;
 }
 
 export const LanguageAccordion: React.FC<LanguageAccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   locale,
   disabled,
 }) => {
@@ -56,6 +57,7 @@ export const LanguageAccordion: React.FC<LanguageAccordionProps> = ({
         enqueueSnackbar(t('Saved successfully.'), {
           variant: 'success',
         });
+        handleAccordionChange(null);
       },
       onError: () => {
         enqueueSnackbar(t('Saving failed.'), {
@@ -67,8 +69,9 @@ export const LanguageAccordion: React.FC<LanguageAccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={PreferenceAccordion.Language}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={label}
       value={selectedLanguage}
       fullWidth

--- a/src/components/Settings/preferences/accordions/LocaleAccordion/LocaleAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/LocaleAccordion/LocaleAccordion.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from 'src/theme';
 import { LocaleAccordion } from './LocaleAccordion';
 
@@ -33,12 +34,12 @@ const mutationSpy = jest.fn();
 
 interface ComponentsProps {
   localeDisplay: string;
-  expandedPanel: string;
+  expandedAccordion: PreferenceAccordion | null;
 }
 
 const Components: React.FC<ComponentsProps> = ({
   localeDisplay,
-  expandedPanel,
+  expandedAccordion,
 }) => (
   <SnackbarProvider>
     <TestRouter router={router}>
@@ -46,7 +47,7 @@ const Components: React.FC<ComponentsProps> = ({
         <GqlMockedProvider onCall={mutationSpy}>
           <LocaleAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            expandedAccordion={expandedAccordion}
             localeDisplay={localeDisplay}
             handleSetupChange={handleSetupChange}
           />
@@ -64,7 +65,7 @@ describe('LocaleAccordion', () => {
   });
   it('should render accordion closed', () => {
     const { getByText, queryByRole } = render(
-      <Components localeDisplay={'en-GB'} expandedPanel="" />,
+      <Components localeDisplay={'en-GB'} expandedAccordion={null} />,
     );
 
     expect(getByText(label)).toBeInTheDocument();
@@ -75,7 +76,10 @@ describe('LocaleAccordion', () => {
     const value = ''; //value is required
 
     const { getByRole } = render(
-      <Components localeDisplay={value} expandedPanel={label} />,
+      <Components
+        localeDisplay={value}
+        expandedAccordion={PreferenceAccordion.Locale}
+      />,
     );
 
     const button = getByRole('button', { name: 'Save' });
@@ -87,7 +91,10 @@ describe('LocaleAccordion', () => {
 
   it('Changes and saves the input', async () => {
     const { getByRole, getByText } = render(
-      <Components localeDisplay={'es-419'} expandedPanel={label} />,
+      <Components
+        localeDisplay={'es-419'}
+        expandedAccordion={PreferenceAccordion.Locale}
+      />,
     );
     const input = getByRole('combobox');
     const button = getByRole('button', { name: 'Save' });

--- a/src/components/Settings/preferences/accordions/LocaleAccordion/LocaleAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/LocaleAccordion/LocaleAccordion.tsx
@@ -10,6 +10,7 @@ import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionI
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
 import { Preference } from 'src/graphql/types.generated';
+import { AccordionProps } from '../../../accordionHelper';
 import { useUpdatePersonalPreferencesMutation } from '../UpdatePersonalPreferences.generated';
 
 const preferencesSchema: yup.ObjectSchema<Pick<Preference, 'localeDisplay'>> =
@@ -17,9 +18,7 @@ const preferencesSchema: yup.ObjectSchema<Pick<Preference, 'localeDisplay'>> =
     localeDisplay: yup.string().required(),
   });
 
-interface LocaleAccordionProps {
-  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
-  expandedAccordion: PreferenceAccordion | null;
+interface LocaleAccordionProps extends AccordionProps<PreferenceAccordion> {
   localeDisplay: string;
   disabled?: boolean;
   handleSetupChange: () => Promise<void>;

--- a/src/components/Settings/preferences/accordions/LocaleAccordion/LocaleAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/LocaleAccordion/LocaleAccordion.tsx
@@ -5,6 +5,7 @@ import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 import { useApiConstants } from 'src/components/Constants/UseApiConstants';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
@@ -17,8 +18,8 @@ const preferencesSchema: yup.ObjectSchema<Pick<Preference, 'localeDisplay'>> =
   });
 
 interface LocaleAccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
+  expandedAccordion: PreferenceAccordion | null;
   localeDisplay: string;
   disabled?: boolean;
   handleSetupChange: () => Promise<void>;
@@ -26,7 +27,7 @@ interface LocaleAccordionProps {
 
 export const LocaleAccordion: React.FC<LocaleAccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   localeDisplay,
   disabled,
   handleSetupChange,
@@ -67,7 +68,7 @@ export const LocaleAccordion: React.FC<LocaleAccordionProps> = ({
         enqueueSnackbar(t('Saved successfully.'), {
           variant: 'success',
         });
-        handleAccordionChange(label);
+        handleAccordionChange(null);
       },
       onError: () => {
         enqueueSnackbar(t('Saving failed.'), {
@@ -80,8 +81,9 @@ export const LocaleAccordion: React.FC<LocaleAccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={PreferenceAccordion.Locale}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={label}
       value={selectedLocale || ''}
       fullWidth

--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from 'src/theme';
 import { MonthlyGoalAccordion } from './MonthlyGoalAccordion';
 
@@ -33,12 +34,12 @@ const mutationSpy = jest.fn();
 
 interface ComponentsProps {
   monthlyGoal: number | null;
-  expandedPanel: string;
+  expandedAccordion: PreferenceAccordion | null;
 }
 
 const Components: React.FC<ComponentsProps> = ({
   monthlyGoal,
-  expandedPanel,
+  expandedAccordion,
 }) => (
   <SnackbarProvider>
     <TestRouter router={router}>
@@ -46,7 +47,7 @@ const Components: React.FC<ComponentsProps> = ({
         <GqlMockedProvider onCall={mutationSpy}>
           <MonthlyGoalAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            expandedAccordion={expandedAccordion}
             monthlyGoal={monthlyGoal}
             currency={'USD'}
             accountListId={accountListId}
@@ -66,7 +67,7 @@ describe('MonthlyGoalAccordion', () => {
   });
   it('should render accordion closed', () => {
     const { getByText, queryByRole } = render(
-      <Components monthlyGoal={100} expandedPanel="" />,
+      <Components monthlyGoal={100} expandedAccordion={null} />,
     );
 
     expect(getByText(label)).toBeInTheDocument();
@@ -74,7 +75,10 @@ describe('MonthlyGoalAccordion', () => {
   });
   it('should render accordion open and textfield should have a value', () => {
     const { getByRole } = render(
-      <Components monthlyGoal={20000} expandedPanel={label} />,
+      <Components
+        monthlyGoal={20000}
+        expandedAccordion={PreferenceAccordion.MonthlyGoal}
+      />,
     );
 
     const input = getByRole('spinbutton', { name: label });
@@ -89,7 +93,10 @@ describe('MonthlyGoalAccordion', () => {
     const value = null; //value is required
 
     const { getByRole, getByText } = render(
-      <Components monthlyGoal={value} expandedPanel={label} />,
+      <Components
+        monthlyGoal={value}
+        expandedAccordion={PreferenceAccordion.MonthlyGoal}
+      />,
     );
 
     const input = getByRole('spinbutton', { name: label });
@@ -104,7 +111,10 @@ describe('MonthlyGoalAccordion', () => {
 
   it('Changes and saves the input', async () => {
     const { getByRole } = render(
-      <Components monthlyGoal={1000} expandedPanel={label} />,
+      <Components
+        monthlyGoal={1000}
+        expandedAccordion={PreferenceAccordion.MonthlyGoal}
+      />,
     );
     const input = getByRole('spinbutton', { name: label });
     const button = getByRole('button', { name: 'Save' });

--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
@@ -11,6 +11,7 @@ import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
 import { AccountListSettingsInput } from 'src/graphql/types.generated';
 import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat } from 'src/lib/intlFormat';
+import { AccordionProps } from '../../../accordionHelper';
 import { useUpdateAccountPreferencesMutation } from '../UpdateAccountPreferences.generated';
 
 const accountPreferencesSchema: yup.ObjectSchema<
@@ -19,9 +20,8 @@ const accountPreferencesSchema: yup.ObjectSchema<
   monthlyGoal: yup.number().required(),
 });
 
-interface MonthlyGoalAccordionProps {
-  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
-  expandedAccordion: PreferenceAccordion | null;
+interface MonthlyGoalAccordionProps
+  extends AccordionProps<PreferenceAccordion> {
   monthlyGoal: number | null;
   accountListId: string;
   currency: string;

--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
@@ -4,6 +4,7 @@ import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
@@ -19,8 +20,8 @@ const accountPreferencesSchema: yup.ObjectSchema<
 });
 
 interface MonthlyGoalAccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
+  expandedAccordion: PreferenceAccordion | null;
   monthlyGoal: number | null;
   accountListId: string;
   currency: string;
@@ -30,7 +31,7 @@ interface MonthlyGoalAccordionProps {
 
 export const MonthlyGoalAccordion: React.FC<MonthlyGoalAccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   monthlyGoal,
   accountListId,
   currency,
@@ -68,7 +69,7 @@ export const MonthlyGoalAccordion: React.FC<MonthlyGoalAccordionProps> = ({
         enqueueSnackbar(t('Saved successfully.'), {
           variant: 'success',
         });
-        handleAccordionChange(label);
+        handleAccordionChange(null);
       },
       onError: () => {
         enqueueSnackbar(t('Saving failed.'), {
@@ -81,8 +82,9 @@ export const MonthlyGoalAccordion: React.FC<MonthlyGoalAccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={PreferenceAccordion.MonthlyGoal}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={label}
       value={monthlyGoalString}
       fullWidth

--- a/src/components/Settings/preferences/accordions/MpdInfoAccordion/MpdInfoAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/MpdInfoAccordion/MpdInfoAccordion.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from 'src/theme';
 import { MpdInfoAccordion } from './MpdInfoAccordion';
 
@@ -36,14 +37,14 @@ interface ComponentsProps {
   activeMpdMonthlyGoal: number | null;
   activeMpdFinishAt: string | null;
   activeMpdStartAt: string | null;
-  expandedPanel: string;
+  expandedAccordion: PreferenceAccordion | null;
 }
 
 const Components: React.FC<ComponentsProps> = ({
   activeMpdMonthlyGoal,
   activeMpdStartAt,
   activeMpdFinishAt,
-  expandedPanel,
+  expandedAccordion,
 }) => (
   <SnackbarProvider>
     <TestRouter router={router}>
@@ -52,7 +53,7 @@ const Components: React.FC<ComponentsProps> = ({
           <GqlMockedProvider onCall={mutationSpy}>
             <MpdInfoAccordion
               handleAccordionChange={handleAccordionChange}
-              expandedPanel={expandedPanel}
+              expandedAccordion={expandedAccordion}
               activeMpdMonthlyGoal={activeMpdMonthlyGoal}
               activeMpdFinishAt={activeMpdFinishAt}
               activeMpdStartAt={activeMpdStartAt}
@@ -78,7 +79,7 @@ describe('MpdInfoAccordion', () => {
         activeMpdStartAt={null}
         activeMpdFinishAt={null}
         activeMpdMonthlyGoal={100}
-        expandedPanel=""
+        expandedAccordion={null}
       />,
     );
 
@@ -91,7 +92,7 @@ describe('MpdInfoAccordion', () => {
         activeMpdStartAt={'2024-01-16'}
         activeMpdFinishAt={'2024-03-16'}
         activeMpdMonthlyGoal={20000}
-        expandedPanel={label}
+        expandedAccordion={PreferenceAccordion.MpdInfo}
       />,
     );
 
@@ -114,7 +115,7 @@ describe('MpdInfoAccordion', () => {
         activeMpdStartAt={null}
         activeMpdFinishAt={null}
         activeMpdMonthlyGoal={null}
-        expandedPanel={label}
+        expandedAccordion={PreferenceAccordion.MpdInfo}
       />,
     );
 
@@ -131,7 +132,7 @@ describe('MpdInfoAccordion', () => {
         activeMpdStartAt={'2011-02-22'}
         activeMpdFinishAt={'2011-12-01'}
         activeMpdMonthlyGoal={1000}
-        expandedPanel={label}
+        expandedAccordion={PreferenceAccordion.MpdInfo}
       />,
     );
     const inputStart = getAllByRole('textbox')[0];

--- a/src/components/Settings/preferences/accordions/MpdInfoAccordion/MpdInfoAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/MpdInfoAccordion/MpdInfoAccordion.tsx
@@ -14,6 +14,7 @@ import { CustomDateField } from 'src/components/common/DateTimePickers/CustomDat
 import { useLocale } from 'src/hooks/useLocale';
 import { nullableDateTime } from 'src/lib/formikHelpers';
 import { currencyFormat, dateFormat } from 'src/lib/intlFormat';
+import { AccordionProps } from '../../../accordionHelper';
 import { useUpdateAccountPreferencesMutation } from '../UpdateAccountPreferences.generated';
 
 const numberOrNullTransform = (_: unknown, val: unknown) =>
@@ -30,9 +31,7 @@ const accountPreferencesSchema = yup.object({
 
 type Attributes = yup.InferType<typeof accountPreferencesSchema>;
 
-interface MpdInfoAccordionProps {
-  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
-  expandedAccordion: PreferenceAccordion | null;
+interface MpdInfoAccordionProps extends AccordionProps<PreferenceAccordion> {
   activeMpdMonthlyGoal: number | null;
   activeMpdStartAt: string | null;
   activeMpdFinishAt: string | null;

--- a/src/components/Settings/preferences/accordions/MpdInfoAccordion/MpdInfoAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/MpdInfoAccordion/MpdInfoAccordion.tsx
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { HelperPositionEnum } from 'src/components/Shared/Forms/FieldHelper';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
@@ -30,8 +31,8 @@ const accountPreferencesSchema = yup.object({
 type Attributes = yup.InferType<typeof accountPreferencesSchema>;
 
 interface MpdInfoAccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
+  expandedAccordion: PreferenceAccordion | null;
   activeMpdMonthlyGoal: number | null;
   activeMpdStartAt: string | null;
   activeMpdFinishAt: string | null;
@@ -42,7 +43,7 @@ interface MpdInfoAccordionProps {
 
 export const MpdInfoAccordion: React.FC<MpdInfoAccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   activeMpdMonthlyGoal,
   activeMpdStartAt,
   activeMpdFinishAt,
@@ -74,7 +75,7 @@ export const MpdInfoAccordion: React.FC<MpdInfoAccordionProps> = ({
         enqueueSnackbar(t('Saved successfully.'), {
           variant: 'success',
         });
-        handleAccordionChange(label);
+        handleAccordionChange(null);
       },
       onError: () => {
         enqueueSnackbar(t('Saving failed.'), {
@@ -108,8 +109,9 @@ export const MpdInfoAccordion: React.FC<MpdInfoAccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={PreferenceAccordion.MpdInfo}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={label}
       value={goalDateString}
       fullWidth

--- a/src/components/Settings/preferences/accordions/PrimaryOrgAccordion/PrimaryOrgAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/PrimaryOrgAccordion/PrimaryOrgAccordion.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from 'src/theme';
 import { PrimaryOrgAccordion } from './PrimaryOrgAccordion';
 
@@ -61,12 +62,12 @@ const mockData = {
 
 interface ComponentsProps {
   salaryOrganizationId: string;
-  expandedPanel: string;
+  expandedAccordion: PreferenceAccordion | null;
 }
 
 const Components: React.FC<ComponentsProps> = ({
   salaryOrganizationId,
-  expandedPanel,
+  expandedAccordion,
 }) => (
   <SnackbarProvider>
     <TestRouter router={router}>
@@ -74,7 +75,7 @@ const Components: React.FC<ComponentsProps> = ({
         <GqlMockedProvider onCall={mutationSpy}>
           <PrimaryOrgAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            expandedAccordion={expandedAccordion}
             salaryOrganizationId={salaryOrganizationId}
             organizations={mockData}
             accountListId={accountListId}
@@ -95,7 +96,7 @@ describe('PrimaryOrgAccordion', () => {
     const { getByText, queryByRole } = render(
       <Components
         salaryOrganizationId={'0673b517-4f4d-4c47-965e-0757a198a8a4'}
-        expandedPanel=""
+        expandedAccordion={null}
       />,
     );
 
@@ -107,7 +108,10 @@ describe('PrimaryOrgAccordion', () => {
     const value = ''; //value is required
 
     const { getByRole } = render(
-      <Components salaryOrganizationId={value} expandedPanel={label} />,
+      <Components
+        salaryOrganizationId={value}
+        expandedAccordion={PreferenceAccordion.PrimaryOrg}
+      />,
     );
 
     const button = getByRole('button', { name: 'Save' });
@@ -121,7 +125,7 @@ describe('PrimaryOrgAccordion', () => {
     const { getByRole, getByText } = render(
       <Components
         salaryOrganizationId={'7ab3ec4b-7108-40bf-a998-ce813d10c821'}
-        expandedPanel={label}
+        expandedAccordion={PreferenceAccordion.PrimaryOrg}
       />,
     );
     const button = getByRole('button', { name: 'Save' });

--- a/src/components/Settings/preferences/accordions/PrimaryOrgAccordion/PrimaryOrgAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/PrimaryOrgAccordion/PrimaryOrgAccordion.tsx
@@ -5,6 +5,7 @@ import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 import { GetUsersOrganizationsAccountsQuery } from 'src/components/Settings/integrations/Organization/Organizations.generated';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
@@ -18,8 +19,8 @@ const preferencesSchema: yup.ObjectSchema<
 });
 
 interface PrimaryOrgAccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
+  expandedAccordion: PreferenceAccordion | null;
   organizations: GetUsersOrganizationsAccountsQuery | undefined;
   salaryOrganizationId: string;
   accountListId: string;
@@ -28,7 +29,7 @@ interface PrimaryOrgAccordionProps {
 
 export const PrimaryOrgAccordion: React.FC<PrimaryOrgAccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   organizations,
   salaryOrganizationId,
   accountListId,
@@ -64,7 +65,7 @@ export const PrimaryOrgAccordion: React.FC<PrimaryOrgAccordionProps> = ({
         enqueueSnackbar(t('Saved successfully.'), {
           variant: 'success',
         });
-        handleAccordionChange(label);
+        handleAccordionChange(null);
       },
       onError: () => {
         enqueueSnackbar(t('Saving failed.'), {
@@ -76,8 +77,9 @@ export const PrimaryOrgAccordion: React.FC<PrimaryOrgAccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={PreferenceAccordion.PrimaryOrg}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={label}
       value={selectedOrgName}
       fullWidth

--- a/src/components/Settings/preferences/accordions/PrimaryOrgAccordion/PrimaryOrgAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/PrimaryOrgAccordion/PrimaryOrgAccordion.tsx
@@ -10,6 +10,7 @@ import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionI
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
 import { AccountList } from 'src/graphql/types.generated';
+import { AccordionProps } from '../../../accordionHelper';
 import { useUpdateAccountPreferencesMutation } from '../UpdateAccountPreferences.generated';
 
 const preferencesSchema: yup.ObjectSchema<
@@ -18,9 +19,7 @@ const preferencesSchema: yup.ObjectSchema<
   salaryOrganizationId: yup.string().required(),
 });
 
-interface PrimaryOrgAccordionProps {
-  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
-  expandedAccordion: PreferenceAccordion | null;
+interface PrimaryOrgAccordionProps extends AccordionProps<PreferenceAccordion> {
   organizations: GetUsersOrganizationsAccountsQuery | undefined;
   salaryOrganizationId: string;
   accountListId: string;

--- a/src/components/Settings/preferences/accordions/TimeZoneAccordion/TimeZoneAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/TimeZoneAccordion/TimeZoneAccordion.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import theme from 'src/theme';
 import { TimeZoneAccordion } from './TimeZoneAccordion';
 
@@ -44,17 +45,20 @@ const timeZones = [
 
 interface ComponentsProps {
   timeZone: string;
-  expandedPanel: string;
+  expandedAccordion: PreferenceAccordion | null;
 }
 
-const Components: React.FC<ComponentsProps> = ({ timeZone, expandedPanel }) => (
+const Components: React.FC<ComponentsProps> = ({
+  timeZone,
+  expandedAccordion,
+}) => (
   <SnackbarProvider>
     <TestRouter router={router}>
       <ThemeProvider theme={theme}>
         <GqlMockedProvider onCall={mutationSpy}>
           <TimeZoneAccordion
             handleAccordionChange={handleAccordionChange}
-            expandedPanel={expandedPanel}
+            expandedAccordion={expandedAccordion}
             timeZone={timeZone}
             timeZones={timeZones}
           />
@@ -70,7 +74,7 @@ describe('TimeZoneAccordion', () => {
   });
   it('should render accordion closed', () => {
     const { getByText, queryByRole } = render(
-      <Components timeZone={'USD'} expandedPanel="" />,
+      <Components timeZone={'USD'} expandedAccordion={null} />,
     );
 
     expect(getByText(label)).toBeInTheDocument();
@@ -81,7 +85,10 @@ describe('TimeZoneAccordion', () => {
     const value = ''; //value is required
 
     const { getByRole } = render(
-      <Components timeZone={value} expandedPanel={label} />,
+      <Components
+        timeZone={value}
+        expandedAccordion={PreferenceAccordion.TimeZone}
+      />,
     );
 
     const button = getByRole('button', { name: 'Save' });
@@ -95,7 +102,7 @@ describe('TimeZoneAccordion', () => {
     const { getByRole, getByText } = render(
       <Components
         timeZone={'Eastern Time (US & Canada)'}
-        expandedPanel={label}
+        expandedAccordion={PreferenceAccordion.TimeZone}
       />,
     );
     const input = getByRole('combobox');

--- a/src/components/Settings/preferences/accordions/TimeZoneAccordion/TimeZoneAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/TimeZoneAccordion/TimeZoneAccordion.tsx
@@ -9,6 +9,7 @@ import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionI
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
 import { Preference } from 'src/graphql/types.generated';
+import { AccordionProps } from '../../../accordionHelper';
 import { useUpdatePersonalPreferencesMutation } from '../UpdatePersonalPreferences.generated';
 
 const preferencesSchema: yup.ObjectSchema<Pick<Preference, 'timeZone'>> =
@@ -16,9 +17,7 @@ const preferencesSchema: yup.ObjectSchema<Pick<Preference, 'timeZone'>> =
     timeZone: yup.string().required(),
   });
 
-interface TimeZoneAccordionProps {
-  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
-  expandedAccordion: PreferenceAccordion | null;
+interface TimeZoneAccordionProps extends AccordionProps<PreferenceAccordion> {
   timeZone: string;
   timeZones: Array<Record<string, string>>;
   disabled?: boolean;

--- a/src/components/Settings/preferences/accordions/TimeZoneAccordion/TimeZoneAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/TimeZoneAccordion/TimeZoneAccordion.tsx
@@ -4,6 +4,7 @@ import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
@@ -16,8 +17,8 @@ const preferencesSchema: yup.ObjectSchema<Pick<Preference, 'timeZone'>> =
   });
 
 interface TimeZoneAccordionProps {
-  handleAccordionChange: (panel: string) => void;
-  expandedPanel: string;
+  handleAccordionChange: (accordion: PreferenceAccordion | null) => void;
+  expandedAccordion: PreferenceAccordion | null;
   timeZone: string;
   timeZones: Array<Record<string, string>>;
   disabled?: boolean;
@@ -25,7 +26,7 @@ interface TimeZoneAccordionProps {
 
 export const TimeZoneAccordion: React.FC<TimeZoneAccordionProps> = ({
   handleAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   timeZone,
   timeZones,
   disabled,
@@ -57,7 +58,7 @@ export const TimeZoneAccordion: React.FC<TimeZoneAccordionProps> = ({
         enqueueSnackbar(t('Saved successfully.'), {
           variant: 'success',
         });
-        handleAccordionChange(label);
+        handleAccordionChange(null);
       },
       onError: () => {
         enqueueSnackbar(t('Saving failed.'), {
@@ -69,8 +70,9 @@ export const TimeZoneAccordion: React.FC<TimeZoneAccordionProps> = ({
 
   return (
     <AccordionItem
+      accordion={PreferenceAccordion.TimeZone}
       onAccordionChange={handleAccordionChange}
-      expandedPanel={expandedPanel}
+      expandedAccordion={expandedAccordion}
       label={label}
       value={selectedTimeZone}
       fullWidth

--- a/src/components/Shared/Forms/Accordions/AccordionEnum.ts
+++ b/src/components/Shared/Forms/Accordions/AccordionEnum.ts
@@ -13,13 +13,14 @@ export enum CoachAccordion {
   ManageCoachesAccess = 'ManageCoachesAccess',
 }
 
+// These must match the values passed to WebRouter#integration_preferences_url in mpdx_api
 export enum IntegrationAccordion {
-  Chalkline = 'Chalkline',
-  Google = 'Google',
-  Mailchimp = 'Mailchimp',
-  Okta = 'Okta',
-  Organization = 'Organization',
-  Prayerletters = 'Prayerletters',
+  Chalkline = 'chalkline',
+  Google = 'google',
+  Mailchimp = 'mailchimp',
+  Okta = 'okta',
+  Organization = 'organization',
+  Prayerletters = 'prayerletters.com',
 }
 
 export enum OrganizationAccordion {

--- a/src/components/Shared/Forms/Accordions/AccordionEnum.ts
+++ b/src/components/Shared/Forms/Accordions/AccordionEnum.ts
@@ -1,0 +1,44 @@
+export enum AccountAccordion {
+  ManageAccountAccess = 'ManageAccountAccess',
+  MergeAccounts = 'MergeAccounts',
+  MergeSpouseAccounts = 'MergeSpouseAccounts',
+}
+
+export enum AdminAccordion {
+  ImpersonateUser = 'ImpersonateUser',
+  ResetAccount = 'ResetAccount',
+}
+
+export enum CoachAccordion {
+  ManageCoachesAccess = 'ManageCoachesAccess',
+}
+
+export enum IntegrationAccordion {
+  Chalkline = 'Chalkline',
+  Google = 'Google',
+  Mailchimp = 'Mailchimp',
+  Okta = 'Okta',
+  Organization = 'Organization',
+  Prayerletters = 'Prayerletters',
+}
+
+export enum OrganizationAccordion {
+  ImpersonateUser = 'ImpersonateUser',
+  ManageOrganizationAccess = 'ManageOrganizationAccess',
+}
+
+export enum PreferenceAccordion {
+  AccountName = 'AccountName',
+  Currency = 'Currency',
+  DefaultAccount = 'DefaultAccount',
+  EarlyAdopter = 'EarlyAdopter',
+  ExportAllData = 'ExportAllData',
+  HomeCountry = 'HomeCountry',
+  HourToSendNotifications = 'HourToSendNotifications',
+  Language = 'Language',
+  Locale = 'Locale',
+  MonthlyGoal = 'MonthlyGoal',
+  MpdInfo = 'MpdInfo',
+  PrimaryOrg = 'PrimaryOrg',
+  TimeZone = 'TimeZone',
+}

--- a/src/components/Shared/Forms/Accordions/AccordionItem.test.tsx
+++ b/src/components/Shared/Forms/Accordions/AccordionItem.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import theme from 'src/theme';
 import { AccordionItem } from './AccordionItem';
 
-const expandedPanel = 'expandedPanel';
+const expandedAccordion = 'expandedAccordion';
 
 describe('AccordionItem', () => {
   const onAccordionChange = jest.fn();
@@ -15,8 +15,9 @@ describe('AccordionItem', () => {
     const { queryByText } = render(
       <ThemeProvider theme={theme}>
         <AccordionItem
-          label={'expandedPanel'}
-          expandedPanel=""
+          accordion={expandedAccordion}
+          label={'expandedAccordion'}
+          expandedAccordion={null}
           onAccordionChange={onAccordionChange}
           value="ValueText"
         >
@@ -31,8 +32,9 @@ describe('AccordionItem', () => {
     const { queryByTestId } = render(
       <ThemeProvider theme={theme}>
         <AccordionItem
-          label={'expandedPanel'}
-          expandedPanel=""
+          accordion={expandedAccordion}
+          label={'expandedAccordion'}
+          expandedAccordion={null}
           onAccordionChange={onAccordionChange}
           value=""
         >
@@ -48,8 +50,9 @@ describe('AccordionItem', () => {
     const { getByText } = render(
       <ThemeProvider theme={theme}>
         <AccordionItem
-          label={'expandedPanel'}
-          expandedPanel=""
+          accordion={expandedAccordion}
+          label={'expandedAccordion'}
+          expandedAccordion={null}
           onAccordionChange={onAccordionChange}
           value="ValueText"
         >
@@ -58,16 +61,17 @@ describe('AccordionItem', () => {
       </ThemeProvider>,
     );
 
-    expect(getByText('expandedPanel')).toBeInTheDocument();
+    expect(getByText('expandedAccordion')).toBeInTheDocument();
   });
 
   it('Should render value', () => {
     const { getByText } = render(
       <ThemeProvider theme={theme}>
         <AccordionItem
-          label={'expandedPanel'}
+          accordion={expandedAccordion}
+          label={'expandedAccordion'}
           value={'AccordionValue'}
-          expandedPanel=""
+          expandedAccordion={null}
           onAccordionChange={onAccordionChange}
         >
           Children
@@ -82,9 +86,10 @@ describe('AccordionItem', () => {
     const { getByText } = render(
       <ThemeProvider theme={theme}>
         <AccordionItem
-          label={'expandedPanel'}
+          accordion={expandedAccordion}
+          label={'expandedAccordion'}
           value={'AccordionValue'}
-          expandedPanel={expandedPanel}
+          expandedAccordion={expandedAccordion}
           onAccordionChange={onAccordionChange}
         >
           Children
@@ -99,9 +104,10 @@ describe('AccordionItem', () => {
     const { getByText } = render(
       <ThemeProvider theme={theme}>
         <AccordionItem
-          label={'expandedPanel'}
+          accordion={expandedAccordion}
+          label={'expandedAccordion'}
           value={'AccordionValue'}
-          expandedPanel={expandedPanel}
+          expandedAccordion={expandedAccordion}
           fullWidth={true}
           onAccordionChange={onAccordionChange}
         >
@@ -117,9 +123,10 @@ describe('AccordionItem', () => {
     const { getByText } = render(
       <ThemeProvider theme={theme}>
         <AccordionItem
-          label={'expandedPanel'}
+          accordion={expandedAccordion}
+          label={'expandedAccordion'}
           value={'AccordionValue'}
-          expandedPanel={expandedPanel}
+          expandedAccordion={expandedAccordion}
           fullWidth={true}
           image={'image.png'}
           onAccordionChange={onAccordionChange}
@@ -136,9 +143,10 @@ describe('AccordionItem', () => {
     const { getByTestId } = render(
       <ThemeProvider theme={theme}>
         <AccordionItem
-          label={'expandedPanel'}
+          accordion={expandedAccordion}
+          label={'expandedAccordion'}
           value={'AccordionValue'}
-          expandedPanel={expandedPanel}
+          expandedAccordion={expandedAccordion}
           onAccordionChange={onAccordionChange}
         >
           Children

--- a/src/components/Shared/Forms/Accordions/AccordionItem.tsx
+++ b/src/components/Shared/Forms/Accordions/AccordionItem.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { ExpandMore } from '@mui/icons-material';
 import {
   Accordion,
@@ -117,9 +117,10 @@ const AccordionLeftDetailsImage = styled(Box)(({ theme }) => ({
   },
 }));
 
-interface AccordionItemProps {
-  onAccordionChange: (label: string) => void;
-  expandedPanel: string;
+interface AccordionItemProps<AccordionEnum> {
+  accordion: AccordionEnum;
+  onAccordionChange: (accordion: AccordionEnum | null) => void;
+  expandedAccordion: AccordionEnum | null;
   label: string;
   value: string;
   children?: React.ReactNode;
@@ -128,24 +129,23 @@ interface AccordionItemProps {
   disabled?: boolean;
 }
 
-export const AccordionItem: React.FC<AccordionItemProps> = ({
+export const AccordionItem = <AccordionEnum,>({
+  accordion,
   onAccordionChange,
-  expandedPanel,
+  expandedAccordion,
   label,
   value,
   children,
   fullWidth = false,
   image,
   disabled,
-}) => {
-  const expanded = useMemo(
-    () => expandedPanel?.toLowerCase() === label.toLowerCase(),
-    [expandedPanel, label],
-  );
+}: AccordionItemProps<AccordionEnum>) => {
+  const expanded = expandedAccordion === accordion;
+
   return (
     <StyledAccordion
-      onChange={() => onAccordionChange(label)}
-      expanded={expanded}
+      onChange={(_, expanded) => onAccordionChange(expanded ? accordion : null)}
+      expanded={expandedAccordion === accordion}
       disableGutters
       disabled={disabled}
     >

--- a/src/components/Tool/GoogleImport/GoogleImport.tsx
+++ b/src/components/Tool/GoogleImport/GoogleImport.tsx
@@ -33,6 +33,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 import { useGetContactTagListQuery } from 'src/components/Contacts/ContactDetails/ContactDetailsTab/Tags/ContactTags.generated';
 import { LoadingSpinner } from 'src/components/Settings/Organization/LoadingSpinner';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { ContactTagInput } from 'src/components/Tags/Tags';
 import { Confirmation } from 'src/components/common/Modal/Confirmation/Confirmation';
 import Modal from 'src/components/common/Modal/Modal';
@@ -226,7 +227,7 @@ const GoogleImport: React.FC<Props> = ({ accountListId }: Props) => {
                   tool="googleImport"
                   button={
                     <Button
-                      href={`/accountLists/${accountListId}/settings/integrations?selectedTab=google`}
+                      href={`/accountLists/${accountListId}/settings/integrations?selectedTab=${IntegrationAccordion.Google}`}
                       variant="contained"
                     >
                       {t('Connect Google Account')}
@@ -298,7 +299,7 @@ const GoogleImport: React.FC<Props> = ({ accountListId }: Props) => {
                             }
                             action={
                               <Button
-                                href={`/accountLists/${accountListId}/settings/integrations?selectedTab=google`}
+                                href={`/accountLists/${accountListId}/settings/integrations?selectedTab==${IntegrationAccordion.Google}`}
                                 size="small"
                                 variant="contained"
                               >


### PR DESCRIPTION
## Description

Use enums to identify which accordion is expanded. This will fix a bug where links in emails like `/accountLists/$accountListId/settings/integrations?selectedTab=$integrationName` wouldn't open if the user's language isn't English. This is because it is looking up the accordion by it's translated label. Now it will find the accordion by a stable enum value.

Indirectly related to [MPDX-8540](https://jira.cru.org/browse/MPDX-8540)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
