### PR TITLE
[MPDX-8540] Add preferences link to monthly goal widget

### DIFF
--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
@@ -263,7 +263,7 @@ describe('MonthlyGoal', () => {
 
   describe('Monthly Goal', () => {
     it('should set the monthly goal to the user-entered goal if it exists', async () => {
-      const { findByRole } = render(
+      const { findByRole, queryByRole } = render(
         <Components
           monthlyGoalProps={defaultProps}
           healthIndicatorData={[
@@ -280,10 +280,14 @@ describe('MonthlyGoal', () => {
           name: /\$999.50/i,
         }),
       ).toBeInTheDocument();
+
+      expect(
+        queryByRole('link', { name: 'Set Monthly Goal' }),
+      ).not.toBeInTheDocument();
     });
 
     it('should set the monthly goal to the machine calculated goal', async () => {
-      const { findByRole, queryByRole } = render(
+      const { findByRole, getByRole, queryByRole } = render(
         <Components
           monthlyGoalProps={{ ...defaultProps, goal: undefined }}
           healthIndicatorData={[healthIndicatorScore]}
@@ -301,7 +305,13 @@ describe('MonthlyGoal', () => {
           name: /\$999.50/i,
         }),
       ).not.toBeInTheDocument();
+
+      expect(getByRole('link', { name: 'Set Monthly Goal' })).toHaveAttribute(
+        'href',
+        '/accountLists/account-list-1/settings/preferences?selectedTab=MonthlyGoal',
+      );
     });
+
     it('should set the monthly goal to 0 if both the machineCalculatedGoal and monthly goal are unset', async () => {
       const { findByRole, queryByRole } = render(
         <Components

--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
@@ -1,3 +1,4 @@
+import NextLink from 'next/link';
 import React, { ReactElement, useMemo } from 'react';
 import {
   Box,
@@ -13,6 +14,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { makeStyles } from 'tss-react/mui';
 import { HealthIndicatorWidget } from 'src/components/Reports/HealthIndicatorReport/HealthIndicatorWidget/HealthIndicatorWidget';
+import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import {
   ContactFilterPledgeReceivedEnum,
   StatusEnum,
@@ -181,6 +183,14 @@ const MonthlyGoal = ({
                             currencyFormat(goal, currencyCode, locale)
                           )}
                         </Typography>
+                        {!staffEnteredGoal && (
+                          <Button
+                            component={NextLink}
+                            href={`/accountLists/${accountListId}/settings/preferences?selectedTab=${PreferenceAccordion.MonthlyGoal}`}
+                          >
+                            {t('Set Monthly Goal')}
+                          </Button>
+                        )}
                       </Box>
                     </Tooltip>
                   </Grid>


### PR DESCRIPTION
## Description

If the machine calculated goal is being used, add a button that lets the user set their monthly goal in preferences.

## Testing

* User with HI data
  * Set a monthly goal in preferences and test that the Set Monthly Goal button does not appear on the dashboard
  * Clear the monthly goal in preferences and test that the Set Monthly Goal button appears on the dashboard and links to the monthly goal accordion in preferences
* User without HI data
  * Test that the Set Monthly Goal button does not appear on the dashboard

[MPDX-8540](https://jira.cru.org/browse/MPDX-8540)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
