### PR TITLE
[MPDX-8667] Eliminate race conditions in appeals filter state

### DIFF
--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.test.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.test.tsx
@@ -17,20 +17,19 @@ import { AppealsListFilterPanel } from './AppealsListFilterPanel';
 
 const accountListId = 'accountListId';
 const appealId = 'appealId';
-const activeFilters = { status: [AppealStatusEnum.Asked] };
 const selectedIds = ['1', '2'];
 const routerReplace = jest.fn();
 const router = {
   query: {
     accountListId,
     appealId: ['1', 'list'],
-    filters: JSON.stringify(activeFilters),
   },
   replace: routerReplace,
   isReady: true,
 };
 const onClose = jest.fn();
 const deselectAll = jest.fn();
+const setListAppealStatus = jest.fn();
 
 const defaultContactCountMock = {
   data: {
@@ -40,9 +39,6 @@ const defaultContactCountMock = {
   },
   loading: false,
 };
-
-const deserializeFilters = (filters: string) =>
-  JSON.parse(decodeURIComponent(filters));
 
 const Components = ({ ids = selectedIds }) => (
   <ThemeProvider theme={theme}>
@@ -65,6 +61,7 @@ const Components = ({ ids = selectedIds }) => (
                   appealId,
                   selectedIds: ids,
                   deselectAll,
+                  setListAppealStatus,
                   askedCountQueryResult: defaultContactCountMock,
                   excludedCountQueryResult: defaultContactCountMock,
                   committedCountQueryResult: defaultContactCountMock,
@@ -125,7 +122,7 @@ describe('AppealsListFilterPanel', () => {
     expect(getByRole('button', { name: 'Select Contact' })).toBeInTheDocument();
   });
 
-  it('should filter contacts on appeal status', async () => {
+  it('should change appeal status', async () => {
     const { getByText } = render(<Components />);
 
     expect(deselectAll).not.toHaveBeenCalled();
@@ -133,48 +130,29 @@ describe('AppealsListFilterPanel', () => {
 
     userEvent.click(getByText('Given'));
     expect(deselectAll).toHaveBeenCalled();
-    expect(
-      deserializeFilters(routerReplace.mock.lastCall[0].query.filters),
-    ).toEqual({
-      ...activeFilters,
-      appealStatus: AppealStatusEnum.Processed,
-    });
+    expect(setListAppealStatus).toHaveBeenCalledWith(
+      AppealStatusEnum.Processed,
+    );
 
     userEvent.click(getByText('Received'));
     expect(deselectAll).toHaveBeenCalled();
-    expect(
-      deserializeFilters(routerReplace.mock.lastCall[0].query.filters),
-    ).toEqual({
-      ...activeFilters,
-      appealStatus: AppealStatusEnum.ReceivedNotProcessed,
-    });
+    expect(setListAppealStatus).toHaveBeenCalledWith(
+      AppealStatusEnum.ReceivedNotProcessed,
+    );
 
     userEvent.click(getByText('Committed'));
     expect(deselectAll).toHaveBeenCalled();
-    expect(
-      deserializeFilters(routerReplace.mock.lastCall[0].query.filters),
-    ).toEqual({
-      ...activeFilters,
-      appealStatus: AppealStatusEnum.NotReceived,
-    });
+    expect(setListAppealStatus).toHaveBeenCalledWith(
+      AppealStatusEnum.NotReceived,
+    );
 
     userEvent.click(getByText('Asked'));
     expect(deselectAll).toHaveBeenCalled();
-    expect(
-      deserializeFilters(routerReplace.mock.lastCall[0].query.filters),
-    ).toEqual({
-      ...activeFilters,
-      appealStatus: AppealStatusEnum.Asked,
-    });
+    expect(setListAppealStatus).toHaveBeenCalledWith(AppealStatusEnum.Asked);
 
     userEvent.click(getByText('Excluded'));
     expect(deselectAll).toHaveBeenCalled();
-    expect(
-      deserializeFilters(routerReplace.mock.lastCall[0].query.filters),
-    ).toEqual({
-      ...activeFilters,
-      appealStatus: AppealStatusEnum.Excluded,
-    });
+    expect(setListAppealStatus).toHaveBeenCalledWith(AppealStatusEnum.Excluded);
   });
 
   describe('Modals', () => {

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
@@ -19,7 +19,6 @@ import {
   preloadMassActionsExportEmailsModal,
 } from 'src/components/Contacts/MassActions/Exports/Emails/DynamicMassActionsExportEmailsModal';
 import { DynamicMailMergedLabelModal } from 'src/components/Contacts/MassActions/Exports/MailMergedLabelModal/DynamicMailMergedLabelModal';
-import { useUrlFilters } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
 import {
   AppealStatusEnum,
   AppealTourEnum,
@@ -69,13 +68,14 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
     selectedIds,
     deselectAll,
     tour,
+    listAppealStatus,
+    setListAppealStatus,
     askedCountQueryResult,
     excludedCountQueryResult,
     committedCountQueryResult,
     givenCountQueryResult,
     receivedCountQueryResult,
   } = React.useContext(AppealsContext) as AppealsType;
-  const { activeFilters, setActiveFilters } = useUrlFilters();
   const [exportsModalOpen, setExportsModalOpen] = useState(false);
   const [labelModalOpen, setLabelModalOpen] = useState(false);
   const [exportEmailsModalOpen, setExportEmailsModalOpen] = useState(false);
@@ -106,13 +106,9 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
 
   const handleFilterItemClick = (newAppealListView: AppealStatusEnum) => {
     deselectAll();
-    setActiveFilters({
-      ...activeFilters,
-      appealStatus: newAppealListView,
-    });
+    setListAppealStatus(newAppealListView);
   };
 
-  const appealListView = activeFilters.appealStatus;
   const noContactsSelected = !selectedIds.length;
 
   return (
@@ -145,7 +141,7 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
                   title={t('Given')}
                   count={givenCount?.contacts.totalCount}
                   loading={givenLoading}
-                  isSelected={appealListView === AppealStatusEnum.Processed}
+                  isSelected={listAppealStatus === AppealStatusEnum.Processed}
                   onClick={handleFilterItemClick}
                 />
                 <AppealsListFilterPanelItem
@@ -154,7 +150,7 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
                   count={receivedCount?.contacts.totalCount}
                   loading={receivedLoading}
                   isSelected={
-                    appealListView === AppealStatusEnum.ReceivedNotProcessed
+                    listAppealStatus === AppealStatusEnum.ReceivedNotProcessed
                   }
                   onClick={handleFilterItemClick}
                 />
@@ -163,7 +159,7 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
                   title={t('Committed')}
                   count={committedCount?.contacts.totalCount}
                   loading={committedLoading}
-                  isSelected={appealListView === AppealStatusEnum.NotReceived}
+                  isSelected={listAppealStatus === AppealStatusEnum.NotReceived}
                   onClick={handleFilterItemClick}
                 />
                 <AppealsListFilterPanelItem
@@ -171,7 +167,7 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
                   title={t('Asked')}
                   count={askedCount?.contacts.totalCount}
                   loading={askedLoading}
-                  isSelected={appealListView === AppealStatusEnum.Asked}
+                  isSelected={listAppealStatus === AppealStatusEnum.Asked}
                   onClick={handleFilterItemClick}
                 />
                 <AppealsListFilterPanelItem
@@ -179,7 +175,7 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
                   title={t('Excluded')}
                   count={excludedCount?.contacts.totalCount}
                   loading={excludedLoading}
-                  isSelected={appealListView === AppealStatusEnum.Excluded}
+                  isSelected={listAppealStatus === AppealStatusEnum.Excluded}
                   onClick={handleFilterItemClick}
                 />
 

--- a/src/components/Tool/Appeal/List/ContactsList/ContactsList.test.tsx
+++ b/src/components/Tool/Appeal/List/ContactsList/ContactsList.test.tsx
@@ -44,44 +44,42 @@ const Components = ({
   tour = false,
   appealStatus = AppealStatusEnum.Asked,
   contactsQueryResult = defaultContactsQueryResult,
-}: ComponentsProps) => {
-  const activeFilters = { appealStatus };
-  const router = {
-    query: { accountListId, filters: JSON.stringify(activeFilters) },
-    isReady: true,
-  };
-
-  return (
-    <TestRouter router={router}>
-      <GqlMockedProvider>
-        <ThemeProvider theme={theme}>
-          <AppealsWrapper>
-            <AppealsContext.Provider
-              value={
-                {
-                  appealId,
-                  accountListId,
-                  tour,
-                  isFiltered: true,
-                  contactsQueryResult,
-                  getContactUrl,
-                  isRowChecked,
-                  contactDetailsOpen,
-                  toggleSelectionById,
-                } as unknown as AppealsType
-              }
-            >
-              <ContactsList
-                appealInfo={defaultAppealQuery}
-                appealInfoLoading={appealInfoLoading}
-              />
-            </AppealsContext.Provider>
-          </AppealsWrapper>
-        </ThemeProvider>
-      </GqlMockedProvider>
-    </TestRouter>
-  );
-};
+}: ComponentsProps) => (
+  <TestRouter
+    router={{
+      query: { accountListId },
+      isReady: true,
+    }}
+  >
+    <GqlMockedProvider>
+      <ThemeProvider theme={theme}>
+        <AppealsWrapper>
+          <AppealsContext.Provider
+            value={
+              {
+                appealId,
+                accountListId,
+                tour,
+                isFiltered: true,
+                contactsQueryResult,
+                listAppealStatus: appealStatus,
+                getContactUrl,
+                isRowChecked,
+                contactDetailsOpen,
+                toggleSelectionById,
+              } as unknown as AppealsType
+            }
+          >
+            <ContactsList
+              appealInfo={defaultAppealQuery}
+              appealInfoLoading={appealInfoLoading}
+            />
+          </AppealsContext.Provider>
+        </AppealsWrapper>
+      </ThemeProvider>
+    </GqlMockedProvider>
+  </TestRouter>
+);
 
 describe('ContactsRow', () => {
   describe('NullState Message', () => {
@@ -139,37 +137,37 @@ describe('ContactsRow', () => {
   });
 
   describe('Layout', () => {
-    it('Given', async () => {
+    it('Given', () => {
       const { queryByText } = render(
         <Components appealStatus={AppealStatusEnum.Processed} />,
       );
-      expect(await queryByText('Reason')).not.toBeInTheDocument();
+      expect(queryByText('Reason')).not.toBeInTheDocument();
     });
 
-    it('Excluded', async () => {
-      const { findByText } = render(
+    it('Excluded', () => {
+      const { getByText } = render(
         <Components appealStatus={AppealStatusEnum.Excluded} />,
       );
-      expect(await findByText('Reason')).toBeInTheDocument();
+      expect(getByText('Reason')).toBeInTheDocument();
     });
 
-    it('Asked', async () => {
+    it('Asked', () => {
       const { queryByText } = render(<Components />);
-      expect(await queryByText('Reason')).not.toBeInTheDocument();
+      expect(queryByText('Reason')).not.toBeInTheDocument();
     });
 
-    it('Committed', async () => {
+    it('Committed', () => {
       const { queryByText } = render(
         <Components appealStatus={AppealStatusEnum.NotReceived} />,
       );
-      expect(await queryByText('Reason')).not.toBeInTheDocument();
+      expect(queryByText('Reason')).not.toBeInTheDocument();
     });
 
-    it('Received', async () => {
+    it('Received', () => {
       const { queryByText } = render(
         <Components appealStatus={AppealStatusEnum.ReceivedNotProcessed} />,
       );
-      expect(await queryByText('Reason')).not.toBeInTheDocument();
+      expect(queryByText('Reason')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/Tool/Appeal/List/ContactsList/ContactsList.tsx
+++ b/src/components/Tool/Appeal/List/ContactsList/ContactsList.tsx
@@ -88,20 +88,19 @@ export const ContactsList: React.FC<ContactsListProps> = ({
           'No gifts have been received and not yet processed to this appeal',
         );
     }
-  }, [appealStatus]);
+  }, [t, appealStatus]);
 
   const columnName = useMemo(() => {
-    let name = t('Regular Giving');
     if (
       appealStatus === AppealStatusEnum.NotReceived ||
       appealStatus === AppealStatusEnum.ReceivedNotProcessed
     ) {
-      name = t('Amount Committed');
+      return t('Amount Committed');
     } else if (appealStatus === AppealStatusEnum.Processed) {
-      name = t('Donation(s)');
+      return t('Donation(s)');
     }
-    return name;
-  }, [activeFilters]);
+    return t('Regular Giving');
+  }, [t, activeFilters]);
 
   const isExcludedContact = appealStatus === AppealStatusEnum.Excluded;
 

--- a/src/components/Tool/Appeal/List/ContactsList/ContactsList.tsx
+++ b/src/components/Tool/Appeal/List/ContactsList/ContactsList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { Grid, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import { useTranslation } from 'react-i18next';
@@ -49,13 +49,13 @@ export const ContactsList: React.FC<ContactsListProps> = ({
 }) => {
   const { t } = useTranslation();
   const { classes } = useStyles();
-  const [nullStateTitle, setNullStateTitle] = React.useState<string>('');
 
   const {
     appealId,
     accountListId,
     tour,
     contactsQueryResult,
+    listAppealStatus: appealStatus,
     isFiltered,
     contactDetailsOpen,
   } = React.useContext(AppealsContext) as AppealsType;
@@ -68,54 +68,36 @@ export const ContactsList: React.FC<ContactsListProps> = ({
       appealId: appealId ?? '',
       accountListId: accountListId ?? '',
     },
-    skip: activeFilters.appealStatus !== AppealStatusEnum.Excluded,
+    skip: appealStatus !== AppealStatusEnum.Excluded,
   });
 
-  const appealStatus =
-    (activeFilters.appealStatus as AppealStatusEnum) ?? AppealStatusEnum.Asked;
-
-  useEffect(() => {
-    if (!activeFilters.appealStatus) {
-      return;
+  const nullStateTitle = useMemo(() => {
+    switch (appealStatus) {
+      case AppealStatusEnum.Processed:
+        return t('No donations yet towards this appeal');
+      case AppealStatusEnum.Excluded:
+        return t('No contacts have been excluded from this appeal');
+      case AppealStatusEnum.Asked:
+        return t('All contacts for this appeal have committed to this appeal');
+      case AppealStatusEnum.NotReceived:
+        return t(
+          'There are no contacts for this appeal that have not been received.',
+        );
+      case AppealStatusEnum.ReceivedNotProcessed:
+        return t(
+          'No gifts have been received and not yet processed to this appeal',
+        );
     }
-    switch (activeFilters.appealStatus.toLowerCase()) {
-      case 'processed':
-        setNullStateTitle(t('No donations yet towards this appeal'));
-        break;
-      case 'excluded':
-        setNullStateTitle(t('No contacts have been excluded from this appeal'));
-        break;
-      case 'asked':
-        setNullStateTitle(
-          t('All contacts for this appeal have committed to this appeal'),
-        );
-        break;
-      case 'not_received':
-        setNullStateTitle(
-          t(
-            'There are no contacts for this appeal that have not been received.',
-          ),
-        );
-        break;
-      case 'received_not_processed':
-        setNullStateTitle(
-          t('No gifts have been received and not yet processed to this appeal'),
-        );
-        break;
-      default:
-        setNullStateTitle('');
-        break;
-    }
-  }, [activeFilters]);
+  }, [appealStatus]);
 
   const columnName = useMemo(() => {
     let name = t('Regular Giving');
     if (
-      activeFilters.appealStatus === AppealStatusEnum.NotReceived ||
-      activeFilters.appealStatus === AppealStatusEnum.ReceivedNotProcessed
+      appealStatus === AppealStatusEnum.NotReceived ||
+      appealStatus === AppealStatusEnum.ReceivedNotProcessed
     ) {
       name = t('Amount Committed');
-    } else if (activeFilters.appealStatus === AppealStatusEnum.Processed) {
+    } else if (appealStatus === AppealStatusEnum.Processed) {
       name = t('Donation(s)');
     }
     return name;


### PR DESCRIPTION
## Description

In the appeals list, storing the appeal status filter in the URL was a major source of race conditions and the filters and URL getting out of sync. This PR eliminates those issues by storing the appeal status in state instead of in the URL.

This PR is highly-dependent on work in #1343, but I'm putting it in a separate PR for ease of review since it is fairly self-contained.

MPDX-8667

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
