### PR TITLE
MPDX-8457 - Allow empty string as default task name

### DIFF
--- a/src/components/Task/Modal/Form/TaskModalHelper.ts
+++ b/src/components/Task/Modal/Form/TaskModalHelper.ts
@@ -206,8 +206,6 @@ const setTaskName = (
   setFieldTouched: SetFieldTouched,
 ) => {
   const defaultTaskName = getDefaultTaskName(activityType, activityTypes);
-  if (defaultTaskName) {
-    setFieldValue('subject', defaultTaskName);
-  }
+  setFieldValue('subject', defaultTaskName);
   setTimeout(() => setFieldTouched('activityType', true));
 };


### PR DESCRIPTION
## Description
In this PR, I change the frontend to allow an empty string as the default task name.

Initially, we didn't want that, but with the recent changes, certain actions will have an empty string as their detailed task name.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
