### PR TITLE
MPDX 8663 Fix dashboard weekly report completed task count

### DIFF
--- a/src/components/Coaching/CoachingDetail/LevelOfEffort/LevelOfEffort.graphql
+++ b/src/components/Coaching/CoachingDetail/LevelOfEffort/LevelOfEffort.graphql
@@ -11,6 +11,7 @@ query LevelOfEffort($accountListId: ID!, $range: String!) {
       followUpEmail
       followUpTextMessage
       followUpSocialMedia
+      followUpLetterCard
       followUpInPerson
       followUpToDo
       partnerCareUpdateInformation

--- a/src/components/Coaching/CoachingDetail/LevelOfEffort/LevelOfEffort.tsx
+++ b/src/components/Coaching/CoachingDetail/LevelOfEffort/LevelOfEffort.tsx
@@ -63,6 +63,7 @@ export const LevelOfEffort: React.FC<LevelOfEffortProps> = ({
         'followUpPhoneCall',
         'followUpSocialMedia',
         'followUpTextMessage',
+        'followUpLetterCard',
         'followUpToDo',
         'initiationEmail',
         'initiationInPerson',

--- a/src/components/Dashboard/ThisWeek/WeeklyActivity/GetWeeklyActivity.graphql
+++ b/src/components/Dashboard/ThisWeek/WeeklyActivity/GetWeeklyActivity.graphql
@@ -14,6 +14,8 @@ query GetWeeklyActivity(
         INITIATION_SOCIAL_MEDIA
         INITIATION_SPECIAL_GIFT_APPEAL
         INITIATION_TEXT_MESSAGE
+        INITIATION_EMAIL
+        INITIATION_TO_DO
       ]
       result: [COMPLETED, DONE]
     }
@@ -47,6 +49,8 @@ query GetWeeklyActivity(
         FOLLOW_UP_TEXT_MESSAGE
         FOLLOW_UP_IN_PERSON
         FOLLOW_UP_PHONE_CALL
+        FOLLOW_UP_LETTER_CARD
+        FOLLOW_UP_TO_DO
       ]
       result: [COMPLETED, DONE]
     }
@@ -101,6 +105,8 @@ query GetWeeklyActivity(
         PARTNER_CARE_DIGITAL_NEWSLETTER
         PARTNER_CARE_PHYSICAL_NEWSLETTER
         PARTNER_CARE_THANK
+        PARTNER_CARE_LETTER_CARD
+        PARTNER_CARE_PRAYER_REQUEST
       ]
       result: [COMPLETED, DONE]
     }


### PR DESCRIPTION
## Description

It was brought to our attention in Helpscout that the **Dashboard's weekly report** was displaying the incorrect number of completed tasks. Since this same calculation is used in the **Coaching Report's level of effort**, I compared both and found that the coaching report was correctly showing the total counts. During the investigation, I also noticed that the Follow Up Letter/Card field was missing from the level of effort calculation, which caused a slight discrepancy. 

After the backend team updated the query to include the missing Follow Up field, I added it to the coaching report. Before fixing the dashboard totals, I tested each task field and found that **six fields** were missing from the dashboard count. I then updated the `GetWeeklyActivity.graphql` file to include those missing fields.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
