### PR TITLE
MPDX-8620 - Only Show Fill Out Weekly Report button show for those with reports

### DIFF
--- a/src/components/Dashboard/ThisWeek/WeeklyActivity/WeeklyActivity.test.tsx
+++ b/src/components/Dashboard/ThisWeek/WeeklyActivity/WeeklyActivity.test.tsx
@@ -9,7 +9,16 @@ import {
   GetWeeklyActivityQueryDefaultMocks,
   GetWeeklyActivityQueryLoadingMocks,
 } from './WeeklyActivity.mock';
+import {
+  EmptyCoachingAnswerSetMock,
+  PopulateCoachingAnswerSetMock,
+} from './WeeklyReportModal/WeeklyReport.mock';
 import WeeklyActivity from '.';
+
+// Mock the useOrganizationId hook
+jest.mock('src/hooks/useOrganizationId', () => ({
+  useOrganizationId: () => 'org-123',
+}));
 
 const accountListId = 'abc';
 
@@ -121,7 +130,10 @@ describe('WeeklyActivity', () => {
       <SnackbarProvider>
         <ThemeProvider theme={theme}>
           <MockedProvider
-            mocks={GetWeeklyActivityQueryDefaultMocks()}
+            mocks={[
+              ...GetWeeklyActivityQueryDefaultMocks(),
+              PopulateCoachingAnswerSetMock(),
+            ]}
             addTypename={false}
           >
             <WeeklyActivity accountListId={accountListId} />
@@ -134,5 +146,33 @@ describe('WeeklyActivity', () => {
       await findByRole('button', { name: 'Fill out weekly report' }),
     );
     expect(await findByLabelText('Weekly Report')).toBeInTheDocument();
+  });
+
+  it('should not show Fill out weekly report button', async () => {
+    const { queryByRole, findByRole } = render(
+      <SnackbarProvider>
+        <ThemeProvider theme={theme}>
+          <MockedProvider
+            mocks={[
+              ...GetWeeklyActivityQueryDefaultMocks(),
+              EmptyCoachingAnswerSetMock(),
+            ]}
+            addTypename={false}
+          >
+            <WeeklyActivity accountListId={accountListId} />
+          </MockedProvider>
+        </ThemeProvider>
+      </SnackbarProvider>,
+    );
+
+    expect(
+      await findByRole('link', { name: 'View Activity Detail' }),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        queryByRole('button', { name: 'Fill out weekly report' }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/Dashboard/ThisWeek/WeeklyActivity/WeeklyReportModal/WeeklyReport.mock.ts
+++ b/src/components/Dashboard/ThisWeek/WeeklyActivity/WeeklyReportModal/WeeklyReport.mock.ts
@@ -1,0 +1,72 @@
+import { MockedResponse } from '@apollo/client/testing';
+import {
+  CurrentCoachingAnswerSetDocument,
+  CurrentCoachingAnswerSetQuery,
+} from './WeeklyReportModal.generated';
+
+const populatedCoachingAnswerSet: CurrentCoachingAnswerSetQuery = {
+  currentCoachingAnswerSet: {
+    questions: [
+      {
+        id: 'question-1',
+        prompt: 'What is your goal for this week?',
+        required: true,
+        position: 1,
+      },
+      {
+        id: 'question-2',
+        prompt: 'Rate your progress on a scale of 1 to 5.',
+        required: true,
+        position: 2,
+      },
+      {
+        id: 'question-3',
+        prompt: 'What challenges did you face?',
+        required: true,
+        position: 3,
+      },
+    ],
+    answers: [],
+    id: 'answer-set-123',
+    completedAt: null,
+  },
+};
+
+const emptyCoachingAnswerSet: CurrentCoachingAnswerSetQuery = {
+  currentCoachingAnswerSet: {
+    questions: [],
+    answers: [],
+    id: 'answer-set-123',
+    completedAt: null,
+  },
+};
+
+export const PopulateCoachingAnswerSetMock = (): MockedResponse => {
+  return {
+    request: {
+      query: CurrentCoachingAnswerSetDocument,
+      variables: {
+        accountListId: 'abc',
+        organizationId: 'org-123',
+      },
+    },
+    result: {
+      data: populatedCoachingAnswerSet,
+    },
+  };
+};
+
+export const EmptyCoachingAnswerSetMock = (): MockedResponse => {
+  return {
+    request: {
+      query: CurrentCoachingAnswerSetDocument,
+      variables: {
+        accountListId: 'abc',
+        organizationId: 'org-123',
+      },
+    },
+    result: {
+      data: emptyCoachingAnswerSet,
+    },
+  };
+};


### PR DESCRIPTION
## Description

FILL OUT WEEKLY REPORT is only available if the account is shared with a coach.  Make this available even if there is no coach.   I (Scott Paros) also believe this report is only set up properly for US staff, but the report link to the questions is available for global staff as well.  We need to hide this link for global staff.

This PR really only addresses the second part of this request as "Weekly Reports" don't seem to be dependent on being shared with a coach. At least as far as I can tell.

Jira ticket available [here](https://jira.cru.org/browse/MPDX-8620)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
