### PR TITLE
MPDX-7917 Fixed missing alert message when uploading the same large image

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonName/PersonName.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonName/PersonName.tsx
@@ -71,6 +71,9 @@ export const PersonName: React.FC<PersonNameProps> = ({
     if (personId && file) {
       setAvatar(file);
     }
+    // Please do not remove this line
+    // It is essential for the file size validation alert on repeated uploads
+    event.target.value = '';
   };
 
   return (


### PR DESCRIPTION
## Description

Initially, HelpScout reported wanting to upgrade the UI to show an alert message when uploading images larger than 1MB. It was discovered that this ticket was already resolved, however, there was a minor issue missed. When attempting to upload the same file twice, the alert message would not appear. I found out handling a file change would only be triggered if the file input was changed. To fix this, I reset the input to ensure uploading the same file could be attempted more than once. 

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
