### PR TITLE
[no-Jira] High-priority accessibility improvements

### DIFF
--- a/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
@@ -331,19 +331,18 @@ const TasksPage: React.FC = () => {
                         height: `calc(100vh - ${navBarHeight} - ${headerHeight} - ${buttonBarHeight})`,
                       }}
                       itemContent={(index, task) => (
-                        <Box key={index} flexDirection="row" width="100%">
-                          <TaskRow
-                            accountListId={accountListId}
-                            task={task}
-                            onContactSelected={setContactFocus}
-                            onTaskCheckToggle={toggleSelectionById}
-                            isChecked={isRowChecked(task.id)}
-                            useTopMargin={index === 0}
-                            getContactHrefObject={getContactHrefObject}
-                            removeSelectedIds={deselectMultipleIds}
-                            filterPanelOpen={filterPanelOpen}
-                          />
-                        </Box>
+                        <TaskRow
+                          key={task.id}
+                          accountListId={accountListId}
+                          task={task}
+                          onContactSelected={setContactFocus}
+                          onTaskCheckToggle={toggleSelectionById}
+                          isChecked={isRowChecked(task.id)}
+                          useTopMargin={index === 0}
+                          getContactHrefObject={getContactHrefObject}
+                          removeSelectedIds={deselectMultipleIds}
+                          filterPanelOpen={filterPanelOpen}
+                        />
                       )}
                       groupBy={(item) => {
                         if (item.completedAt) {

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsHeader.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsHeader.tsx
@@ -20,7 +20,7 @@ import { StarContactIconButton } from '../../StarContactIconButton/StarContactIc
 import { EditIcon } from '../ContactDetailsTab/StyledComponents';
 import { EditPartnershipInfoModal } from '../ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal';
 import { useGetContactDetailsHeaderQuery } from './ContactDetailsHeader.generated';
-import { ContactDetailsMoreAcitions } from './ContactDetailsMoreActions/ContactDetailsMoreActions';
+import { ContactDetailsMoreActions } from './ContactDetailsMoreActions/ContactDetailsMoreActions';
 import { ContactHeaderAddressSection } from './ContactHeaderSection/ContactHeaderAddressSection';
 import { ContactHeaderEmailSection } from './ContactHeaderSection/ContactHeaderEmailSection';
 import { ContactHeaderNewsletterSection } from './ContactHeaderSection/ContactHeaderNewsletterSection';
@@ -196,7 +196,7 @@ export const ContactDetailsHeader: React.FC<Props> = ({
             contactId={contactId}
             isStarred={data?.contact?.starred || false}
           />
-          <ContactDetailsMoreAcitions
+          <ContactDetailsMoreActions
             contactId={contactId}
             status={data?.contact.status ?? StatusEnum.Unresponsive}
             onClose={onClose}

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.test.tsx
@@ -13,7 +13,7 @@ import useTaskModal from '../../../../../hooks/useTaskModal';
 import theme from '../../../../../theme';
 import { ContactDetailProvider } from '../../ContactDetailContext';
 import { UpdateContactOtherMutation } from '../../ContactDetailsTab/Other/EditContactOtherModal/EditContactOther.generated';
-import { ContactDetailsMoreAcitions } from './ContactDetailsMoreActions';
+import { ContactDetailsMoreActions } from './ContactDetailsMoreActions';
 
 const accountListId = '111';
 const contactId = 'contact-1';
@@ -56,7 +56,7 @@ describe('ContactDetailsMoreActions', () => {
             <GqlMockedProvider>
               <ContactsWrapper>
                 <ContactDetailProvider>
-                  <ContactDetailsMoreAcitions
+                  <ContactDetailsMoreActions
                     status={StatusEnum.AskInFuture}
                     contactId={contactId}
                     onClose={onClose}
@@ -88,7 +88,7 @@ describe('ContactDetailsMoreActions', () => {
             <GqlMockedProvider>
               <ContactsWrapper>
                 <ContactDetailProvider>
-                  <ContactDetailsMoreAcitions
+                  <ContactDetailsMoreActions
                     status={StatusEnum.AskInFuture}
                     contactId={contactId}
                     onClose={onClose}
@@ -121,7 +121,7 @@ describe('ContactDetailsMoreActions', () => {
             <GqlMockedProvider>
               <ContactsWrapper>
                 <ContactDetailProvider>
-                  <ContactDetailsMoreAcitions
+                  <ContactDetailsMoreActions
                     status={StatusEnum.AskInFuture}
                     contactId={contactId}
                     onClose={onClose}
@@ -166,7 +166,7 @@ describe('ContactDetailsMoreActions', () => {
             >
               <ContactsWrapper>
                 <ContactDetailProvider>
-                  <ContactDetailsMoreAcitions
+                  <ContactDetailsMoreActions
                     status={StatusEnum.AskInFuture}
                     contactId={contactId}
                     onClose={onClose}
@@ -207,7 +207,7 @@ describe('ContactDetailsMoreActions', () => {
             <GqlMockedProvider>
               <ContactsWrapper>
                 <ContactDetailProvider>
-                  <ContactDetailsMoreAcitions
+                  <ContactDetailsMoreActions
                     status={StatusEnum.AskInFuture}
                     contactId={contactId}
                     onClose={onClose}
@@ -246,7 +246,7 @@ describe('ContactDetailsMoreActions', () => {
             <GqlMockedProvider>
               <ContactsWrapper>
                 <ContactDetailProvider>
-                  <ContactDetailsMoreAcitions
+                  <ContactDetailsMoreActions
                     status={StatusEnum.AskInFuture}
                     contactId={contactId}
                     onClose={onClose}
@@ -282,7 +282,7 @@ describe('ContactDetailsMoreActions', () => {
             <GqlMockedProvider cache={cache}>
               <ContactsWrapper>
                 <ContactDetailProvider>
-                  <ContactDetailsMoreAcitions
+                  <ContactDetailsMoreActions
                     status={StatusEnum.AskInFuture}
                     contactId={contactId}
                     onClose={onClose}

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
@@ -1,11 +1,17 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import ListIcon from '@mui/icons-material/FormatListBulleted';
 import MoreVert from '@mui/icons-material/MoreVert';
 import PersonIcon from '@mui/icons-material/Person';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
-import { Box, IconButton, ListItemText, Menu } from '@mui/material';
+import {
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+} from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
@@ -42,15 +48,6 @@ import {
   preloadMoreActionHideContactModal,
 } from './DynamicMoreActionHideContactModal';
 
-type AddMenuItem = {
-  visibility: boolean;
-  text: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  icon: any;
-  onClick: () => void;
-  onMouseEnter: () => void;
-};
-
 const MoreButtonIcon = styled(MoreVert)(({ theme }) => ({
   width: 24,
   height: 24,
@@ -58,69 +55,29 @@ const MoreButtonIcon = styled(MoreVert)(({ theme }) => ({
 }));
 
 const MenuContainer = styled(Menu)(({ theme }) => ({
-  '& .MuiPaper-root': {
+  '.MuiPaper-root': {
     width: '35ch',
     [theme.breakpoints.down('xs')]: {
       width: '100%',
     },
   },
-  '& .MuiMenu-list': {
-    padding: 0,
+  '.MuiList-root': {
+    paddingBlock: 0,
   },
-  '& .MuiListItemText-root': {
-    margin: 0,
-  },
-}));
-
-const RowContainer = styled(Box)(({ theme }) => ({
-  padding: theme.spacing(1),
-  borderBottom: '1px solid',
-  borderBottomColor: theme.palette.divider,
-  '&:hover': {
-    backgroundColor: theme.palette.grey[100],
-  },
-  '&:last-child': {
-    borderBottom: 'none',
+  '.MuiMenuItem-root + .MuiMenuItem-root': {
+    borderTop: `1px solid ${theme.palette.divider}`,
   },
 }));
 
-const MenuItemText = styled(ListItemText)(({ theme }) => ({
-  padding: theme.spacing(0, 1),
-}));
-
-const ActionPanel = ({
-  actionContent,
-}: {
-  actionContent: AddMenuItem[];
-}): ReactElement => {
-  return (
-    <Box display="flex" flexDirection="column" justifyContent="center">
-      {actionContent
-        .filter((i: AddMenuItem) => i.visibility)
-        .map(({ text, icon, onClick, onMouseEnter }, index) => (
-          <RowContainer
-            key={index}
-            display="flex"
-            onClick={onClick}
-            onMouseEnter={onMouseEnter}
-          >
-            {icon}
-            <MenuItemText primary={text} />
-          </RowContainer>
-        ))}
-    </Box>
-  );
-};
-
-interface ContactDetailsMoreAcitionsProps {
+interface ContactDetailsMoreActionsProps {
   contactId: string;
   status: StatusEnum;
   onClose: () => void;
   contextType?: ContactContextTypesEnum;
 }
 
-export const ContactDetailsMoreAcitions: React.FC<
-  ContactDetailsMoreAcitionsProps
+export const ContactDetailsMoreActions: React.FC<
+  ContactDetailsMoreActionsProps
 > = ({
   contactId,
   status,
@@ -275,7 +232,14 @@ export const ContactDetailsMoreAcitions: React.FC<
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
         transformOrigin={{ vertical: 'top', horizontal: 'center' }}
       >
-        <ActionPanel actionContent={actionContent} />
+        {actionContent
+          .filter((item) => item.visibility)
+          .map(({ text, icon, onClick, onMouseEnter }, index) => (
+            <MenuItem key={index} onClick={onClick} onMouseEnter={onMouseEnter}>
+              <ListItemIcon>{icon}</ListItemIcon>
+              <ListItemText>{text}</ListItemText>
+            </MenuItem>
+          ))}
       </MenuContainer>
       <Modal
         isOpen={referralsModalOpen}

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
@@ -259,14 +259,15 @@ export const ContactDetailsMoreAcitions: React.FC<
   return (
     <>
       <IconButton
-        aria-controls="add-menu"
-        aria-haspopup="true"
+        aria-label={t('More Actions')}
+        aria-controls="more-actions"
+        aria-haspopup="menu"
         onClick={(event) => setAnchorEl(event.currentTarget)}
       >
         <MoreButtonIcon titleAccess={t('More Actions')} />
       </IconButton>
       <MenuContainer
-        id="add-menu"
+        id="more-actions"
         keepMounted
         open={Boolean(anchorEl)}
         onClose={() => setAnchorEl(undefined)}

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactDetailsTabMailing.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactDetailsTabMailing.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import CreateIcon from '@mui/icons-material/Create';
 import LocationOn from '@mui/icons-material/LocationOn';
-import { Box, IconButton, Link, Typography } from '@mui/material';
+import { Box, Button, IconButton, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { DateTime } from 'luxon';
 import { useTranslation } from 'react-i18next';
@@ -40,10 +40,6 @@ const ContactDetailsMailingLabelTextContainer = styled(Box)(({}) => ({
 
 const StyledAddressTypography = styled(Typography)(() => ({
   lineHeight: '1.25',
-}));
-
-const ContactMailingShowMoreLabel = styled(Typography)(({ theme }) => ({
-  color: theme.palette.info.main,
 }));
 
 const ContactAddressPrimaryText = styled(Typography)(({ theme }) => ({
@@ -207,22 +203,19 @@ export const ContactDetailsTabMailing: React.FC<MailingProp> = ({
               ))}
             {nonPrimaryAddresses.length > 0 && (
               <ContactDetailsMailingLabelTextContainer>
-                <Link href="#" underline="hover">
-                  <ContactMailingShowMoreLabel
-                    variant="subtitle1"
-                    onClick={() =>
-                      setShowContactDetailTabMoreOpen(
-                        !showContactDetailTabMoreOpen,
-                      )
-                    }
-                  >
-                    {showContactDetailTabMoreOpen
-                      ? t('Show Less')
-                      : t('Show {{amount}} More', {
-                          amount: nonPrimaryAddresses.length,
-                        })}
-                  </ContactMailingShowMoreLabel>
-                </Link>
+                <Button
+                  onClick={() =>
+                    setShowContactDetailTabMoreOpen(
+                      !showContactDetailTabMoreOpen,
+                    )
+                  }
+                >
+                  {showContactDetailTabMoreOpen
+                    ? t('Show Fewer')
+                    : t('Show {{amount}} More', {
+                        amount: nonPrimaryAddresses.length,
+                      })}
+                </Button>
               </ContactDetailsMailingLabelTextContainer>
             )}
           </ContactDetailsMailingTextContainer>

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactDetailsTabMailing.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Mailing/ContactDetailsTabMailing.tsx
@@ -125,7 +125,7 @@ export const ContactDetailsTabMailing: React.FC<MailingProp> = ({
                     onClick={() => {
                       setEditingAddressId(primaryAddress.id);
                     }}
-                    aria-label={t('Edit Address Icon')}
+                    aria-label={t('Edit Address')}
                   >
                     <AddressEditIcon />
                   </AddressEditIconContainer>
@@ -178,7 +178,7 @@ export const ContactDetailsTabMailing: React.FC<MailingProp> = ({
                       onClick={() => {
                         setEditingAddressId(address.id);
                       }}
-                      aria-label={t('Edit Icon')}
+                      aria-label={t('Edit Address')}
                     >
                       <AddressEditIcon />
                     </AddressEditIconContainer>

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/PartnerAccounts/ContactDetailsPartnerAccounts.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/PartnerAccounts/ContactDetailsPartnerAccounts.test.tsx
@@ -177,11 +177,11 @@ describe('ContactDetailsPartnerAccounts', () => {
   });
 
   it('handle clicking delete button', async () => {
-    const { getByText, findByText, queryAllByRole } = render(<Components />);
+    const { getByText, findByText, getAllByRole } = render(<Components />);
 
     expect(await findByText('accountNumber-1')).toBeInTheDocument();
 
-    userEvent.click(queryAllByRole('button', { name: '' })[0]);
+    userEvent.click(getAllByRole('button', { name: 'Delete' })[0]);
     expect(getByText('accountNumber-1')).toBeInTheDocument();
     expect(getByText('accountNumber-2')).toBeInTheDocument();
     await waitFor(() =>

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/PartnerAccounts/ContactDetailsPartnerAccounts.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/PartnerAccounts/ContactDetailsPartnerAccounts.tsx
@@ -176,38 +176,45 @@ export const ContactDetailsPartnerAccounts: React.FC<
           )}
         </Formik>
       )}
-      {data.contact.contactDonorAccounts.nodes.map((donorAccount) => (
-        <ContactPartnerAccountsTextContainer key={donorAccount.id}>
-          <Box display="flex" flexDirection="column">
-            {donorAccount.donorAccount.organization.id && (
-              <OrganizationName>
-                {donorAccount.donorAccount.organization.name}
-              </OrganizationName>
-            )}
-            <PartnerAccountTextContainer>
-              <PartnerAccountTextLabel>
-                {t('Account Number:')}
-              </PartnerAccountTextLabel>
-              <Typography>{donorAccount.donorAccount.accountNumber}</Typography>
-            </PartnerAccountTextContainer>
-            <PartnerAccountTextContainer>
-              <PartnerAccountTextLabel>
-                {t('Account Name:')}
-              </PartnerAccountTextLabel>
-              <Typography variant="body2">
-                {donorAccount.donorAccount.displayName}
-              </Typography>
-            </PartnerAccountTextContainer>
-          </Box>
-          <IconButton
-            onClick={() =>
-              deleteContactDonorAccount(donorAccount.donorAccount.id)
-            }
-          >
-            <Delete />
-          </IconButton>
-        </ContactPartnerAccountsTextContainer>
-      ))}
+      {data.contact.contactDonorAccounts.nodes.map((donorAccount) => {
+        const nameId = `partner-account-${donorAccount.donorAccount.accountNumber}`;
+        return (
+          <ContactPartnerAccountsTextContainer key={donorAccount.id}>
+            <Box display="flex" flexDirection="column">
+              {donorAccount.donorAccount.organization.id && (
+                <OrganizationName>
+                  {donorAccount.donorAccount.organization.name}
+                </OrganizationName>
+              )}
+              <PartnerAccountTextContainer>
+                <PartnerAccountTextLabel>
+                  {t('Account Number:')}
+                </PartnerAccountTextLabel>
+                <Typography>
+                  {donorAccount.donorAccount.accountNumber}
+                </Typography>
+              </PartnerAccountTextContainer>
+              <PartnerAccountTextContainer>
+                <PartnerAccountTextLabel>
+                  {t('Account Name:')}
+                </PartnerAccountTextLabel>
+                <Typography variant="body2" id={nameId}>
+                  {donorAccount.donorAccount.displayName}
+                </Typography>
+              </PartnerAccountTextContainer>
+            </Box>
+            <IconButton
+              aria-label={t('Delete')}
+              aria-describedby={nameId}
+              onClick={() =>
+                deleteContactDonorAccount(donorAccount.donorAccount.id)
+              }
+            >
+              <Delete />
+            </IconButton>
+          </ContactPartnerAccountsTextContainer>
+        );
+      })}
     </ContactPartnerAccountsContainer>
   );
 };

--- a/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/ContactTaskRow.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/ContactTaskRow.test.tsx
@@ -102,6 +102,7 @@ describe('ContactTaskRow', () => {
     const task = gqlMock<TaskRowFragment>(TaskRowFragmentDoc, {
       mocks: {
         startAt,
+        completedAt: null,
         result: ResultEnum.None,
         user: {
           firstName: 'John',
@@ -135,7 +136,7 @@ describe('ContactTaskRow', () => {
       const { findByText, getByRole } = render(<Components task={task} />);
 
       expect(await findByText(task.subject)).toBeVisible();
-      userEvent.click(getByRole('img', { hidden: true, name: 'Check' }));
+      userEvent.click(getByRole('button', { name: 'Complete Task' }));
       expect(openTaskModal).toHaveBeenCalledWith({
         view: TaskModalEnum.Complete,
         taskId: task.id,

--- a/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/TaskCompleteButton/TaskCompleteButton.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/TaskCompleteButton/TaskCompleteButton.test.tsx
@@ -15,21 +15,10 @@ describe('TaskCompleteButton', () => {
       </ThemeProvider>,
     );
 
-    const completeButton = getByRole('button');
-    const checkIcon = getByRole('img', { hidden: true, name: 'Check' });
-
-    expect(completeButton).toBeInTheDocument();
-    expect(checkIcon).toBeInTheDocument();
-
-    const completeButtonStyle =
-      completeButton && window.getComputedStyle(completeButton);
-
-    expect(completeButtonStyle?.backgroundColor).toMatchInlineSnapshot(
-      `"transparent"`,
+    expect(getByRole('button', { name: 'Complete Task' })).toHaveStyle(
+      'background-color: transparent; color: rgb(0, 202, 153);',
     );
-    expect(completeButtonStyle?.color).toMatchInlineSnapshot(
-      `"rgb(0, 202, 153)"`,
-    );
+    expect(getByRole('img')).toBeInTheDocument();
   });
 
   it('should render complete', () => {
@@ -41,21 +30,10 @@ describe('TaskCompleteButton', () => {
       </ThemeProvider>,
     );
 
-    const completeButton = getByRole('button');
-    const checkIcon = getByRole('img', { hidden: true, name: 'Check' });
-
-    expect(completeButton).toBeInTheDocument();
-    expect(checkIcon).toBeInTheDocument();
-
-    const completeButtonStyle =
-      completeButton && window.getComputedStyle(completeButton);
-
-    expect(completeButtonStyle?.backgroundColor).toMatchInlineSnapshot(
-      `"rgb(0, 202, 153)"`,
+    expect(getByRole('button', { name: 'Complete Task' })).toHaveStyle(
+      'background-color: rgb(0, 202, 153); color: rgb(255, 255, 255);',
     );
-    expect(completeButtonStyle?.color).toMatchInlineSnapshot(
-      `"rgb(255, 255, 255)"`,
-    );
+    expect(getByRole('img')).toBeInTheDocument();
   });
 
   it('should handle click', () => {
@@ -63,15 +41,11 @@ describe('TaskCompleteButton', () => {
 
     const { getByRole } = render(
       <ThemeProvider theme={theme}>
-        <TaskCompleteButton isComplete={true} onClick={onClick} />
+        <TaskCompleteButton isComplete={false} onClick={onClick} />
       </ThemeProvider>,
     );
 
-    const completeButton = getByRole('button');
-
-    expect(completeButton).toBeInTheDocument();
-
-    userEvent.click(completeButton);
+    userEvent.click(getByRole('button', { name: 'Complete Task' }));
 
     expect(onClick).toHaveBeenCalled();
   });

--- a/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/TaskCompleteButton/TaskCompleteButton.tsx
+++ b/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/TaskCompleteButton/TaskCompleteButton.tsx
@@ -3,11 +3,10 @@ import Check from '@mui/icons-material/Check';
 import { Button, ButtonProps } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
-import theme from 'src/theme';
 
 const ButtonWrap = styled(Button, {
   shouldForwardProp: (prop) => prop !== 'isComplete',
-})<{ isComplete?: boolean }>(({ isComplete }) => ({
+})<{ isComplete?: boolean }>(({ isComplete, theme }) => ({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
@@ -18,8 +17,11 @@ const ButtonWrap = styled(Button, {
   border: `2px solid ${theme.palette.mpdxGreen.main}`,
   margin: theme.spacing(2),
   color: isComplete ? theme.palette.common.white : theme.palette.mpdxGreen.main,
-  '&:hover': {
+  '&:hover, &:focus': {
     backgroundColor: theme.palette.mpdxGreen.main,
+    color: theme.palette.common.white,
+  },
+  '&.Mui-disabled': {
     color: theme.palette.common.white,
   },
   '@media (max-width:500px)': {
@@ -40,9 +42,10 @@ export const TaskCompleteButton: React.FC<TaskCompleteButtonProps> = ({
     <ButtonWrap
       data-testid="checkCompleteButton"
       isComplete={isComplete}
+      disabled={isComplete}
       {...props}
     >
-      <Check titleAccess={t('Check')} />
+      <Check titleAccess={t('Complete Task')} />
     </ButtonWrap>
   );
 };

--- a/src/components/Contacts/ContactRow/ContactRow.test.tsx
+++ b/src/components/Contacts/ContactRow/ContactRow.test.tsx
@@ -129,9 +129,9 @@ describe('ContactsRow', () => {
   });
 
   it('should open log task modal', async () => {
-    const { getByTitle } = render(<Components />);
+    const { getByRole } = render(<Components />);
 
-    const taskButton = getByTitle('Log Task');
+    const taskButton = getByRole('button', { name: 'Log Task' });
     userEvent.click(taskButton);
     expect(openTaskModal).toHaveBeenCalledWith({
       view: TaskModalEnum.Log,

--- a/src/components/Contacts/ContactRow/ContactRow.tsx
+++ b/src/components/Contacts/ContactRow/ContactRow.tsx
@@ -156,7 +156,7 @@ export const ContactRow: React.FC<Props> = ({ contact, useTopMargin }) => {
         </Grid>
       </Grid>
       <Hidden xsDown>
-        <Box onClick={(event) => event.stopPropagation()}>
+        <Box onClick={(event) => event.preventDefault()}>
           <ContactUncompletedTasksCount
             uncompletedTasksCount={uncompletedTasksCount}
             contactId={contactId}

--- a/src/components/Contacts/ContactUncompletedTasksCount/ContactUncompletedTasksCount.test.tsx
+++ b/src/components/Contacts/ContactUncompletedTasksCount/ContactUncompletedTasksCount.test.tsx
@@ -15,7 +15,7 @@ describe('ContactUncompletedTasksCount', () => {
       </ThemeProvider>,
     );
 
-    const TaskCompletedIcon = getByRole('img', {
+    const TaskCompletedIcon = getByRole('button', {
       name: 'Log Task',
     });
 

--- a/src/components/Contacts/ContactUncompletedTasksCount/ContactUncompletedTasksCount.tsx
+++ b/src/components/Contacts/ContactUncompletedTasksCount/ContactUncompletedTasksCount.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import { Box, Typography } from '@mui/material';
+import { Box, IconButton, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { TaskModalEnum } from 'src/components/Task/Modal/TaskModal';
@@ -11,7 +11,7 @@ interface ContactUncompletedTasksCountProps {
   contactId: string;
 }
 
-const LogTaskButton = styled(CheckCircleOutlineIcon)(({ theme }) => ({
+const LogTaskIcon = styled(CheckCircleOutlineIcon)(({ theme }) => ({
   color: theme.palette.cruGrayMedium.main,
   '&:hover': {
     color: theme.palette.cruGrayDark.main,
@@ -26,8 +26,8 @@ export const ContactUncompletedTasksCount: React.FC<
 
   return (
     <Box display="flex" alignItems="center" px={5}>
-      <LogTaskButton
-        titleAccess={t('Log Task')}
+      <IconButton
+        aria-label={t('Log Task')}
         onClick={() =>
           openTaskModal({
             view: TaskModalEnum.Log,
@@ -37,17 +37,17 @@ export const ContactUncompletedTasksCount: React.FC<
           })
         }
         onMouseEnter={() => preloadTaskModal(TaskModalEnum.Log)}
-      />
-      <Box ml={2}>
-        <Typography
-          color="textSecondary"
-          style={{
-            visibility: uncompletedTasksCount > 0 ? 'visible' : 'hidden',
-          }}
-        >
-          {uncompletedTasksCount}
-        </Typography>
-      </Box>
+      >
+        <LogTaskIcon />
+      </IconButton>
+      <Typography
+        color="textSecondary"
+        style={{
+          visibility: uncompletedTasksCount > 0 ? 'visible' : 'hidden',
+        }}
+      >
+        {uncompletedTasksCount}
+      </Typography>
     </Box>
   );
 };

--- a/src/components/Contacts/StarContactIconButton/StarContactIconButton.test.tsx
+++ b/src/components/Contacts/StarContactIconButton/StarContactIconButton.test.tsx
@@ -12,7 +12,7 @@ const contactId = '1';
 
 describe('StarTaskIconButton', () => {
   it('renders not starred', async () => {
-    const { queryByTestId } = render(
+    const { getByRole, queryByTestId } = render(
       <GqlMockedProvider>
         <ThemeProvider theme={theme}>
           <StarContactIconButton
@@ -29,10 +29,11 @@ describe('StarTaskIconButton', () => {
 
     expect(starFilledIcon).not.toBeInTheDocument();
     expect(starOutlineIcon).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Add star' })).toBeInTheDocument();
   });
 
   it('renders starred', async () => {
-    const { queryByTestId } = render(
+    const { queryByTestId, getByRole } = render(
       <GqlMockedProvider>
         <ThemeProvider theme={theme}>
           <StarContactIconButton
@@ -49,12 +50,13 @@ describe('StarTaskIconButton', () => {
 
     expect(starFilledIcon).toBeInTheDocument();
     expect(starOutlineIcon).not.toBeInTheDocument();
+    expect(getByRole('button', { name: 'Remove star' })).toBeInTheDocument();
   });
 
   it('should toggle starred state', async () => {
     const mutationSpy = jest.fn();
 
-    const { getByTestId } = render(
+    const { getByRole } = render(
       <GqlMockedProvider onCall={mutationSpy}>
         <ThemeProvider theme={theme}>
           <StarContactIconButton
@@ -65,24 +67,14 @@ describe('StarTaskIconButton', () => {
         </ThemeProvider>
       </GqlMockedProvider>,
     );
-    const starOutlineIcon = getByTestId('Outline Star Icon');
 
-    userEvent.click(starOutlineIcon);
+    userEvent.click(getByRole('button', { name: 'Add star' }));
 
     await waitFor(() =>
-      expect(mutationSpy).toHaveBeenCalledWith({
-        operation: expect.objectContaining({
-          operationName: 'SetContactStarred',
-          variables: { accountListId: 'abc', contactId: '1', starred: true },
-        }),
-        response: {
-          data: {
-            updateContact: {
-              __typename: 'ContactUpdateMutationPayload',
-              contact: { __typename: 'Contact', id: '2418942', starred: true },
-            },
-          },
-        },
+      expect(mutationSpy).toHaveGraphqlOperation('SetContactStarred', {
+        accountListId,
+        contactId,
+        starred: true,
       }),
     );
   });

--- a/src/components/Contacts/StarContactIconButton/StarContactIconButton.tsx
+++ b/src/components/Contacts/StarContactIconButton/StarContactIconButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { IconButton, IconButtonProps } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 import { StarredItemIcon } from '../../common/StarredItemIcon/StarredItemIcon';
 import { useSetContactStarredMutation } from './SetContactStarred.generated';
 
@@ -16,14 +17,15 @@ export const StarContactIconButton: React.FC<Props> = ({
   isStarred,
   size = 'medium',
 }) => {
+  const { t } = useTranslation();
   const [setContactStarred] = useSetContactStarredMutation();
 
   return (
     <IconButton
+      aria-label={isStarred ? t('Remove star') : t('Add star')}
       size={size}
-      component="div"
       onClick={(event) => {
-        event.stopPropagation();
+        event.preventDefault();
         setContactStarred({
           variables: { accountListId, contactId, starred: !isStarred },
           optimisticResponse: {

--- a/src/components/Layouts/Primary/NavBar/NavBar.test.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavBar.test.tsx
@@ -48,15 +48,13 @@ describe('NavBar', () => {
     const { getByRole, queryByTestId } = render(<TestComponent openMobile />);
 
     expect(queryByTestId('NavBarDrawer')).toBeInTheDocument();
-    expect(getByRole('menuitem', { name: 'Dashboard' })).toBeInTheDocument();
+    expect(getByRole('link', { name: 'Dashboard' })).toBeInTheDocument();
   });
 
   it('hides links during the setup tour', () => {
     const { queryByRole } = render(<TestComponent openMobile onSetupTour />);
 
-    expect(
-      queryByRole('menuitem', { name: 'Dashboard' }),
-    ).not.toBeInTheDocument();
+    expect(queryByRole('link', { name: 'Dashboard' })).not.toBeInTheDocument();
   });
 
   describe("What's New link", () => {
@@ -67,7 +65,7 @@ describe('NavBar', () => {
       const { getByRole } = render(<TestComponent openMobile />);
 
       expect(
-        getByRole('menuitem', { name: "Help logo What's New" }),
+        getByRole('link', { name: "Help logo What's New" }),
       ).toHaveAttribute('href', '/new');
     });
 
@@ -77,7 +75,7 @@ describe('NavBar', () => {
       const { queryByRole } = render(<TestComponent openMobile />);
 
       expect(
-        queryByRole('menuitem', { name: "Help logo What's New" }),
+        queryByRole('link', { name: "Help logo What's New" }),
       ).not.toBeInTheDocument();
     });
   });

--- a/src/components/Layouts/Primary/NavBar/NavItem/NavItem.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavItem/NavItem.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import type { FC, ReactNode } from 'react';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
-import { Button, Collapse, ListItemButton, MenuItem } from '@mui/material';
+import { Button, Collapse, ListItem } from '@mui/material';
 import { styled, useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { LeafListItem, Title } from '../StyledComponents';
@@ -20,11 +20,11 @@ interface NavItemProps {
   whatsNewLink?: boolean;
 }
 
-const StyledListItem = styled(ListItemButton)(() => ({
+const StyledListItem = styled(ListItem)({
   display: 'block',
   paddingTop: 0,
   paddingBottom: 0,
-}));
+});
 
 const StyledButton = styled(Button)(({ theme }) => ({
   color: theme.palette.common.white,
@@ -99,19 +99,24 @@ export const NavItem: FC<NavItemProps> = ({
   }
 
   return (
-    <LeafListItem disableGutters key={title} {...rest}>
-      <MenuItem component={NextLink} href={href} style={style}>
-        {Icon && <Icon style={iconStyle} size="20" />}
-        {whatsNewLink && process.env.HELP_WHATS_NEW_IMAGE_URL && (
-          <img
-            src={process.env.HELP_WHATS_NEW_IMAGE_URL}
-            alt={t('Help logo')}
-            height={24}
-            style={{ marginRight: theme.spacing(1) }}
-          />
-        )}
-        <Title>{title}</Title>
-      </MenuItem>
+    <LeafListItem
+      disableGutters
+      key={title}
+      component={NextLink}
+      href={href}
+      style={style}
+      {...rest}
+    >
+      {Icon && <Icon style={iconStyle} size="20" />}
+      {whatsNewLink && process.env.HELP_WHATS_NEW_IMAGE_URL && (
+        <img
+          src={process.env.HELP_WHATS_NEW_IMAGE_URL}
+          alt={t('Help logo')}
+          height={24}
+          style={{ marginRight: theme.spacing(1) }}
+        />
+      )}
+      <Title>{title}</Title>
     </LeafListItem>
   );
 };

--- a/src/components/Layouts/Primary/NavBar/NavTools/SearchMenuPanel/SearchMenuPanel.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/SearchMenuPanel/SearchMenuPanel.tsx
@@ -1,24 +1,33 @@
 import React, { ReactElement } from 'react';
 import SearchIcon from '@mui/icons-material/Search';
 import { Box, InputAdornment, TextField } from '@mui/material';
+import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
+
+const WhiteTextField = styled(TextField)({
+  '.MuiFormLabel-root, .MuiInputBase-input, .MuiSvgIcon-root': {
+    color: 'white',
+  },
+  '.MuiOutlinedInput-notchedOutline': {
+    borderColor: 'white',
+  },
+});
 
 export const SearchMenuPanel = (): ReactElement => {
   const { t } = useTranslation();
 
   return (
     <Box p={2}>
-      <TextField
+      <WhiteTextField
         color="secondary"
         label={t('Search')}
         InputProps={{
           startAdornment: (
             <InputAdornment position="start">
-              <SearchIcon color="action" />
+              <SearchIcon />
             </InputAdornment>
           ),
         }}
-        variant="outlined"
       />
     </Box>
   );

--- a/src/components/Layouts/Primary/NavBar/StyledComponents.ts
+++ b/src/components/Layouts/Primary/NavBar/StyledComponents.ts
@@ -1,11 +1,11 @@
-import { Button, ListItemButton } from '@mui/material';
+import { Button, ListItem, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
-export const LeafListItem = styled(ListItemButton)(() => ({
+export const LeafListItem = styled(ListItem)({
   display: 'flex',
   paddingTop: 0,
   paddingBottom: 0,
-}));
+}) as unknown as typeof ListItem;
 
 export const LeafButton = styled(Button)(({ theme }) => ({
   color: theme.palette.text.secondary,
@@ -16,7 +16,7 @@ export const LeafButton = styled(Button)(({ theme }) => ({
   width: '100%',
 }));
 
-export const Title = styled('span')(({ theme }) => ({
+export const Title = styled(Typography)(({ theme }) => ({
   color: theme.palette.common.white,
   fontSize: 16,
   marginRight: 'auto',

--- a/src/components/Layouts/Primary/TopBar/Items/NotificationMenu/NotificationMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NotificationMenu/NotificationMenu.tsx
@@ -151,6 +151,7 @@ export const NotificationContent = ({
 const NotificationMenu = ({
   isInDrawer = false,
 }: NotificationMenuProps): ReactElement => {
+  const { t } = useTranslation();
   const { classes } = useStyles();
   const accountListId = useAccountListId();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>();
@@ -234,24 +235,28 @@ const NotificationMenu = ({
     );
   }
 
+  const unread = data?.userNotifications?.unreadCount;
   return (
     <>
       <IconButton
         className={classes.link}
+        aria-label={
+          unread
+            ? t('Notifications ({{unread}} unread)', {
+                unread,
+              })
+            : t('Notifications')
+        }
         aria-controls="notification-menu"
-        aria-haspopup="true"
+        aria-haspopup="menu"
         onClick={handleClick}
       >
         <Badge
-          badgeContent={data?.userNotifications?.unreadCount}
+          badgeContent={unread}
           classes={{ badge: classes.customBadge }}
           max={99}
         >
-          {data?.userNotifications?.unreadCount !== 0 ? (
-            <NotificationsIcon />
-          ) : (
-            <NotificationsNoneIcon />
-          )}
+          {unread !== 0 ? <NotificationsIcon /> : <NotificationsNoneIcon />}
         </Badge>
       </IconButton>
       <Menu

--- a/src/components/Layouts/Primary/TopBar/Items/SearchMenu/SearchMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/SearchMenu/SearchMenu.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import SearchIcon from '@mui/icons-material/Search';
 import { IconButton } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { useTranslation } from 'react-i18next';
 import {
   DynamicSearchDialog,
   preloadSearchDialog,
@@ -17,13 +18,14 @@ const SearchButton = styled(IconButton)(() => ({
 }));
 
 const SearchMenu: React.FC = () => {
+  const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 
   return (
     <>
       <SearchButton
-        aria-controls="search-menu"
-        aria-haspopup="true"
+        aria-label={t('Search')}
+        aria-haspopup="dialog"
         onClick={() => setOpen(true)}
         onMouseEnter={preloadSearchDialog}
       >

--- a/src/components/Task/TaskRow/TaskActionPhase.tsx
+++ b/src/components/Task/TaskRow/TaskActionPhase.tsx
@@ -1,21 +1,23 @@
-import { Box, Typography } from '@mui/material';
+import { useId } from 'react';
+import { Box, ButtonBase, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { useTranslation } from 'react-i18next';
 import { ActivityData } from 'src/hooks/usePhaseData';
 
-export const SubjectWrapOuter = styled(Box)(({ theme }) => ({
+export const SubjectWrapOuter = styled(ButtonBase)(({ theme }) => ({
   width: 'fit-content',
   alignItems: 'center',
   marginRight: theme.spacing(1),
   display: 'flex',
+  '&:hover, &:focus': {
+    textDecoration: 'underline',
+  },
 }));
 
-export const SubjectWrapInner = styled(Box)(({}) => ({
+export const SubjectWrapInner = styled(Box)({
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
-  '&:hover': {
-    textDecoration: 'underline',
-  },
   display: 'flex',
   flexDirection: 'column',
   minWidth: '92px',
@@ -23,15 +25,15 @@ export const SubjectWrapInner = styled(Box)(({}) => ({
     flexDirection: 'row',
     minWidth: 'none',
   },
-}));
+});
 
-const TaskPhase = styled(Typography)(() => ({
+const TaskPhase = styled(Typography)({
   fontSize: '14px',
   letterSpacing: '0.25',
   whiteSpace: 'nowrap',
   fontWeight: 700,
   display: 'flex',
-}));
+});
 
 const TaskType = styled(Typography)(({ theme }) => ({
   fontSize: '14px',
@@ -44,16 +46,24 @@ const TaskType = styled(Typography)(({ theme }) => ({
 
 interface TaskActionPhaseProps {
   activityData: ActivityData | null | undefined;
+  describedBy?: string;
   isXs?: boolean;
 }
 
 export const TaskActionPhase: React.FC<TaskActionPhaseProps> = ({
   activityData,
+  describedBy,
   isXs = false,
 }) => {
+  const { t } = useTranslation();
+  const phaseId = useId();
+
   return (
-    <SubjectWrapOuter>
-      <SubjectWrapInner data-testid="phase-action-wrap">
+    <SubjectWrapOuter
+      aria-label={t('Edit task')}
+      aria-describedby={describedBy ? phaseId + ' ' + describedBy : phaseId}
+    >
+      <SubjectWrapInner id={phaseId} data-testid="phase-action-wrap">
         {!isXs && (
           <TaskPhase>
             {activityData?.phase ? `${activityData.phase}  ` : ''}

--- a/src/components/Task/TaskRow/TaskRow.test.tsx
+++ b/src/components/Task/TaskRow/TaskRow.test.tsx
@@ -242,6 +242,7 @@ describe('TaskRow', () => {
       const task = gqlMock<TaskRowFragment>(TaskRowFragmentDoc, {
         mocks: {
           startAt,
+          completedAt: null,
           result: ResultEnum.None,
         },
       });
@@ -262,8 +263,7 @@ describe('TaskRow', () => {
       );
 
       expect(getAllByText(task.subject).length).toBe(1);
-      userEvent.click(getByRole('img', { hidden: true, name: 'Check' }));
-      userEvent.click(getByRole('img', { hidden: true, name: 'Check' }));
+      userEvent.click(getByRole('button', { name: 'Complete Task' }));
       expect(openTaskModal).toHaveBeenCalledWith({
         taskId: task.id,
         view: TaskModalEnum.Complete,

--- a/src/components/Task/TaskRow/TaskRow.tsx
+++ b/src/components/Task/TaskRow/TaskRow.tsx
@@ -49,6 +49,8 @@ const TaskRowWrapper = styled(Box, {
 })<{ isChecked?: boolean }>(({ theme, isChecked }) => ({
   ...(isChecked ? { backgroundColor: theme.palette.cruGrayLight.main } : {}),
   minWidth: '300px',
+  width: '100%',
+  padding: theme.spacing(1),
 }));
 
 const ContactRowButton = styled(Box, {
@@ -153,10 +155,8 @@ export const TaskRow: React.FC<TaskRowProps> = ({
   const areMoreTags = tagsToShow < task.tagList.length;
 
   return (
-    <TaskRowWrapper role="row" p={1} isChecked={isChecked}>
+    <TaskRowWrapper role="row" isChecked={isChecked}>
       <ContactRowButton
-        display="flex"
-        alignItems="center"
         data-testid="task-row"
         onClick={() => onTaskCheckToggle(taskId)}
         useTopMargin={useTopMargin}

--- a/src/components/Task/TaskRow/TaskRow.tsx
+++ b/src/components/Task/TaskRow/TaskRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import LocalOffer from '@mui/icons-material/LocalOffer';
 import {
   Avatar,
@@ -153,6 +153,7 @@ export const TaskRow: React.FC<TaskRowProps> = ({
     : '';
   const tagsToShow = 3;
   const areMoreTags = tagsToShow < task.tagList.length;
+  const subjectId = useId();
 
   return (
     <TaskRowWrapper role="row" isChecked={isChecked}>
@@ -210,10 +211,15 @@ export const TaskRow: React.FC<TaskRowProps> = ({
                 }}
                 onMouseEnter={() => preloadTaskModal(TaskModalEnum.Edit)}
               >
-                <TaskActionPhase activityData={activityData} isXs={isXs} />
+                <TaskActionPhase
+                  activityData={activityData}
+                  describedBy={subjectId}
+                  isXs={isXs}
+                />
               </Box>
             )}
             <Box
+              id={subjectId}
               sx={{
                 width: '100%',
                 overflow: 'hidden',


### PR DESCRIPTION
## Description

Implements all but one of the high-priority accessibility items from the [MPDX Accessibility Roadmap](https://docs.google.com/spreadsheets/d/170qSto7vhGcfQ6ZI5kBoy__rJczxWmFcefouyThiHaY/edit?gid=990418609#gid=990418609). Each commit fixes a single issue.

## Testing

* Add labels to search, add, and notifications buttons
  * Tab through the buttons with VoiceOver enabled
  * Test that labels are announced
<img width="143" alt="Screenshot 2025-04-02 at 11 29 36 AM" src="https://github.com/user-attachments/assets/d707503c-7bb8-4504-8bdf-f217d7f405ba" />

* Prevent log task and star buttons from opening the contact
  * Click the log task and star buttons in the contact list
  * Test that the contact doesn't open in the panel
<img width="1039" alt="Screenshot 2025-04-02 at 11 31 48 AM" src="https://github.com/user-attachments/assets/4121573a-d6e8-4f36-bb0e-f3cd44cf29f6" />

* Make the Log Task icon a true button
  * Tab through the contact list to get to the Log Task button with VoiceOver
  * Test that it is focusable and its label is announced

* Make more actions keyboard navigable
  * Open a contact in the contact list
  * Tab through to get to the More Actions triple dots button
  * Test that it is focusable and its label is announced
  * Test that the menu can be navigated with the arrow keys
<img width="790" alt="Screenshot 2025-04-02 at 11 34 32 AM" src="https://github.com/user-attachments/assets/0ae37c35-1e7b-46c3-bcef-e6226b271d62" />
<img width="311" alt="Screenshot 2025-04-02 at 2 13 21 PM" src="https://github.com/user-attachments/assets/66a9375c-86b5-440e-96b3-f65b2a064643" />

* Make Show More addresses link a button
  * Open a contact in the contact list
  * Go to the Contact Details tab and find the Addresses section
  * Tab through to get to the Show X More button
  * Test that it is focusable and its label is announced
<img width="782" alt="Screenshot 2025-04-02 at 11 36 41 AM" src="https://github.com/user-attachments/assets/41f8063e-4b41-431f-8b68-985bc68e3074" />

* Add label to delete partner account buttons
  * Open a contact in the contact list
  * Go to the Contact Details tab and find the Partner Accounts section
  * Tab through to get to the Delete button
  * Test that it is focusable and its label is announced, along with the partner account that would be deleted
<img width="354" alt="Screenshot 2025-04-02 at 11 38 32 AM" src="https://github.com/user-attachments/assets/eabe03a2-0649-4c5e-9e21-7ad9e6ae9fcb" />

* Adjust edit address labels
  * Open a contact in the contact list
  * Go to the Contact Details tab and find the Addresses section
  * Tab through to get to the Edit Address button
  * Test that it is focusable and its label is Edit Address (they used to be "Edit Address Icon" and "Edit Icon")
  * Test this with the primary address and a non-primary address
<img width="338" alt="Screenshot 2025-04-02 at 11 40 55 AM" src="https://github.com/user-attachments/assets/fc38b44b-692a-4626-ae9f-062ab7de1533" />

* Improve Complete Task button label
  * Go to the tasks list
  * Tab through to get to a complete button for an incomplete task
  * Test that it switches to green when focused and has a label
  * Tab through to get to a complete button for a complete task
  * Test that it is disabled and *not* keyboard navigable (completed tasks cannot be completed again)
<img width="370" alt="Screenshot 2025-04-02 at 11 42 55 AM" src="https://github.com/user-attachments/assets/5e166c7f-5dec-4ea6-9a90-e781f359c4b0" />

* Move styles to styled components
  * Test that the styling of task rows hasn't changed
<img width="871" alt="Screenshot 2025-04-02 at 11 43 49 AM" src="https://github.com/user-attachments/assets/0e8cab37-df9d-4c3d-b3c8-a186bd563cec" />

* Make edit task button keyboard navigable
  * Go to the tasks list
  * Tab through past the complete button to the task type and phase
  * Test that is is underlined when focused, announces the label, and opens the edit task modal
<img width="241" alt="Screenshot 2025-04-02 at 11 45 02 AM" src="https://github.com/user-attachments/assets/e9a0fa32-e8a8-4d2b-8def-1349a6261ba8" />

* Fix double tabbing in Reports and Tools mobile menu items
  * Use a narrow screen to see the mobile nav
  * Tab through the menu
  * Test that you only have to tab once to get through Reports and Tools instead of twice
<img width="309" alt="Screenshot 2025-04-02 at 11 46 11 AM" src="https://github.com/user-attachments/assets/4dd99b16-a087-4d0b-8ece-107caa9e0ea2" />

* Increase contrast of mobile navbar search panel
  * Use a narrow screen to see the mobile nav
  * Type in the search box
  * Test that the text and outline is white (the outline turns yellow when it is focused)
<img width="305" alt="Screenshot 2025-04-02 at 11 46 35 AM" src="https://github.com/user-attachments/assets/621a30bb-42eb-4c68-b941-bcd6fa240f2a" />

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
