### PR TITLE
[MPDX-8566] Preference goal warnings

### DIFF
--- a/src/components/AccountLists/AccountLists.test.tsx
+++ b/src/components/AccountLists/AccountLists.test.tsx
@@ -73,7 +73,7 @@ describe('AccountLists', () => {
       </ThemeProvider>,
     );
     expect(getByRole('link')).toHaveTextContent(
-      'AccountGoal$1,000*Gifts Started60%Committed80%*Last updated Jan 1, 2024',
+      'AccountGoal$1,000*Gifts Started60%Committed80%*Below machine-calculated goal',
     );
   });
 
@@ -209,6 +209,62 @@ describe('AccountLists', () => {
         </ThemeProvider>,
       );
       expect(queryByText('Last updated Dec 30, 2019')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('below machine-calculated warning', () => {
+    it('is shown if goal is less than the machine-calculated goal', () => {
+      const data = gqlMock<GetAccountListsQuery>(GetAccountListsDocument, {
+        mocks: {
+          accountLists: {
+            nodes: [
+              {
+                currency: 'USD',
+                monthlyGoal: 5000,
+                healthIndicatorData: {
+                  machineCalculatedGoal: 10000,
+                  machineCalculatedGoalCurrency: 'USD',
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const { getByText } = render(
+        <ThemeProvider theme={theme}>
+          <AccountLists data={data} />
+        </ThemeProvider>,
+      );
+      expect(getByText('Below machine-calculated goal')).toBeInTheDocument();
+    });
+
+    it('is hidden if goal is greater than or equal to the machine-calculated goal', async () => {
+      const data = gqlMock<GetAccountListsQuery>(GetAccountListsDocument, {
+        mocks: {
+          accountLists: {
+            nodes: [
+              {
+                currency: 'USD',
+                monthlyGoal: 5000,
+                healthIndicatorData: {
+                  machineCalculatedGoal: 5000,
+                  machineCalculatedGoalCurrency: 'USD',
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const { queryByText } = render(
+        <ThemeProvider theme={theme}>
+          <AccountLists data={data} />
+        </ThemeProvider>,
+      );
+      expect(
+        queryByText('Below machine-calculated goal'),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/AccountLists/AccountLists.test.tsx
+++ b/src/components/AccountLists/AccountLists.test.tsx
@@ -167,7 +167,7 @@ describe('AccountLists', () => {
       </ThemeProvider>,
     );
     expect(getByRole('link')).toHaveTextContent(
-      'AccountGoal€2,000*Gifts Started-Committed-*machine-calculated',
+      'AccountGifts Started-Committed-',
     );
   });
 

--- a/src/components/AccountLists/AccountLists.tsx
+++ b/src/components/AccountLists/AccountLists.tsx
@@ -132,7 +132,10 @@ const AccountLists = ({ data }: Props): ReactElement => {
                       label: t('Last updated {{date}}', {
                         date: dateFormat(preferencesGoalDate, locale),
                       }),
-                      variant: 'body2',
+                      color:
+                        preferencesGoalDate <= DateTime.now().minus({ year: 1 })
+                          ? 'statusWarning.main'
+                          : undefined,
                     }
                   : null;
                 const annotationId = `annotation-${id}`;
@@ -182,6 +185,7 @@ const AccountLists = ({ data }: Props): ReactElement => {
                                     </Typography>
                                     <Typography
                                       variant="h6"
+                                      display="flex"
                                       aria-describedby={annotationId}
                                     >
                                       {currencyFormat(
@@ -238,7 +242,7 @@ const AccountLists = ({ data }: Props): ReactElement => {
                                 id={annotationId}
                                 component="div"
                                 color={annotation.color}
-                                variant={annotation.variant}
+                                variant="body2"
                               >
                                 <span aria-hidden>*</span>
                                 {annotation.label}

--- a/src/components/AccountLists/AccountLists.tsx
+++ b/src/components/AccountLists/AccountLists.tsx
@@ -99,6 +99,7 @@ const AccountLists = ({ data }: Props): ReactElement => {
                 goal,
                 goalSource,
                 preferencesGoalUpdatedAt,
+                preferencesGoalLow,
                 preferencesGoalOld,
               } = getHealthIndicatorInfo(accountList, healthIndicatorData);
 
@@ -108,22 +109,26 @@ const AccountLists = ({ data }: Props): ReactElement => {
                 : NaN;
               const totalPercentage = hasValidGoal ? totalPledges / goal : NaN;
 
-              const annotation: Annotation | null =
-                goalSource === GoalSource.MachineCalculated
-                  ? {
-                      label: t('machine-calculated'),
-                      color: 'statusWarning.main',
-                    }
-                  : preferencesGoalUpdatedAt
-                  ? {
-                      label: t('Last updated {{date}}', {
-                        date: dateFormat(preferencesGoalUpdatedAt, locale),
-                      }),
-                      color: preferencesGoalOld
-                        ? 'statusWarning.main'
-                        : undefined,
-                    }
-                  : null;
+              const annotation: Annotation | null = preferencesGoalLow
+                ? {
+                    label: t('Below machine-calculated goal'),
+                    color: 'statusWarning.main',
+                  }
+                : goalSource === GoalSource.MachineCalculated
+                ? {
+                    label: t('machine-calculated'),
+                    color: 'statusWarning.main',
+                  }
+                : preferencesGoalUpdatedAt
+                ? {
+                    label: t('Last updated {{date}}', {
+                      date: dateFormat(preferencesGoalUpdatedAt, locale),
+                    }),
+                    color: preferencesGoalOld
+                      ? 'statusWarning.main'
+                      : undefined,
+                  }
+                : null;
               const annotationId = `annotation-${id}`;
 
               return (

--- a/src/components/AccountLists/AccountLists.tsx
+++ b/src/components/AccountLists/AccountLists.tsx
@@ -13,11 +13,11 @@ import {
   TypographyProps,
 } from '@mui/material';
 import { motion } from 'framer-motion';
-import { DateTime } from 'luxon';
 import { useTranslation } from 'react-i18next';
 import { makeStyles } from 'tss-react/mui';
 import { GetAccountListsQuery } from 'pages/GetAccountLists.generated';
 import { useLocale } from 'src/hooks/useLocale';
+import { GoalSource, getHealthIndicatorInfo } from 'src/lib/healthIndicator';
 import {
   currencyFormat,
   dateFormat,
@@ -85,177 +85,149 @@ const AccountLists = ({ data }: Props): ReactElement => {
       >
         <Container>
           <Grid container spacing={3}>
-            {data.accountLists.nodes.map(
-              ({
+            {data.accountLists.nodes.map((accountList) => {
+              const {
                 id,
                 name,
-                monthlyGoal: preferencesGoal,
-                monthlyGoalUpdatedAt: preferencesGoalUpdatedAt,
                 receivedPledges,
                 totalPledges,
-                currency: preferencesCurrency,
+                currency,
                 healthIndicatorData,
-              }) => {
-                const hasPreferencesGoal = typeof preferencesGoal === 'number';
-                const monthlyGoal = hasPreferencesGoal
-                  ? preferencesGoal
-                  : healthIndicatorData?.machineCalculatedGoal;
-                const currency = hasPreferencesGoal
-                  ? preferencesCurrency
-                  : healthIndicatorData?.machineCalculatedGoalCurrency;
-                const hasMachineCalculatedGoal =
-                  !hasPreferencesGoal && typeof monthlyGoal === 'number';
-                const preferencesGoalDate =
-                  typeof preferencesGoal === 'number' &&
-                  preferencesGoalUpdatedAt &&
-                  DateTime.fromISO(preferencesGoalUpdatedAt);
+              } = accountList;
 
-                // If the currency comes from the machine calculated goal and is different from the
-                // user's currency preference, we can't calculate the received or total percentages
-                // because the numbers are in different currencies
-                const hasValidGoal =
-                  currency === preferencesCurrency && !!monthlyGoal;
-                const receivedPercentage = hasValidGoal
-                  ? receivedPledges / monthlyGoal
-                  : NaN;
-                const totalPercentage = hasValidGoal
-                  ? totalPledges / monthlyGoal
-                  : NaN;
+              const {
+                goal,
+                goalSource,
+                preferencesGoalUpdatedAt,
+                preferencesGoalOld,
+              } = getHealthIndicatorInfo(accountList, healthIndicatorData);
 
-                const annotation: Annotation | null = hasMachineCalculatedGoal
+              const hasValidGoal = goal !== null;
+              const receivedPercentage = hasValidGoal
+                ? receivedPledges / goal
+                : NaN;
+              const totalPercentage = hasValidGoal ? totalPledges / goal : NaN;
+
+              const annotation: Annotation | null =
+                goalSource === GoalSource.MachineCalculated
                   ? {
                       label: t('machine-calculated'),
                       color: 'statusWarning.main',
                     }
-                  : preferencesGoalDate
+                  : preferencesGoalUpdatedAt
                   ? {
                       label: t('Last updated {{date}}', {
-                        date: dateFormat(preferencesGoalDate, locale),
+                        date: dateFormat(preferencesGoalUpdatedAt, locale),
                       }),
-                      color:
-                        preferencesGoalDate <= DateTime.now().minus({ year: 1 })
-                          ? 'statusWarning.main'
-                          : undefined,
+                      color: preferencesGoalOld
+                        ? 'statusWarning.main'
+                        : undefined,
                     }
                   : null;
-                const annotationId = `annotation-${id}`;
+              const annotationId = `annotation-${id}`;
 
-                return (
-                  <Grid key={id} item xs={12} sm={4}>
-                    <AnimatedCard
-                      elevation={3}
-                      data-testid={`account-list-${id}`}
+              return (
+                <Grid key={id} item xs={12} sm={4}>
+                  <AnimatedCard
+                    elevation={3}
+                    data-testid={`account-list-${id}`}
+                  >
+                    <Link
+                      component={NextLink}
+                      href={`/accountLists/${id}`}
+                      underline="none"
+                      color="inherit"
                     >
-                      <Link
-                        component={NextLink}
-                        href={`/accountLists/${id}`}
-                        underline="none"
-                        color="inherit"
-                      >
-                        <CardActionArea>
-                          <CardContent className={classes.cardContent}>
-                            <Box flex={1}>
-                              <Typography variant="h5" noWrap>
-                                {name}
-                              </Typography>
-                            </Box>
-                            <Grid container>
-                              {monthlyGoal && (
-                                <Tooltip
-                                  title={
-                                    !hasPreferencesGoal &&
-                                    t(
-                                      'Your current goal of {{goal}} is machine-calculated, based on the past year of NetSuite data. You can adjust this goal in your settings preferences.',
-                                      {
-                                        goal: currencyFormat(
-                                          monthlyGoal,
-                                          preferencesCurrency,
-                                          locale,
-                                        ),
-                                      },
-                                    )
-                                  }
-                                >
-                                  <Grid xs={4} item>
-                                    <Typography
-                                      component="div"
-                                      color="textSecondary"
-                                    >
-                                      {t('Goal')}
-                                    </Typography>
-                                    <Typography
-                                      variant="h6"
-                                      display="flex"
-                                      aria-describedby={annotationId}
-                                    >
-                                      {currencyFormat(
-                                        monthlyGoal,
+                      <CardActionArea>
+                        <CardContent className={classes.cardContent}>
+                          <Box flex={1}>
+                            <Typography variant="h5" noWrap>
+                              {name}
+                            </Typography>
+                          </Box>
+                          <Grid container>
+                            {goal && (
+                              <Tooltip
+                                title={
+                                  goalSource === GoalSource.MachineCalculated &&
+                                  t(
+                                    'Your current goal of {{goal}} is machine-calculated, based on the past year of NetSuite data. You can adjust this goal in your settings preferences.',
+                                    {
+                                      goal: currencyFormat(
+                                        goal,
                                         currency,
                                         locale,
-                                      )}
-                                      {annotation && (
-                                        <Typography
-                                          component="span"
-                                          color={annotation.color}
-                                          ml={0.25}
-                                          aria-hidden
-                                        >
-                                          *
-                                        </Typography>
-                                      )}
-                                    </Typography>
-                                  </Grid>
-                                </Tooltip>
-                              )}
-                              <Grid xs={monthlyGoal ? 4 : 6} item>
-                                <Typography
-                                  component="div"
-                                  color="textSecondary"
-                                >
-                                  {t('Gifts Started')}
-                                </Typography>
-                                <Typography variant="h6">
-                                  {Number.isFinite(receivedPercentage)
-                                    ? percentageFormat(
-                                        receivedPercentage,
-                                        locale,
-                                      )
-                                    : '-'}
-                                </Typography>
-                              </Grid>
-                              <Grid xs={monthlyGoal ? 4 : 6} item>
-                                <Typography
-                                  component="div"
-                                  color="textSecondary"
-                                >
-                                  {t('Committed')}
-                                </Typography>
-                                <Typography variant="h6">
-                                  {Number.isFinite(totalPercentage)
-                                    ? percentageFormat(totalPercentage, locale)
-                                    : '-'}
-                                </Typography>
-                              </Grid>
-                            </Grid>
-                            {annotation && (
-                              <Typography
-                                id={annotationId}
-                                component="div"
-                                color={annotation.color}
-                                variant="body2"
+                                      ),
+                                    },
+                                  )
+                                }
                               >
-                                <span aria-hidden>*</span>
-                                {annotation.label}
-                              </Typography>
+                                <Grid xs={4} item>
+                                  <Typography
+                                    component="div"
+                                    color="textSecondary"
+                                  >
+                                    {t('Goal')}
+                                  </Typography>
+                                  <Typography
+                                    variant="h6"
+                                    display="flex"
+                                    aria-describedby={annotationId}
+                                  >
+                                    {currencyFormat(goal, currency, locale)}
+                                    {annotation && (
+                                      <Typography
+                                        component="span"
+                                        color={annotation.color}
+                                        ml={0.25}
+                                        aria-hidden
+                                      >
+                                        *
+                                      </Typography>
+                                    )}
+                                  </Typography>
+                                </Grid>
+                              </Tooltip>
                             )}
-                          </CardContent>
-                        </CardActionArea>
-                      </Link>
-                    </AnimatedCard>
-                  </Grid>
-                );
-              },
-            )}
+                            <Grid xs={goal ? 4 : 6} item>
+                              <Typography component="div" color="textSecondary">
+                                {t('Gifts Started')}
+                              </Typography>
+                              <Typography variant="h6">
+                                {Number.isFinite(receivedPercentage)
+                                  ? percentageFormat(receivedPercentage, locale)
+                                  : '-'}
+                              </Typography>
+                            </Grid>
+                            <Grid xs={goal ? 4 : 6} item>
+                              <Typography component="div" color="textSecondary">
+                                {t('Committed')}
+                              </Typography>
+                              <Typography variant="h6">
+                                {Number.isFinite(totalPercentage)
+                                  ? percentageFormat(totalPercentage, locale)
+                                  : '-'}
+                              </Typography>
+                            </Grid>
+                          </Grid>
+                          {annotation && (
+                            <Typography
+                              id={annotationId}
+                              component="div"
+                              color={annotation.color}
+                              variant="body2"
+                            >
+                              <span aria-hidden>*</span>
+                              {annotation.label}
+                            </Typography>
+                          )}
+                        </CardContent>
+                      </CardActionArea>
+                    </Link>
+                  </AnimatedCard>
+                </Grid>
+              );
+            })}
           </Grid>
         </Container>
       </motion.div>

--- a/src/components/Announcements/AnnouncementAction/AnnouncementAction.test.tsx
+++ b/src/components/Announcements/AnnouncementAction/AnnouncementAction.test.tsx
@@ -120,7 +120,7 @@ describe('AnnouncementAction', () => {
 
         const button = getByText('Contacts');
         expect(button).toHaveStyle({
-          'background-color': '#ED6C02',
+          'background-color': '#D34400',
           color: '#FFFFFF',
         });
       });
@@ -131,7 +131,7 @@ describe('AnnouncementAction', () => {
 
         const button = getByText('Contacts');
         expect(button).toHaveStyle({
-          'background-color': '#ED6C02',
+          'background-color': '#D34400',
           color: '#FFFFFF',
         });
       });

--- a/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/TaskDate/TaskDate.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/TaskDate/TaskDate.test.tsx
@@ -17,13 +17,7 @@ describe('TaskCommentsButton', () => {
       </ThemeProvider>,
     );
 
-    const dateText = getByText('Oct 12, 21');
-
-    expect(dateText).toBeInTheDocument();
-
-    const style = dateText && window.getComputedStyle(dateText);
-
-    expect(style?.color).toMatchInlineSnapshot(`"rgb(56, 63, 67)"`);
+    expect(getByText('Oct 12, 21')).toHaveStyle('color: #383F43');
   });
 
   it('should render complete', () => {
@@ -33,13 +27,7 @@ describe('TaskCommentsButton', () => {
       </ThemeProvider>,
     );
 
-    const dateText = getByText('Oct 12, 21');
-
-    expect(dateText).toBeInTheDocument();
-
-    const style = dateText && window.getComputedStyle(dateText);
-
-    expect(style?.color).toMatchInlineSnapshot(`"rgb(156, 159, 161)"`);
+    expect(getByText('Oct 12, 21')).toHaveStyle('color: #9C9FA1');
   });
 
   it('should render late', () => {
@@ -49,13 +37,7 @@ describe('TaskCommentsButton', () => {
       </ThemeProvider>,
     );
 
-    const dateText = getByText('Oct 12, 19');
-
-    expect(dateText).toBeInTheDocument();
-
-    const style = dateText && window.getComputedStyle(dateText);
-
-    expect(style?.color).toMatchInlineSnapshot(`"rgb(211, 47, 47)"`);
+    expect(getByText('Oct 12, 19')).toHaveStyle('color: #991313');
   });
 
   it('should not render year', () => {
@@ -65,7 +47,6 @@ describe('TaskCommentsButton', () => {
       </ThemeProvider>,
     );
 
-    const dateText = getByText('Oct 12');
-    expect(dateText).toBeInTheDocument();
+    expect(getByText('Oct 12')).toBeInTheDocument();
   });
 });

--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
@@ -26,7 +26,13 @@ const Components = ({
       mocks={{
         HealthIndicator: {
           accountList: {
-            healthIndicatorData,
+            healthIndicatorData:
+              healthIndicatorData === null
+                ? null
+                : {
+                    machineCalculatedGoalCurrency: 'USD',
+                    ...healthIndicatorData,
+                  },
           },
         },
       }}
@@ -301,7 +307,37 @@ describe('MonthlyGoal', () => {
       });
     });
 
-    it('should set the monthly goal to the machine calculated goal', async () => {
+    describe('below machine-calculated warning', () => {
+      it('is shown if goal is less than the machine-calculated goal', async () => {
+        const { findByText } = render(
+          <Components
+            accountList={{ monthlyGoal: 5000 }}
+            healthIndicatorData={{ machineCalculatedGoal: 10000 }}
+          />,
+        );
+
+        expect(
+          await findByText('Below machine-calculated goal'),
+        ).toBeInTheDocument();
+      });
+
+      it('is hidden if goal is greater than or equal to the machine-calculated goal', async () => {
+        const { queryByText } = render(
+          <Components
+            accountList={{ monthlyGoal: 5000 }}
+            healthIndicatorData={{ machineCalculatedGoal: 5000 }}
+          />,
+        );
+
+        await waitFor(() =>
+          expect(
+            queryByText('Below machine-calculated goal'),
+          ).not.toBeInTheDocument(),
+        );
+      });
+    });
+
+    it('should set the monthly goal to the machine-calculated goal', async () => {
       const {
         findByRole,
         findByLabelText,

--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
@@ -338,27 +338,12 @@ describe('MonthlyGoal', () => {
     });
 
     it('should set the monthly goal to the machine-calculated goal', async () => {
-      const {
-        findByRole,
-        findByLabelText,
-        getByRole,
-        queryByRole,
-        queryByText,
-      } = render(
+      const { findByRole, getByRole, queryByRole, queryByText } = render(
         <Components
-          accountList={{
-            monthlyGoal: null,
-            monthlyGoalUpdatedAt: '2024-01-01T00:00:00Z',
-          }}
+          accountList={{ monthlyGoal: null }}
           healthIndicatorData={{ machineCalculatedGoal: 7000 }}
         />,
       );
-
-      expect(
-        await findByLabelText(
-          /^Your current goal of \$7,000 is machine-calculated/,
-        ),
-      ).toHaveStyle('color: rgb(211, 68, 0)');
 
       expect(
         await findByRole('heading', { name: '$7,000' }),

--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
@@ -159,6 +159,16 @@ const MonthlyGoal = ({
       }
     : null;
   const annotationId = useId();
+  const annotationNode = annotation && (
+    <Typography
+      id={annotationId}
+      color={annotation.warning ? 'statusWarning.main' : 'textSecondary'}
+      variant="body2"
+    >
+      <span aria-hidden>*</span>
+      {annotation.label}
+    </Typography>
+  );
 
   return (
     <>
@@ -250,6 +260,8 @@ const MonthlyGoal = ({
                             </>
                           )}
                         </Typography>
+                        {/* Without the HI card there is enough space for the annotation so display it here */}
+                        {annotation && !showHealthIndicator && annotationNode}
                         {annotation?.warning && (
                           <Button
                             component={NextLink}
@@ -379,22 +391,10 @@ const MonthlyGoal = ({
                     </Grid>
                   )}
                 </Hidden>
-                {annotation && (
+                {/* With the HI card there isn't enough space for the annotation next to the monthly goal so display it here */}
+                {annotation && showHealthIndicator && (
                   <Hidden smDown>
-                    <Grid item>
-                      <Typography
-                        id={annotationId}
-                        color={
-                          annotation.warning
-                            ? 'statusWarning.main'
-                            : 'textSecondary'
-                        }
-                        variant="body2"
-                      >
-                        <span aria-hidden>*</span>
-                        {annotation.label}
-                      </Typography>
-                    </Grid>
+                    <Grid item>{annotationNode}</Grid>
                   </Hidden>
                 )}
               </Grid>

--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
@@ -255,7 +255,7 @@ const MonthlyGoal = ({
                             component={NextLink}
                             href={`/accountLists/${accountListId}/settings/preferences?selectedTab=${PreferenceAccordion.MonthlyGoal}`}
                             variant="outlined"
-                            color="statusWarning"
+                            color="warning"
                             sx={(theme) => ({
                               marginTop: theme.spacing(1),
                               textAlign: 'center',

--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
@@ -10,7 +10,6 @@ import {
   Theme,
   Tooltip,
   Typography,
-  TypographyProps,
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { makeStyles } from 'tss-react/mui';
@@ -56,7 +55,7 @@ const useStyles = makeStyles()((_theme: Theme) => ({
 
 interface Annotation {
   label: string;
-  color: TypographyProps['color'];
+  warning: boolean;
 }
 
 export interface MonthlyGoalProps {
@@ -144,19 +143,19 @@ const MonthlyGoal = ({
   const annotation: Annotation | null = preferencesGoalLow
     ? {
         label: t('Below machine-calculated goal'),
-        color: 'statusWarning.main',
+        warning: true,
       }
     : goalSource === GoalSource.MachineCalculated
     ? {
         label: t('Machine-calculated goal'),
-        color: 'statusWarning.main',
+        warning: true,
       }
     : preferencesGoalUpdatedAt
     ? {
         label: t('Last updated {{date}}', {
           date: dateFormat(preferencesGoalUpdatedAt, locale),
         }),
-        color: preferencesGoalOld ? 'statusWarning.main' : 'textSecondary',
+        warning: preferencesGoalOld,
       }
     : null;
   const annotationId = useId();
@@ -238,7 +237,11 @@ const MonthlyGoal = ({
                               {annotation && (
                                 <Typography
                                   component="span"
-                                  color={annotation.color}
+                                  color={
+                                    annotation.warning
+                                      ? 'statusWarning.main'
+                                      : 'textSecondary'
+                                  }
                                   aria-hidden
                                 >
                                   *
@@ -247,22 +250,12 @@ const MonthlyGoal = ({
                             </>
                           )}
                         </Typography>
-                        {annotation && (
-                          <Typography
-                            id={annotationId}
-                            color={annotation.color}
-                            variant="body2"
-                          >
-                            <span aria-hidden>*</span>
-                            {annotation.label}
-                          </Typography>
-                        )}
-                        {(goalSource === GoalSource.MachineCalculated ||
-                          preferencesGoalLow) && (
+                        {annotation?.warning && (
                           <Button
                             component={NextLink}
                             href={`/accountLists/${accountListId}/settings/preferences?selectedTab=${PreferenceAccordion.MonthlyGoal}`}
                             variant="outlined"
+                            color="statusWarning"
                             sx={(theme) => ({
                               marginTop: theme.spacing(1),
                               textAlign: 'center',
@@ -386,6 +379,24 @@ const MonthlyGoal = ({
                     </Grid>
                   )}
                 </Hidden>
+                {annotation && (
+                  <Hidden smDown>
+                    <Grid item>
+                      <Typography
+                        id={annotationId}
+                        color={
+                          annotation.warning
+                            ? 'statusWarning.main'
+                            : 'textSecondary'
+                        }
+                        variant="body2"
+                      >
+                        <span aria-hidden>*</span>
+                        {annotation.label}
+                      </Typography>
+                    </Grid>
+                  </Hidden>
+                )}
               </Grid>
             </CardContent>
           </AnimatedCard>

--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.test.tsx
@@ -35,9 +35,9 @@ const mutationSpy = jest.fn();
 
 interface ComponentsProps {
   monthlyGoal: number | null;
-  monthlyGoalUpdatedAt?: string;
+  monthlyGoalUpdatedAt?: string | null;
   machineCalculatedGoal?: number;
-  machineCalculatedGoalCurrency?: string;
+  machineCalculatedGoalCurrency?: string | null;
   expandedAccordion: PreferenceAccordion | null;
 }
 
@@ -85,34 +85,128 @@ describe('MonthlyGoalAccordion', () => {
     mutationSpy.mockClear();
   });
 
-  it('should render accordion closed', () => {
-    const { getByTestId, getByText, queryByRole } = render(
-      <Components
-        monthlyGoal={100}
-        monthlyGoalUpdatedAt="2024-01-01T00:00:00"
-        expandedAccordion={null}
-      />,
-    );
+  describe('closed', () => {
+    it('renders label and hides the textbox', () => {
+      const { getByText, queryByRole } = render(
+        <Components monthlyGoal={100} expandedAccordion={null} />,
+      );
 
-    expect(getByTestId('AccordionSummaryValue')).toHaveTextContent(
-      '$100 (last updated Jan 1, 2024)',
-    );
-    expect(getByText(label)).toBeInTheDocument();
-    expect(queryByRole('textbox')).not.toBeInTheDocument();
-  });
+      expect(getByText(label)).toBeInTheDocument();
+      expect(queryByRole('textbox')).not.toBeInTheDocument();
+    });
 
-  it('should render accordion closed with calculated goal', async () => {
-    const { findByText, queryByRole } = render(
-      <Components
-        monthlyGoal={null}
-        machineCalculatedGoal={1000}
-        machineCalculatedGoalCurrency="EUR"
-        expandedAccordion={null}
-      />,
-    );
+    it('renders goal without updated date', () => {
+      const { getByTestId } = render(
+        <Components
+          monthlyGoal={100}
+          monthlyGoalUpdatedAt={null}
+          expandedAccordion={null}
+        />,
+      );
 
-    expect(await findByText('€1,000 (estimated)')).toBeInTheDocument();
-    expect(queryByRole('textbox')).not.toBeInTheDocument();
+      expect(getByTestId('AccordionSummaryValue')).toHaveTextContent('$100');
+    });
+
+    it('renders goal and updated date', () => {
+      const { getByTestId } = render(
+        <Components
+          monthlyGoal={100}
+          monthlyGoalUpdatedAt="2024-01-01T00:00:00"
+          expandedAccordion={null}
+        />,
+      );
+
+      expect(getByTestId('AccordionSummaryValue')).toHaveTextContent(
+        '$100 (last updated Jan 1, 2024)',
+      );
+    });
+
+    it('renders too low warning', async () => {
+      const { getByTestId } = render(
+        <Components
+          monthlyGoal={100}
+          machineCalculatedGoal={1000}
+          expandedAccordion={null}
+        />,
+      );
+
+      await waitFor(() =>
+        expect(getByTestId('AccordionSummaryValue')).toHaveTextContent(
+          '$100 (below machine-calculated support goal)',
+        ),
+      );
+    });
+
+    it('hides too low warning when currencies do not match', async () => {
+      const { getByTestId } = render(
+        <Components
+          monthlyGoal={100}
+          machineCalculatedGoal={1000}
+          machineCalculatedGoalCurrency="EUR"
+          expandedAccordion={null}
+        />,
+      );
+
+      await waitFor(() =>
+        expect(getByTestId('AccordionSummaryValue')).not.toHaveTextContent(
+          /below machine-calculated support goal/,
+        ),
+      );
+    });
+
+    it('renders calculated goal', async () => {
+      const { getByTestId } = render(
+        <Components
+          monthlyGoal={null}
+          machineCalculatedGoal={1000}
+          machineCalculatedGoalCurrency="EUR"
+          expandedAccordion={null}
+        />,
+      );
+
+      await waitFor(() =>
+        expect(getByTestId('AccordionSummaryValue')).toHaveTextContent(
+          '€1,000 (estimated)',
+        ),
+      );
+    });
+
+    it('renders calculated goal without currency', async () => {
+      const { getByTestId } = render(
+        <Components
+          monthlyGoal={null}
+          machineCalculatedGoal={1000}
+          machineCalculatedGoalCurrency={null}
+          expandedAccordion={null}
+        />,
+      );
+
+      await waitFor(() =>
+        expect(getByTestId('AccordionSummaryValue')).toHaveTextContent(
+          '1,000 (estimated)',
+        ),
+      );
+    });
+
+    it('renders only goal when calculated goal is missing', async () => {
+      const { getByTestId } = render(
+        <Components monthlyGoal={100} expandedAccordion={null} />,
+      );
+
+      await waitFor(() =>
+        expect(getByTestId('AccordionSummaryValue')).toHaveTextContent('$100'),
+      );
+    });
+
+    it('renders nothing when goal and calculated goal are missing', async () => {
+      const { queryByTestId } = render(
+        <Components monthlyGoal={null} expandedAccordion={null} />,
+      );
+
+      await waitFor(() =>
+        expect(queryByTestId('AccordionSummaryValue')).not.toBeInTheDocument(),
+      );
+    });
   });
 
   it('should render accordion open and textfield should have a value', () => {

--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
@@ -2,7 +2,6 @@ import React, { ReactElement, useMemo } from 'react';
 import WarningIcon from '@mui/icons-material/Warning';
 import { Box, Button, TextField, Tooltip, Typography } from '@mui/material';
 import { Formik } from 'formik';
-import { DateTime } from 'luxon';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
@@ -11,6 +10,7 @@ import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionI
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { AccountListSettingsInput } from 'src/graphql/types.generated';
 import { useLocale } from 'src/hooks/useLocale';
+import { GoalSource, getHealthIndicatorInfo } from 'src/lib/healthIndicator';
 import { currencyFormat, dateFormat, numberFormat } from 'src/lib/intlFormat';
 import { AccordionProps } from '../../../accordionHelper';
 import { useUpdateAccountPreferencesMutation } from '../UpdateAccountPreferences.generated';
@@ -26,9 +26,9 @@ const formatMonthlyGoal = (
   goal: number | null,
   currency: string | null,
   locale: string,
-): string => {
+): string | null => {
   if (goal === null) {
-    return '';
+    return null;
   }
 
   if (currency) {
@@ -68,59 +68,54 @@ export const MonthlyGoalAccordion: React.FC<MonthlyGoalAccordionProps> = ({
       accountListId,
     },
   });
+
+  const accountList = currency
+    ? { currency, monthlyGoal: initialMonthlyGoal, monthlyGoalUpdatedAt }
+    : null;
+  const healthIndicatorData = data?.healthIndicatorData.at(-1);
   const {
-    machineCalculatedGoal: calculatedGoal,
-    machineCalculatedGoalCurrency: calculatedCurrency,
-  } = data?.healthIndicatorData.at(-1) ?? {};
+    goalSource,
+    machineCalculatedGoalCurrency,
+    unsafeMachineCalculatedGoal,
+    preferencesGoalLow,
+    preferencesGoalUpdatedAt,
+  } = getHealthIndicatorInfo(accountList, healthIndicatorData);
+
   const formattedCalculatedGoal = useMemo(
     () =>
       formatMonthlyGoal(
-        calculatedGoal ?? null,
-        calculatedCurrency ?? null,
+        unsafeMachineCalculatedGoal,
+        machineCalculatedGoalCurrency,
         locale,
       ),
-    [calculatedGoal, calculatedCurrency, locale],
+    [unsafeMachineCalculatedGoal, machineCalculatedGoalCurrency, locale],
   );
 
   const accordionValue = useMemo(() => {
     const goal = formatMonthlyGoal(initialMonthlyGoal, currency, locale);
 
-    if (initialMonthlyGoal === null) {
-      if (typeof calculatedGoal === 'number') {
-        // There is no preferences goal, but there is a machine-calculated goal
-        return t('{{goal}} (estimated)', { goal: formattedCalculatedGoal });
+    if (goalSource === GoalSource.Preferences) {
+      if (preferencesGoalLow) {
+        return (
+          <Typography component="span" color="statusWarning.main">
+            {t('{{goal}} (below machine-calculated support goal)', { goal })}
+          </Typography>
+        );
+      } else if (preferencesGoalUpdatedAt) {
+        return t('{{goal}} (last updated {{updated}})', {
+          goal,
+          updated: dateFormat(preferencesGoalUpdatedAt, locale),
+        });
       } else {
-        // There is no preferences goal or machine-calculated goal
-        return null;
+        return goal;
       }
-    } else if (
-      typeof currency === 'string' &&
-      currency === calculatedCurrency &&
-      typeof calculatedGoal === 'number' &&
-      initialMonthlyGoal < calculatedGoal
-    ) {
-      // Staff-entered goal is below machine-calculated goal
-      return (
-        <Typography component="span" color="statusWarning.main">
-          {t('{{goal}} (below machine-calculated support goal)', { goal })}
-        </Typography>
-      );
-    } else if (monthlyGoalUpdatedAt) {
-      // Staff-entered goal has an updated date
-      const date = DateTime.fromISO(monthlyGoalUpdatedAt);
-      return t('{{goal}} (last updated {{updated}})', {
-        goal,
-        updated: dateFormat(date, locale),
-      });
-    } else {
-      // Staff-entered goal does not have an updated date
-      return goal;
+    } else if (formattedCalculatedGoal !== null) {
+      return t('{{goal}} (estimated)', { goal: formattedCalculatedGoal });
     }
   }, [
     initialMonthlyGoal,
-    calculatedGoal,
     formattedCalculatedGoal,
-    monthlyGoalUpdatedAt,
+    preferencesGoalUpdatedAt,
     currency,
     locale,
   ]);
@@ -154,13 +149,13 @@ export const MonthlyGoalAccordion: React.FC<MonthlyGoalAccordionProps> = ({
   };
 
   const getInstructions = () => {
-    if (typeof calculatedGoal !== 'number') {
+    if (unsafeMachineCalculatedGoal === null) {
       return t(
         'This amount should be set to the amount your organization has determined is your target monthly goal. If you do not know, make your best guess for now. You can change it at any time.',
       );
     }
 
-    if (initialMonthlyGoal) {
+    if (goalSource === GoalSource.MachineCalculated) {
       return t(
         'Based on the past year, NetSuite estimates that you need at least {{goal}} of monthly support. You can choose your own target monthly goal or leave it blank to use the estimate.',
         { goal: formattedCalculatedGoal },
@@ -175,9 +170,12 @@ export const MonthlyGoalAccordion: React.FC<MonthlyGoalAccordionProps> = ({
 
   const getWarning = (currentGoal: number | null) => {
     if (
-      typeof currentGoal === 'number' &&
-      typeof calculatedGoal === 'number' &&
-      currentGoal < calculatedGoal
+      currentGoal &&
+      accountList &&
+      getHealthIndicatorInfo(
+        { ...accountList, monthlyGoal: currentGoal },
+        healthIndicatorData,
+      ).preferencesGoalLow
     ) {
       return (
         <Typography
@@ -258,26 +256,27 @@ export const MonthlyGoalAccordion: React.FC<MonthlyGoalAccordionProps> = ({
               >
                 {t('Save')}
               </Button>
-              {calculatedGoal && initialMonthlyGoal !== null && (
-                <Tooltip
-                  title={t(
-                    'Reset to NetSuite estimated goal of {{calculatedGoal}}',
-                    {
-                      calculatedGoal: formattedCalculatedGoal,
-                    },
-                  )}
-                >
-                  <Button
-                    variant="outlined"
-                    type="button"
-                    onClick={() => {
-                      onSubmit({ monthlyGoal: null });
-                    }}
+              {unsafeMachineCalculatedGoal !== null &&
+                goalSource === GoalSource.Preferences && (
+                  <Tooltip
+                    title={t(
+                      'Reset to NetSuite estimated goal of {{calculatedGoal}}',
+                      {
+                        calculatedGoal: formattedCalculatedGoal,
+                      },
+                    )}
                   >
-                    {t('Reset to Calculated Goal')}
-                  </Button>
-                </Tooltip>
-              )}
+                    <Button
+                      variant="outlined"
+                      type="button"
+                      onClick={() => {
+                        onSubmit({ monthlyGoal: null });
+                      }}
+                    >
+                      {t('Reset to Calculated Goal')}
+                    </Button>
+                  </Tooltip>
+                )}
             </Box>
           </form>
         )}

--- a/src/components/Shared/Forms/Accordions/AccordionItem.tsx
+++ b/src/components/Shared/Forms/Accordions/AccordionItem.tsx
@@ -104,7 +104,7 @@ interface AccordionItemProps<AccordionEnum> {
   onAccordionChange: (accordion: AccordionEnum | null) => void;
   expandedAccordion: AccordionEnum | null;
   label: string;
-  value: string;
+  value: React.ReactNode;
   children?: React.ReactNode;
   fullWidth?: boolean;
   image?: React.ReactNode;

--- a/src/components/Shared/Forms/FieldWrapper.tsx
+++ b/src/components/Shared/Forms/FieldWrapper.tsx
@@ -9,7 +9,7 @@ import {
 
 interface FieldWrapperProps {
   labelText?: string;
-  helperText?: string;
+  helperText?: React.ReactNode;
   helperPosition?: HelperPositionEnum;
   formControlDisabled?: FormControlProps['disabled'];
   formControlError?: FormControlProps['error'];
@@ -22,7 +22,7 @@ interface FieldWrapperProps {
 
 export const FieldWrapper: React.FC<FieldWrapperProps> = ({
   labelText = '',
-  helperText = '',
+  helperText = null,
   helperPosition = HelperPositionEnum.Top,
   formControlDisabled = false,
   formControlError = false,
@@ -47,12 +47,10 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = ({
     ''
   );
 
-  const helperTextOutput = helperText ? (
+  const helperTextOutput = helperText && (
     <StyledFormHelperText {...formHelperTextProps}>
-      {t(helperText)}
+      {helperText}
     </StyledFormHelperText>
-  ) : (
-    ''
   );
 
   return (

--- a/src/lib/healthIndicator.test.ts
+++ b/src/lib/healthIndicator.test.ts
@@ -1,0 +1,159 @@
+import { DateTime } from 'luxon';
+import { GoalSource, getHealthIndicatorInfo } from './healthIndicator';
+
+describe('getHealthIndicatorInfo', () => {
+  it('attributes are null when the account list and HI data is loading', () => {
+    expect(getHealthIndicatorInfo(null, null)).toEqual({
+      goal: null,
+      goalSource: null,
+      mismatchedCurrencies: false,
+      machineCalculatedGoal: null,
+      machineCalculatedGoalCurrency: null,
+      unsafeMachineCalculatedGoal: null,
+      preferencesGoal: null,
+      preferencesGoalUpdatedAt: null,
+      preferencesGoalLow: false,
+      preferencesGoalOld: false,
+    });
+  });
+
+  it('uses the preferences goal if it is set', () => {
+    expect(
+      getHealthIndicatorInfo(
+        {
+          currency: 'USD',
+          monthlyGoal: 2000,
+          monthlyGoalUpdatedAt: '2019-06-01T00:00:00Z',
+        },
+        { machineCalculatedGoal: 1000, machineCalculatedGoalCurrency: 'USD' },
+      ),
+    ).toEqual({
+      goal: 2000,
+      goalSource: GoalSource.Preferences,
+      mismatchedCurrencies: false,
+      machineCalculatedGoal: 1000,
+      machineCalculatedGoalCurrency: 'USD',
+      unsafeMachineCalculatedGoal: 1000,
+      preferencesGoal: 2000,
+      preferencesGoalUpdatedAt: DateTime.local(2019, 6, 1),
+      preferencesGoalLow: false,
+      preferencesGoalOld: false,
+    });
+  });
+
+  it('uses the preferences goal if machine-calculated goal is not loaded', () => {
+    expect(
+      getHealthIndicatorInfo(
+        {
+          currency: 'USD',
+          monthlyGoal: 2000,
+          monthlyGoalUpdatedAt: '2019-06-01T00:00:00Z',
+        },
+        null,
+      ),
+    ).toEqual({
+      goal: 2000,
+      goalSource: GoalSource.Preferences,
+      mismatchedCurrencies: false,
+      machineCalculatedGoal: null,
+      machineCalculatedGoalCurrency: null,
+      unsafeMachineCalculatedGoal: null,
+      preferencesGoal: 2000,
+      preferencesGoalUpdatedAt: DateTime.local(2019, 6, 1),
+      preferencesGoalLow: false,
+      preferencesGoalOld: false,
+    });
+  });
+
+  it('uses the machine-calculated goal if a preferences goal is not set', () => {
+    expect(
+      getHealthIndicatorInfo(
+        { currency: 'USD' },
+        { machineCalculatedGoal: 1000, machineCalculatedGoalCurrency: 'USD' },
+      ),
+    ).toEqual({
+      goal: 1000,
+      goalSource: GoalSource.MachineCalculated,
+      mismatchedCurrencies: false,
+      machineCalculatedGoal: 1000,
+      machineCalculatedGoalCurrency: 'USD',
+      unsafeMachineCalculatedGoal: 1000,
+      preferencesGoal: null,
+      preferencesGoalUpdatedAt: null,
+      preferencesGoalLow: false,
+      preferencesGoalOld: false,
+    });
+  });
+
+  it('ignores the machine-calculated goal if its currency does the preferences currency', () => {
+    expect(
+      getHealthIndicatorInfo(
+        { currency: 'USD' },
+        { machineCalculatedGoal: 1000, machineCalculatedGoalCurrency: 'EUR' },
+      ),
+    ).toMatchObject({
+      goal: null,
+      goalSource: null,
+      mismatchedCurrencies: true,
+      machineCalculatedGoal: null,
+      machineCalculatedGoalCurrency: 'EUR',
+      unsafeMachineCalculatedGoal: 1000,
+    });
+  });
+
+  it('ignores the machine-calculated goal if its currency is not set', () => {
+    expect(
+      getHealthIndicatorInfo(
+        { currency: 'USD' },
+        { machineCalculatedGoal: 1000 },
+      ),
+    ).toMatchObject({
+      goal: null,
+      goalSource: null,
+      mismatchedCurrencies: true,
+      machineCalculatedGoal: null,
+      machineCalculatedGoalCurrency: null,
+      unsafeMachineCalculatedGoal: 1000,
+    });
+  });
+
+  describe('preferencesGoalUpdatedAt', () => {
+    it('is null when the preferences goal is not set', () => {
+      expect(
+        getHealthIndicatorInfo(
+          { currency: 'USD', monthlyGoalUpdatedAt: '2019-06-01T00:00:00Z' },
+          { machineCalculatedGoal: 1000, machineCalculatedGoalCurrency: 'EUR' },
+        ),
+      ).toMatchObject({
+        preferencesGoal: null,
+        preferencesGoalUpdatedAt: null,
+      });
+    });
+  });
+
+  describe('preferencesGoalLow', () => {
+    it('is true when the preferences goal is less than the machine-calculated goal', () => {
+      expect(
+        getHealthIndicatorInfo(
+          { currency: 'USD', monthlyGoal: 500 },
+          { machineCalculatedGoal: 1000, machineCalculatedGoalCurrency: 'USD' },
+        ).preferencesGoalLow,
+      ).toBe(true);
+    });
+  });
+
+  describe('preferencesGoalOld', () => {
+    it('is true when the preferences goal is older than a year', () => {
+      expect(
+        getHealthIndicatorInfo(
+          {
+            currency: 'USD',
+            monthlyGoal: 2000,
+            monthlyGoalUpdatedAt: '2018-01-01T00:00:00Z',
+          },
+          {},
+        ).preferencesGoalOld,
+      ).toBe(true);
+    });
+  });
+});

--- a/src/lib/healthIndicator.test.ts
+++ b/src/lib/healthIndicator.test.ts
@@ -6,7 +6,6 @@ describe('getHealthIndicatorInfo', () => {
     expect(getHealthIndicatorInfo(null, null)).toEqual({
       goal: null,
       goalSource: null,
-      mismatchedCurrencies: false,
       machineCalculatedGoal: null,
       machineCalculatedGoalCurrency: null,
       unsafeMachineCalculatedGoal: null,
@@ -30,7 +29,6 @@ describe('getHealthIndicatorInfo', () => {
     ).toEqual({
       goal: 2000,
       goalSource: GoalSource.Preferences,
-      mismatchedCurrencies: false,
       machineCalculatedGoal: 1000,
       machineCalculatedGoalCurrency: 'USD',
       unsafeMachineCalculatedGoal: 1000,
@@ -54,7 +52,6 @@ describe('getHealthIndicatorInfo', () => {
     ).toEqual({
       goal: 2000,
       goalSource: GoalSource.Preferences,
-      mismatchedCurrencies: false,
       machineCalculatedGoal: null,
       machineCalculatedGoalCurrency: null,
       unsafeMachineCalculatedGoal: null,
@@ -74,7 +71,6 @@ describe('getHealthIndicatorInfo', () => {
     ).toEqual({
       goal: 1000,
       goalSource: GoalSource.MachineCalculated,
-      mismatchedCurrencies: false,
       machineCalculatedGoal: 1000,
       machineCalculatedGoalCurrency: 'USD',
       unsafeMachineCalculatedGoal: 1000,
@@ -94,7 +90,6 @@ describe('getHealthIndicatorInfo', () => {
     ).toMatchObject({
       goal: null,
       goalSource: null,
-      mismatchedCurrencies: true,
       machineCalculatedGoal: null,
       machineCalculatedGoalCurrency: 'EUR',
       unsafeMachineCalculatedGoal: 1000,
@@ -110,7 +105,6 @@ describe('getHealthIndicatorInfo', () => {
     ).toMatchObject({
       goal: null,
       goalSource: null,
-      mismatchedCurrencies: true,
       machineCalculatedGoal: null,
       machineCalculatedGoalCurrency: null,
       unsafeMachineCalculatedGoal: 1000,

--- a/src/lib/healthIndicator.ts
+++ b/src/lib/healthIndicator.ts
@@ -16,9 +16,6 @@ interface HealthIndicatorInfo {
   /** Whether the goal came from preferences is is machine-calculated */
   goalSource: GoalSource | null;
 
-  /** `true` if the machine-calculated goal's currency differs from the account's currency */
-  mismatchedCurrencies: boolean;
-
   /** The machine-calculated goal, `null` if it is not loaded or is unavailable */
   machineCalculatedGoal: number | null;
 
@@ -99,7 +96,6 @@ export const getHealthIndicatorInfo = (
   return {
     goal,
     goalSource,
-    mismatchedCurrencies,
     machineCalculatedGoal,
     machineCalculatedGoalCurrency,
     unsafeMachineCalculatedGoal,

--- a/src/lib/healthIndicator.ts
+++ b/src/lib/healthIndicator.ts
@@ -1,0 +1,111 @@
+import { DateTime } from 'luxon';
+import { AccountList, HealthIndicatorData } from 'src/graphql/types.generated';
+
+export enum GoalSource {
+  Preferences = 'Preferences',
+  MachineCalculated = 'MachineCalculated',
+}
+
+interface HealthIndicatorInfo {
+  /**
+   * The overall goal, `null` if it is not loaded or is unavailable. It is the preferences goal if
+   * it is set, and defaults to the machine-calculated goal otherwise.
+   **/
+  goal: number | null;
+
+  /** Whether the goal came from preferences is is machine-calculated */
+  goalSource: GoalSource | null;
+
+  /** `true` if the machine-calculated goal's currency differs from the account's currency */
+  mismatchedCurrencies: boolean;
+
+  /** The machine-calculated goal, `null` if it is not loaded or is unavailable */
+  machineCalculatedGoal: number | null;
+
+  /** The machine-calculated goal's currency, `null` if it is not loaded or is unavailable */
+  machineCalculatedGoalCurrency: string | null;
+
+  /**
+   * The machine-calculated goal, `null` if it is not loaded or is unavailable.
+   *
+   * WARNING: Unlike `machineCalculatedGoal`, it will be set even if its currency doesn't match the
+   * user's currency. It may be displayed to the user, but care must be taken not to use it in
+   * any numerical calculations because all other amounts will be in the user's currency.
+   **/
+  unsafeMachineCalculatedGoal: number | null;
+
+  /** The goal set in preferences, `null` if it is not loaded or is unavailable */
+  preferencesGoal: number | null;
+
+  /** The date that the preferences goal was last updated */
+  preferencesGoalUpdatedAt: DateTime | null;
+
+  /** `true` if the preferences goal is less than the machine-calculated goal */
+  preferencesGoalLow: boolean;
+
+  /** `true` if the preferences goal has not been updated in the last year */
+  preferencesGoalOld: boolean;
+}
+
+export const getHealthIndicatorInfo = (
+  accountList:
+    | Pick<AccountList, 'currency' | 'monthlyGoal' | 'monthlyGoalUpdatedAt'>
+    | null
+    | undefined,
+  healthIndicatorData:
+    | Pick<
+        HealthIndicatorData,
+        'machineCalculatedGoal' | 'machineCalculatedGoalCurrency'
+      >
+    | null
+    | undefined,
+): HealthIndicatorInfo => {
+  const mismatchedCurrencies =
+    !!accountList &&
+    !!healthIndicatorData &&
+    accountList.currency !== healthIndicatorData.machineCalculatedGoalCurrency;
+  // The machine-calculated goal cannot be used if its currency does not match the account list's currency
+  const machineCalculatedGoal =
+    !mismatchedCurrencies && healthIndicatorData?.machineCalculatedGoal
+      ? healthIndicatorData.machineCalculatedGoal
+      : null;
+  const machineCalculatedGoalCurrency =
+    healthIndicatorData?.machineCalculatedGoalCurrency ?? null;
+  const unsafeMachineCalculatedGoal =
+    healthIndicatorData?.machineCalculatedGoal ?? null;
+
+  const preferencesGoal = accountList?.monthlyGoal ?? null;
+  const preferencesGoalUpdatedAt =
+    preferencesGoal !== null &&
+    typeof accountList?.monthlyGoalUpdatedAt === 'string'
+      ? DateTime.fromISO(accountList.monthlyGoalUpdatedAt)
+      : null;
+  const preferencesGoalLow =
+    preferencesGoal !== null &&
+    machineCalculatedGoal !== null &&
+    preferencesGoal < machineCalculatedGoal;
+  const preferencesGoalOld =
+    preferencesGoalUpdatedAt !== null &&
+    preferencesGoalUpdatedAt <= DateTime.now().minus({ year: 1 });
+
+  const goal = preferencesGoal ?? machineCalculatedGoal;
+  const goalSource =
+    preferencesGoal !== null
+      ? GoalSource.Preferences
+      : machineCalculatedGoal !== null
+      ? GoalSource.MachineCalculated
+      : null;
+
+  return {
+    goal,
+    goalSource,
+    mismatchedCurrencies,
+    machineCalculatedGoal,
+    machineCalculatedGoalCurrency,
+    unsafeMachineCalculatedGoal,
+    preferencesGoal,
+    preferencesGoalUpdatedAt,
+    preferencesGoalLow,
+    preferencesGoalOld,
+  };
+};

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -136,6 +136,15 @@ const theme = createTheme({
     progressBarGray: {
       main: progressBarColors.gray,
     },
+    success: {
+      main: statusColors.success,
+    },
+    warning: {
+      main: statusColors.warning,
+    },
+    error: {
+      main: statusColors.danger,
+    },
     statusSuccess: {
       main: statusColors.success,
     },


### PR DESCRIPTION
## Description

* Warn if the preferences goal is below the machine-calculated goal
* Warn if the preferences goal has not been updated in the last year
* Extract HI logic into a reusable module

The goal is to implement a UI similar to this mock-up from stakeholders. Note that we are considering language change to something like "system-generated support goal" but that is still being discussed.

![image](https://github.com/user-attachments/assets/838968db-50c2-49c5-8a7e-04aa8e1ebc14)

MPDX-8566

## Testing

* On Pedro's account list
  * Change the monthly goal in preferences to less than $6,000/month
  * Verify that you see a warning above the input while typing and in the accordion header after saving
  * Verify that you see a warning on the My Accounts grid, on the dashboard, and on the MPD Health report
* On Pedro's account list
  * Change the monthly goal to >$6,000/month
  * In `src/lib/healthIndicator.ts` change `DateTime.now().minus({ year: 1 })` to `DateTime.now()`
  * Verify that the "Updated at" label is red on the My Accounts grid, on the dashboard, and on the MPD Health report

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
