### PR TITLE
MPDX-8593 Fixed missing language translation for actions

### DIFF
--- a/src/components/Task/MassActions/ConfirmationModal/MassActionsTasksConfirmationModal.tsx
+++ b/src/components/Task/MassActions/ConfirmationModal/MassActionsTasksConfirmationModal.tsx
@@ -28,6 +28,9 @@ export const MassActionsTasksConfirmationModal: React.FC<
 > = ({ open, idsCount, action, setOpen, onConfirm }) => {
   const { t } = useTranslation();
 
+  const translatedAction =
+    action === Action.Complete ? t('complete') : t('delete');
+
   const [hasConfirmedDeletion, setHasConfirmedDeletion] = useState(false);
 
   const shouldConfirmDeletion = useMemo(() => {
@@ -51,7 +54,7 @@ export const MassActionsTasksConfirmationModal: React.FC<
           <Typography>
             {t(
               'Are you sure you wish to {{action}} the {{count}} selected tasks?',
-              { action, count: idsCount },
+              { action: translatedAction, count: idsCount },
             )}
           </Typography>
         ) : (
@@ -71,7 +74,7 @@ export const MassActionsTasksConfirmationModal: React.FC<
               }
               label={t(
                 'Yes, I want to {{action}} the {{count}} selected tasks.',
-                { action, count: idsCount },
+                { action: translatedAction, count: idsCount },
               )}
               data-testid="confirmDeletionCheckbox"
             />


### PR DESCRIPTION
## Description

It was brought to my attention that the `action` variable was not translating correctly based on the selected language inside the delete/complete task confirmation box. I have added the logic to ensure that each action is being translated properly.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
