### PR TITLE
MPDX-8523 - Move Due Date and Due Time onto same line in Mass Edit Task Modal.

### DIFF
--- a/src/components/Task/MassActions/EditTasks/MassActionsEditTasksModal.tsx
+++ b/src/components/Task/MassActions/EditTasks/MassActionsEditTasksModal.tsx
@@ -213,25 +213,7 @@ export const MassActionsEditTasksModal: React.FC<
                     onChange={(userId) => setFieldValue('userId', userId)}
                   />
                 </Grid>
-                {!noDueDate && (
-                  <DateTimeFieldPair
-                    dateLabel={t('Due Date')}
-                    timeLabel={t('Due Time')}
-                    value={startAt}
-                    onChange={(date) => setFieldValue('startAt', date)}
-                    render={(dateField, timeField) => (
-                      <>
-                        <Grid item xs={12} sm={6}>
-                          {dateField}
-                        </Grid>
-                        <Grid item xs={12} sm={6}>
-                          {timeField}
-                        </Grid>
-                      </>
-                    )}
-                  />
-                )}
-                <Grid item xs={12} sm={6}>
+                <Grid item xs={12} sm={12}>
                   <FormControlLabel
                     control={<Checkbox checked={noDueDate} color="secondary" />}
                     label={t('No Due Date')}
@@ -239,6 +221,24 @@ export const MassActionsEditTasksModal: React.FC<
                     onChange={handleChange}
                   />
                 </Grid>
+                {!noDueDate && (
+                  <DateTimeFieldPair
+                    dateLabel={t('Due Date')}
+                    timeLabel={t('Due Time')}
+                    value={startAt}
+                    onChange={(date) => setFieldValue('startAt', date)}
+                    render={(dateField, timeField) => (
+                      <Grid sx={{ ml: 0, mt: 0 }} container spacing={2} xs={12}>
+                        <Grid item xs={12} sm={6}>
+                          {dateField}
+                        </Grid>
+                        <Grid item xs={12} sm={6}>
+                          {timeField}
+                        </Grid>
+                      </Grid>
+                    )}
+                  />
+                )}
                 <Grid item xs={12}>
                   <TextField
                     label={t('Add New Comment')}


### PR DESCRIPTION
## Description

In the mass edit tasks modal, I think we should put the due date and due time next to each other on the same line instead of split up on different lines. Jira ticket available [here](https://jira.cru.org/browse/MPDX-8523).

I requested Ryan's Guinee's feedback on wether the "No Due Date" option should go on it's own line or share a line with Assignee. He suggested it should be on it's own line.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
