### PR TITLE
MPDX-8663 Fix dashboard weekly report count

### DIFF
--- a/src/common/Selects/PledgeFrequencySelect.test.tsx
+++ b/src/common/Selects/PledgeFrequencySelect.test.tsx
@@ -12,7 +12,7 @@ const value = '';
 
 describe('PledgeFrequencySelect', () => {
   it('should render the select', async () => {
-    const { getByRole, getByTestId, findByText } = render(
+    const { getByRole } = render(
       <LocalizationProvider dateAdapter={AdapterLuxon}>
         <ThemeProvider theme={theme}>
           <PledgeFrequencySelect
@@ -20,20 +20,14 @@ describe('PledgeFrequencySelect', () => {
             value={value}
             onChange={onChange}
           />
-          ,
         </ThemeProvider>
       </LocalizationProvider>,
     );
 
-    const select = getByTestId('pledgeFrequency');
-    expect(select).toBeInTheDocument();
+    const openDropdown = getByRole('combobox');
+    expect(openDropdown).toBeInTheDocument();
 
-    const open = getByRole('combobox');
-    await userEvent.click(open);
-
-    const option = await findByText('Annual');
-    userEvent.click(option);
-
-    expect(option).toBeInTheDocument();
+    userEvent.click(openDropdown);
+    userEvent.click(await getByRole('option', { name: 'Annual' }));
   });
 });

--- a/src/common/Selects/PledgeFrequencySelect.test.tsx
+++ b/src/common/Selects/PledgeFrequencySelect.test.tsx
@@ -6,28 +6,28 @@ import userEvent from '@testing-library/user-event';
 import theme from '../../theme';
 import { PledgeFrequencySelect } from './PledgeFrequencySelect';
 
-const onChange = jest.fn();
+const mockOnChange = jest.fn();
 const label = '';
 const value = '';
 
 describe('PledgeFrequencySelect', () => {
-  it('should render the select', async () => {
+  it('should render the select', () => {
     const { getByRole } = render(
       <LocalizationProvider dateAdapter={AdapterLuxon}>
         <ThemeProvider theme={theme}>
           <PledgeFrequencySelect
             label={label}
             value={value}
-            onChange={onChange}
+            onChange={mockOnChange}
           />
         </ThemeProvider>
       </LocalizationProvider>,
     );
 
-    const openDropdown = getByRole('combobox');
-    expect(openDropdown).toBeInTheDocument();
+    userEvent.click(getByRole('combobox'));
+    userEvent.click(getByRole('option', { name: 'Annual' }));
 
-    userEvent.click(openDropdown);
-    userEvent.click(await getByRole('option', { name: 'Annual' }));
+    const mockValue = mockOnChange.mock.calls[0][0];
+    expect(mockValue.target.value).toEqual('ANNUAL');
   });
 });

--- a/src/common/Selects/PledgeFrequencySelect.test.tsx
+++ b/src/common/Selects/PledgeFrequencySelect.test.tsx
@@ -1,0 +1,39 @@
+import { ThemeProvider } from '@mui/material/styles';
+import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import theme from '../../theme';
+import { PledgeFrequencySelect } from './PledgeFrequencySelect';
+
+const onChange = jest.fn();
+const label = '';
+const value = '';
+
+describe('PledgeFrequencySelect', () => {
+  it('should render the select', async () => {
+    const { getByRole, getByTestId, findByText } = render(
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <ThemeProvider theme={theme}>
+          <PledgeFrequencySelect
+            label={label}
+            value={value}
+            onChange={onChange}
+          />
+          ,
+        </ThemeProvider>
+      </LocalizationProvider>,
+    );
+
+    const select = getByTestId('pledgeFrequency');
+    expect(select).toBeInTheDocument();
+
+    const open = getByRole('combobox');
+    await userEvent.click(open);
+
+    const option = await findByText('Annual');
+    userEvent.click(option);
+
+    expect(option).toBeInTheDocument();
+  });
+});

--- a/src/common/Selects/PledgeFrequencySelect.tsx
+++ b/src/common/Selects/PledgeFrequencySelect.tsx
@@ -12,7 +12,7 @@ export const PledgeFrequencySelect = ({
 }: PledgeFrequencySelectProps) => {
   const { getLocalizedPledgeFrequency } = useLocalizedConstants();
   return (
-    <Select data-testid="pledgeFrequency" {...props}>
+    <Select {...props}>
       {children}
       {Object.values(PledgeFrequencyEnum).map((value) => (
         <MenuItem key={value} value={value}>

--- a/src/common/Selects/PledgeFrequencySelect.tsx
+++ b/src/common/Selects/PledgeFrequencySelect.tsx
@@ -1,0 +1,26 @@
+import { MenuItem, MenuItemProps, Select, SelectProps } from '@mui/material';
+import { PledgeFrequencyEnum } from 'src/graphql/types.generated';
+
+type PledgeFrequencySelectProps = Partial<SelectProps> & {
+  MenuItemProps?: Partial<MenuItemProps> & { [testid: string]: string };
+  getFunctionLabel: (label: string) => React.ReactNode;
+  children?: React.ReactNode;
+};
+
+export const PledgeFrequencySelect = ({
+  MenuItemProps,
+  getFunctionLabel,
+  children,
+  ...props
+}: PledgeFrequencySelectProps) => {
+  return (
+    <Select {...props}>
+      {children}
+      {Object.values(PledgeFrequencyEnum).map((value) => (
+        <MenuItem key={value} value={value} {...MenuItemProps}>
+          {getFunctionLabel(value)}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+};

--- a/src/common/Selects/PledgeFrequencySelect.tsx
+++ b/src/common/Selects/PledgeFrequencySelect.tsx
@@ -1,24 +1,22 @@
-import { MenuItem, MenuItemProps, Select, SelectProps } from '@mui/material';
+import { MenuItem, Select, SelectProps } from '@mui/material';
 import { PledgeFrequencyEnum } from 'src/graphql/types.generated';
+import { useLocalizedConstants } from 'src/hooks/useLocalizedConstants';
 
 type PledgeFrequencySelectProps = Partial<SelectProps> & {
-  MenuItemProps?: Partial<MenuItemProps> & { [testid: string]: string };
-  getFunctionLabel: (label: string) => React.ReactNode;
   children?: React.ReactNode;
 };
 
 export const PledgeFrequencySelect = ({
-  MenuItemProps,
-  getFunctionLabel,
   children,
   ...props
 }: PledgeFrequencySelectProps) => {
+  const { getLocalizedPledgeFrequency } = useLocalizedConstants();
   return (
     <Select {...props}>
       {children}
       {Object.values(PledgeFrequencyEnum).map((value) => (
-        <MenuItem key={value} value={value} {...MenuItemProps}>
-          {getFunctionLabel(value)}
+        <MenuItem key={value} value={value}>
+          {getLocalizedPledgeFrequency(value)}
         </MenuItem>
       ))}
     </Select>

--- a/src/common/Selects/PledgeFrequencySelect.tsx
+++ b/src/common/Selects/PledgeFrequencySelect.tsx
@@ -12,7 +12,7 @@ export const PledgeFrequencySelect = ({
 }: PledgeFrequencySelectProps) => {
   const { getLocalizedPledgeFrequency } = useLocalizedConstants();
   return (
-    <Select {...props}>
+    <Select data-testid="pledgeFrequency" {...props}>
       {children}
       {Object.values(PledgeFrequencyEnum).map((value) => (
         <MenuItem key={value} value={value}>

--- a/src/components/Coaching/CoachingDetail/LevelOfEffort/LevelOfEffort.graphql
+++ b/src/components/Coaching/CoachingDetail/LevelOfEffort/LevelOfEffort.graphql
@@ -11,6 +11,7 @@ query LevelOfEffort($accountListId: ID!, $range: String!) {
       followUpEmail
       followUpTextMessage
       followUpSocialMedia
+      followUpLetterCard
       followUpInPerson
       followUpToDo
       partnerCareUpdateInformation

--- a/src/components/Coaching/CoachingDetail/LevelOfEffort/LevelOfEffort.tsx
+++ b/src/components/Coaching/CoachingDetail/LevelOfEffort/LevelOfEffort.tsx
@@ -62,6 +62,7 @@ export const LevelOfEffort: React.FC<LevelOfEffortProps> = ({
         'followUpInPerson',
         'followUpPhoneCall',
         'followUpSocialMedia',
+        'followUpLetterCard',
         'followUpTextMessage',
         'followUpToDo',
         'initiationEmail',

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
@@ -470,6 +470,7 @@ export const EditPartnershipInfoModal: React.FC<
                         {t('Frequency')}
                       </InputLabel>
                       <PledgeFrequencySelectInteractive
+                        //data-testid="pledgeFrequency"
                         label={t('Frequency')}
                         labelId="frequency-select-label"
                         value={pledgeFrequency ?? ''}

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
@@ -129,8 +129,7 @@ export const EditPartnershipInfoModal: React.FC<
   const accountListId = useAccountListId();
   const constants = useApiConstants();
   const { enqueueSnackbar } = useSnackbar();
-  const { getLocalizedContactStatus, getLocalizedPledgeFrequency } =
-    useLocalizedConstants();
+  const { getLocalizedContactStatus } = useLocalizedConstants();
 
   const phases = constants?.phases;
   const [showRemoveCommitmentWarning, setShowRemoveCommitmentWarning] =
@@ -498,7 +497,6 @@ export const EditPartnershipInfoModal: React.FC<
                               )
                             : undefined
                         }
-                        getFunctionLabel={getLocalizedPledgeFrequency}
                       >
                         <MenuItem value={''} disabled></MenuItem>
                       </PledgeFrequencySelectInteractive>

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
@@ -470,7 +470,6 @@ export const EditPartnershipInfoModal: React.FC<
                         {t('Frequency')}
                       </InputLabel>
                       <PledgeFrequencySelectInteractive
-                        //data-testid="pledgeFrequency"
                         label={t('Frequency')}
                         labelId="frequency-select-label"
                         value={pledgeFrequency ?? ''}

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
@@ -25,6 +25,7 @@ import { DateTime } from 'luxon';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { PledgeFrequencySelect } from 'src/common/Selects/PledgeFrequencySelect';
 import { CustomDateField } from 'src/components/common/DateTimePickers/CustomDateField';
 import {
   CancelButton,
@@ -84,7 +85,7 @@ const RemoveCommitmentActions = styled(Box)(({ theme }) => ({
   gap: theme.spacing(1),
 }));
 
-const SelectInteractive = styled(Select, {
+const PledgeFrequencySelectInteractive = styled(PledgeFrequencySelect, {
   shouldForwardProp: (prop) => prop !== 'isDisabled',
 })<{ isDisabled?: boolean }>(({ isDisabled }) => ({
   '& MuiSelect-select, & fieldset': {
@@ -469,7 +470,7 @@ export const EditPartnershipInfoModal: React.FC<
                       <InputLabel id="frequency-select-label">
                         {t('Frequency')}
                       </InputLabel>
-                      <SelectInteractive
+                      <PledgeFrequencySelectInteractive
                         label={t('Frequency')}
                         labelId="frequency-select-label"
                         value={pledgeFrequency ?? ''}
@@ -497,14 +498,10 @@ export const EditPartnershipInfoModal: React.FC<
                               )
                             : undefined
                         }
+                        getFunctionLabel={getLocalizedPledgeFrequency}
                       >
                         <MenuItem value={''} disabled></MenuItem>
-                        {Object.values(PledgeFrequencyEnum).map((value) => (
-                          <MenuItem key={value} value={value}>
-                            {getLocalizedPledgeFrequency(value)}
-                          </MenuItem>
-                        ))}
-                      </SelectInteractive>
+                      </PledgeFrequencySelectInteractive>
                     </FormControl>
                   </ContactInputWrapper>
                 </Grid>

--- a/src/components/Tool/FixCommitmentInfo/Contact.tsx
+++ b/src/components/Tool/FixCommitmentInfo/Contact.tsx
@@ -25,6 +25,7 @@ import { DateTime } from 'luxon';
 import { useTranslation } from 'react-i18next';
 import { makeStyles } from 'tss-react/mui';
 import * as yup from 'yup';
+import { PledgeFrequencySelect } from 'src/common/Selects/PledgeFrequencySelect';
 import { useApiConstants } from 'src/components/Constants/UseApiConstants';
 import { TabKey } from 'src/components/Contacts/ContactDetails/ContactDetails';
 import { PledgeFrequencyEnum, StatusEnum } from 'src/graphql/types.generated';
@@ -472,7 +473,7 @@ const Contact: React.FC<Props> = ({
                               <InputLabel id="frequency-label">
                                 {t('Frequency')}
                               </InputLabel>
-                              <Select
+                              <PledgeFrequencySelect
                                 className={classes.select}
                                 inputProps={{
                                   'data-testid': 'pledgeFrequency-input',
@@ -490,19 +491,11 @@ const Contact: React.FC<Props> = ({
                                     event.target.value,
                                   )
                                 }
-                              >
-                                {Object.values(PledgeFrequencyEnum).map(
-                                  (value) => (
-                                    <MenuItem
-                                      key={value}
-                                      value={value}
-                                      data-testid="pledgeFrequencyOptions"
-                                    >
-                                      {getLocalizedPledgeFrequency(value)}
-                                    </MenuItem>
-                                  ),
-                                )}
-                              </Select>
+                                MenuItemProps={{
+                                  'data-testid': 'pledgeFrequencyOptions',
+                                }}
+                                getFunctionLabel={getLocalizedPledgeFrequency}
+                              />
                             </FormControl>
                           </Box>
                         </Grid>

--- a/src/components/Tool/FixCommitmentInfo/Contact.tsx
+++ b/src/components/Tool/FixCommitmentInfo/Contact.tsx
@@ -478,7 +478,7 @@ const Contact: React.FC<Props> = ({
                                 inputProps={{
                                   'data-testid': 'pledgeFrequency-input',
                                 }}
-                                data-testid="pledgeFrequency"
+                                //data-testid="pledgeFrequency"
                                 label={t('Frequency')}
                                 labelId="frequency-label"
                                 placeholder="Frequency"

--- a/src/components/Tool/FixCommitmentInfo/Contact.tsx
+++ b/src/components/Tool/FixCommitmentInfo/Contact.tsx
@@ -478,7 +478,6 @@ const Contact: React.FC<Props> = ({
                                 inputProps={{
                                   'data-testid': 'pledgeFrequency-input',
                                 }}
-                                //data-testid="pledgeFrequency"
                                 label={t('Frequency')}
                                 labelId="frequency-label"
                                 placeholder="Frequency"

--- a/src/components/Tool/FixCommitmentInfo/Contact.tsx
+++ b/src/components/Tool/FixCommitmentInfo/Contact.tsx
@@ -491,10 +491,6 @@ const Contact: React.FC<Props> = ({
                                     event.target.value,
                                   )
                                 }
-                                MenuItemProps={{
-                                  'data-testid': 'pledgeFrequencyOptions',
-                                }}
-                                getFunctionLabel={getLocalizedPledgeFrequency}
                               />
                             </FormControl>
                           </Box>


### PR DESCRIPTION
## Description

It was brought to our attention in Helpscout that the Dashboard weekly reports are not displaying the correct number of completed tasks. It was discovered that the coaching reports, which include the same completed task calculations, are displaying correctly, however, it is missing the Follow Up Letter/Card field. 

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
