### PR TITLE
[HS-1334026] Avoid dropping pages with concurrent requests to the same nodes list

### DIFF
--- a/src/lib/apollo/cache.test.ts
+++ b/src/lib/apollo/cache.test.ts
@@ -1,0 +1,81 @@
+import { InMemoryCache } from '@apollo/client';
+import { gqlMock } from '__tests__/util/graphqlMocking';
+import {
+  GetNotificationsDocument,
+  GetNotificationsQuery,
+  GetNotificationsQueryVariables,
+} from 'src/components/Layouts/Primary/TopBar/Items/NotificationMenu/GetNotificationsQuery.generated';
+import { createCache } from './cache';
+
+const variables: GetNotificationsQueryVariables = {
+  accountListId: 'account-list-1',
+};
+
+const readCache = (
+  cache: InMemoryCache,
+): GetNotificationsQuery | null | undefined =>
+  cache.readQuery<GetNotificationsQuery, GetNotificationsQueryVariables>({
+    query: GetNotificationsDocument,
+    variables: variables,
+  });
+
+const writeCache = (
+  cache: InMemoryCache,
+  page: number,
+  nodeCount: number,
+  unreadCount: number = 0,
+) => {
+  const after = page === 0 ? null : page.toString();
+  const endCursor = (page + 1).toString();
+
+  // Now write page one and page four to the cache simultaneously
+  cache.writeQuery<GetNotificationsQuery, GetNotificationsQueryVariables>({
+    query: GetNotificationsDocument,
+    variables: { ...variables, after },
+    data: gqlMock<GetNotificationsQuery, GetNotificationsQueryVariables>(
+      GetNotificationsDocument,
+      {
+        variables,
+        mocks: {
+          userNotifications: {
+            nodes: new Array(nodeCount).fill(undefined).map(() => ({})),
+            pageInfo: {
+              endCursor,
+              hasNextPage: true,
+            },
+            unreadCount,
+          },
+        },
+      },
+    ),
+  });
+};
+
+describe('cache', () => {
+  it('handles concurrent queries to the same page list', () => {
+    const cache = createCache();
+
+    // Prime the cache with 3 pages loaded of data
+    writeCache(cache, 3, 9);
+
+    // Now write page one and page four to the cache simultaneously
+    writeCache(cache, 0, 3);
+    writeCache(cache, 3, 3);
+
+    // Check that endCursor is ready to load page 2 next
+    const data = readCache(cache);
+    expect(data?.userNotifications.nodes).toHaveLength(3);
+    expect(data?.userNotifications.pageInfo.endCursor).toBe('1');
+  });
+
+  it('preserves extra fields', () => {
+    const cache = createCache();
+
+    // Write the same page twice but change an extra field: `unreadCount`
+    writeCache(cache, 0, 3, 100);
+    writeCache(cache, 0, 3, 0);
+
+    // Ensure that the last value written wins
+    expect(readCache(cache)?.userNotifications.unreadCount).toBe(0);
+  });
+});

--- a/src/lib/apollo/relayStylePaginationWithNodes.tsx
+++ b/src/lib/apollo/relayStylePaginationWithNodes.tsx
@@ -75,19 +75,23 @@ export function relayStylePaginationWithNodes<TNode = Reference>(
     merge(
       existing = makeEmptyData(),
       incoming,
-      { args, isReference, readField, mergeObjects },
+      { args, isReference, readField },
     ) {
-      // `merge` can be called multiple times with the same incoming data as Apollo recursively
-      // merges data at various levels in the tree. If the incoming data is the same as the existing
-      // data, simply ignore it.
-      if (
-        incoming.pageInfo?.endCursor &&
-        incoming.pageInfo?.endCursor === existing.pageInfo.endCursor
-      ) {
-        return mergeObjects(
-          existing,
-          __rest(incoming, ['edges', 'nodes', 'pageInfo']),
-        );
+      // If the cache already contains some but not all of the pages, a
+      // `useQuery`/`useFetchAllPages` pair can quickly corrupt it.
+      // 1. `useQuery` attempts to fetch the first page, while `useFetchAllPages` simultaneously
+      //    attempts to fetch the next page after the last one in the cache.
+      // 2. `BatchHttpLink` batches the requests and responses together.
+      // 3. Apollo cache receives the responses and overwrites the pages with the `useQuery`
+      //    response. It then immediately overwrites those pages with the `useFetchAllPages`
+      //    response. The first few pages have been overwritten and lost.
+      // 4. `useFetchAllPages` continues fetching the next pages without ever recovering the missing
+      //    initial pages.
+      // When we detect this situation, we keep the first page (the one without `after`) and ignore
+      // the second one
+      if (args?.after && args.after !== existing.pageInfo.endCursor) {
+        // This page does not come after the one in the cache, so ignore it
+        return existing;
       }
 
       const incomingEdges = incoming.edges


### PR DESCRIPTION
## Description

### History

For months, we've had issues with the Apollo cache sometimes losing dropping the initial pages of data when it loads more pages with `fetchMore` or `fetchAllPages`. #1259 tried to fix this, and it may have helped in some cases. Unfortunately, it another edge case that was fixed in #1296. However, [users](https://secure.helpscout.net/conversation/2891583216/1334026?viewId=7296729) were still seeing pages being dropped, specifically on the donations page.

### Reproduction

I was eventually able to start reproducing this bug when I bumped the `batchInterval` in `src/lib/apollo/link.ts` to 1000 (one second). That caused more requests to be batched, and I noticed that the data loss happened when multiple requests to the same page list were combined into the same page. For example, a request that loads the donations in January without an `after` cursor and a request that loads the donations in January with an `after` cursor.

### Fix

After fixing that (see the code and comment for details), I realized that this was the same underlying issue that #1259 was trying to fix. Specifically on the coaching lists page, the first page of coaches was being dropped. This is because the NavBar and NavMenu both load the coaching list in addition to the page itself. When those requests were batched and deduplicated, `merge` ran multiple times with the same data. It is not because of recursive merges like I originally thought when I wrote the comment.

### Tests

The test cases minimally reproduce the bugs I was able to reproduce while testing. I used TDD to ensure that the tests fail before my change and that my change fixes them. I also removed the existing cursor check because the test fails with both checks absent (i.e. the state of `relayStylePaginationWithNodes` before #1259) and passes with the code in this PR. I also added a test case to ensure that the bug in #1296 doesn't resurface.

### UI Testing

* Setup
  * Remove the additional checks from `relayStylePaginationWithNodes` added in this PR and in #1259 (`git restore src/lib/apollo/relayStylePaginationWithNodes.tsx --source=7e336a6f8c2ce8ff42cb55ba30683328e190f143`)
  * Change the `batchInterval` in `src/lib/apollo/link.ts` to `1000`
  * Change the page size in `LoadCoachingList.graphql` to `1`
* Test 1
  * Go to the coaching accounts page on an account with at least 2 coaching accounts
  * See that it loads the first page then replaces it with the first page
* Test 2
  * Go to the donations report on a month with around 100 donations (feel free to impersonate my account)
  * Click on a month and let it load a couple of pages of donations **but not all of them**
  * Switch to a different month and let it load
  * Switch back to the first month
  * See that it drops the first few pages of donations
  * You may have to try it a couple of times to reproduce
* Revert the code changes to `relayStylePaginationWithNodes` and make sure that you can't reproduce either bug anymore (keep the changes to `link.ts` and `LoadCoachingList.graphql`

Motivating HelpScout ticket: https://secure.helpscout.net/conversation/2891583216/1334026?viewId=7296729

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
