### PR TITLE
MPDX-8593 Move Action enum to its own file for bundle analysis

### DIFF
--- a/src/components/Shared/MassActions/TasksMassActionsDropdown.tsx
+++ b/src/components/Shared/MassActions/TasksMassActionsDropdown.tsx
@@ -27,7 +27,7 @@ import { ResultEnum } from 'src/graphql/types.generated';
 import { useUpdateTasksQueries } from 'src/hooks/useUpdateTasksQueries';
 import { dispatch } from 'src/lib/analytics';
 import { useAccountListId } from '../../../hooks/useAccountListId';
-import { Action } from '../../Task/MassActions/ConfirmationModal/MassActionsTasksConfirmationModal';
+import { Action } from '../../Task/MassActions/ConfirmationModal/ActionEnum';
 import { MassActionsDropdown } from './MassActionsDropdown';
 
 interface TasksMassActionsDropdownProps {

--- a/src/components/Task/MassActions/ConfirmationModal/ActionEnum.ts
+++ b/src/components/Task/MassActions/ConfirmationModal/ActionEnum.ts
@@ -1,0 +1,4 @@
+export enum Action {
+  Complete = 'complete',
+  Delete = 'delete',
+}

--- a/src/components/Task/MassActions/ConfirmationModal/MassActionsTasksConfirmationModal.tsx
+++ b/src/components/Task/MassActions/ConfirmationModal/MassActionsTasksConfirmationModal.tsx
@@ -13,11 +13,8 @@ import {
   SubmitButton,
 } from 'src/components/common/Modal/ActionButtons/ActionButtons';
 import Modal from '../../../common/Modal/Modal';
+import { Action } from './ActionEnum';
 
-export enum Action {
-  Complete = 'complete',
-  Delete = 'delete',
-}
 interface MassActionsTasksConfirmationModalProps {
   open: boolean;
   action: Action;


### PR DESCRIPTION
## Description

After merging the changes made for MPDX-8593, it was realized that the bundle analyzer increased the bundle size. To lower this cost, I have moved the Action enum into a separate file and updated the imports. This should eliminate any doubt that the old file containing the enum is being pulled altogether instead of the desired snippet of code. 

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
