### PR TITLE
[MPDX-8567] Support multiple HI periods and missing periods

### DIFF
--- a/pages/accountLists/GetDashboard.graphql
+++ b/pages/accountLists/GetDashboard.graphql
@@ -22,6 +22,7 @@ query GetDashboard($accountListId: ID!, $periodBegin: ISO8601Date!) {
     averageIgnoreCurrent
     periods {
       startDate
+      endDate
       convertedTotal
       totals {
         currency

--- a/src/components/Dashboard/Dashboard.test.tsx
+++ b/src/components/Dashboard/Dashboard.test.tsx
@@ -48,7 +48,8 @@ const data: GetDashboardQuery = {
     periods: [
       {
         convertedTotal: 200,
-        startDate: '2011-12-1',
+        startDate: '2011-12-01',
+        endDate: '2011-12-31',
         totals: [
           {
             currency: 'USD',
@@ -58,7 +59,8 @@ const data: GetDashboardQuery = {
       },
       {
         convertedTotal: 400,
-        startDate: '2012-1-1',
+        startDate: '2012-01-01',
+        endDate: '2012-01-31',
         totals: [
           {
             currency: 'USD',
@@ -68,7 +70,8 @@ const data: GetDashboardQuery = {
       },
       {
         convertedTotal: 900,
-        startDate: '2012-2-1',
+        startDate: '2012-02-01',
+        endDate: '2012-02-29',
         totals: [
           {
             currency: 'USD',
@@ -90,7 +93,8 @@ const data: GetDashboardQuery = {
       },
       {
         convertedTotal: 1100,
-        startDate: '2012-3-1',
+        startDate: '2012-03-01',
+        endDate: '2012-03-31',
         totals: [
           {
             currency: 'USD',

--- a/src/components/Dashboard/DonationHistories/DonationHistories.test.tsx
+++ b/src/components/Dashboard/DonationHistories/DonationHistories.test.tsx
@@ -58,11 +58,13 @@ const donationsData: DonationHistoriesData = {
       {
         convertedTotal: 50,
         startDate: '2019-01-01',
+        endDate: '2019-01-31',
         totals: [{ currency: 'USD', convertedAmount: 50 }],
       },
       {
         convertedTotal: 60,
         startDate: '2019-02-01',
+        endDate: '2019-02-31',
         totals: [{ currency: 'NZD', convertedAmount: 60 }],
       },
     ],
@@ -95,12 +97,14 @@ describe('DonationHistories', () => {
         periods: [
           {
             convertedTotal: 0,
-            startDate: '1-1-2019',
+            startDate: '2019-01-01',
+            endDate: '2019-01-31',
             totals: [{ currency: 'USD', convertedAmount: 0 }],
           },
           {
             convertedTotal: 0,
-            startDate: '1-2-2019',
+            startDate: '2019-02-01',
+            endDate: '2019-02-28',
             totals: [{ currency: 'NZD', convertedAmount: 0 }],
           },
         ],

--- a/src/components/Dashboard/DonationHistories/DonationHistories.tsx
+++ b/src/components/Dashboard/DonationHistories/DonationHistories.tsx
@@ -70,7 +70,10 @@ export interface DonationHistoriesData {
     'averageIgnoreCurrent'
   > & {
     periods: Array<
-      Pick<Types.DonationHistoriesPeriod, 'startDate' | 'convertedTotal'> & {
+      Pick<
+        Types.DonationHistoriesPeriod,
+        'startDate' | 'endDate' | 'convertedTotal'
+      > & {
         totals: Array<Pick<Types.Total, 'currency' | 'convertedAmount'>>;
       }
     >;

--- a/src/components/Dashboard/DonationHistories/graphData.test.ts
+++ b/src/components/Dashboard/DonationHistories/graphData.test.ts
@@ -38,6 +38,7 @@ describe('calculateGraphData', () => {
               {
                 convertedTotal: 30,
                 startDate: '2020-11-01',
+                endDate: '2020-11-30',
                 totals: [
                   { currency: 'USD', convertedAmount: 10 },
                   { currency: 'EUR', convertedAmount: 20 },
@@ -46,6 +47,7 @@ describe('calculateGraphData', () => {
               {
                 convertedTotal: 40,
                 startDate: '2020-12-01',
+                endDate: '2020-12-31',
                 totals: [
                   { currency: 'EUR', convertedAmount: 15 },
                   { currency: 'CAD', convertedAmount: 15 },
@@ -91,11 +93,11 @@ describe('calculateGraphData', () => {
           },
           reportsDonationHistories: {
             periods: [
-              { startDate: '2020-08-01' },
-              { startDate: '2020-09-01' },
-              { startDate: '2020-10-01' },
-              { startDate: '2020-11-01' },
-              { startDate: '2020-12-01' },
+              { startDate: '2020-08-01', endDate: '2020-08-31' },
+              { startDate: '2020-09-01', endDate: '2020-09-30' },
+              { startDate: '2020-10-01', endDate: '2020-10-31' },
+              { startDate: '2020-11-01', endDate: '2020-11-30' },
+              { startDate: '2020-12-01', endDate: '2020-12-31' },
             ],
           },
           healthIndicatorData: [
@@ -150,15 +152,16 @@ describe('calculateGraphData', () => {
           },
           reportsDonationHistories: {
             periods: [
-              { startDate: '2020-07-01' },
-              { startDate: '2020-08-01' },
-              { startDate: '2020-09-01' },
-              { startDate: '2020-10-01' },
-              { startDate: '2020-11-01' },
-              { startDate: '2020-12-01' },
+              { startDate: '2020-07-01', endDate: '2020-07-31' },
+              { startDate: '2020-08-01', endDate: '2020-08-31' },
+              { startDate: '2020-09-01', endDate: '2020-09-30' },
+              { startDate: '2020-10-01', endDate: '2020-10-31' },
+              { startDate: '2020-11-01', endDate: '2020-11-30' },
+              { startDate: '2020-12-01', endDate: '2020-12-31' },
             ],
           },
           // August, September, and November are missing
+          // December has two periods
           healthIndicatorData: [
             {
               indicationPeriodBegin: '2020-07-01',
@@ -177,6 +180,12 @@ describe('calculateGraphData', () => {
               machineCalculatedGoal: 120,
               machineCalculatedGoalCurrency: 'USD',
             },
+            {
+              indicationPeriodBegin: '2020-12-02',
+              staffEnteredGoal: 240,
+              machineCalculatedGoal: 120,
+              machineCalculatedGoalCurrency: 'USD',
+            },
           ],
         },
         variables,
@@ -190,7 +199,7 @@ describe('calculateGraphData', () => {
         { goal: 200, startDate: 'Sep 20' }, // extrapolated from July
         { goal: 110, startDate: 'Oct 20' },
         { goal: 110, startDate: 'Nov 20' }, // extrapolated from October
-        { goal: 220, startDate: 'Dec 20' },
+        { goal: 240, startDate: 'Dec 20' }, // uses latest December period
       ]);
     });
   });
@@ -249,120 +258,64 @@ describe('calculateGraphData', () => {
   });
 
   describe('domainMax', () => {
+    const data = gqlMock<GetDonationGraphQuery, GetDonationGraphQueryVariables>(
+      GetDonationGraphDocument,
+      {
+        mocks: {
+          accountList: {
+            monthlyGoal: 10,
+            totalPledges: 20,
+          },
+          reportsDonationHistories: {
+            periods: [
+              {
+                startDate: '2020-11-01',
+                endDate: '2020-11-30',
+                convertedTotal: 30,
+              },
+              {
+                startDate: '2020-12-01',
+                endDate: '2020-12-31',
+                convertedTotal: 40,
+              },
+            ],
+            averageIgnoreCurrent: 50,
+          },
+          healthIndicatorData: [
+            { indicationPeriodBegin: '2020-11-01', staffEnteredGoal: 60 },
+            { indicationPeriodBegin: '2020-12-01', staffEnteredGoal: 200 },
+          ],
+        },
+        variables,
+      },
+    );
+
     it('is zero when data is undefined', () => {
+      data.healthIndicatorData[0].staffEnteredGoal = 100;
+
       expect(
         calculateGraphData({ ...graphOptions, data: undefined }).domainMax,
       ).toBe(0);
     });
 
     it('is the period with the greatest total', () => {
-      const data = gqlMock<
-        GetDonationGraphQuery,
-        GetDonationGraphQueryVariables
-      >(GetDonationGraphDocument, {
-        mocks: {
-          accountList: {
-            monthlyGoal: 10,
-            totalPledges: 20,
-          },
-          reportsDonationHistories: {
-            periods: [
-              { startDate: '2020-11-01', convertedTotal: 100 },
-              { startDate: '2020-12-01', convertedTotal: 40 },
-            ],
-            averageIgnoreCurrent: 50,
-          },
-          healthIndicatorData: [
-            { indicationPeriodBegin: '2020-11-01', staffEnteredGoal: 60 },
-            { indicationPeriodBegin: '2020-12-01', staffEnteredGoal: 200 },
-          ],
-        },
-        variables,
-      });
+      data.reportsDonationHistories.periods[0].convertedTotal = 100;
 
       expect(calculateGraphData({ ...graphOptions, data }).domainMax).toBe(100);
     });
 
     it('is the period with the greatest goal', () => {
-      const data = gqlMock<
-        GetDonationGraphQuery,
-        GetDonationGraphQueryVariables
-      >(GetDonationGraphDocument, {
-        mocks: {
-          accountList: {
-            monthlyGoal: 10,
-            totalPledges: 20,
-          },
-          reportsDonationHistories: {
-            periods: [
-              { startDate: '2020-11-01', convertedTotal: 30 },
-              { startDate: '2020-12-01', convertedTotal: 40 },
-            ],
-            averageIgnoreCurrent: 50,
-          },
-          healthIndicatorData: [
-            { indicationPeriodBegin: '2020-11-01', staffEnteredGoal: 100 },
-            { indicationPeriodBegin: '2020-12-01', staffEnteredGoal: 200 },
-          ],
-        },
-        variables,
-      });
-
       expect(calculateGraphData({ ...graphOptions, data }).domainMax).toBe(100);
     });
 
     it('is the monthly goal', () => {
-      const data = gqlMock<
-        GetDonationGraphQuery,
-        GetDonationGraphQueryVariables
-      >(GetDonationGraphDocument, {
-        mocks: {
-          accountList: {
-            monthlyGoal: 100,
-            totalPledges: 20,
-          },
-          reportsDonationHistories: {
-            periods: [
-              { startDate: '2020-11-01', convertedTotal: 30 },
-              { startDate: '2020-12-01', convertedTotal: 40 },
-            ],
-            averageIgnoreCurrent: 50,
-          },
-          healthIndicatorData: [
-            { indicationPeriodBegin: '2020-11-01', staffEnteredGoal: 60 },
-            { indicationPeriodBegin: '2020-12-01', staffEnteredGoal: 200 },
-          ],
-        },
-        variables,
-      });
+      data.accountList.monthlyGoal = 100;
 
       expect(calculateGraphData({ ...graphOptions, data }).domainMax).toBe(100);
     });
 
     it('is the total pledges', () => {
-      const data = gqlMock<
-        GetDonationGraphQuery,
-        GetDonationGraphQueryVariables
-      >(GetDonationGraphDocument, {
-        mocks: {
-          accountList: {
-            monthlyGoal: 10,
-            totalPledges: 100,
-          },
-          reportsDonationHistories: {
-            periods: [
-              { startDate: '2020-11-01', convertedTotal: 30 },
-              { startDate: '2020-12-01', convertedTotal: 40 },
-            ],
-            averageIgnoreCurrent: 50,
-          },
-          healthIndicatorData: [
-            { indicationPeriodBegin: '2020-11-01', staffEnteredGoal: 60 },
-            { indicationPeriodBegin: '2020-12-01', staffEnteredGoal: 200 },
-          ],
-        },
-        variables,
-      });
+      data.accountList.totalPledges = 100;
 
       expect(calculateGraphData({ ...graphOptions, data }).domainMax).toBe(100);
     });

--- a/src/components/Dashboard/DonationHistories/graphData.ts
+++ b/src/components/Dashboard/DonationHistories/graphData.ts
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon';
+import { monthYearFormat } from 'src/lib/intlFormat';
 import { DonationHistoriesData } from './DonationHistories';
 
 export interface CalculateGraphDataOptions {
@@ -38,16 +39,20 @@ export const calculateGraphData = ({
     totalPledges: pledged,
   } = data?.accountList ?? {};
   const { healthIndicatorData, reportsDonationHistories } = data ?? {};
-  const currentMonth = DateTime.now().startOf('month').toISODate();
+  const currentMonth = DateTime.now();
 
   const currencies: CurrencyBar[] = [];
   const periods = reportsDonationHistories?.periods?.map((period) => {
-    // Look up the health indicator period that most closely matches the current period, without
+    const startDate = DateTime.fromISO(period.startDate);
+
+    // Look up the latest health indicator period in or before the current report period, without
     // going over. This handles potentially missing periods because health indicator data is not
-    // guaranteed to be available for every month. Because health indicator periods are sorted
-    // in ascending order, if e.g. March has no health indicator data, February will be used instead.
+    // guaranteed to be available for every day. Because health indicator periods are sorted
+    // in ascending order, if e.g. March has no health indicator data, February will be used
+    // instead. If there are multiple health indicator periods in a report period, the latest one
+    // will be selected.
     const hiPeriod = healthIndicatorData?.findLast(
-      (item) => item.indicationPeriodBegin <= period.startDate,
+      (item) => item.indicationPeriodBegin <= period.endDate,
     );
     // The machine calculated goal cannot be used if its currency differs from the user's currency
     const machineCalculatedGoal =
@@ -57,7 +62,7 @@ export const calculateGraphData = ({
 
     const periodGoal =
       // In the current month, give the goal from preferences the highest precedence
-      (period.startDate === currentMonth ? goal : null) ??
+      (startDate.hasSame(currentMonth, 'month') ? goal : null) ??
       // Fall back to the staff-entered goal if the preferences goal is unavailable or it is not the current month
       hiPeriod?.staffEnteredGoal ??
       // Finally, fall back to the machine-calculated goal as a last resort
@@ -65,12 +70,10 @@ export const calculateGraphData = ({
 
     const periodData: Period = {
       currencies: {},
-      startDate: DateTime.fromISO(period.startDate)
-        .toJSDate()
-        .toLocaleDateString(locale, { month: 'short', year: '2-digit' }),
+      startDate: monthYearFormat(startDate, locale, false),
       total: period.convertedTotal,
       goal: periodGoal ?? null,
-      period: DateTime.fromISO(period.startDate),
+      period: startDate,
     };
     period.totals.forEach((total) => {
       if (!currencies.find((currency) => total.currency === currency.name)) {

--- a/src/components/Reports/DonationsReport/GetDonationGraph.graphql
+++ b/src/components/Reports/DonationsReport/GetDonationGraph.graphql
@@ -28,6 +28,7 @@ fragment DonationGraphHistories on DonationHistories {
   averageIgnoreCurrent
   periods {
     startDate
+    endDate
     convertedTotal
     totals {
       currency

--- a/src/components/Reports/HealthIndicatorReport/HealthIndicatorGraph/useGraphData.test.tsx
+++ b/src/components/Reports/HealthIndicatorReport/HealthIndicatorGraph/useGraphData.test.tsx
@@ -92,10 +92,10 @@ describe('weightedAverage', () => {
     expect(weightedAverage([], 'field', [])).toBeNull();
   });
 
-  it('returns null when items contains only missing values', () => {
+  it('returns 0 when items contains only missing values', () => {
     expect(
       weightedAverage([{ field: null }, { field: undefined }], 'field', [1, 1]),
-    ).toBeNull();
+    ).toBe(0);
   });
 
   it('calculates the weighted average of the field', () => {
@@ -121,7 +121,7 @@ describe('weightedAverage', () => {
         'field',
         [1, 1, 1, 1, 1],
       ),
-    ).toBe(2);
+    ).toBe(1.2);
   });
 });
 
@@ -247,11 +247,11 @@ describe('useGraphData', () => {
     expect(result.current.average).toBe(null);
     await waitForNextUpdate();
     // Jan 10 - Feb 14 = 36 span * 10 HI
-    // Feb 15 - Feb 24 = 10 span * null HI
+    // Feb 15 - Feb 24 = 10 span * 0 HI
     // Feb 25          = 1 span  * 80 HI
     // Feb 26          = 1 span  * 90 HI
-    // Average = (36*10 + 1*80 + 1*90) / 38 = ~13.95, rounds to 14
-    expect(result.current.average).toBe(14);
+    // Average = (36*10 + 10*0 + 1*80 + 1*90) / 48 = ~11.04, rounds to 11
+    expect(result.current.average).toBe(11);
   });
 
   it('extrapolates missing periods and averages periods in the same month', async () => {
@@ -282,29 +282,29 @@ describe('useGraphData', () => {
       {
         // No February periods, so all indicators are null
         month: 'Feb 2024',
-        consistency: null,
-        depth: null,
-        ownership: null,
-        success: null,
-        consistencyScaled: null,
-        depthScaled: null,
-        ownershipScaled: null,
-        successScaled: null,
+        consistency: 0,
+        depth: 0,
+        ownership: 0,
+        success: 0,
+        consistencyScaled: 0,
+        depthScaled: 0,
+        ownershipScaled: 0,
+        successScaled: 0,
       },
       {
         // Mar 4 - Mar 5 = 2 span * 40 HI
-        // Mar 6 - Mar 9 = 4 span * null HI
+        // Mar 6 - Mar 9 = 4 span * 0 HI
         // Mar 10        = 1 span * 50 HI
-        // Average = (2*40 + 1*50) / 3 = ~43.33, rounds to 43
+        // Average = (2*40 + 4*0 + 1*50) / 7 = ~18.57, rounds to 19
         month: 'Mar 2024',
-        consistency: 43,
-        depth: 43,
-        ownership: 43,
-        success: 43,
-        consistencyScaled: 6,
-        depthScaled: 6,
-        ownershipScaled: 19,
-        successScaled: 12,
+        consistency: 19,
+        depth: 19,
+        ownership: 19,
+        success: 19,
+        consistencyScaled: 3,
+        depthScaled: 3,
+        ownershipScaled: 8,
+        successScaled: 5,
       },
     ]);
   });

--- a/src/components/Reports/HealthIndicatorReport/HealthIndicatorGraph/useGraphData.test.tsx
+++ b/src/components/Reports/HealthIndicatorReport/HealthIndicatorGraph/useGraphData.test.tsx
@@ -1,8 +1,34 @@
 import { ReactElement } from 'react';
 import { renderHook } from '@testing-library/react-hooks';
-import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import { HealthIndicatorGraphQuery } from './HealthIndicatorGraph.generated';
-import { useGraphData } from './useGraphData';
+import { GqlMockedProvider, gqlMock } from '__tests__/util/graphqlMocking';
+import { HealthIndicatorQueryVariables } from 'src/components/Dashboard/MonthlyGoal/HealthIndicator.generated';
+import {
+  HealthIndicatorGraphDocument,
+  HealthIndicatorGraphQuery,
+} from './HealthIndicatorGraph.generated';
+import {
+  calculatePeriodSpans,
+  uniqueMonths,
+  useGraphData,
+  weightedAverage,
+} from './useGraphData';
+
+const AverageWrapper = ({ children }: { children: ReactElement }) => (
+  <GqlMockedProvider<{ HealthIndicatorGraph: HealthIndicatorGraphQuery }>
+    mocks={{
+      HealthIndicatorGraph: {
+        healthIndicatorData: [
+          { indicationPeriodBegin: '2024-01-10', overallHi: 10 },
+          { indicationPeriodBegin: '2024-02-15', overallHi: null },
+          { indicationPeriodBegin: '2024-02-25', overallHi: 80 },
+          { indicationPeriodBegin: '2024-02-26', overallHi: 90 },
+        ],
+      },
+    }}
+  >
+    {children}
+  </GqlMockedProvider>
+);
 
 const Wrapper = ({ children }: { children: ReactElement }) => (
   <GqlMockedProvider<{ HealthIndicatorGraph: HealthIndicatorGraphQuery }>
@@ -10,28 +36,46 @@ const Wrapper = ({ children }: { children: ReactElement }) => (
       HealthIndicatorGraph: {
         healthIndicatorData: [
           {
-            indicationPeriodBegin: '2024-01-01',
-            overallHi: 33,
-            consistencyHi: 7,
-            depthHi: 21,
-            ownershipHi: 35,
-            successHi: 49,
+            indicationPeriodBegin: '2024-01-10',
+            consistencyHi: 10,
+            depthHi: 10,
+            ownershipHi: 10,
+            successHi: 10,
           },
           {
-            indicationPeriodBegin: '2024-02-01',
-            overallHi: null,
+            indicationPeriodBegin: '2024-01-31',
+            consistencyHi: 40,
+            depthHi: 40,
+            ownershipHi: 40,
+            successHi: 40,
+          },
+          {
+            indicationPeriodBegin: '2024-02-15',
             consistencyHi: null,
             depthHi: null,
             ownershipHi: null,
             successHi: null,
           },
           {
-            indicationPeriodBegin: '2024-03-01',
-            overallHi: 40,
-            consistencyHi: 14,
-            depthHi: 28,
-            ownershipHi: 42,
-            successHi: 56,
+            indicationPeriodBegin: '2024-03-04',
+            consistencyHi: 40,
+            depthHi: 40,
+            ownershipHi: 40,
+            successHi: 40,
+          },
+          {
+            indicationPeriodBegin: '2024-03-06',
+            consistencyHi: null,
+            depthHi: null,
+            ownershipHi: null,
+            successHi: null,
+          },
+          {
+            indicationPeriodBegin: '2024-03-10',
+            consistencyHi: 50,
+            depthHi: 50,
+            ownershipHi: 50,
+            successHi: 50,
           },
         ],
       },
@@ -42,6 +86,141 @@ const Wrapper = ({ children }: { children: ReactElement }) => (
 );
 
 const accountListId = 'account-list-1';
+
+describe('weightedAverage', () => {
+  it('returns null when items is empty', () => {
+    expect(weightedAverage([], 'field', [])).toBeNull();
+  });
+
+  it('returns null when items contains only missing values', () => {
+    expect(
+      weightedAverage([{ field: null }, { field: undefined }], 'field', [1, 1]),
+    ).toBeNull();
+  });
+
+  it('calculates the weighted average of the field', () => {
+    expect(
+      weightedAverage(
+        [{ field: 1 }, { field: 3 }, { field: 5 }],
+        'field',
+        [1, 2, 1],
+      ),
+    ).toBe(3);
+  });
+
+  it('ignores missing values', () => {
+    expect(
+      weightedAverage(
+        [
+          { field: 1 },
+          { field: null },
+          { field: 2 },
+          { field: undefined },
+          { field: 3 },
+        ],
+        'field',
+        [1, 1, 1, 1, 1],
+      ),
+    ).toBe(2);
+  });
+});
+
+describe('uniqueMonths', () => {
+  it('returns an empty set when data is undefined', () => {
+    expect(uniqueMonths(undefined)).toEqual(new Set());
+  });
+
+  it('returns the unique months', () => {
+    const data = gqlMock<
+      HealthIndicatorGraphQuery,
+      HealthIndicatorQueryVariables
+    >(HealthIndicatorGraphDocument, {
+      variables: { accountListId },
+      mocks: {
+        healthIndicatorData: [
+          { indicationPeriodBegin: '2024-01-01' },
+          { indicationPeriodBegin: '2024-01-02' },
+          { indicationPeriodBegin: '2024-01-03' },
+          { indicationPeriodBegin: '2024-02-04' },
+          { indicationPeriodBegin: '2024-04-05' },
+        ],
+      },
+    });
+    expect(uniqueMonths(data)).toEqual(
+      new Set(['2024-01', '2024-02', '2024-04']),
+    );
+  });
+});
+
+const makePeriod = (
+  indicationPeriodBegin: string,
+): HealthIndicatorGraphQuery['healthIndicatorData'][number] => ({
+  id: '',
+  indicationPeriodBegin,
+});
+
+describe('calculatePeriodSpans', () => {
+  it('returns all 1s when no periods are missing', () => {
+    expect(
+      calculatePeriodSpans([
+        makePeriod('2024-01-05'),
+        makePeriod('2024-01-06'),
+        makePeriod('2024-01-07'),
+        makePeriod('2024-01-08'),
+        makePeriod('2024-01-09'),
+        makePeriod('2024-01-10'),
+      ]),
+    ).toEqual([1, 1, 1, 1, 1, 1]);
+  });
+
+  it('returns an empty array when there are no periods', () => {
+    expect(calculatePeriodSpans([])).toEqual([]);
+  });
+
+  it('extrapolates missing days', () => {
+    expect(
+      calculatePeriodSpans([
+        makePeriod('2024-01-05'),
+        makePeriod('2024-01-15'),
+        makePeriod('2024-01-28'),
+      ]),
+    ).toEqual([
+      10, // January 5-14
+      13, // January 15-27
+      1, // January 28
+    ]);
+  });
+
+  it('handles spanning multiple months', () => {
+    expect(
+      calculatePeriodSpans([
+        makePeriod('2024-01-30'),
+        makePeriod('2024-02-03'),
+        makePeriod('2024-03-03'),
+        makePeriod('2024-03-04'),
+        makePeriod('2024-03-06'),
+      ]),
+    ).toEqual([
+      4, // January 30-February 2
+      29, // February 2-March 2
+      1, // March 3
+      2, // March 4-5
+      1, // March 6
+    ]);
+  });
+
+  it('handles spanning daylight savings start', () => {
+    expect(
+      calculatePeriodSpans([
+        makePeriod('2024-03-09'),
+        makePeriod('2024-03-10'),
+      ]),
+    ).toEqual([
+      1, // March 9
+      1, // March 10
+    ]);
+  });
+});
 
 describe('useGraphData', () => {
   it('loading is true while the data is loading', async () => {
@@ -61,16 +240,21 @@ describe('useGraphData', () => {
     const { result, waitForNextUpdate } = renderHook(
       () => useGraphData(accountListId),
       {
-        wrapper: Wrapper,
+        wrapper: AverageWrapper,
       },
     );
 
     expect(result.current.average).toBe(null);
     await waitForNextUpdate();
-    expect(result.current.average).toBe(37); // (33 + 44) / 2, rounded
+    // Jan 10 - Feb 14 = 36 span * 10 HI
+    // Feb 15 - Feb 24 = 10 span * null HI
+    // Feb 25          = 1 span  * 80 HI
+    // Feb 26          = 1 span  * 90 HI
+    // Average = (36*10 + 1*80 + 1*90) / 38 = ~13.95, rounds to 14
+    expect(result.current.average).toBe(14);
   });
 
-  it('calculates the periods', async () => {
+  it('extrapolates missing periods and averages periods in the same month', async () => {
     const { result, waitForNextUpdate } = renderHook(
       () => useGraphData(accountListId),
       {
@@ -82,17 +266,21 @@ describe('useGraphData', () => {
     await waitForNextUpdate();
     expect(result.current.periods).toEqual([
       {
+        // Jan 10 - Jan 30 = 21 span * 10 HI
+        // Jan 31          = 1 span  * 40 HI
+        // Average = (21*10 + 1*40) / 22 = ~11.36, rounds to 11
         month: 'Jan 2024',
-        consistency: 7,
-        depth: 21,
-        ownership: 35,
-        success: 49,
-        consistencyScaled: 1,
-        depthScaled: 3,
-        ownershipScaled: 15,
-        successScaled: 14,
+        consistency: 11,
+        depth: 11,
+        ownership: 11,
+        success: 11,
+        consistencyScaled: 2,
+        depthScaled: 2,
+        ownershipScaled: 5,
+        successScaled: 3,
       },
       {
+        // No February periods, so all indicators are null
         month: 'Feb 2024',
         consistency: null,
         depth: null,
@@ -104,15 +292,19 @@ describe('useGraphData', () => {
         successScaled: null,
       },
       {
+        // Mar 4 - Mar 5 = 2 span * 40 HI
+        // Mar 6 - Mar 9 = 4 span * null HI
+        // Mar 10        = 1 span * 50 HI
+        // Average = (2*40 + 1*50) / 3 = ~43.33, rounds to 43
         month: 'Mar 2024',
-        consistency: 14,
-        consistencyScaled: 2,
-        depth: 28,
-        depthScaled: 4,
-        ownership: 42,
-        ownershipScaled: 18,
-        success: 56,
-        successScaled: 16,
+        consistency: 43,
+        depth: 43,
+        ownership: 43,
+        success: 43,
+        consistencyScaled: 6,
+        depthScaled: 6,
+        ownershipScaled: 19,
+        successScaled: 12,
       },
     ]);
   });

--- a/src/components/Reports/HealthIndicatorReport/HealthIndicatorGraph/useGraphData.ts
+++ b/src/components/Reports/HealthIndicatorReport/HealthIndicatorGraph/useGraphData.ts
@@ -1,8 +1,11 @@
+import { useMemo } from 'react';
 import { DateTime } from 'luxon';
 import { useLocale } from 'src/hooks/useLocale';
 import { monthYearFormat } from 'src/lib/intlFormat';
-import { isNotNullish } from 'src/lib/typeGuards';
-import { useHealthIndicatorGraphQuery } from './HealthIndicatorGraph.generated';
+import {
+  HealthIndicatorGraphQuery,
+  useHealthIndicatorGraphQuery,
+} from './HealthIndicatorGraph.generated';
 
 export interface Period {
   month: string;
@@ -23,11 +26,94 @@ interface UseGraphDataResult {
 }
 
 // Scale a health indicator value by its weight in the overall calculation
-const scale = (
-  value: number | null | undefined,
-  weight = 1,
-): number | null | undefined => {
-  return typeof value === 'number' ? (value * weight) / 7 : value;
+const scale = (value: number | null, weight = 1): number | null => {
+  return value === null ? null : (value * weight) / 7;
+};
+
+// Round a health indicator value if it is set
+const round = (value: number | null): number | null => {
+  return value === null ? null : Math.round(value);
+};
+
+/**
+ * Calculate the weighted average value of a particular field in an array of items, ignoring
+ * missing values.
+ *
+ * @param items An array of records with a property {@link field} that is `number | null | undefined`
+ * @param field The field in {@link items} to be averaged
+ * @param weights An array of each item's weight. It must have the same length as {@link items}.
+ * @returns `null` if no records had the field, or the average otherwise
+ */
+export const weightedAverage = <
+  Item extends { [_ in Field]?: number | null | undefined },
+  Field extends keyof Item,
+>(
+  items: Array<Item>,
+  field: Field,
+  weights: number[],
+): number | null => {
+  const { total, denominator } = items.reduce(
+    ({ total, denominator }, item, index) => {
+      const value = item[field];
+      if (typeof value !== 'number') {
+        // Ignore missing values
+        return { total, denominator };
+      }
+
+      const weight = weights[index];
+      return {
+        total: total + value * weight,
+        denominator: denominator + weight,
+      };
+    },
+    { total: 0, denominator: 0 },
+  );
+
+  return denominator === 0 ? null : total / denominator;
+};
+
+/**
+ * Calculate the unique months represented in the health indicator periods.
+ */
+export const uniqueMonths = (
+  data: HealthIndicatorGraphQuery | undefined,
+): Set<string> => {
+  return new Set(
+    data?.healthIndicatorData.map((period) =>
+      // Extract the year and month from the ISO timestamp
+      period.indicationPeriodBegin.slice(0, 7),
+    ),
+  );
+};
+
+/**
+ * If there are missing periods, we need to extrapolate the existing periods to fill in the missing
+ * ones. When there are missing periods, the periods around them will need to span multiple days
+ * instead of just a single day. This code calculates how many days each period spans.
+ *
+ * For example:
+ * - In a month without missing periods, this will be an array of 1s, i.e. [1, 1, 1, 1, 1, ...].
+ * - In January with periods for the 5th, 15th, and 25th, this will be [10, 10, 1] because the
+ *   first period spans from January 5-14, the second spans from January 15-24, and the third
+ *   only covers January 25.
+ *
+ * See the test cases for more examples of the expected outputs of various inputs.
+ */
+export const calculatePeriodSpans = (
+  periods: HealthIndicatorGraphQuery['healthIndicatorData'],
+): number[] => {
+  return periods.map((period, index) => {
+    // The last period always has a span of 1
+    if (index === periods.length - 1) {
+      return 1;
+    }
+
+    const start = DateTime.fromISO(period.indicationPeriodBegin);
+    // Periods end at the start of the next period
+    const end = DateTime.fromISO(periods[index + 1].indicationPeriodBegin);
+    // Calculate how many days the period spans
+    return end.diff(start, 'days').days;
+  });
 };
 
 export const useGraphData = (accountListId: string): UseGraphDataResult => {
@@ -39,37 +125,52 @@ export const useGraphData = (accountListId: string): UseGraphDataResult => {
     },
   });
 
-  const average = data
-    ? Math.round(
-        data.healthIndicatorData
-          .map((month) => month.overallHi)
-          .filter(isNotNullish)
-          .reduce(
-            (total, overall, _index, months) => total + overall / months.length,
-            0,
-          ),
-      )
-    : null;
+  const averageOverallHi = useMemo(() => {
+    if (!data) {
+      return null;
+    }
 
-  const periods =
-    data?.healthIndicatorData.map((month) => ({
-      month: monthYearFormat(
-        DateTime.fromISO(month.indicationPeriodBegin),
-        locale,
-      ),
-      consistency: month.consistencyHi,
-      depth: month.depthHi,
-      ownership: month.ownershipHi,
-      success: month.successHi,
-      consistencyScaled: scale(month.consistencyHi),
-      depthScaled: scale(month.depthHi),
-      ownershipScaled: scale(month.ownershipHi, 3),
-      successScaled: scale(month.successHi, 2),
-    })) ?? null;
+    const periodSpans = calculatePeriodSpans(data.healthIndicatorData);
+    return weightedAverage(data.healthIndicatorData, 'overallHi', periodSpans);
+  }, [data]);
+
+  const periods = useMemo(() => {
+    if (!data) {
+      return null;
+    }
+
+    return Array.from(uniqueMonths(data).values()).map((isoMonth) => {
+      const periods = data.healthIndicatorData.filter((period) =>
+        period.indicationPeriodBegin.startsWith(isoMonth),
+      );
+
+      const periodSpans = calculatePeriodSpans(periods);
+      const consistency = weightedAverage(
+        periods,
+        'consistencyHi',
+        periodSpans,
+      );
+      const depth = weightedAverage(periods, 'depthHi', periodSpans);
+      const ownership = weightedAverage(periods, 'ownershipHi', periodSpans);
+      const success = weightedAverage(periods, 'successHi', periodSpans);
+
+      return {
+        month: monthYearFormat(DateTime.fromISO(isoMonth), locale),
+        consistency: round(consistency),
+        depth: round(depth),
+        ownership: round(ownership),
+        success: round(success),
+        consistencyScaled: round(scale(consistency)),
+        depthScaled: round(scale(depth)),
+        ownershipScaled: round(scale(ownership, 3)),
+        successScaled: round(scale(success, 2)),
+      };
+    });
+  }, [data]);
 
   return {
     loading,
-    average,
+    average: round(averageOverallHi),
     periods,
   };
 };

--- a/src/components/Reports/HealthIndicatorReport/HealthIndicatorGraph/useGraphData.ts
+++ b/src/components/Reports/HealthIndicatorReport/HealthIndicatorGraph/useGraphData.ts
@@ -36,8 +36,8 @@ const round = (value: number | null): number | null => {
 };
 
 /**
- * Calculate the weighted average value of a particular field in an array of items, ignoring
- * missing values.
+ * Calculate the weighted average value of a particular field in an array of items, treating missing
+ * values as 0.
  *
  * @param items An array of records with a property {@link field} that is `number | null | undefined`
  * @param field The field in {@link items} to be averaged
@@ -54,12 +54,7 @@ export const weightedAverage = <
 ): number | null => {
   const { total, denominator } = items.reduce(
     ({ total, denominator }, item, index) => {
-      const value = item[field];
-      if (typeof value !== 'number') {
-        // Ignore missing values
-        return { total, denominator };
-      }
-
+      const value = item[field] ?? 0;
       const weight = weights[index];
       return {
         total: total + value * weight,


### PR DESCRIPTION
## Description

I recently learned that HI data will be generated daily, not monthly like I initially thought. This PR corrects some assumptions in `DonationHistories` that there will only be one HI period per month. Now it selects the latest HI period in the month if there are multiple available.

The greatest complexity is in modifying `useGraphData` to support extrapolation to fill in arbitrary HI periods. HI data will ideally be generated daily, but we need to handle cases where certain days are missing. The code comments and test cases attempt to document in detail the algorithm I'm using, but please let me know if anything can be clarified.

Note that the test data only has one HI period per month. I'm relying on detailed tests to verify that the changes are working correctly since I can't test the UI directly.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
