### PR TITLE
Allow users to delete anniversary field on Person modal

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -8372,7 +8372,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],\
       ["@surma/rollup-plugin-off-main-thread", [\
         ["npm:2.2.3", {\
-          "packageLocation": "./.yarn/unplugged/@surma-rollup-plugin-off-main-thread-npm-2.2.3-1f57d3eded/node_modules/@surma/rollup-plugin-off-main-thread/",\
+          "packageLocation": "./.yarn/cache/@surma-rollup-plugin-off-main-thread-npm-2.2.3-1f57d3eded-2c02134944.zip/node_modules/@surma/rollup-plugin-off-main-thread/",\
           "packageDependencies": [\
             ["@surma/rollup-plugin-off-main-thread", "npm:2.2.3"],\
             ["ejs", "npm:3.1.10"],\

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonShowMore/PersonShowMore.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonShowMore/PersonShowMore.tsx
@@ -185,7 +185,7 @@ export const PersonShowMore: React.FC<PersonShowMoreProps> = ({
                   ? backupAnniversaryDate
                   : anniversaryDate
               }
-              onChange={(date) => date && handleDateChange(date)}
+              onChange={(date) => handleDateChange(date)}
             />
           </Grid>
         </Grid>


### PR DESCRIPTION
## Description
I've allowed the user to clear/delete the anniversary field. Before you could add it and update it, but if you tried to clear it, it wouldn't work.

Jira Ticket: [MPDX-8563](https://jira.cru.org/browse/MPDX-8563)
HelpScout ticket: https://secure.helpscout.net/conversation/2875662477/1323679/


## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
