### PR TITLE
[MPDX-8564] Visually indicate machine-calculated goals

### DIFF
--- a/src/components/AccountLists/AccountLists.test.tsx
+++ b/src/components/AccountLists/AccountLists.test.tsx
@@ -134,8 +134,7 @@ describe('AccountLists', () => {
     expect(
       getByLabelText(/^Your current goal of \$2,000 is machine-calculated/),
     ).toBeInTheDocument();
-    expect(getByText('Goal')).toHaveStyle('color: rgb(169, 68, 66);');
-    expect(getByText('$2,000')).toHaveStyle('color: rgb(169, 68, 66);');
+    expect(getByText('$2,000')).toHaveStyle('color: rgb(211, 68, 0);');
     expect(getByText('(machine-calculated)')).toBeInTheDocument();
   });
 

--- a/src/components/AccountLists/AccountLists.test.tsx
+++ b/src/components/AccountLists/AccountLists.test.tsx
@@ -107,6 +107,38 @@ describe('AccountLists', () => {
     );
   });
 
+  it('adds color and label to machine calculated goals', () => {
+    const data = gqlMock<GetAccountListsQuery>(GetAccountListsDocument, {
+      mocks: {
+        accountLists: {
+          nodes: [
+            {
+              name: 'Account',
+              monthlyGoal: null,
+              healthIndicatorData: {
+                machineCalculatedGoal: 2000,
+                machineCalculatedGoalCurrency: 'USD',
+              },
+              currency: 'USD',
+            },
+          ],
+        },
+      },
+    });
+
+    const { getByLabelText, getByText } = render(
+      <ThemeProvider theme={theme}>
+        <AccountLists data={data} />
+      </ThemeProvider>,
+    );
+    expect(
+      getByLabelText(/^Your current goal of \$2,000 is machine-calculated/),
+    ).toBeInTheDocument();
+    expect(getByText('Goal')).toHaveStyle('color: rgb(169, 68, 66);');
+    expect(getByText('$2,000')).toHaveStyle('color: rgb(169, 68, 66);');
+    expect(getByText('(machine-calculated)')).toBeInTheDocument();
+  });
+
   it("hides percentages when machine calculated goal currency differs from user's currency", () => {
     const data = gqlMock<GetAccountListsQuery>(GetAccountListsDocument, {
       mocks: {

--- a/src/components/AccountLists/AccountLists.test.tsx
+++ b/src/components/AccountLists/AccountLists.test.tsx
@@ -103,7 +103,7 @@ describe('AccountLists', () => {
       </ThemeProvider>,
     );
     expect(getByRole('link')).toHaveTextContent(
-      'AccountGoal$2,000Gifts Started30%Committed40%',
+      'AccountGoal$2,000*Gifts Started30%Committed40%*machine-calculated',
     );
   });
 
@@ -134,8 +134,9 @@ describe('AccountLists', () => {
     expect(
       getByLabelText(/^Your current goal of \$2,000 is machine-calculated/),
     ).toBeInTheDocument();
-    expect(getByText('$2,000')).toHaveStyle('color: rgb(211, 68, 0);');
-    expect(getByText('(machine-calculated)')).toBeInTheDocument();
+    expect(getByText('machine-calculated')).toHaveStyle(
+      'color: rgb(211, 68, 0);',
+    );
   });
 
   it("hides percentages when machine calculated goal currency differs from user's currency", () => {
@@ -165,7 +166,7 @@ describe('AccountLists', () => {
       </ThemeProvider>,
     );
     expect(getByRole('link')).toHaveTextContent(
-      'AccountGoal€2,000Gifts Started-Committed-',
+      'AccountGoal€2,000*Gifts Started-Committed-*machine-calculated',
     );
   });
 });

--- a/src/components/AccountLists/AccountLists.tsx
+++ b/src/components/AccountLists/AccountLists.tsx
@@ -90,6 +90,8 @@ const AccountLists = ({ data }: Props): ReactElement => {
                 const currency = hasPreferencesGoal
                   ? preferencesCurrency
                   : healthIndicatorData?.machineCalculatedGoalCurrency;
+                const hasMachineCalculatedGoal =
+                  !hasPreferencesGoal && typeof monthlyGoal === 'number';
 
                 // If the currency comes from the machine calculated goal and is different from the
                 // user's currency preference, we can't calculate the received or total percentages
@@ -102,6 +104,8 @@ const AccountLists = ({ data }: Props): ReactElement => {
                 const totalPercentage = hasValidGoal
                   ? totalPledges / monthlyGoal
                   : NaN;
+
+                const ariaId = `goal-${id}`;
 
                 return (
                   <Grid key={id} item xs={12} sm={4}>
@@ -148,16 +152,22 @@ const AccountLists = ({ data }: Props): ReactElement => {
                                     </Typography>
                                     <Typography
                                       variant="h6"
-                                      color={
-                                        hasPreferencesGoal
-                                          ? undefined
-                                          : 'statusWarning.main'
-                                      }
+                                      aria-describedby={ariaId}
                                     >
                                       {currencyFormat(
                                         monthlyGoal,
                                         currency,
                                         locale,
+                                      )}
+                                      {hasMachineCalculatedGoal && (
+                                        <Typography
+                                          component="span"
+                                          color="statusWarning.main"
+                                          ml={0.25}
+                                          aria-hidden
+                                        >
+                                          *
+                                        </Typography>
                                       )}
                                     </Typography>
                                   </Grid>
@@ -196,10 +206,12 @@ const AccountLists = ({ data }: Props): ReactElement => {
                             {!hasPreferencesGoal &&
                               typeof monthlyGoal === 'number' && (
                                 <Typography
+                                  aria-describedby={ariaId}
                                   component="div"
                                   color="statusWarning.main"
                                 >
-                                  ({t('machine-calculated')})
+                                  <span aria-hidden>*</span>
+                                  {t('machine-calculated')}
                                 </Typography>
                               )}
                           </CardContent>

--- a/src/components/AccountLists/AccountLists.tsx
+++ b/src/components/AccountLists/AccountLists.tsx
@@ -8,6 +8,7 @@ import {
   Grid,
   Link,
   Theme,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import { motion } from 'framer-motion';
@@ -123,21 +124,48 @@ const AccountLists = ({ data }: Props): ReactElement => {
                             </Box>
                             <Grid container>
                               {monthlyGoal && (
-                                <Grid xs={4} item>
-                                  <Typography
-                                    component="div"
-                                    color="textSecondary"
-                                  >
-                                    {t('Goal')}
-                                  </Typography>
-                                  <Typography variant="h6">
-                                    {currencyFormat(
-                                      monthlyGoal,
-                                      currency,
-                                      locale,
-                                    )}
-                                  </Typography>
-                                </Grid>
+                                <Tooltip
+                                  title={
+                                    !hasPreferencesGoal &&
+                                    t(
+                                      'Your current goal of {{goal}} is machine-calculated, based on the past year of NetSuite data. You can adjust this goal in your settings preferences.',
+                                      {
+                                        goal: currencyFormat(
+                                          monthlyGoal,
+                                          preferencesCurrency,
+                                          locale,
+                                        ),
+                                      },
+                                    )
+                                  }
+                                >
+                                  <Grid xs={4} item>
+                                    <Typography
+                                      component="div"
+                                      color={
+                                        hasPreferencesGoal
+                                          ? 'textSecondary'
+                                          : 'statusDanger.main'
+                                      }
+                                    >
+                                      {t('Goal')}
+                                    </Typography>
+                                    <Typography
+                                      variant="h6"
+                                      color={
+                                        hasPreferencesGoal
+                                          ? undefined
+                                          : 'statusDanger.main'
+                                      }
+                                    >
+                                      {currencyFormat(
+                                        monthlyGoal,
+                                        currency,
+                                        locale,
+                                      )}
+                                    </Typography>
+                                  </Grid>
+                                </Tooltip>
                               )}
                               <Grid xs={monthlyGoal ? 4 : 6} item>
                                 <Typography
@@ -169,6 +197,15 @@ const AccountLists = ({ data }: Props): ReactElement => {
                                 </Typography>
                               </Grid>
                             </Grid>
+                            {!hasPreferencesGoal &&
+                              typeof monthlyGoal === 'number' && (
+                                <Typography
+                                  component="div"
+                                  color="statusDanger.main"
+                                >
+                                  ({t('machine-calculated')})
+                                </Typography>
+                              )}
                           </CardContent>
                         </CardActionArea>
                       </Link>

--- a/src/components/AccountLists/AccountLists.tsx
+++ b/src/components/AccountLists/AccountLists.tsx
@@ -142,11 +142,7 @@ const AccountLists = ({ data }: Props): ReactElement => {
                                   <Grid xs={4} item>
                                     <Typography
                                       component="div"
-                                      color={
-                                        hasPreferencesGoal
-                                          ? 'textSecondary'
-                                          : 'statusDanger.main'
-                                      }
+                                      color="textSecondary"
                                     >
                                       {t('Goal')}
                                     </Typography>
@@ -155,7 +151,7 @@ const AccountLists = ({ data }: Props): ReactElement => {
                                       color={
                                         hasPreferencesGoal
                                           ? undefined
-                                          : 'statusDanger.main'
+                                          : 'statusWarning.main'
                                       }
                                     >
                                       {currencyFormat(
@@ -201,7 +197,7 @@ const AccountLists = ({ data }: Props): ReactElement => {
                               typeof monthlyGoal === 'number' && (
                                 <Typography
                                   component="div"
-                                  color="statusDanger.main"
+                                  color="statusWarning.main"
                                 >
                                   ({t('machine-calculated')})
                                 </Typography>

--- a/src/components/Coaching/CoachingDetail/helpers.test.ts
+++ b/src/components/Coaching/CoachingDetail/helpers.test.ts
@@ -1,4 +1,4 @@
-import { getLastNewsletter, getResultColor } from './helpers';
+import { getLastNewsletter } from './helpers';
 
 describe('getLastNewsletter', () => {
   it('returns the latest date when two dates are provided', () => {
@@ -18,21 +18,5 @@ describe('getLastNewsletter', () => {
 
   it('returns null when both dates are missing', () => {
     expect(getLastNewsletter(null, null)).toBeNull();
-  });
-});
-
-describe('getResultColor', () => {
-  it('is green when at or above the goal', () => {
-    expect(getResultColor(10, 10)).toBe('#5CB85C');
-    expect(getResultColor(11, 10)).toBe('#5CB85C');
-  });
-
-  it('is yellow when at or above 80% of the goal', () => {
-    expect(getResultColor(8, 10)).toBe('#8A6D3B');
-    expect(getResultColor(9, 10)).toBe('#8A6D3B');
-  });
-
-  it('is red when below 80% of the goal', () => {
-    expect(getResultColor(7, 10)).toBe('#A94442');
   });
 });

--- a/src/components/Coaching/CoachingDetail/helpers.ts
+++ b/src/components/Coaching/CoachingDetail/helpers.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
 import { dateFormatMonthOnly } from 'src/lib/intlFormat';
-import theme from 'src/theme';
 import { CoachingPeriodEnum } from './CoachingDetail';
 
 export const getLastNewsletter = (
@@ -15,17 +14,6 @@ export const getLastNewsletter = (
     return physicalDate;
   } else {
     return null;
-  }
-};
-
-// Calculate the color of a result based on how close it is to the goal
-export const getResultColor = (amount: number, goal: number): string => {
-  if (amount >= goal) {
-    return theme.palette.statusSuccess.main;
-  } else if (amount >= goal * 0.8) {
-    return theme.palette.statusWarning.main;
-  } else {
-    return theme.palette.statusDanger.main;
   }
 };
 

--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import matchMediaMock from '__tests__/util/matchMediaMock';
+import theme from 'src/theme';
 import { HealthIndicatorQuery } from './HealthIndicator.generated';
 import MonthlyGoal, { MonthlyGoalProps } from './MonthlyGoal';
 
@@ -30,16 +32,18 @@ const Components = ({
   healthIndicatorData = [],
   monthlyGoalProps,
 }: ComponentsProps) => (
-  <GqlMockedProvider<{ HealthIndicator: HealthIndicatorQuery }>
-    mocks={{
-      HealthIndicator: {
-        healthIndicatorData,
-      },
-    }}
-    onCall={mutationSpy}
-  >
-    <MonthlyGoal accountListId={accountListId} {...monthlyGoalProps} />
-  </GqlMockedProvider>
+  <ThemeProvider theme={theme}>
+    <GqlMockedProvider<{ HealthIndicator: HealthIndicatorQuery }>
+      mocks={{
+        HealthIndicator: {
+          healthIndicatorData,
+        },
+      }}
+      onCall={mutationSpy}
+    >
+      <MonthlyGoal accountListId={accountListId} {...monthlyGoalProps} />
+    </GqlMockedProvider>
+  </ThemeProvider>
 );
 
 describe('MonthlyGoal', () => {
@@ -263,7 +267,7 @@ describe('MonthlyGoal', () => {
 
   describe('Monthly Goal', () => {
     it('should set the monthly goal to the user-entered goal if it exists', async () => {
-      const { findByRole, queryByRole } = render(
+      const { findByLabelText, findByRole, queryByRole } = render(
         <Components
           monthlyGoalProps={defaultProps}
           healthIndicatorData={[
@@ -291,12 +295,18 @@ describe('MonthlyGoal', () => {
     });
 
     it('should set the monthly goal to the machine calculated goal', async () => {
-      const { findByRole, getByRole, queryByRole } = render(
+      const { findByRole, findByLabelText, getByRole, queryByRole } = render(
         <Components
           monthlyGoalProps={{ ...defaultProps, goal: undefined }}
           healthIndicatorData={[healthIndicatorScore]}
         />,
       );
+
+      expect(
+        await findByLabelText(
+          /^Your current goal of \$7,000 is machine-calculated/,
+        ),
+      ).toHaveStyle('color: rgb(169, 68, 66)');
 
       expect(
         await findByRole('heading', { name: '$7,000' }),

--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
@@ -276,9 +276,13 @@ describe('MonthlyGoal', () => {
       );
 
       expect(
-        await findByRole('heading', {
-          name: /\$999.50/i,
-        }),
+        await findByLabelText(
+          /^Your current goal of \$999.50 is staff-entered/,
+        ),
+      ).not.toHaveStyle('color: rgb(169, 68, 66)');
+
+      expect(
+        await findByRole('heading', { name: '$999.50' }),
       ).toBeInTheDocument();
 
       expect(
@@ -295,15 +299,11 @@ describe('MonthlyGoal', () => {
       );
 
       expect(
-        await findByRole('heading', {
-          name: /\$7,000/i,
-        }),
+        await findByRole('heading', { name: '$7,000' }),
       ).toBeInTheDocument();
 
       expect(
-        queryByRole('heading', {
-          name: /\$999.50/i,
-        }),
+        queryByRole('heading', { name: '$999.50' }),
       ).not.toBeInTheDocument();
 
       expect(getByRole('link', { name: 'Set Monthly Goal' })).toHaveAttribute(
@@ -325,22 +325,14 @@ describe('MonthlyGoal', () => {
         />,
       );
 
-      expect(
-        await findByRole('heading', {
-          name: /\$0/i,
-        }),
-      ).toBeInTheDocument();
+      expect(await findByRole('heading', { name: '$0' })).toBeInTheDocument();
 
       expect(
-        queryByRole('heading', {
-          name: /\$7,000/i,
-        }),
+        queryByRole('heading', { name: '$7,000' }),
       ).not.toBeInTheDocument();
 
       expect(
-        queryByRole('heading', {
-          name: /\$999.50/i,
-        }),
+        queryByRole('heading', { name: '$999.50' }),
       ).not.toBeInTheDocument();
     });
   });

--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
@@ -306,7 +306,7 @@ describe('MonthlyGoal', () => {
         await findByLabelText(
           /^Your current goal of \$7,000 is machine-calculated/,
         ),
-      ).toHaveStyle('color: rgb(169, 68, 66)');
+      ).toHaveStyle('color: rgb(211, 68, 0)');
 
       expect(
         await findByRole('heading', { name: '$7,000' }),

--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
@@ -163,7 +163,14 @@ const MonthlyGoal = ({
               <Grid container spacing={{ sm: 1, md: 2 }}>
                 <Hidden smDown>
                   <Grid {...cssProps.statGrid} item data-testid="goalGrid">
-                    <Tooltip title={toolTipText}>
+                    <Tooltip
+                      title={toolTipText}
+                      color={
+                        !staffEnteredGoal && machineCalculatedGoal
+                          ? 'statusDanger.main'
+                          : undefined
+                      }
+                    >
                       <Box>
                         <Typography component="div" color="textSecondary">
                           <div

--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
@@ -167,7 +167,7 @@ const MonthlyGoal = ({
                       title={toolTipText}
                       color={
                         !staffEnteredGoal && machineCalculatedGoal
-                          ? 'statusDanger.main'
+                          ? 'statusWarning.main'
                           : undefined
                       }
                     >

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -25,9 +25,12 @@ const progressBarColors = {
 };
 
 const statusColors = {
-  success: '#5CB85C',
-  warning: '#8A6D3B',
-  danger: '#A94442',
+  // Green from the Cru brand colors
+  success: '#24C976',
+  // Vermillion from the Cru brand colors
+  warning: '#D34400',
+  // Ruby from the Cru brand colors
+  danger: '#991313',
 };
 
 const graphColors = {


### PR DESCRIPTION
## Description

* In the My Accounts grid, indicate when the machine-calculated goal is being displayed.
* Add a tooltip that explains what a machine-calculated goal is and where it comes from.
* In the My Accounts grid and the dashboard, change the color of the goal to an error/warning color when it is machine-calculated.

MPDX-8564

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
