### PR TITLE
[No-Jira] Add Error Message for invalid MailChimp connections

### DIFF
--- a/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.test.tsx
+++ b/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.test.tsx
@@ -152,7 +152,7 @@ describe('MailchimpAccount', () => {
     it('is connected but with an API key error', async () => {
       mailchimpAccount.validateKey = false;
       const mutationSpy = jest.fn();
-      const { queryByText, getByRole } = render(
+      const { findByText, findByRole, queryByText } = render(
         <Components>
           <GqlMockedProvider<{
             MailchimpAccount: MailchimpAccountQuery | undefined;
@@ -172,16 +172,14 @@ describe('MailchimpAccount', () => {
         </Components>,
       );
 
-      await waitFor(() => {
-        expect(
-          queryByText(
-            'There is an error with your MailChimp connection. Please disconnect and connect to MailChimp again.',
-          ),
-        ).toBeInTheDocument();
-      });
+      expect(
+        await findByText(
+          'There is an error with your MailChimp connection. Please disconnect and reconnect to MailChimp.',
+        ),
+      ).toBeInTheDocument();
 
       expect(
-        getByRole('button', {
+        await findByRole('button', {
           name: /disconnect/i,
         }),
       ).toBeInTheDocument();

--- a/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.test.tsx
+++ b/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.test.tsx
@@ -32,15 +32,14 @@ jest.mock('notistack', () => ({
 }));
 
 const handleAccordionChange = jest.fn();
+const mutationSpy = jest.fn();
 
 const Components = ({
   expandedAccordion,
   mailchimpAccount,
-  mutationSpy,
 }: {
   expandedAccordion: IntegrationAccordion | null;
   mailchimpAccount: Types.MailchimpAccount | null;
-  mutationSpy?: jest.Mock;
 }) => (
   <SnackbarProvider>
     <TestRouter router={router}>
@@ -228,12 +227,10 @@ describe('MailchimpAccount', () => {
     });
 
     it('should call updateMailchimpAccount', async () => {
-      const mutationSpy = jest.fn();
       const { getByText, getByRole } = render(
         <Components
           expandedAccordion={IntegrationAccordion.Mailchimp}
           mailchimpAccount={mailchimpAccount}
-          mutationSpy={mutationSpy}
         />,
       );
 
@@ -283,12 +280,10 @@ describe('MailchimpAccount', () => {
     });
 
     it('should call deleteMailchimpAccount', async () => {
-      const mutationSpy = jest.fn();
       const { getByText, getByRole } = render(
         <Components
           expandedAccordion={IntegrationAccordion.Mailchimp}
           mailchimpAccount={mailchimpAccount}
-          mutationSpy={mutationSpy}
         />,
       );
 
@@ -360,12 +355,10 @@ describe('MailchimpAccount', () => {
     it('should call syncMailchimpAccount', async () => {
       mailchimpAccount.valid = true;
       mailchimpAccount.autoLogCampaigns = true;
-      const mutationSpy = jest.fn();
       const { getByText, getByRole } = render(
         <Components
           expandedAccordion={IntegrationAccordion.Mailchimp}
           mailchimpAccount={mailchimpAccount}
-          mutationSpy={mutationSpy}
         />,
       );
 

--- a/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.test.tsx
+++ b/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.test.tsx
@@ -149,6 +149,48 @@ describe('MailchimpAccount', () => {
     beforeEach(() => {
       mailchimpAccount = { ...standardMailchimpAccount };
     });
+    it('is connected but with an API key error', async () => {
+      mailchimpAccount.validateKey = false;
+      const mutationSpy = jest.fn();
+      const { queryByText, getByRole } = render(
+        <Components>
+          <GqlMockedProvider<{
+            MailchimpAccount: MailchimpAccountQuery | undefined;
+          }>
+            mocks={{
+              MailchimpAccount: {
+                mailchimpAccount: [mailchimpAccount],
+              },
+            }}
+            onCall={mutationSpy}
+          >
+            <MailchimpAccordion
+              handleAccordionChange={handleAccordionChange}
+              expandedAccordion={IntegrationAccordion.Mailchimp}
+            />
+          </GqlMockedProvider>
+        </Components>,
+      );
+
+      await waitFor(() => {
+        expect(
+          queryByText(
+            'There is an error with your MailChimp connection. Please disconnect and connect to MailChimp again.',
+          ),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        getByRole('button', {
+          name: /disconnect/i,
+        }),
+      ).toBeInTheDocument();
+
+      expect(
+        queryByText('Pick a list to use for your newsletter'),
+      ).not.toBeInTheDocument();
+    });
+
     it('is connected but no lists present', async () => {
       mailchimpAccount.listsPresent = false;
       const mutationSpy = jest.fn();

--- a/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.tsx
+++ b/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.tsx
@@ -378,7 +378,22 @@ export const MailchimpAccordion: React.FC<AccordionProps> = ({
             </StyledButton>
           </Box>
         )}
-
+      {!loading && mailchimpAccount && !mailchimpAccount?.validateKey && (
+        <Box>
+          <Alert severity="error">
+            {t(
+              'There is an error with your MailChimp connection. Please disconnect and connect to MailChimp again.',
+            )}
+          </Alert>
+          <StyledServicesButton
+            onClick={handleDisconnect}
+            variant="outlined"
+            color="error"
+          >
+            {t('Disconnect')}
+          </StyledServicesButton>
+        </Box>
+      )}
       {showDeleteModal && (
         <DeleteMailchimpAccountModal
           accountListId={accountListId || ''}

--- a/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.tsx
+++ b/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.tsx
@@ -382,7 +382,7 @@ export const MailchimpAccordion: React.FC<AccordionProps> = ({
         <Box>
           <Alert severity="error">
             {t(
-              'There is an error with your MailChimp connection. Please disconnect and connect to MailChimp again.',
+              'There is an error with your MailChimp connection. Please disconnect and reconnect to MailChimp.',
             )}
           </Alert>
           <StyledServicesButton


### PR DESCRIPTION
## Description
[HS-1320872](https://secure.helpscout.net/conversation/2872011976/1320872?viewId=7669074)
The user is not seeing any buttons to connect a MailChimp account. He has a connection but there is an error with the API key so `validateKey` is set to false.

- Add an error message and disconnect button when `validateKey` is false.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
