### PR TITLE
[MPDX-8570] Improve the graph average label

### DIFF
--- a/src/components/Reports/HealthIndicatorReport/HealthIndicatorGraph/HealthIndicatorGraph.test.tsx
+++ b/src/components/Reports/HealthIndicatorReport/HealthIndicatorGraph/HealthIndicatorGraph.test.tsx
@@ -60,7 +60,7 @@ describe('HealthIndicatorGraph', () => {
     );
 
     expect(await findByTestId('HealthIndicatorGraphHeader')).toHaveTextContent(
-      'Average 50',
+      'Overall average 50',
     );
   });
 });

--- a/src/components/Reports/HealthIndicatorReport/HealthIndicatorGraph/HealthIndicatorGraph.tsx
+++ b/src/components/Reports/HealthIndicatorReport/HealthIndicatorGraph/HealthIndicatorGraph.tsx
@@ -67,7 +67,7 @@ export const HealthIndicatorGraph: React.FC<HealthIndicatorGraphProps> = ({
         title={
           average && (
             <LegendReferenceLine
-              name={t('Average')}
+              name={t('Overall average')}
               value={average}
               color={palette.graphTeal.main}
             />

--- a/src/components/common/LegendReferenceLine/LegendReferenceLine.tsx
+++ b/src/components/common/LegendReferenceLine/LegendReferenceLine.tsx
@@ -32,7 +32,7 @@ export const LegendReferenceLine: React.FC<LegendReferenceLineProps> = ({
   <Container>
     <Line sx={{ backgroundColor: color }} />
     <Typography variant="body1" component="span">
-      <strong>{name}</strong> {value}
+      {name} <strong>{value}</strong>
     </Typography>
   </Container>
 );


### PR DESCRIPTION
## Description

Update the "Average" label in the Health Indicator graph to be more descriptive.

I also moved the bold style in the legend from the title to the value.

Before:
<img width="600" alt="Screenshot 2025-03-28 at 2 20 21 PM" src="https://github.com/user-attachments/assets/a457d623-9d59-4d3a-bde6-4c744d7b74f0" />

After:
<img width="600" alt="Screenshot 2025-03-28 at 2 20 36 PM" src="https://github.com/user-attachments/assets/7403a2d6-4467-40b3-a108-a03920c1d418" />

Because I think it looks better this way:
<img width="600" alt="Screenshot 2025-03-28 at 2 20 48 PM" src="https://github.com/user-attachments/assets/190371a8-059b-42f3-bb40-c504d3286388" />

Than this way:
<img width="600" alt="Screenshot 2025-03-28 at 2 21 09 PM" src="https://github.com/user-attachments/assets/080b9119-f3d4-4e5c-b5dc-c1dd896f4e79" />

I'm going to double-check with Scott, but let me know if you have preferences one way or another.

MPDX-8570

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
