### PR TITLE
MPDX-8526 - Prevent the next action being defaulted in certain conditions

### DIFF
--- a/src/components/Task/Modal/Form/TaskModalHelper.ts
+++ b/src/components/Task/Modal/Form/TaskModalHelper.ts
@@ -118,7 +118,19 @@ export const handleResultChange = ({
     result as DisplayResultEnum,
     ActivityTypeEnum.None,
   );
-  const defaultNextAction = findNextAction(completedAction, nextActions);
+
+  // As per Scott's request, we do not set the next action field if the following are true
+  // - The phase is PartnerCare.
+  // - The completed action is InitiationSpecialGiftAppeal.
+  // There has been discussion to add this logic to the constant API.
+  // When/If that happens, this logic should be removed.
+  const doNotSetNextAction =
+    phaseData?.id === PhaseEnum.PartnerCare ||
+    completedAction === ActivityTypeEnum.InitiationSpecialGiftAppeal;
+
+  const defaultNextAction = doNotSetNextAction
+    ? null
+    : findNextAction(completedAction, nextActions);
   setFieldValue('nextAction', defaultNextAction);
 };
 


### PR DESCRIPTION
## Description
In this PR, I have added logic to the default selected Next Action when a result is chosen in the Log Task and Complete Task modal.

Jira ticket: [MPDX-8526](https://jira.cru.org/browse/MPDX-8526)

We no longer set the default Next Action when any of the following IF statements are true:
- The phase is PartnerCare. As mentioned in the Jira task, Scott noted all the Partner Care actions, except for `Letter/Card`. I will confirm that he intends for all of them to behave the same way. It would be unusual if `Letter/Card` didn't.
- The completed action is `Special Gift Appeal`.

We hope this logic will eventually move to the backend. However, since they need to estimate the time and it might not happen within this tertile, I have included it here to expedite task progress. We expect to remove this code within the next six months.


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
