### PR TITLE
[MPDX-8579] Replace machine-calculated labels with NetSuite-calculated

### DIFF
--- a/src/components/AccountLists/AccountLists.test.tsx
+++ b/src/components/AccountLists/AccountLists.test.tsx
@@ -73,7 +73,7 @@ describe('AccountLists', () => {
       </ThemeProvider>,
     );
     expect(getByRole('link')).toHaveTextContent(
-      'AccountGoal$1,000*Gifts Started60%Committed80%*Below machine-calculated goal',
+      'AccountGoal$1,000*Gifts Started60%Committed80%*Below NetSuite-calculated goal',
     );
   });
 
@@ -104,7 +104,7 @@ describe('AccountLists', () => {
       </ThemeProvider>,
     );
     expect(getByRole('link')).toHaveTextContent(
-      'AccountGoal$2,000*Gifts Started30%Committed40%*machine-calculated',
+      'AccountGoal$2,000*Gifts Started30%Committed40%*NetSuite-calculated',
     );
   });
 
@@ -133,9 +133,9 @@ describe('AccountLists', () => {
       </ThemeProvider>,
     );
     expect(
-      getByLabelText(/^Your current goal of \$2,000 is machine-calculated/),
+      getByLabelText(/^Your current goal of \$2,000 is NetSuite-calculated/),
     ).toBeInTheDocument();
-    expect(getByText('machine-calculated')).toHaveStyle(
+    expect(getByText('NetSuite-calculated')).toHaveStyle(
       'color: rgb(211, 68, 0);',
     );
   });
@@ -236,7 +236,7 @@ describe('AccountLists', () => {
           <AccountLists data={data} />
         </ThemeProvider>,
       );
-      expect(getByText('Below machine-calculated goal')).toBeInTheDocument();
+      expect(getByText('Below NetSuite-calculated goal')).toBeInTheDocument();
     });
 
     it('is hidden if goal is greater than or equal to the machine-calculated goal', async () => {
@@ -263,7 +263,7 @@ describe('AccountLists', () => {
         </ThemeProvider>,
       );
       expect(
-        queryByText('Below machine-calculated goal'),
+        queryByText('Below NetSuite-calculated goal'),
       ).not.toBeInTheDocument();
     });
   });

--- a/src/components/AccountLists/AccountLists.test.tsx
+++ b/src/components/AccountLists/AccountLists.test.tsx
@@ -45,7 +45,7 @@ describe('AccountLists', () => {
     ).toBeInTheDocument();
   });
 
