### PR TITLE
[no-Jira] Improve panel layout navigation

### DIFF
--- a/pages/accountLists/[accountListId]/reports/financialAccounts/[financialAccountId]/entries.page.test.tsx
+++ b/pages/accountLists/[accountListId]/reports/financialAccounts/[financialAccountId]/entries.page.test.tsx
@@ -69,7 +69,7 @@ describe('Financial Accounts Page', () => {
     const { findByRole } = render(<Components />);
 
     expect(
-      await findByRole('heading', { name: 'Filter (1)' }),
+      await findByRole('heading', { name: 'Filter (1 active)' }),
     ).toBeInTheDocument();
   });
 
@@ -78,11 +78,11 @@ describe('Financial Accounts Page', () => {
 
     // Filters
     expect(
-      await findByRole('heading', { name: 'Filter (1)' }),
+      await findByRole('heading', { name: 'Filter (1 active)' }),
     ).toBeInTheDocument();
     userEvent.click(getByRole('img', { name: 'Close' }));
     expect(
-      queryByRole('heading', { name: 'Filter (1)' }),
+      queryByRole('heading', { name: 'Filter (1 active)' }),
     ).not.toBeInTheDocument();
 
     // Menu

--- a/pages/accountLists/[accountListId]/reports/partnerGivingAnalysis/[[...contactId]].page.test.tsx
+++ b/pages/accountLists/[accountListId]/reports/partnerGivingAnalysis/[[...contactId]].page.test.tsx
@@ -117,7 +117,9 @@ describe('partnerGivingAnalysis page', () => {
   it('renders filters panel', async () => {
     const { findByRole } = render(<TestingComponent />);
 
-    expect(await findByRole('heading', { name: 'Filter' })).toBeInTheDocument();
+    expect(
+      await findByRole('complementary', { name: 'Filter' }),
+    ).toBeInTheDocument();
   });
 
   it('toggles filter panel', async () => {

--- a/pages/accountLists/[accountListId]/settings/Wrapper.tsx
+++ b/pages/accountLists/[accountListId]/settings/Wrapper.tsx
@@ -1,6 +1,5 @@
 import Head from 'next/head';
 import React, { useState } from 'react';
-import { Box } from '@mui/material';
 import { navBarHeight } from 'src/components/Layouts/Primary/Primary';
 import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
 import {
@@ -39,40 +38,38 @@ export const SettingsWrapper: React.FC<SettingsWrapperProps> = ({
       <Head>
         <title>{`${appName} | ${pageTitle}`}</title>
       </Head>
-      <Box component="main">
-        <SidePanelsLayout
-          isScrollBox
-          leftPanel={
-            <MultiPageMenu
-              isOpen={isNavListOpen}
-              selectedId={selectedMenuId}
-              onClose={handleNavListToggle}
-              navType={NavTypeEnum.Settings}
+      <SidePanelsLayout
+        isScrollBox
+        leftPanel={
+          <MultiPageMenu
+            isOpen={isNavListOpen}
+            selectedId={selectedMenuId}
+            onClose={handleNavListToggle}
+            navType={NavTypeEnum.Settings}
+          />
+        }
+        leftOpen={isNavListOpen}
+        leftWidth="290px"
+        mainContent={
+          <>
+            <MultiPageHeader
+              isNavListOpen={isNavListOpen}
+              onNavListToggle={handleNavListToggle}
+              title={pageHeading}
+              rightExtra={null}
+              headerType={HeaderTypeEnum.Settings}
             />
-          }
-          leftOpen={isNavListOpen}
-          leftWidth="290px"
-          mainContent={
-            <>
-              <MultiPageHeader
-                isNavListOpen={isNavListOpen}
-                onNavListToggle={handleNavListToggle}
-                title={pageHeading}
-                rightExtra={null}
-                headerType={HeaderTypeEnum.Settings}
-              />
-              <PageContentWrapper
-                maxWidth="lg"
-                style={{
-                  height: `calc(100vh - ${navBarHeight} - ${multiPageHeaderHeight})`,
-                }}
-              >
-                {children}
-              </PageContentWrapper>
-            </>
-          }
-        />
-      </Box>
+            <PageContentWrapper
+              maxWidth="lg"
+              style={{
+                height: `calc(100vh - ${navBarHeight} - ${multiPageHeaderHeight})`,
+              }}
+            >
+              {children}
+            </PageContentWrapper>
+          </>
+        }
+      />
     </>
   );
 };

--- a/pages/accountLists/[accountListId]/tools/ToolsWrapper.tsx
+++ b/pages/accountLists/[accountListId]/tools/ToolsWrapper.tsx
@@ -1,7 +1,6 @@
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React, { JSXElementConstructor, ReactElement, useState } from 'react';
-import { Box } from '@mui/material';
 import { DynamicContactsRightPanel } from 'src/components/Contacts/ContactsRightPanel/DynamicContactsRightPanel';
 import { navBarHeight } from 'src/components/Layouts/Primary/Primary';
 import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
@@ -47,59 +46,57 @@ export const ToolsWrapper: React.FC<ToolsWrapperProps> = ({
       <Head>
         <title>{`${appName} | ${pageTitle}`}</title>
       </Head>
-      <Box component="main">
-        {accountListId ? (
-          <SidePanelsLayout
-            leftOpen={isToolDrawerOpen}
-            isScrollBox={false}
-            leftPanel={
-              <NavToolList
-                selectedId={selectedMenuId || ''}
-                isOpen={isToolDrawerOpen}
-                toggle={setIsToolDrawerOpen}
-              />
-            }
-            leftWidth="290px"
-            mainContent={
-              <>
-                {showToolsHeader && (
-                  <>
-                    <MultiPageHeader
-                      isNavListOpen={isToolDrawerOpen}
-                      onNavListToggle={() =>
-                        setIsToolDrawerOpen(!isToolDrawerOpen)
-                      }
-                      title={pageTitle || ''}
-                      headerType={HeaderTypeEnum.Tools}
-                    />
-                    <PageContentWrapper
-                      maxWidth="lg"
-                      style={{
-                        height: `calc(100vh - ${navBarHeight} - ${multiPageHeaderHeight})`,
-                      }}
-                    >
-                      {children}
-                    </PageContentWrapper>
-                  </>
-                )}
-                {!showToolsHeader && children}
-              </>
-            }
-            rightPanel={
-              selectedContactId ? (
-                <ContactsWrapper>
-                  <DynamicContactsRightPanel onClose={handleCloseContact} />
-                </ContactsWrapper>
-              ) : undefined
-            }
-            rightOpen={typeof selectedContactId !== 'undefined'}
-            rightWidth="60%"
-            headerHeight={'0px'}
-          />
-        ) : (
-          <Loading loading data-testid="ToolsWrapperLoading" />
-        )}
-      </Box>
+      {accountListId ? (
+        <SidePanelsLayout
+          leftOpen={isToolDrawerOpen}
+          isScrollBox={false}
+          leftPanel={
+            <NavToolList
+              selectedId={selectedMenuId || ''}
+              isOpen={isToolDrawerOpen}
+              toggle={setIsToolDrawerOpen}
+            />
+          }
+          leftWidth="290px"
+          mainContent={
+            <>
+              {showToolsHeader && (
+                <>
+                  <MultiPageHeader
+                    isNavListOpen={isToolDrawerOpen}
+                    onNavListToggle={() =>
+                      setIsToolDrawerOpen(!isToolDrawerOpen)
+                    }
+                    title={pageTitle || ''}
+                    headerType={HeaderTypeEnum.Tools}
+                  />
+                  <PageContentWrapper
+                    maxWidth="lg"
+                    style={{
+                      height: `calc(100vh - ${navBarHeight} - ${multiPageHeaderHeight})`,
+                    }}
+                  >
+                    {children}
+                  </PageContentWrapper>
+                </>
+              )}
+              {!showToolsHeader && children}
+            </>
+          }
+          rightPanel={
+            selectedContactId ? (
+              <ContactsWrapper>
+                <DynamicContactsRightPanel onClose={handleCloseContact} />
+              </ContactsWrapper>
+            ) : undefined
+          }
+          rightOpen={typeof selectedContactId !== 'undefined'}
+          rightWidth="60%"
+          headerHeight={'0px'}
+        />
+      ) : (
+        <Loading loading data-testid="ToolsWrapperLoading" />
+      )}
     </>
   );
 };

--- a/pages/accountLists/[accountListId]/tools/ToolsWrapper.tsx
+++ b/pages/accountLists/[accountListId]/tools/ToolsWrapper.tsx
@@ -28,7 +28,6 @@ export const ToolsWrapper: React.FC<ToolsWrapperProps> = ({
   pageTitle,
   pageUrl,
   selectedMenuId,
-  showToolsHeader = true,
   children,
 }) => {
   const { push } = useRouter();
@@ -60,27 +59,20 @@ export const ToolsWrapper: React.FC<ToolsWrapperProps> = ({
           leftWidth="290px"
           mainContent={
             <>
-              {showToolsHeader && (
-                <>
-                  <MultiPageHeader
-                    isNavListOpen={isToolDrawerOpen}
-                    onNavListToggle={() =>
-                      setIsToolDrawerOpen(!isToolDrawerOpen)
-                    }
-                    title={pageTitle || ''}
-                    headerType={HeaderTypeEnum.Tools}
-                  />
-                  <PageContentWrapper
-                    maxWidth="lg"
-                    style={{
-                      height: `calc(100vh - ${navBarHeight} - ${multiPageHeaderHeight})`,
-                    }}
-                  >
-                    {children}
-                  </PageContentWrapper>
-                </>
-              )}
-              {!showToolsHeader && children}
+              <MultiPageHeader
+                isNavListOpen={isToolDrawerOpen}
+                onNavListToggle={() => setIsToolDrawerOpen(!isToolDrawerOpen)}
+                title={pageTitle || ''}
+                headerType={HeaderTypeEnum.Tools}
+              />
+              <PageContentWrapper
+                maxWidth="lg"
+                style={{
+                  height: `calc(100vh - ${navBarHeight} - ${multiPageHeaderHeight})`,
+                }}
+              >
+                {children}
+              </PageContentWrapper>
             </>
           }
           rightPanel={

--- a/pages/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]].page.test.tsx
+++ b/pages/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]].page.test.tsx
@@ -210,7 +210,9 @@ describe('Appeal navigation', () => {
     userEvent.click(getByRole('img', { name: 'Toggle Filter Panel' }));
 
     await waitFor(() => {
-      expect(getByRole('heading', { name: 'Filter' })).toBeInTheDocument();
+      expect(
+        getByRole('complementary', { name: 'Filter' }),
+      ).toBeInTheDocument();
       expect(
         getByRole('heading', { name: 'See More Filters' }),
       ).toBeInTheDocument();

--- a/pages/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]].page.tsx
@@ -1,23 +1,23 @@
+import Head from 'next/head';
 import React, { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import AppealsDetailsPage from 'src/components/Tool/Appeal/AppealDetails/AppealsDetailsPage';
-import { ToolsWrapper } from '../../ToolsWrapper';
+import useGetAppSettings from 'src/hooks/useGetAppSettings';
 import { AppealsWrapper } from '../AppealsWrapper';
 
 const Appeals = (): ReactElement => {
   const { t } = useTranslation();
-  const pageUrl = 'appeals';
+  const { appName } = useGetAppSettings();
+  const pageTitle = t('Appeals');
 
   return (
-    <ToolsWrapper
-      pageTitle={t('Appeals')}
-      pageUrl={pageUrl}
-      selectedMenuId="appeals"
-      showToolsHeader={false}
-    >
+    <>
+      <Head>
+        <title>{`${appName} | ${pageTitle}`}</title>
+      </Head>
       <AppealsDetailsPage />
-    </ToolsWrapper>
+    </>
   );
 };
 

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsHeader.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsHeader.tsx
@@ -175,7 +175,11 @@ export const ContactDetailsHeader: React.FC<Props> = ({
             </Box>
           ) : (
             <>
-              <PrimaryContactName data-testid="ContactName" variant="h5">
+              <PrimaryContactName
+                data-testid="ContactName"
+                variant="h5"
+                id="right-panel-header"
+              >
                 {data?.contact.name}
               </PrimaryContactName>
               <IconButton

--- a/src/components/Contacts/ContactsMap/ContactsMapPanel.tsx
+++ b/src/components/Contacts/ContactsMap/ContactsMapPanel.tsx
@@ -169,7 +169,9 @@ export const ContactsMapPanel: React.FC<ContactMapsPanelProps> = ({
     <>
       <Box padding={2}>
         <Box display="flex" justifyContent="space-between" alignItems="center">
-          <Typography variant="h6">{t('Partners by Status')}</Typography>
+          <Typography variant="h6" id="left-panel-header">
+            {t('Partners by Status')}
+          </Typography>
           <IconButton onClick={onClose} aria-label={t('Close')}>
             <Close titleAccess={t('Close')} />
           </IconButton>

--- a/src/components/Layouts/SidePanelsLayout.tsx
+++ b/src/components/Layouts/SidePanelsLayout.tsx
@@ -118,20 +118,6 @@ export const SidePanelsLayout: FC<SidePanelsLayoutProps> = ({
 
   return (
     <OuterWrapper>
-      <RightPanelWrapper
-        component="aside"
-        aria-labelledby="right-panel-header"
-        data-testid="RightPanelWrapper"
-        width={isMobile ? '100%' : rightWidth}
-        headerHeight={headerHeight}
-        isScrollable
-        style={{
-          transform: rightOpen ? 'none' : 'translate(100%)',
-        }}
-        id="scrollOverride"
-      >
-        {rightOpen && rightPanel}
-      </RightPanelWrapper>
       <ExpandingContent open={rightOpen}>
         <CollapsibleWrapper justifyContent="flex-end">
           <LeftPanelWrapper
@@ -151,6 +137,20 @@ export const SidePanelsLayout: FC<SidePanelsLayoutProps> = ({
           </ExpandingContent>
         </CollapsibleWrapper>
       </ExpandingContent>
+      <RightPanelWrapper
+        component="aside"
+        aria-labelledby="right-panel-header"
+        data-testid="RightPanelWrapper"
+        width={isMobile ? '100%' : rightWidth}
+        headerHeight={headerHeight}
+        isScrollable
+        style={{
+          transform: rightOpen ? 'none' : 'translate(100%)',
+        }}
+        id="scrollOverride"
+      >
+        {rightOpen && rightPanel}
+      </RightPanelWrapper>
     </OuterWrapper>
   );
 };

--- a/src/components/Layouts/SidePanelsLayout.tsx
+++ b/src/components/Layouts/SidePanelsLayout.tsx
@@ -11,10 +11,10 @@ interface ToolbarMixin extends CSSProperties {
   };
 }
 
-type FullHeightBoxProps = {
+interface FullHeightBoxProps {
   isScrollable?: boolean;
   headerHeight: number | string;
-};
+}
 
 const FullHeightBox = styled(Box, {
   shouldForwardProp: (prop) =>
@@ -119,6 +119,8 @@ export const SidePanelsLayout: FC<SidePanelsLayoutProps> = ({
   return (
     <OuterWrapper>
       <RightPanelWrapper
+        component="aside"
+        aria-labelledby="right-panel-header"
         data-testid="RightPanelWrapper"
         width={isMobile ? '100%' : rightWidth}
         headerHeight={headerHeight}
@@ -133,6 +135,8 @@ export const SidePanelsLayout: FC<SidePanelsLayoutProps> = ({
       <ExpandingContent open={rightOpen}>
         <CollapsibleWrapper justifyContent="flex-end">
           <LeftPanelWrapper
+            component="aside"
+            aria-labelledby="left-panel-header"
             width={leftWidth}
             flexBasis={leftWidth}
             headerHeight="0px"
@@ -142,7 +146,9 @@ export const SidePanelsLayout: FC<SidePanelsLayoutProps> = ({
           >
             {leftOpen && leftPanel}
           </LeftPanelWrapper>
-          <ExpandingContent open={leftOpen}>{mainContent}</ExpandingContent>
+          <ExpandingContent component="main" open={leftOpen}>
+            {mainContent}
+          </ExpandingContent>
         </CollapsibleWrapper>
       </ExpandingContent>
     </OuterWrapper>

--- a/src/components/Shared/Filters/FilterPanel.tsx
+++ b/src/components/Shared/Filters/FilterPanel.tsx
@@ -614,9 +614,9 @@ export const FilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
                 justifyContent="space-between"
                 alignItems="center"
               >
-                <Typography variant="h6">
+                <Typography variant="h6" id="left-panel-header">
                   {selectedFilterCount > 0
-                    ? t('Filter ({{count}})', {
+                    ? t('Filter ({{count}} active)', {
                         count: selectedFilterCount,
                       })
                     : t('Filter')}

--- a/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.tsx
@@ -143,7 +143,9 @@ export const MultiPageMenu: React.FC<Props & BoxProps> = ({
                 justifyContent="space-between"
                 alignItems="center"
               >
-                <Typography variant="h6">{navTitle}</Typography>
+                <Typography variant="h6" id="left-panel-header">
+                  {navTitle}
+                </Typography>
                 <IconButton onClick={onClose}>
                   <Close titleAccess={t('Close')} />
                 </IconButton>

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
@@ -126,7 +126,9 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
                 justifyContent="space-between"
                 alignItems="center"
               >
-                <Typography variant="h6">{t('Appeals')}</Typography>
+                <Typography variant="h6" id="left-panel-header">
+                  {t('Appeals')}
+                </Typography>
                 <IconButton
                   onClick={onClose}
                   aria-label={t('Close')}

--- a/src/components/Tool/NavToolList/NavToolList.tsx
+++ b/src/components/Tool/NavToolList/NavToolList.tsx
@@ -79,7 +79,9 @@ const NavToolList = ({ selectedId, isOpen, toggle }: Props): ReactElement => {
                 justifyContent="space-between"
                 alignItems="center"
               >
-                <Typography variant="h6">{t('Tools')}</Typography>
+                <Typography variant="h6" id="left-panel-header">
+                  {t('Tools')}
+                </Typography>
                 <IconButton
                   data-testid="ToolNavToggle"
                   onClick={() => toggle(!isOpen)}


### PR DESCRIPTION
## Description

* Use `aside` element for left and right panels.
* Use `main` element for main content.
* Add labels to left and right panels.

## Testing

* Go to the Contacts page
  * Use Ctrl+Option+Shift+Right/Left to navigate between the left panel, main content, and right panel (if it is moving between navbar items use Ctrl+Option+Shift+Up to navigate out of the navbar)
  * After opening a contact, Press Ctrl+Option+Shift+Up twice, then Ctrl+Option+Shift+Right to get to the contact's panel.

Other improvements are possible, but the main areas of the layout are much easier to navigate between in VoiceOver. I'm assuming that other accessibility software has similar methods for jumping between sections of the page.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
