### PR TITLE
[MPDX-8502] Add addressPrimary filter to ReportContactFilterSetInput

### DIFF
--- a/pages/api/Schema/reports/partnerGivingAnalysis/partnerGivingAnalysis.graphql
+++ b/pages/api/Schema/reports/partnerGivingAnalysis/partnerGivingAnalysis.graphql
@@ -77,6 +77,11 @@ input ReportContactFilterSetInput {
   addressLatLng: String
 
   """
+  Filter by Primary Address; Accepts values 'true', or 'false'
+  """
+  addressPrimary: Boolean
+
+  """
   Filter where address value is false; accepts "false"
   """
   addressValid: Boolean

--- a/pages/api/graphql-rest.page.ts
+++ b/pages/api/graphql-rest.page.ts
@@ -538,6 +538,7 @@ class MpdxRestApi extends RESTDataSource {
       switch (key) {
         // Boolean
         case 'addressHistoric':
+        case 'addressPrimary':
         case 'addressValid':
         case 'anyTags':
         case 'noAppeals':


### PR DESCRIPTION
## Description

Add new `addressPrimary` contact filter to PGA contact filters. I believe that this needs to be merged immediately after https://github.com/CruGlobal/mpdx_api/pull/2928 because users using the new filter will get GraphQL errors.

MPDX-8502

## Testing

* Go to stage.mpdx.org
  * Go to the Partner Giving Analysis report
  * Check the "Address Is Primary" filter under "Contact Location"
  * See that there is a GraphQL error
* Go to this PR's preview environment
  * Go to the Partner Giving Analysis report
  * Check the "Address Is Primary" filter under "Contact Location"
  * See that there is **not** a GraphQL error

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