-  it('ignores machine calculated goal when monthly goal is set', () => {
+  it('ignores machine-calculated goal when monthly goal is set', () => {
     const data = gqlMock<GetAccountListsQuery>(GetAccountListsDocument, {
       mocks: {
         accountLists: {
@@ -77,7 +77,7 @@ describe('AccountLists', () => {
     );
   });
 
-  it('uses machine calculated goal when goal is not set', () => {
+  it('uses machine-calculated goal when goal is not set', () => {
     const data = gqlMock<GetAccountListsQuery>(GetAccountListsDocument, {
       mocks: {
         accountLists: {
@@ -108,7 +108,7 @@ describe('AccountLists', () => {
     );
   });
 
-  it('adds color and label to machine calculated goals', () => {
+  it('adds color and label to machine-calculated goals', () => {
     const data = gqlMock<GetAccountListsQuery>(GetAccountListsDocument, {
       mocks: {
         accountLists: {
@@ -140,7 +140,7 @@ describe('AccountLists', () => {
     );
   });
 
-  it("hides percentages when machine calculated goal currency differs from user's currency", () => {
+  it("hides percentages when machine-calculated goal currency differs from user's currency", () => {
     const data = gqlMock<GetAccountListsQuery>(GetAccountListsDocument, {
       mocks: {
         accountLists: {

--- a/src/components/AccountLists/AccountLists.tsx
+++ b/src/components/AccountLists/AccountLists.tsx
@@ -111,12 +111,12 @@ const AccountLists = ({ data }: Props): ReactElement => {
 
               const annotation: Annotation | null = preferencesGoalLow
                 ? {
-                    label: t('Below machine-calculated goal'),
+                    label: t('Below NetSuite-calculated goal'),
                     color: 'statusWarning.main',
                   }
                 : goalSource === GoalSource.MachineCalculated
                 ? {
-                    label: t('machine-calculated'),
+                    label: t('NetSuite-calculated'),
                     color: 'statusWarning.main',
                   }
                 : preferencesGoalUpdatedAt
@@ -156,7 +156,7 @@ const AccountLists = ({ data }: Props): ReactElement => {
                                 title={
                                   goalSource === GoalSource.MachineCalculated &&
                                   t(
-                                    'Your current goal of {{goal}} is machine-calculated, based on the past year of NetSuite data. You can adjust this goal in your settings preferences.',
+                                    'Your current goal of {{goal}} is NetSuite-calculated, based on the past year of NetSuite data. You can adjust this goal in your settings preferences.',
                                     {
                                       goal: currencyFormat(
                                         goal,

--- a/src/components/Dashboard/DonationHistories/graphData.test.ts
+++ b/src/components/Dashboard/DonationHistories/graphData.test.ts
@@ -81,7 +81,7 @@ describe('calculateGraphData', () => {
       ]);
     });
 
-    it('uses the machine calculated goal when the staff entered goal is missing', () => {
+    it('uses the machine-calculated goal when the staff entered goal is missing', () => {
       const data = gqlMock<
         GetDonationGraphQuery,
         GetDonationGraphQueryVariables

--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.test.tsx
@@ -317,7 +317,7 @@ describe('MonthlyGoal', () => {
         );
 
         expect(
-          await findByText('Below machine-calculated goal'),
+          await findByText('Below NetSuite-calculated goal'),
         ).toBeInTheDocument();
       });
 
@@ -331,7 +331,7 @@ describe('MonthlyGoal', () => {
 
         await waitFor(() =>
           expect(
-            queryByText('Below machine-calculated goal'),
+            queryByText('Below NetSuite-calculated goal'),
           ).not.toBeInTheDocument(),
         );
       });

--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
@@ -121,7 +121,7 @@ const MonthlyGoal = ({
       );
     } else if (machineCalculatedGoal) {
       return t(
-        'Your current goal of {{goal}} is machine-calculated, based on the past year of NetSuite data. You can adjust this goal in your settings preferences.',
+        'Your current goal of {{goal}} is NetSuite-calculated, based on the past year of NetSuite data. You can adjust this goal in your settings preferences.',
         { goal: currencyFormat(machineCalculatedGoal, currency, locale) },
       );
     } else {
@@ -142,12 +142,12 @@ const MonthlyGoal = ({
 
   const annotation: Annotation | null = preferencesGoalLow
     ? {
-        label: t('Below machine-calculated goal'),
+        label: t('Below NetSuite-calculated goal'),
         warning: true,
       }
     : goalSource === GoalSource.MachineCalculated
     ? {
-        label: t('Machine-calculated goal'),
+        label: t('NetSuite-calculated goal'),
         warning: true,
       }
     : preferencesGoalUpdatedAt

--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.test.tsx
@@ -132,7 +132,7 @@ describe('MonthlyGoalAccordion', () => {
 
       await waitFor(() =>
         expect(getByTestId('AccordionSummaryValue')).toHaveTextContent(
-          '$100 (below machine-calculated support goal)',
+          '$100 (below NetSuite-calculated support goal)',
         ),
       );
     });
@@ -149,7 +149,7 @@ describe('MonthlyGoalAccordion', () => {
 
       await waitFor(() =>
         expect(getByTestId('AccordionSummaryValue')).not.toHaveTextContent(
-          /below machine-calculated support goal/,
+          /below NetSuite-calculated support goal/,
         ),
       );
     });

--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
@@ -98,7 +98,7 @@ export const MonthlyGoalAccordion: React.FC<MonthlyGoalAccordionProps> = ({
       if (preferencesGoalLow) {
         return (
           <Typography component="span" color="statusWarning.main">
-            {t('{{goal}} (below machine-calculated support goal)', { goal })}
+            {t('{{goal}} (below NetSuite-calculated support goal)', { goal })}
           </Typography>
         );
       } else if (preferencesGoalUpdatedAt) {


### PR DESCRIPTION
## Description

Replace all user-facing labels that say "machine-calculated" with the phrase "NetSuite-calculated". I'm not renaming the comments, variables, or test case names because the GraphQL fields are still reference `machineCalculated`. NetSuite only needs to show up in messaging to the user.

MPDX-8579

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
