### PR TITLE
[MPDX-8667] Use ContactPanelProvider and UrlFiltersProvider in appeals

### DIFF
--- a/pages/accountLists/[accountListId]/reports/financialAccounts/[financialAccountId]/entries.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/financialAccounts/[financialAccountId]/entries.page.tsx
@@ -11,7 +11,6 @@ import {
   FinancialAccountType,
 } from 'src/components/Reports/FinancialAccountsReport/Context/FinancialAccountsContext';
 import { DynamicFilterPanel } from 'src/components/Shared/Filters/DynamicFilterPanel';
-import { ContextTypesEnum } from 'src/components/Shared/Filters/FilterPanel';
 import { headerHeight } from 'src/components/Shared/Header/ListHeader';
 import {
   MultiPageMenu,
@@ -129,7 +128,6 @@ const FinancialAccountEntries = (): ReactElement => {
                   }
                   savedFilters={[]}
                   onClose={() => setPanelOpen(null)}
-                  contextType={ContextTypesEnum.FinancialAccountReport}
                   showSaveButton={false}
                 />
               ) : undefined

--- a/pages/accountLists/[accountListId]/reports/partnerGivingAnalysis/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/partnerGivingAnalysis/[[...contactId]].page.tsx
@@ -108,7 +108,6 @@ const PageContent: React.FC = () => {
           onFilterListToggle={handleFilterListToggle}
           onNavListToggle={handleNavListToggle}
           title={t('Partner Giving Analysis')}
-          contactDetailsOpen={isOpen}
         />
       }
       rightPanel={isOpen ? <DynamicContactsRightPanel /> : undefined}

--- a/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
@@ -232,7 +232,6 @@ const PageContent: React.FC = () => {
                   page={PageEnum.Task}
                   filterPanelOpen={filterPanelOpen}
                   toggleFilterPanel={toggleFilterPanel}
-                  contactDetailsOpen={isOpen}
                   onCheckAllItems={toggleSelectAll}
                   totalItems={data?.tasks?.totalCount}
                   headerCheckboxState={selectionType}

--- a/pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper.tsx
+++ b/pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper.tsx
@@ -1,79 +1,62 @@
 import { useRouter } from 'next/router';
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
+  AppealTourEnum,
   AppealsProvider,
   TableViewModeEnum,
 } from 'src/components/Tool/Appeal/AppealsContext/AppealsContext';
+import { ContactPanelProvider } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { UrlFiltersProvider } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
 
 interface Props {
   children?: React.ReactNode;
 }
 
-export enum PageEnum {
-  DetailsPage = 'DetailsPage',
-  ContactsPage = 'ContactsPage',
-}
-
 export const AppealsWrapper: React.FC<Props> = ({ children }) => {
   const router = useRouter();
-  const { query, push } = router;
+  const { query } = router;
 
   const [filterPanelOpen, setFilterPanelOpen] = useState<boolean>(false);
-  const [page, setPage] = useState<PageEnum>();
-  const [appealId, setAppealId] = useState<string | undefined>(undefined);
-  const [contactId, setContactId] = useState<string | string[] | undefined>(
-    undefined,
+
+  const appealIdParams = Array.isArray(query.appealId) ? query.appealId : [];
+  const appealId = appealIdParams[0];
+
+  // TODO: Pull the default value from preferences
+  const [viewMode, setViewMode] = useState(
+    appealIdParams[1] === 'list'
+      ? TableViewModeEnum.List
+      : TableViewModeEnum.Flows,
+  );
+  const [tour, setTour] = useState<AppealTourEnum | null>(
+    appealIdParams[2] === 'tour' ? AppealTourEnum.Start : null,
   );
 
-  const { appealId: appealIdParams, accountListId } = query;
-
-  useEffect(() => {
-    if (appealIdParams === undefined) {
-      push({
-        pathname: '/accountLists/[accountListId]/tools/appeals',
-        query: {
-          accountListId,
-        },
-      });
-      return;
-    }
-    const length = appealIdParams.length;
-    setAppealId(appealIdParams[0]);
-    if (length === 1) {
-      setPage(PageEnum.DetailsPage);
-    } else if (
-      length === 2 &&
-      (appealIdParams[1].toLowerCase() === 'flows' ||
-        appealIdParams[1].toLowerCase() === 'list')
-    ) {
-      setPage(PageEnum.DetailsPage);
-      setContactId(appealIdParams);
-    } else if (length === 3 && appealIdParams[2].toLowerCase() === 'tour') {
-      setPage(PageEnum.ContactsPage);
-      setContactId(appealIdParams);
-    } else if (length > 2) {
-      setPage(PageEnum.DetailsPage);
-      setContactId(appealIdParams);
-    }
-  }, [appealIdParams, accountListId]);
-
-  const doNothing = () => {};
+  const appealIdPrefix = useMemo(() => {
+    const appealIdPrefix = [appealId, viewMode];
+    return viewMode === TableViewModeEnum.List && tour
+      ? [...appealIdPrefix, 'tour']
+      : appealIdPrefix;
+  }, [appealId, viewMode, tour]);
 
   return (
-    <UrlFiltersProvider>
-      <AppealsProvider
-        filterPanelOpen={filterPanelOpen}
-        setFilterPanelOpen={setFilterPanelOpen}
-        appealId={appealId}
-        contactId={contactId}
-        page={page}
-        viewMode={TableViewModeEnum.List}
-        setViewMode={doNothing}
-        userOptionsLoading={false}
-      >
-        {children}
-      </AppealsProvider>
-    </UrlFiltersProvider>
+    <ContactPanelProvider
+      contactIdParam="appealId"
+      contactIdPrefix={appealIdPrefix}
+    >
+      <UrlFiltersProvider>
+        <AppealsProvider
+          filterPanelOpen={filterPanelOpen}
+          setFilterPanelOpen={setFilterPanelOpen}
+          appealId={appealId}
+          viewMode={viewMode}
+          setViewMode={setViewMode}
+          tour={tour}
+          setTour={setTour}
+          userOptionsLoading={false}
+        >
+          {children}
+        </AppealsProvider>
+      </UrlFiltersProvider>
+    </ContactPanelProvider>
   );
 };

--- a/pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper.tsx
+++ b/pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper.tsx
@@ -1,11 +1,5 @@
 import { useRouter } from 'next/router';
-import React, {
-  Dispatch,
-  SetStateAction,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useGetUserOptionsLazyQuery } from 'src/components/Contacts/ContactFlow/GetUserOptions.generated';
 import {
   AppealTourEnum,
@@ -14,6 +8,7 @@ import {
 } from 'src/components/Tool/Appeal/AppealsContext/AppealsContext';
 import { ContactPanelProvider } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { UrlFiltersProvider } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
+import { useUpdateUserOptionMutation } from 'src/hooks/UserPreference.generated';
 
 /**
  * Extract the view mode from a string.
@@ -70,6 +65,17 @@ export const AppealsWrapper: React.FC<Props> = ({ children }) => {
     }
   }, [viewMode]);
 
+  const [updateUserOption] = useUpdateUserOptionMutation();
+  const setAndSaveViewMode = useCallback((newViewMode: TableViewModeEnum) => {
+    setViewMode(newViewMode);
+    updateUserOption({
+      variables: {
+        key: 'contacts_view',
+        value: newViewMode,
+      },
+    });
+  }, []);
+
   const appealIdPrefix = useMemo(() => {
     const appealIdPrefix = [appealId];
     if (viewMode !== null) {
@@ -93,9 +99,7 @@ export const AppealsWrapper: React.FC<Props> = ({ children }) => {
           setFilterPanelOpen={setFilterPanelOpen}
           appealId={appealId}
           viewMode={viewMode}
-          setViewMode={
-            setViewMode as Dispatch<SetStateAction<TableViewModeEnum>>
-          }
+          setViewMode={setAndSaveViewMode}
           tour={tour}
           setTour={setTour}
           userOptionsLoading={false}

--- a/pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper.tsx
+++ b/pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper.tsx
@@ -4,6 +4,7 @@ import { useGetUserOptionsLazyQuery } from 'src/components/Contacts/ContactFlow/
 import {
   AppealTourEnum,
   AppealsProvider,
+  AppealsViewModeEnum,
   TableViewModeEnum,
 } from 'src/components/Tool/Appeal/AppealsContext/AppealsContext';
 import { ContactPanelProvider } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
@@ -15,7 +16,7 @@ import { useUpdateUserOptionMutation } from 'src/hooks/UserPreference.generated'
  */
 const parseViewMode = (
   viewMode: string | null | undefined,
-): TableViewModeEnum | null => {
+): AppealsViewModeEnum | null => {
   if (typeof viewMode !== 'string') {
     return null;
   }
@@ -66,7 +67,7 @@ export const AppealsWrapper: React.FC<Props> = ({ children }) => {
   }, [viewMode]);
 
   const [updateUserOption] = useUpdateUserOptionMutation();
-  const setAndSaveViewMode = useCallback((newViewMode: TableViewModeEnum) => {
+  const setAndSaveViewMode = useCallback((newViewMode: AppealsViewModeEnum) => {
     setViewMode(newViewMode);
     updateUserOption({
       variables: {

--- a/src/components/Coaching/CoachingDetail/Activity/Activity.tsx
+++ b/src/components/Coaching/CoachingDetail/Activity/Activity.tsx
@@ -418,7 +418,7 @@ export const Activity: React.FC<ActivityProps> = ({
                 component={NextLink}
                 href={
                   primaryAppeal
-                    ? `/accountLists/${accountListId}/tools/appeals/appeal/${primaryAppeal.id}/list`
+                    ? `/accountLists/${accountListId}/tools/appeals/appeal/${primaryAppeal.id}`
                     : `/accountLists/${accountListId}/tools/appeals`
                 }
                 underline="none"

--- a/src/components/Contacts/ContactPartnershipStatus/ContactPartnershipStatus.test.tsx
+++ b/src/components/Contacts/ContactPartnershipStatus/ContactPartnershipStatus.test.tsx
@@ -2,61 +2,66 @@ import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
+import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { loadConstantsMockData } from 'src/components/Constants/LoadConstantsMock';
+import { ContactPanelProvider } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { StatusEnum } from 'src/graphql/types.generated';
 import i18n from 'src/lib/i18n';
 import theme from '../../../theme';
 import { ContactPartnershipStatus } from './ContactPartnershipStatus';
 
-const status = StatusEnum.PartnerFinancial;
+const defaultStatus = StatusEnum.PartnerFinancial;
 
-describe('ContactPartnershipStatus', () => {
-  it('default', async () => {
-    const { findByText } = render(
+interface TestComponentProps {
+  pledgeAmount?: number | null;
+  pledgeCurrency?: string | null;
+  status?: StatusEnum;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({
+  pledgeAmount = null,
+  pledgeCurrency = null,
+  status = defaultStatus,
+}) => {
+  return (
+    <TestRouter>
       <GqlMockedProvider>
         <ThemeProvider theme={theme}>
           <I18nextProvider i18n={i18n}>
-            <ContactPartnershipStatus
-              lateAt={null}
-              contactDetailsOpen={false}
-              pledgeStartDate={null}
-              pledgeAmount={null}
-              pledgeCurrency={null}
-              pledgeFrequency={null}
-              pledgeReceived={false}
-              status={status}
-            />
+            <ContactPanelProvider>
+              <ContactPartnershipStatus
+                lateAt={null}
+                pledgeStartDate={null}
+                pledgeAmount={pledgeAmount}
+                pledgeCurrency={pledgeCurrency}
+                pledgeFrequency={null}
+                pledgeReceived={false}
+                status={status}
+              />
+            </ContactPanelProvider>
           </I18nextProvider>
         </ThemeProvider>
-      </GqlMockedProvider>,
-    );
+      </GqlMockedProvider>
+    </TestRouter>
+  );
+};
+
+describe('ContactPartnershipStatus', () => {
+  it('default', async () => {
+    const { findByText } = render(<TestComponent />);
     expect(
       await findByText(
-        loadConstantsMockData.constant.status?.find((s) => s.id === status)
-          ?.value || '',
+        loadConstantsMockData.constant.status?.find(
+          (s) => s.id === defaultStatus,
+        )?.value || '',
       ),
     ).toBeInTheDocument();
   });
 
   it('render partner pray', async () => {
     const { findByText } = render(
-      <GqlMockedProvider>
-        <ThemeProvider theme={theme}>
-          <I18nextProvider i18n={i18n}>
-            <ContactPartnershipStatus
-              lateAt={null}
-              contactDetailsOpen={false}
-              pledgeStartDate={null}
-              pledgeAmount={null}
-              pledgeCurrency={null}
-              pledgeFrequency={null}
-              pledgeReceived={false}
-              status={StatusEnum.PartnerPray}
-            />
-          </I18nextProvider>
-        </ThemeProvider>
-      </GqlMockedProvider>,
+      <TestComponent status={StatusEnum.PartnerPray} />,
     );
     expect(
       await findByText(
@@ -70,44 +75,22 @@ describe('ContactPartnershipStatus', () => {
   describe('pledge amount', () => {
     it('renders pledge amount', () => {
       const { getByText } = render(
-        <GqlMockedProvider>
-          <ThemeProvider theme={theme}>
-            <I18nextProvider i18n={i18n}>
-              <ContactPartnershipStatus
-                lateAt={null}
-                contactDetailsOpen={false}
-                pledgeStartDate={null}
-                pledgeAmount={100}
-                pledgeCurrency={'USD'}
-                pledgeFrequency={null}
-                pledgeReceived={false}
-                status={StatusEnum.PartnerPray}
-              />
-            </I18nextProvider>
-          </ThemeProvider>
-        </GqlMockedProvider>,
+        <TestComponent
+          pledgeAmount={100}
+          pledgeCurrency="USD"
+          status={StatusEnum.PartnerPray}
+        />,
       );
       expect(getByText('$100')).toBeInTheDocument();
     });
 
     it('does not render pledge amount when 0', () => {
       const { queryByText } = render(
-        <GqlMockedProvider>
-          <ThemeProvider theme={theme}>
-            <I18nextProvider i18n={i18n}>
-              <ContactPartnershipStatus
-                lateAt={null}
-                contactDetailsOpen={false}
-                pledgeStartDate={null}
-                pledgeAmount={0}
-                pledgeCurrency={'USD'}
-                pledgeFrequency={null}
-                pledgeReceived={false}
-                status={StatusEnum.PartnerPray}
-              />
-            </I18nextProvider>
-          </ThemeProvider>
-        </GqlMockedProvider>,
+        <TestComponent
+          pledgeAmount={0}
+          pledgeCurrency="USD"
+          status={StatusEnum.PartnerPray}
+        />,
       );
       expect(queryByText('$0')).not.toBeInTheDocument();
       expect(queryByText('0')).not.toBeInTheDocument();

--- a/src/components/Contacts/ContactPartnershipStatus/ContactPartnershipStatus.tsx
+++ b/src/components/Contacts/ContactPartnershipStatus/ContactPartnershipStatus.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Hidden, Typography } from '@mui/material';
+import { useContactPanel } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { StatusEnum as ContactPartnershipStatusEnum } from 'src/graphql/types.generated';
 import { useLocale } from 'src/hooks/useLocale';
 import { useLocalizedConstants } from 'src/hooks/useLocalizedConstants';
@@ -12,7 +13,6 @@ import { ContactPledgeReceivedIcon } from './ContactPledgeReceivedIcon/ContactPl
 interface ContactPartnershipStatusProps {
   lateAt: ContactRowFragment['lateAt'];
   pledgeStartDate: ContactRowFragment['pledgeStartDate'];
-  contactDetailsOpen: boolean;
   pledgeAmount: ContactRowFragment['pledgeAmount'];
   pledgeCurrency: ContactRowFragment['pledgeCurrency'];
   pledgeFrequency: ContactRowFragment['pledgeFrequency'];
@@ -25,7 +25,6 @@ export const ContactPartnershipStatus: React.FC<
 > = ({
   lateAt,
   pledgeStartDate,
-  contactDetailsOpen,
   pledgeAmount,
   pledgeCurrency,
   pledgeFrequency,
@@ -33,13 +32,14 @@ export const ContactPartnershipStatus: React.FC<
   status,
 }) => {
   const locale = useLocale();
+  const { isOpen: contactPanelOpen } = useContactPanel();
   const { getLocalizedPledgeFrequency } = useLocalizedConstants();
 
   return (
     <Box
       display="flex"
       alignItems="center"
-      justifyContent={contactDetailsOpen ? 'flex-end' : undefined}
+      justifyContent={contactPanelOpen ? 'flex-end' : undefined}
     >
       <Box display="flex" alignItems="center" width={32}>
         {status === ContactPartnershipStatusEnum.PartnerFinancial && (

--- a/src/components/Contacts/ContactRow/ContactRow.tsx
+++ b/src/components/Contacts/ContactRow/ContactRow.tsx
@@ -60,7 +60,6 @@ export const ContactRow: React.FC<Props> = ({ contact, useTopMargin }) => {
   const {
     accountListId,
     isRowChecked: isChecked,
-    contactDetailsOpen,
     toggleSelectionById: onContactCheckToggle,
   } = React.useContext(ContactsContext) as ContactsType;
   const { buildContactUrl } = useContactPanel();
@@ -145,7 +144,6 @@ export const ContactRow: React.FC<Props> = ({ contact, useTopMargin }) => {
         </Grid>
         <Grid item xs={2} md={6}>
           <ContactPartnershipStatus
-            contactDetailsOpen={contactDetailsOpen}
             lateAt={lateAt}
             pledgeStartDate={pledgeStartDate}
             pledgeAmount={pledgeAmount}

--- a/src/components/Contacts/ContactsContext/ContactsContext.test.tsx
+++ b/src/components/Contacts/ContactsContext/ContactsContext.test.tsx
@@ -95,12 +95,8 @@ const TestWrapper: React.FC<TestWrapper> = ({
 };
 
 const InnerComponent: React.FC = () => {
-  const {
-    viewMode,
-    handleViewModeChange,
-    userOptionsLoading,
-    toggleSelectionById,
-  } = useContext(ContactsContext) as ContactsType;
+  const { viewMode, setViewMode, userOptionsLoading, toggleSelectionById } =
+    useContext(ContactsContext) as ContactsType;
   const { activeFilters } = useUrlFilters();
 
   return (
@@ -108,25 +104,13 @@ const InnerComponent: React.FC = () => {
       {!userOptionsLoading ? (
         <>
           <Typography>{viewMode}</Typography>
-          <Button
-            onClick={(event) =>
-              handleViewModeChange(event, TableViewModeEnum.List)
-            }
-          >
+          <Button onClick={() => setViewMode(TableViewModeEnum.List)}>
             List Button
           </Button>
-          <Button
-            onClick={(event) =>
-              handleViewModeChange(event, TableViewModeEnum.Flows)
-            }
-          >
+          <Button onClick={() => setViewMode(TableViewModeEnum.Flows)}>
             Flows Button
           </Button>
-          <Button
-            onClick={(event) =>
-              handleViewModeChange(event, TableViewModeEnum.Map)
-            }
-          >
+          <Button onClick={() => setViewMode(TableViewModeEnum.Map)}>
             Map Button
           </Button>
         </>

--- a/src/components/Contacts/ContactsContext/ContactsContext.test.tsx
+++ b/src/components/Contacts/ContactsContext/ContactsContext.test.tsx
@@ -14,8 +14,8 @@ import theme from '../../../theme';
 import { TableViewModeEnum } from '../../Shared/Header/ListHeader';
 import {
   ContactsContext,
-  ContactsContextSavedFilters,
   ContactsType,
+  parseSavedFilters,
 } from './ContactsContext';
 
 const accountListId = 'account-list-1';
@@ -127,7 +127,7 @@ const InnerComponent: React.FC = () => {
 
 const TestRenderContactsFilters: React.FC = () => {
   const { filterData } = useContext(ContactsContext) as ContactsType;
-  const savedFilters = ContactsContextSavedFilters(filterData, accountListId);
+  const savedFilters = parseSavedFilters(filterData, accountListId);
   return (
     <Box>
       {savedFilters.length && (

--- a/src/components/Contacts/ContactsContext/ContactsContext.tsx
+++ b/src/components/Contacts/ContactsContext/ContactsContext.tsx
@@ -36,10 +36,6 @@ export type ContactsType = {
   filtersLoading: boolean;
   toggleFilterPanel: () => void;
   savedFilters: UserOptionFragment[];
-  handleViewModeChange: (
-    event: React.MouseEvent<HTMLElement>,
-    view: string,
-  ) => void;
   selected: Coordinates | null;
   setSelected: Dispatch<SetStateAction<Coordinates | null>>;
   mapRef: React.MutableRefObject<google.maps.Map | null>;
@@ -178,16 +174,6 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
   );
   //#endregion
 
-  //#region User Actions
-
-  const handleViewModeChange = useCallback(
-    (_: React.MouseEvent<HTMLElement>, view: string) => {
-      setViewMode(view as TableViewModeEnum);
-    },
-    [setViewMode],
-  );
-  //#endregion
-
   //#region JSX
 
   // map states and functions
@@ -222,7 +208,6 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
       filtersLoading,
       toggleFilterPanel,
       savedFilters,
-      handleViewModeChange,
       selected,
       setSelected,
       mapRef,
@@ -247,7 +232,6 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
       filtersLoading,
       toggleFilterPanel,
       savedFilters,
-      handleViewModeChange,
       selected,
       setSelected,
       mapData,

--- a/src/components/Contacts/ContactsContext/ContactsContext.tsx
+++ b/src/components/Contacts/ContactsContext/ContactsContext.tsx
@@ -66,7 +66,7 @@ export interface ContactsContextProps {
   filterPanelOpen: boolean;
   setFilterPanelOpen: Dispatch<SetStateAction<boolean>>;
   viewMode: TableViewModeEnum;
-  setViewMode: (newViewMode: TableViewModeEnum) => void;
+  setViewMode: Dispatch<SetStateAction<TableViewModeEnum>>;
   userOptionsLoading: boolean;
 }
 

--- a/src/components/Contacts/ContactsContext/ContactsContext.tsx
+++ b/src/components/Contacts/ContactsContext/ContactsContext.tsx
@@ -61,7 +61,7 @@ export interface ContactsContextProps {
   userOptionsLoading: boolean;
 }
 
-export const ContactsContextSavedFilters = (
+export const parseSavedFilters = (
   filterData: ContactFiltersQuery | undefined,
   accountListId: string | undefined,
 ): UserOptionFragment[] => {
@@ -169,7 +169,7 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
   }, [setFilterPanelOpen]);
 
   const savedFilters: UserOptionFragment[] = useMemo(
-    () => ContactsContextSavedFilters(filterData, accountListId),
+    () => parseSavedFilters(filterData, accountListId),
     [filterData, accountListId],
   );
   //#endregion

--- a/src/components/Contacts/ContactsContext/ContactsContext.tsx
+++ b/src/components/Contacts/ContactsContext/ContactsContext.tsx
@@ -27,7 +27,6 @@ import { Coordinates } from '../ContactsMap/coordinates';
 
 export type ContactsType = {
   accountListId: string | undefined;
-  contactId: string | string[] | undefined;
   contactsQueryResult: ReturnType<typeof useContactsQuery>;
   selectionType: ListHeaderCheckBoxState;
   isRowChecked: (id: string) => boolean;
@@ -36,9 +35,7 @@ export type ContactsType = {
   filterData: ContactFiltersQuery | undefined;
   filtersLoading: boolean;
   toggleFilterPanel: () => void;
-  handleClearAll: () => void;
   savedFilters: UserOptionFragment[];
-  setContactFocus: (id: string | undefined) => void;
   handleViewModeChange: (
     event: React.MouseEvent<HTMLElement>,
     view: string,
@@ -50,8 +47,6 @@ export type ContactsType = {
   mapData: Coordinates[] | undefined;
   filterPanelOpen: boolean;
   setFilterPanelOpen: (open: boolean) => void;
-  contactDetailsOpen: boolean;
-  contactDetailsId: string | undefined;
   viewMode: TableViewModeEnum | undefined;
   setViewMode: (mode: TableViewModeEnum) => void;
   selectedIds: string[];
@@ -105,7 +100,7 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
   const locale = useLocale();
   const accountListId = useAccountListId() ?? '';
 
-  const { setSearchTerm, combinedFilters: contactsFilters } = useUrlFilters();
+  const { combinedFilters: contactsFilters } = useUrlFilters();
 
   //#region Mass Actions
 
@@ -177,10 +172,6 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
     setFilterPanelOpen((open) => !open);
   }, [setFilterPanelOpen]);
 
-  const handleClearAll = useCallback(() => {
-    setSearchTerm('');
-  }, [setSearchTerm]);
-
   const savedFilters: UserOptionFragment[] = useMemo(
     () => ContactsContextSavedFilters(filterData, accountListId),
     [filterData, accountListId],
@@ -217,12 +208,9 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
     [data],
   );
 
-  const setContactFocus = useCallback(() => {}, []);
-
   const contextValue = useMemo(
     () => ({
       accountListId: accountListId ?? '',
-      contactId: undefined,
       contactsQueryResult,
       selectionType,
       isRowChecked,
@@ -233,9 +221,7 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
       filterData,
       filtersLoading,
       toggleFilterPanel,
-      handleClearAll,
       savedFilters,
-      setContactFocus,
       handleViewModeChange,
       selected,
       setSelected,
@@ -244,8 +230,6 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
       panTo,
       filterPanelOpen,
       setFilterPanelOpen,
-      contactDetailsOpen: false,
-      contactDetailsId: undefined,
       viewMode,
       setViewMode,
       userOptionsLoading,
@@ -262,9 +246,7 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
       filterData,
       filtersLoading,
       toggleFilterPanel,
-      handleClearAll,
       savedFilters,
-      setContactFocus,
       handleViewModeChange,
       selected,
       setSelected,

--- a/src/components/Contacts/ContactsMainPanel/ContactsMainPanelHeader.tsx
+++ b/src/components/Contacts/ContactsMainPanel/ContactsMainPanelHeader.tsx
@@ -51,19 +51,16 @@ export const ContactsMainPanelHeader: React.FC = () => {
     toggleSelectAll,
     selectionType,
     filterPanelOpen,
-    contactDetailsOpen,
     viewMode,
     handleViewModeChange,
     selectedIds,
   } = React.useContext(ContactsContext) as ContactsType;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (
     <ListHeader
       page={PageEnum.Contact}
       filterPanelOpen={filterPanelOpen}
       toggleFilterPanel={toggleFilterPanel}
-      contactDetailsOpen={contactDetailsOpen}
       onCheckAllItems={toggleSelectAll}
       contactsView={viewMode}
       totalItems={contactsQueryResult.data?.contacts.totalCount}

--- a/src/components/Contacts/ContactsMainPanel/ContactsMainPanelHeader.tsx
+++ b/src/components/Contacts/ContactsMainPanel/ContactsMainPanelHeader.tsx
@@ -52,7 +52,7 @@ export const ContactsMainPanelHeader: React.FC = () => {
     selectionType,
     filterPanelOpen,
     viewMode,
-    handleViewModeChange,
+    setViewMode,
     selectedIds,
   } = React.useContext(ContactsContext) as ContactsType;
 
@@ -83,7 +83,7 @@ export const ContactsMainPanelHeader: React.FC = () => {
             <StyledToggleButtonGroup
               exclusive
               value={viewMode}
-              onChange={handleViewModeChange}
+              onChange={(_event, value) => setViewMode(value)}
             >
               <ToggleButton
                 value={TableViewModeEnum.List}

--- a/src/components/Dashboard/ThisWeek/Appeals/Appeals.tsx
+++ b/src/components/Dashboard/ThisWeek/Appeals/Appeals.tsx
@@ -144,7 +144,7 @@ const Appeals = ({ loading, appeal }: Props): ReactElement => {
               component={NextLink}
               href={
                 appeal
-                  ? `/accountLists/${accountListId}/tools/appeals/appeal/${appeal.id}/list`
+                  ? `/accountLists/${accountListId}/tools/appeals/appeal/${appeal.id}`
                   : `/accountLists/${accountListId}/tools/appeals`
               }
               className={classes.appealsHeader}

--- a/src/components/Reports/PartnerGivingAnalysisReport/PartnerGivingAnalysisReport.test.tsx
+++ b/src/components/Reports/PartnerGivingAnalysisReport/PartnerGivingAnalysisReport.test.tsx
@@ -4,6 +4,7 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { ContactPanelProvider } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { UrlFiltersProvider } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
 import { GetPartnerGivingAnalysisIdsForMassSelectionQuery } from 'src/hooks/GetIdsForMassSelection.generated';
 import theme from 'src/theme';
@@ -63,16 +64,17 @@ const TestComponent: React.FC<TestComponentProps> = ({
         }
         onCall={mutationSpy}
       >
-        <UrlFiltersProvider>
-          <PartnerGivingAnalysisReport
-            accountListId={accountListId}
-            title={title}
-            panelOpen={null}
-            onNavListToggle={onNavListToggle}
-            onFilterListToggle={onFilterListToggle}
-            contactDetailsOpen={false}
-          />
-        </UrlFiltersProvider>
+        <ContactPanelProvider>
+          <UrlFiltersProvider>
+            <PartnerGivingAnalysisReport
+              accountListId={accountListId}
+              title={title}
+              panelOpen={null}
+              onNavListToggle={onNavListToggle}
+              onFilterListToggle={onFilterListToggle}
+            />
+          </UrlFiltersProvider>
+        </ContactPanelProvider>
       </GqlMockedProvider>
     </ThemeProvider>
   </TestRouter>

--- a/src/components/Reports/PartnerGivingAnalysisReport/PartnerGivingAnalysisReport.tsx
+++ b/src/components/Reports/PartnerGivingAnalysisReport/PartnerGivingAnalysisReport.tsx
@@ -26,7 +26,6 @@ interface Props {
   panelOpen: Panel | null;
   onNavListToggle: () => void;
   onFilterListToggle: () => void;
-  contactDetailsOpen: boolean;
   title: string;
 }
 
@@ -37,7 +36,6 @@ export const PartnerGivingAnalysisReport: React.FC<Props> = ({
   panelOpen,
   onNavListToggle,
   onFilterListToggle,
-  contactDetailsOpen,
   title,
 }) => {
   const { t } = useTranslation();
@@ -144,7 +142,6 @@ export const PartnerGivingAnalysisReport: React.FC<Props> = ({
         page={PageEnum.Report}
         filterPanelOpen={panelOpen === Panel.Filters}
         toggleFilterPanel={onFilterListToggle}
-        contactDetailsOpen={contactDetailsOpen}
         onCheckAllItems={toggleSelectAll}
         showShowingCount={false}
         totalItems={contactCount}

--- a/src/components/Shared/Filters/FilterPanel.tsx
+++ b/src/components/Shared/Filters/FilterPanel.tsx
@@ -98,17 +98,11 @@ export type FilterInput = ContactFilterSetInput &
   TaskFilterSetInput &
   ReportContactFilterSetInput;
 
-export enum ContextTypesEnum {
-  Contacts = 'contacts',
-  Appeals = 'appeals',
-  FinancialAccountReport = 'financialAccountReport',
-}
 export interface FilterPanelProps {
   filters: FilterPanelGroupFragment[];
   defaultExpandedFilterGroups?: Set<string>;
   savedFilters: UserOptionFragment[];
   onClose: () => void;
-  contextType?: ContextTypesEnum;
   showSaveButton?: boolean;
 }
 

--- a/src/components/Shared/Header/ListHeader.test.tsx
+++ b/src/components/Shared/Header/ListHeader.test.tsx
@@ -7,6 +7,7 @@ import { SnackbarProvider } from 'notistack';
 import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { ContactPanelProvider } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { UrlFiltersProvider } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
 import i18n from 'src/lib/i18n';
 import theme from '../../../theme';
@@ -89,6 +90,9 @@ const Components = ({
       ...router,
       query: {
         ...router.query,
+        contactId: contactDetailsOpen
+          ? ['00000000-0000-0000-0000-000000000000']
+          : undefined,
         filters: activeFilters
           ? '%7B%22status%22%3A%5B%22APPOINTMENT_SCHEDULED%22%5D%7D'
           : undefined,
@@ -99,20 +103,21 @@ const Components = ({
       <I18nextProvider i18n={i18n}>
         <GqlMockedProvider>
           <SnackbarProvider>
-            <UrlFiltersProvider>
-              <ListHeader
-                selectedIds={selectedIds}
-                page={page}
-                contactsView={contactsView}
-                headerCheckboxState={headerCheckboxState}
-                filterPanelOpen={filterPanelOpen}
-                contactDetailsOpen={contactDetailsOpen}
-                buttonGroup={buttonGroup}
-                totalItems={totalItems}
-                showShowingCount={showShowingCount}
-                {...mockedProps}
-              />
-            </UrlFiltersProvider>
+            <ContactPanelProvider>
+              <UrlFiltersProvider>
+                <ListHeader
+                  selectedIds={selectedIds}
+                  page={page}
+                  contactsView={contactsView}
+                  headerCheckboxState={headerCheckboxState}
+                  filterPanelOpen={filterPanelOpen}
+                  buttonGroup={buttonGroup}
+                  totalItems={totalItems}
+                  showShowingCount={showShowingCount}
+                  {...mockedProps}
+                />
+              </UrlFiltersProvider>
+            </ContactPanelProvider>
           </SnackbarProvider>
         </GqlMockedProvider>
       </I18nextProvider>

--- a/src/components/Shared/Header/ListHeader.tsx
+++ b/src/components/Shared/Header/ListHeader.tsx
@@ -4,6 +4,7 @@ import ViewList from '@mui/icons-material/ViewList';
 import { Box, Checkbox, Hidden } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
+import { useContactPanel } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { useUrlFilters } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
 import theme from 'src/theme';
 import { SearchBox } from '../../common/SearchBox/SearchBox';
@@ -15,8 +16,8 @@ import { FilterButton } from './styledComponents';
 export const headerHeight = theme.spacing(12);
 
 const HeaderWrap = styled(Box, {
-  shouldForwardProp: (prop) => prop !== 'contactDetailsOpen',
-})<{ contactDetailsOpen?: boolean }>(({}) => ({
+  shouldForwardProp: (prop) => prop !== 'contactPanelOpen',
+})<{ contactPanelOpen?: boolean }>(({}) => ({
   paddingLeft: theme.spacing(0.5),
   paddingRight: theme.spacing(0.5),
   height: headerHeight,
@@ -78,7 +79,6 @@ interface ListHeaderProps {
   filterPanelOpen: boolean;
   contactsView?: TableViewModeEnum;
   toggleFilterPanel: () => void;
-  contactDetailsOpen: boolean;
   onCheckAllItems: (event: React.ChangeEvent<HTMLInputElement>) => void;
   totalItems?: number;
   leftButtonGroup?: ReactElement;
@@ -93,7 +93,6 @@ export const ListHeader: React.FC<ListHeaderProps> = ({
   page,
   headerCheckboxState,
   filterPanelOpen,
-  contactDetailsOpen,
   toggleFilterPanel,
   onCheckAllItems,
   totalItems,
@@ -105,13 +104,14 @@ export const ListHeader: React.FC<ListHeaderProps> = ({
   showShowingCount = false,
   isExcludedAppealPage = false,
 }) => {
+  const { isOpen: contactPanelOpen } = useContactPanel();
   const { activeFilters, searchTerm, setSearchTerm, starred, setStarred } =
     useUrlFilters();
 
   const { t } = useTranslation();
 
   return (
-    <HeaderWrap contactDetailsOpen={contactDetailsOpen}>
+    <HeaderWrap contactPanelOpen={contactPanelOpen}>
       <HeaderWrapInner style={{ marginRight: 8 }}>
         {contactsView !== TableViewModeEnum.Map && (
           <Hidden xsDown>
@@ -168,7 +168,6 @@ export const ListHeader: React.FC<ListHeaderProps> = ({
         {(page === PageEnum.Contact || page === PageEnum.Appeal) && (
           <ContactsMassActionsDropdown
             filterPanelOpen={filterPanelOpen}
-            contactDetailsOpen={contactDetailsOpen}
             buttonGroup={buttonGroup}
             contactsView={contactsView}
             selectedIds={selectedIds}
@@ -180,7 +179,6 @@ export const ListHeader: React.FC<ListHeaderProps> = ({
           <Box mr={2}>
             <ContactsMassActionsDropdown
               filterPanelOpen={filterPanelOpen}
-              contactDetailsOpen={contactDetailsOpen}
               buttonGroup={buttonGroup}
               contactsView={contactsView}
               selectedIds={selectedIds}

--- a/src/components/Shared/MassActions/ContactsMassActionsDropdown.test.tsx
+++ b/src/components/Shared/MassActions/ContactsMassActionsDropdown.test.tsx
@@ -37,23 +37,26 @@ jest.mock('notistack', () => ({
 }));
 
 const ContactComponents = () => (
-  <AppSettingsProvider>
-    <ThemeProvider theme={theme}>
-      <GqlMockedProvider>
-        <LocalizationProvider dateAdapter={AdapterLuxon}>
-          <SnackbarProvider>
-            <ContactsMassActionsDropdown
-              filterPanelOpen={false}
-              contactDetailsOpen={false}
-              contactsView={TableViewModeEnum.List}
-              selectedIds={selectedIds}
-              page={PageEnum.Contact}
-            />
-          </SnackbarProvider>
-        </LocalizationProvider>
-      </GqlMockedProvider>
-    </ThemeProvider>
-  </AppSettingsProvider>
+  <TestRouter>
+    <AppSettingsProvider>
+      <ThemeProvider theme={theme}>
+        <GqlMockedProvider>
+          <LocalizationProvider dateAdapter={AdapterLuxon}>
+            <SnackbarProvider>
+              <ContactsWrapper>
+                <ContactsMassActionsDropdown
+                  filterPanelOpen={false}
+                  contactsView={TableViewModeEnum.List}
+                  selectedIds={selectedIds}
+                  page={PageEnum.Contact}
+                />
+              </ContactsWrapper>
+            </SnackbarProvider>
+          </LocalizationProvider>
+        </GqlMockedProvider>
+      </ThemeProvider>
+    </AppSettingsProvider>
+  </TestRouter>
 );
 
 describe('ContactsMassActionsDropdown', () => {
@@ -267,7 +270,6 @@ describe('ContactsMassActionsDropdown', () => {
                 <ContactsWrapper>
                   <ContactsMassActionsDropdown
                     filterPanelOpen={false}
-                    contactDetailsOpen={false}
                     contactsView={TableViewModeEnum.List}
                     selectedIds={selectedIdsMerge}
                     page={PageEnum.Contact}
@@ -327,7 +329,6 @@ describe('ContactsMassActionsDropdown', () => {
                 <AppealsWrapper>
                   <ContactsMassActionsDropdown
                     filterPanelOpen={false}
-                    contactDetailsOpen={false}
                     contactsView={TableViewModeEnum.List}
                     selectedIds={selectedIdsMerge}
                     page={PageEnum.Appeal}

--- a/src/components/Shared/MassActions/ContactsMassActionsDropdown.tsx
+++ b/src/components/Shared/MassActions/ContactsMassActionsDropdown.tsx
@@ -43,6 +43,7 @@ import {
   DynamicAddExcludedContactModal,
   preloadAddExcludedContactModal,
 } from 'src/components/Tool/Appeal/Modals/AddExcludedContactModal/DynamicAddExcludedContactModal';
+import { useContactPanel } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { StatusEnum } from 'src/graphql/types.generated';
 import useTaskModal from 'src/hooks/useTaskModal';
 import { useAccountListId } from '../../../hooks/useAccountListId';
@@ -55,7 +56,6 @@ import { MassActionsDropdown } from './MassActionsDropdown';
 
 interface ContactsMassActionsDropdownProps {
   filterPanelOpen: boolean;
-  contactDetailsOpen: boolean;
   contactsView?: TableViewModeEnum;
   buttonGroup?: ReactElement;
   selectedIds: string[];
@@ -67,7 +67,6 @@ export const ContactsMassActionsDropdown: React.FC<
   ContactsMassActionsDropdownProps
 > = ({
   filterPanelOpen,
-  contactDetailsOpen,
   contactsView,
   buttonGroup,
   selectedIds,
@@ -77,6 +76,7 @@ export const ContactsMassActionsDropdown: React.FC<
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
   const accountListId = useAccountListId() ?? '';
+  const { isOpen: contactPanelOpen } = useContactPanel();
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
@@ -134,7 +134,7 @@ export const ContactsMassActionsDropdown: React.FC<
           {selectedIds?.length > 0 && (
             <>
               <MassActionsDropdown handleClick={handleClick} open={open}>
-                {filterPanelOpen && contactDetailsOpen ? (
+                {filterPanelOpen && contactPanelOpen ? (
                   <MoreHoriz />
                 ) : (
                   t('Actions')

--- a/src/components/Tool/Appeal/AppealDetails/AppealLeftPanel/AppealsLeftPanel.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealLeftPanel/AppealsLeftPanel.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { DynamicFilterPanel } from 'src/components/Shared/Filters/DynamicFilterPanel';
-import { ContextTypesEnum } from 'src/components/Shared/Filters/FilterPanel';
 import { TableViewModeEnum } from 'src/components/Shared/Header/ListHeader';
 import {
   AppealsContext,
@@ -24,7 +23,6 @@ export const AppealsLeftPanel: React.FC = () => {
       filters={filterData?.accountList?.contactFilterGroups}
       savedFilters={savedFilters}
       onClose={toggleFilterPanel}
-      contextType={ContextTypesEnum.Appeals}
     />
   ) : null;
 };

--- a/src/components/Tool/Appeal/AppealDetails/AppealsDetailsPage.test.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealsDetailsPage.test.tsx
@@ -184,27 +184,19 @@ describe('AppealsDetailsPage', () => {
         />,
       );
 
-      expect(
-        await findByRole('img', { name: /toggle filter panel/i }),
-      ).toBeInTheDocument();
-
-      expect(
-        queryByRole('heading', { name: /export to csv/i }),
-      ).not.toBeInTheDocument();
-
-      userEvent.click(getByRole('img', { name: /toggle filter panel/i }));
-
-      expect(
-        await findByRole('heading', { name: /export to csv/i }),
-      ).toBeInTheDocument();
-
-      userEvent.click(getByRole('img', { name: 'Close' }));
+      userEvent.click(await findByRole('img', { name: 'Close' }));
 
       await waitFor(() =>
         expect(
           queryByRole('heading', { name: /export to csv/i }),
         ).not.toBeInTheDocument(),
       );
+
+      userEvent.click(getByRole('img', { name: /toggle filter panel/i }));
+
+      expect(
+        await findByRole('heading', { name: /export to csv/i }),
+      ).toBeInTheDocument();
     });
 
     it('should open and close on Flows view', async () => {

--- a/src/components/Tool/Appeal/AppealDetails/AppealsDetailsPage.test.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealsDetailsPage.test.tsx
@@ -23,6 +23,8 @@ import AppealsDetailsPage from './AppealsDetailsPage';
 const accountListId = 'account-list-1';
 
 const defaultRouter = {
+  pathname:
+    '/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]]',
   query: { accountListId },
   isReady: true,
 };

--- a/src/components/Tool/Appeal/AppealDetails/AppealsDetailsPage.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealsDetailsPage.tsx
@@ -2,15 +2,12 @@ import React, { useContext } from 'react';
 import { DynamicContactsRightPanel } from 'src/components/Contacts/ContactsRightPanel/DynamicContactsRightPanel';
 import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
 import { headerHeight } from 'src/components/Shared/Header/ListHeader';
-import {
-  ContactPanelProvider,
-  useContactPanel,
-} from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
+import { useContactPanel } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { AppealsContext, AppealsType } from '../AppealsContext/AppealsContext';
 import { AppealsLeftPanel } from './AppealLeftPanel/AppealsLeftPanel';
 import { AppealsMainPanel } from './AppealsMainPanel/AppealsMainPanel';
 
-const PageContent: React.FC = () => {
+const AppealsDetailsPage: React.FC = () => {
   const { isOpen } = useContactPanel();
   const { filterPanelOpen } = useContext(AppealsContext) as AppealsType;
 
@@ -27,11 +24,5 @@ const PageContent: React.FC = () => {
     />
   );
 };
-
-const AppealsDetailsPage: React.FC = () => (
-  <ContactPanelProvider contactIdParam="appealId">
-    <PageContent />
-  </ContactPanelProvider>
-);
 
 export default AppealsDetailsPage;

--- a/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanel.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanel.tsx
@@ -10,8 +10,9 @@ import { useAppealQuery } from './AppealInfo.generated';
 import { AppealsMainPanelHeader } from './AppealsMainPanelHeader';
 
 export const AppealsMainPanel: React.FC = () => {
-  const { accountListId, appealId, viewMode, userOptionsLoading } =
-    React.useContext(AppealsContext) as AppealsType;
+  const { accountListId, appealId, viewMode } = React.useContext(
+    AppealsContext,
+  ) as AppealsType;
 
   const { data: appealInfo, loading: appealInfoLoading } = useAppealQuery({
     variables: {
@@ -24,19 +25,18 @@ export const AppealsMainPanel: React.FC = () => {
   return (
     <>
       <AppealsMainPanelHeader />
-      {!userOptionsLoading &&
-        (viewMode === TableViewModeEnum.List ? (
-          <DynamicContactsList
-            appealInfo={appealInfo}
-            appealInfoLoading={appealInfoLoading}
-          />
-        ) : (
-          <DynamicContactFlow
-            accountListId={accountListId ?? ''}
-            appealInfo={appealInfo}
-            appealInfoLoading={appealInfoLoading}
-          />
-        ))}
+      {viewMode === TableViewModeEnum.List ? (
+        <DynamicContactsList
+          appealInfo={appealInfo}
+          appealInfoLoading={appealInfoLoading}
+        />
+      ) : viewMode === TableViewModeEnum.Flows ? (
+        <DynamicContactFlow
+          accountListId={accountListId ?? ''}
+          appealInfo={appealInfo}
+          appealInfoLoading={appealInfoLoading}
+        />
+      ) : null}
     </>
   );
 };

--- a/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanelHeader.test.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanelHeader.test.tsx
@@ -134,10 +134,12 @@ describe('AppealsMainPanelHeader', () => {
 
     userEvent.type(getByRole('textbox'), 'search term');
 
-    await waitFor(() =>
-      expect(routerReplace.mock.lastCall[0].query.searchTerm).toEqual(
-        'search term',
-      ),
+    await waitFor(
+      () =>
+        expect(routerReplace.mock.lastCall[0].query.searchTerm).toEqual(
+          'search term',
+        ),
+      { timeout: 3000 },
     );
   });
 

--- a/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanelHeader.test.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanelHeader.test.tsx
@@ -30,7 +30,7 @@ jest.mock('notistack', () => ({
 }));
 
 const accountListId = 'accountListId';
-const handleViewModeChange = jest.fn();
+const setViewMode = jest.fn();
 const toggleFilterPanel = jest.fn();
 const toggleSelectAll = jest.fn();
 const routerReplace = jest.fn();
@@ -66,7 +66,7 @@ const Components = ({
                     selectionType: ListHeaderCheckBoxState.Unchecked,
                     filterPanelOpen: false,
                     viewMode: TableViewModeEnum.List,
-                    handleViewModeChange,
+                    setViewMode,
                     selectedIds: [],
                     contactsQueryResult,
                   } as unknown as AppealsType
@@ -153,10 +153,7 @@ describe('AppealsMainPanelHeader', () => {
 
     expect(getByRole('button', { name: 'List View' })).toBeDisabled();
     userEvent.click(getByRole('button', { name: 'Flows View' }));
-    expect(handleViewModeChange).toHaveBeenCalledWith(
-      expect.objectContaining({}),
-      'flows',
-    );
+    expect(setViewMode).toHaveBeenCalledWith('flows');
   });
 
   it('should allow select all to be checked', () => {

--- a/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanelHeader.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanelHeader.tsx
@@ -56,7 +56,6 @@ export const AppealsMainPanelHeader: React.FC = () => {
     toggleSelectAll,
     selectionType,
     filterPanelOpen,
-    contactDetailsOpen,
     viewMode,
     handleViewModeChange,
     selectedIds,
@@ -70,7 +69,6 @@ export const AppealsMainPanelHeader: React.FC = () => {
       page={PageEnum.Appeal}
       filterPanelOpen={filterPanelOpen}
       toggleFilterPanel={toggleFilterPanel}
-      contactDetailsOpen={contactDetailsOpen}
       onCheckAllItems={toggleSelectAll}
       contactsView={viewMode ?? undefined}
       totalItems={contactsQueryResult.data?.contacts.totalCount}

--- a/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanelHeader.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanelHeader.tsx
@@ -72,7 +72,7 @@ export const AppealsMainPanelHeader: React.FC = () => {
       toggleFilterPanel={toggleFilterPanel}
       contactDetailsOpen={contactDetailsOpen}
       onCheckAllItems={toggleSelectAll}
-      contactsView={viewMode}
+      contactsView={viewMode ?? undefined}
       totalItems={contactsQueryResult.data?.contacts.totalCount}
       headerCheckboxState={selectionType}
       selectedIds={selectedIds}

--- a/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanelHeader.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanelHeader.tsx
@@ -57,7 +57,7 @@ export const AppealsMainPanelHeader: React.FC = () => {
     selectionType,
     filterPanelOpen,
     viewMode,
-    handleViewModeChange,
+    setViewMode,
     selectedIds,
   } = React.useContext(AppealsContext) as AppealsType;
   const { activeFilters } = useUrlFilters();
@@ -96,7 +96,7 @@ export const AppealsMainPanelHeader: React.FC = () => {
             <StyledToggleButtonGroup
               exclusive
               value={viewMode}
-              onChange={handleViewModeChange}
+              onChange={(_event, value) => setViewMode(value)}
             >
               <ToggleButton
                 value={TableViewModeEnum.List}

--- a/src/components/Tool/Appeal/AppealsContext/AppealsContext.test.tsx
+++ b/src/components/Tool/Appeal/AppealsContext/AppealsContext.test.tsx
@@ -87,19 +87,14 @@ const AppealStatusFilterTestComponent: React.FC<
 );
 
 const TestRender: React.FC = () => {
-  const {
-    viewMode,
-    handleViewModeChange,
-    appealId,
-    contactDetailsId,
-    setContactFocus,
-  } = useContext(AppealsContext) as AppealsType;
+  const { viewMode, handleViewModeChange, appealId } = useContext(
+    AppealsContext,
+  ) as AppealsType;
   return (
     <Box>
       {viewMode !== null ? (
         <>
           <Typography>appealId: {appealId}</Typography>
-          <Typography>contactDetailsId: {contactDetailsId}</Typography>
           <Typography>{viewMode}</Typography>
           <Button
             onClick={(event) =>
@@ -114,10 +109,6 @@ const TestRender: React.FC = () => {
             }
           >
             Flows Button
-          </Button>
-
-          <Button onClick={() => setContactFocus(undefined)}>
-            Close Contact
           </Button>
         </>
       ) : (
@@ -227,61 +218,6 @@ describe('ContactsPageContext', () => {
           query: {
             accountListId,
             appealId: [appealId, 'list'],
-          },
-        }),
-        undefined,
-        { shallow: true },
-      ),
-    );
-  });
-
-  it('should redirect back to flows view on contact page', async () => {
-    const { getByText, findByText } = render(
-      <ThemeProvider theme={theme}>
-        <TestRouter
-          router={{
-            query: {
-              accountListId,
-              appealId: [appealId, 'flows', contactId],
-            },
-            pathname,
-            isReady,
-            push,
-          }}
-        >
-          <GqlMockedProvider<{ GetUserOptions: GetUserOptionsQuery }>
-            mocks={{
-              GetUserOptions: {
-                userOptions: [
-                  {
-                    id: 'test-id',
-                    key: 'contacts_view',
-                    value: 'flows',
-                  },
-                ],
-              },
-            }}
-          >
-            <AppealsWrapper>
-              <TestRender />
-            </AppealsWrapper>
-          </GqlMockedProvider>
-        </TestRouter>
-      </ThemeProvider>,
-    );
-
-    expect(
-      await findByText(`contactDetailsId: ${contactId}`),
-    ).toBeInTheDocument();
-    expect(await findByText('Close Contact')).toBeInTheDocument();
-    userEvent.click(getByText('Close Contact'));
-
-    await waitFor(() =>
-      expect(push).toHaveBeenCalledWith(
-        expect.objectContaining({
-          query: {
-            accountListId: 'account-list-1',
-            appealId: [appealId, 'flows'],
           },
         }),
         undefined,

--- a/src/components/Tool/Appeal/AppealsContext/AppealsContext.test.tsx
+++ b/src/components/Tool/Appeal/AppealsContext/AppealsContext.test.tsx
@@ -10,10 +10,7 @@ import { ContactFiltersQuery } from 'pages/accountLists/[accountListId]/contacts
 import { AppealsWrapper } from 'pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper';
 import { GetUserOptionsQuery } from 'src/components/Contacts/ContactFlow/GetUserOptions.generated';
 import { ContactsContextSavedFilters as AppealsContextSavedFilters } from 'src/components/Contacts/ContactsContext/ContactsContext';
-import {
-  ListHeaderCheckBoxState,
-  TableViewModeEnum,
-} from 'src/components/Shared/Header/ListHeader';
+import { ListHeaderCheckBoxState } from 'src/components/Shared/Header/ListHeader';
 import { useMassSelection } from 'src/hooks/useMassSelection';
 import theme from 'src/theme';
 import {
@@ -21,6 +18,7 @@ import {
   AppealTourEnum,
   AppealsContext,
   AppealsType,
+  TableViewModeEnum,
 } from './AppealsContext';
 
 const accountListId = 'account-list-1';
@@ -87,7 +85,7 @@ const AppealStatusFilterTestComponent: React.FC<
 );
 
 const TestRender: React.FC = () => {
-  const { viewMode, handleViewModeChange, appealId } = useContext(
+  const { viewMode, setViewMode, appealId } = useContext(
     AppealsContext,
   ) as AppealsType;
   return (
@@ -96,18 +94,10 @@ const TestRender: React.FC = () => {
         <>
           <Typography>appealId: {appealId}</Typography>
           <Typography>{viewMode}</Typography>
-          <Button
-            onClick={(event) =>
-              handleViewModeChange(event, TableViewModeEnum.List)
-            }
-          >
+          <Button onClick={() => setViewMode(TableViewModeEnum.List)}>
             List Button
           </Button>
-          <Button
-            onClick={(event) =>
-              handleViewModeChange(event, TableViewModeEnum.Flows)
-            }
-          >
+          <Button onClick={() => setViewMode(TableViewModeEnum.Flows)}>
             Flows Button
           </Button>
         </>

--- a/src/components/Tool/Appeal/AppealsContext/AppealsContext.test.tsx
+++ b/src/components/Tool/Appeal/AppealsContext/AppealsContext.test.tsx
@@ -9,7 +9,7 @@ import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { ContactFiltersQuery } from 'pages/accountLists/[accountListId]/contacts/Contacts.generated';
 import { AppealsWrapper } from 'pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper';
 import { GetUserOptionsQuery } from 'src/components/Contacts/ContactFlow/GetUserOptions.generated';
-import { ContactsContextSavedFilters as AppealsContextSavedFilters } from 'src/components/Contacts/ContactsContext/ContactsContext';
+import { parseSavedFilters } from 'src/components/Contacts/ContactsContext/ContactsContext';
 import { ListHeaderCheckBoxState } from 'src/components/Shared/Header/ListHeader';
 import { useMassSelection } from 'src/hooks/useMassSelection';
 import theme from 'src/theme';
@@ -110,7 +110,7 @@ const TestRender: React.FC = () => {
 
 const TestRenderContactsFilters: React.FC = () => {
   const { filterData } = useContext(AppealsContext) as AppealsType;
-  const savedFilters = AppealsContextSavedFilters(filterData, accountListId);
+  const savedFilters = parseSavedFilters(filterData, accountListId);
 
   return (
     <Box>

--- a/src/components/Tool/Appeal/AppealsContext/AppealsContext.test.tsx
+++ b/src/components/Tool/Appeal/AppealsContext/AppealsContext.test.tsx
@@ -90,14 +90,13 @@ const TestRender: React.FC = () => {
   const {
     viewMode,
     handleViewModeChange,
-    userOptionsLoading,
     appealId,
     contactDetailsId,
     setContactFocus,
   } = useContext(AppealsContext) as AppealsType;
   return (
     <Box>
-      {!userOptionsLoading ? (
+      {viewMode !== null ? (
         <>
           <Typography>appealId: {appealId}</Typography>
           <Typography>contactDetailsId: {contactDetailsId}</Typography>

--- a/src/components/Tool/Appeal/AppealsContext/AppealsContext.test.tsx
+++ b/src/components/Tool/Appeal/AppealsContext/AppealsContext.test.tsx
@@ -24,8 +24,10 @@ import {
 } from './AppealsContext';
 
 const accountListId = 'account-list-1';
-const appealIdentifier = 'appeal-Id-1';
-const contactId = 'contact-id';
+const pathname =
+  '/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]]';
+const appealId = 'appeal-Id-1';
+const contactId = '00000000-0000-0000-0000-000000000000';
 const push = jest.fn();
 const isReady = true;
 const mutationSpy = jest.fn();
@@ -115,10 +117,6 @@ const TestRender: React.FC = () => {
             Flows Button
           </Button>
 
-          <Button onClick={() => setContactFocus(contactId)}>
-            Open Contact
-          </Button>
-
           <Button onClick={() => setContactFocus(undefined)}>
             Close Contact
           </Button>
@@ -144,14 +142,13 @@ const TestRenderContactsFilters: React.FC = () => {
 };
 
 describe('ContactsPageContext', () => {
-  it('should open a contact and the URL should reflect the opened contact', async () => {
-    const { getByText, findByText } = render(
+  it('should switch views to flows', async () => {
+    const { findByText } = render(
       <ThemeProvider theme={theme}>
         <TestRouter
           router={{
-            query: { accountListId, appealId: [appealIdentifier, 'flows'] },
-            pathname:
-              '/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]]',
+            query: { accountListId, appealId: [appealId, 'list'] },
+            pathname,
             isReady,
             push,
           }}
@@ -176,34 +173,29 @@ describe('ContactsPageContext', () => {
         </TestRouter>
       </ThemeProvider>,
     );
-
-    expect(getByText('Loading')).toBeInTheDocument();
-
-    expect(
-      await findByText(`appealId: ${appealIdentifier}`),
-    ).toBeInTheDocument(),
-      userEvent.click(getByText('Open Contact'));
-
-    expect(
-      await findByText(`contactDetailsId: ${contactId}`),
-    ).toBeInTheDocument();
+    userEvent.click(await findByText('Flows Button'));
+    expect(await findByText('flows')).toBeInTheDocument();
     await waitFor(() =>
-      expect(push).toHaveBeenCalledWith({
-        pathname:
-          '/accountLists/account-list-1/tools/appeals/appeal/appeal-Id-1/flows/contact-id',
-        query: {},
-      }),
+      expect(push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            accountListId,
+            appealId: [appealId, 'flows'],
+          },
+        }),
+        undefined,
+        { shallow: true },
+      ),
     );
   });
 
-  it('should switch views to flows and back to list', async () => {
-    const { getByText, findByText } = render(
+  it('should switch views to list', async () => {
+    const { findByText } = render(
       <ThemeProvider theme={theme}>
         <TestRouter
           router={{
-            query: { accountListId, appealId: [appealIdentifier, 'list'] },
-            pathname:
-              '/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]]',
+            query: { accountListId, appealId: [appealId, 'flows'] },
+            pathname,
             isReady,
             push,
           }}
@@ -228,25 +220,19 @@ describe('ContactsPageContext', () => {
         </TestRouter>
       </ThemeProvider>,
     );
-    expect(await findByText('Flows Button')).toBeInTheDocument();
-    userEvent.click(getByText('Flows Button'));
-    expect(await findByText('flows')).toBeInTheDocument();
-    await waitFor(() =>
-      expect(push).toHaveBeenCalledWith({
-        pathname:
-          '/accountLists/account-list-1/tools/appeals/appeal/appeal-Id-1/flows',
-        query: {},
-      }),
-    );
-
-    userEvent.click(getByText('List Button'));
+    userEvent.click(await findByText('List Button'));
     expect(await findByText('list')).toBeInTheDocument();
     await waitFor(() =>
-      expect(push).toHaveBeenCalledWith({
-        pathname:
-          '/accountLists/account-list-1/tools/appeals/appeal/appeal-Id-1/list',
-        query: {},
-      }),
+      expect(push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            accountListId,
+            appealId: [appealId, 'list'],
+          },
+        }),
+        undefined,
+        { shallow: true },
+      ),
     );
   });
 
@@ -257,10 +243,9 @@ describe('ContactsPageContext', () => {
           router={{
             query: {
               accountListId,
-              appealId: [appealIdentifier, 'flows', contactId],
+              appealId: [appealId, 'flows', contactId],
             },
-            pathname:
-              '/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]]',
+            pathname,
             isReady,
             push,
           }}
@@ -285,7 +270,6 @@ describe('ContactsPageContext', () => {
         </TestRouter>
       </ThemeProvider>,
     );
-    expect(getByText('Loading')).toBeInTheDocument();
 
     expect(
       await findByText(`contactDetailsId: ${contactId}`),
@@ -294,11 +278,16 @@ describe('ContactsPageContext', () => {
     userEvent.click(getByText('Close Contact'));
 
     await waitFor(() =>
-      expect(push).toHaveBeenCalledWith({
-        pathname:
-          '/accountLists/account-list-1/tools/appeals/appeal/appeal-Id-1/flows',
-        query: {},
-      }),
+      expect(push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            accountListId: 'account-list-1',
+            appealId: [appealId, 'flows'],
+          },
+        }),
+        undefined,
+        { shallow: true },
+      ),
     );
   });
 
@@ -306,7 +295,7 @@ describe('ContactsPageContext', () => {
     it('should default to showing asked contacts in list view', async () => {
       render(
         <AppealStatusFilterTestComponent
-          query={{ appealId: [appealIdentifier, 'list', contactId] }}
+          query={{ appealId: [appealId, 'list', contactId] }}
         />,
       );
 
@@ -321,7 +310,7 @@ describe('ContactsPageContext', () => {
       render(
         <AppealStatusFilterTestComponent
           query={{
-            appealId: [appealIdentifier, 'flows', contactId],
+            appealId: [appealId, 'flows', contactId],
           }}
         />,
       );
@@ -341,10 +330,9 @@ describe('ContactsPageContext', () => {
           router={{
             query: {
               accountListId,
-              appealId: [appealIdentifier, 'flows', contactId],
+              appealId: [appealId, 'flows', contactId],
             },
-            pathname:
-              '/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]]',
+            pathname,
             isReady,
             push,
           }}
@@ -433,7 +421,7 @@ describe('ContactsPageContext', () => {
         <ThemeProvider theme={theme}>
           <TestRouter
             router={{
-              query: { accountListId, appealId: [appealIdentifier, 'list'] },
+              query: { accountListId, appealId: [appealId, 'list'] },
               pathname:
                 '/accountLists/[accountListId]/tools/appeals/[[...appealId]]',
               isReady,
@@ -458,7 +446,7 @@ describe('ContactsPageContext', () => {
             router={{
               query: {
                 accountListId,
-                appealId: [appealIdentifier, 'list', 'tour'],
+                appealId: [appealId, 'list', 'tour'],
               },
               pathname:
                 '/accountLists/[accountListId]/tools/appeals/[[...appealId]]',

--- a/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
+++ b/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
@@ -14,7 +14,6 @@ import {
 import { UserOptionFragment } from 'src/components/Shared/Filters/FilterPanel.generated';
 import { useUrlFilters } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
 import { useGetIdsForMassSelectionQuery } from 'src/hooks/GetIdsForMassSelection.generated';
-import { useUpdateUserOptionMutation } from 'src/hooks/UserPreference.generated';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useMassSelection } from 'src/hooks/useMassSelection';
 import { useContactsQuery } from './contacts.generated';
@@ -64,7 +63,7 @@ export interface AppealsType
   selectMultipleIds: (ids: string[]) => void;
   deselectMultipleIds: (ids: string[]) => void;
   viewMode: TableViewModeEnum | null;
-  setViewMode: Dispatch<SetStateAction<TableViewModeEnum>>;
+  setViewMode: (viewMode: TableViewModeEnum) => void;
   contactsQueryResult: ReturnType<typeof useContactsQuery>;
   appealId: string | undefined;
   listAppealStatus: AppealStatusEnum;
@@ -93,7 +92,7 @@ export interface AppealsContextProps
   extends Omit<ContactsContextProps, 'viewMode' | 'setViewMode'> {
   appealId: string | undefined;
   viewMode: TableViewModeEnum | null;
-  setViewMode: Dispatch<SetStateAction<TableViewModeEnum>>;
+  setViewMode: (viewMode: TableViewModeEnum) => void;
   tour: AppealTourEnum | null;
   setTour: Dispatch<SetStateAction<AppealTourEnum | null>>;
 }
@@ -280,25 +279,7 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
   );
   //#endregion
 
-  //#region User Actions
-  const handleViewModeChange = (_, view: string) => {
-    setViewMode(view as TableViewModeEnum);
-    updateOptions(view);
-  };
-  //#endregion
-
   //#region JSX
-
-  const [updateUserOption] = useUpdateUserOptionMutation();
-
-  const updateOptions = async (view: string): Promise<void> => {
-    await updateUserOption({
-      variables: {
-        key: 'contacts_view',
-        value: view,
-      },
-    });
-  };
 
   const nextTourStep = () => {
     switch (tour) {
@@ -345,7 +326,6 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
         filtersLoading: filtersLoading,
         toggleFilterPanel: toggleFilterPanel,
         savedFilters: savedFilters,
-        handleViewModeChange: handleViewModeChange,
         filterPanelOpen: filterPanelOpen,
         setFilterPanelOpen: setFilterPanelOpen,
         viewMode: viewMode,

--- a/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
+++ b/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
@@ -1,17 +1,17 @@
 import React, {
   Dispatch,
   SetStateAction,
+  useCallback,
   useEffect,
   useMemo,
   useState,
 } from 'react';
 import { useContactFiltersQuery } from 'pages/accountLists/[accountListId]/contacts/Contacts.generated';
 import {
-  ContactsContextSavedFilters as AppealsContextSavedFilters,
   ContactsContextProps,
   ContactsType,
+  parseSavedFilters,
 } from 'src/components/Contacts/ContactsContext/ContactsContext';
-import { UserOptionFragment } from 'src/components/Shared/Filters/FilterPanel.generated';
 import { useUrlFilters } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
 import { useGetIdsForMassSelectionQuery } from 'src/hooks/GetIdsForMassSelection.generated';
 import { useAccountListId } from 'src/hooks/useAccountListId';
@@ -269,19 +269,19 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
     skip,
   });
 
-  const toggleFilterPanel = () => {
-    setFilterPanelOpen(!filterPanelOpen);
-  };
+  const toggleFilterPanel = useCallback(() => {
+    setFilterPanelOpen((filterPanelOpen) => !filterPanelOpen);
+  }, []);
 
-  const savedFilters: UserOptionFragment[] = AppealsContextSavedFilters(
-    filterData,
-    accountListId,
+  const savedFilters = useMemo(
+    () => parseSavedFilters(filterData, accountListId),
+    [filterData, accountListId],
   );
   //#endregion
 
   //#region JSX
 
-  const nextTourStep = () => {
+  const nextTourStep = useCallback(() => {
     switch (tour) {
       case AppealTourEnum.Start:
         setTour(AppealTourEnum.ReviewExcluded);
@@ -306,46 +306,80 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
         setTour(null);
         break;
     }
-  };
-  const hideTour = () => {
+  }, [tour]);
+  const hideTour = useCallback(() => {
     setTour(null);
-  };
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      accountListId: accountListId ?? '',
+      contactsQueryResult,
+      selectionType,
+      isRowChecked,
+      toggleSelectAll,
+      toggleSelectionById,
+      selectMultipleIds,
+      deselectMultipleIds,
+      filterData,
+      filtersLoading,
+      toggleFilterPanel,
+      savedFilters,
+      filterPanelOpen,
+      setFilterPanelOpen,
+      viewMode,
+      setViewMode,
+      selectedIds: ids,
+      deselectAll,
+      appealId,
+      tour,
+      setTour,
+      listAppealStatus,
+      setListAppealStatus,
+      nextTourStep,
+      hideTour,
+      askedCountQueryResult,
+      excludedCountQueryResult,
+      committedCountQueryResult,
+      givenCountQueryResult,
+      receivedCountQueryResult,
+    }),
+    [
+      accountListId,
+      contactsQueryResult,
+      selectionType,
+      isRowChecked,
+      toggleSelectAll,
+      toggleSelectionById,
+      selectMultipleIds,
+      deselectMultipleIds,
+      filterData,
+      filtersLoading,
+      toggleFilterPanel,
+      savedFilters,
+      filterPanelOpen,
+      setFilterPanelOpen,
+      viewMode,
+      setViewMode,
+      ids,
+      deselectAll,
+      appealId,
+      tour,
+      setTour,
+      listAppealStatus,
+      setListAppealStatus,
+      nextTourStep,
+      hideTour,
+      askedCountQueryResult,
+      excludedCountQueryResult,
+      committedCountQueryResult,
+      givenCountQueryResult,
+      receivedCountQueryResult,
+    ],
+  );
 
   return (
-    <AppealsContext.Provider
-      value={{
-        accountListId: accountListId ?? '',
-        contactsQueryResult: contactsQueryResult,
-        selectionType: selectionType,
-        isRowChecked: isRowChecked,
-        toggleSelectAll: toggleSelectAll,
-        toggleSelectionById: toggleSelectionById,
-        selectMultipleIds: selectMultipleIds,
-        deselectMultipleIds: deselectMultipleIds,
-        filterData: filterData,
-        filtersLoading: filtersLoading,
-        toggleFilterPanel: toggleFilterPanel,
-        savedFilters: savedFilters,
-        filterPanelOpen: filterPanelOpen,
-        setFilterPanelOpen: setFilterPanelOpen,
-        viewMode: viewMode,
-        setViewMode: setViewMode,
-        selectedIds: ids,
-        deselectAll: deselectAll,
-        appealId,
-        tour,
-        setTour,
-        listAppealStatus,
-        setListAppealStatus,
-        nextTourStep,
-        hideTour,
-        askedCountQueryResult,
-        excludedCountQueryResult,
-        committedCountQueryResult,
-        givenCountQueryResult,
-        receivedCountQueryResult,
-      }}
-    >
+    <AppealsContext.Provider value={contextValue}>
       {children}
     </AppealsContext.Provider>
   );

--- a/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
+++ b/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
@@ -12,6 +12,7 @@ import {
   ContactsType,
   parseSavedFilters,
 } from 'src/components/Contacts/ContactsContext/ContactsContext';
+import { TableViewModeEnum } from 'src/components/Shared/Header/ListHeader';
 import { useUrlFilters } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
 import { useGetIdsForMassSelectionQuery } from 'src/hooks/GetIdsForMassSelection.generated';
 import { useAccountListId } from 'src/hooks/useAccountListId';
@@ -27,10 +28,11 @@ export enum AppealStatusEnum {
   Processed = 'processed',
 }
 
-export enum TableViewModeEnum {
-  List = 'list',
-  Flows = 'flows',
-}
+// The map view mode is not available in appeals
+export type AppealsViewModeEnum =
+  | TableViewModeEnum.List
+  | TableViewModeEnum.Flows;
+export { TableViewModeEnum };
 
 export const shouldSkipContactCount = (tour, filterPanelOpen, viewMode) => {
   if (viewMode === TableViewModeEnum.Flows) {
@@ -62,8 +64,8 @@ export interface AppealsType
   > {
   selectMultipleIds: (ids: string[]) => void;
   deselectMultipleIds: (ids: string[]) => void;
-  viewMode: TableViewModeEnum | null;
-  setViewMode: (viewMode: TableViewModeEnum) => void;
+  viewMode: AppealsViewModeEnum | null;
+  setViewMode: (viewMode: AppealsViewModeEnum) => void;
   contactsQueryResult: ReturnType<typeof useContactsQuery>;
   appealId: string | undefined;
   listAppealStatus: AppealStatusEnum;
@@ -91,8 +93,8 @@ export enum AppealTourEnum {
 export interface AppealsContextProps
   extends Omit<ContactsContextProps, 'viewMode' | 'setViewMode'> {
   appealId: string | undefined;
-  viewMode: TableViewModeEnum | null;
-  setViewMode: (viewMode: TableViewModeEnum) => void;
+  viewMode: AppealsViewModeEnum | null;
+  setViewMode: (viewMode: AppealsViewModeEnum) => void;
   tour: AppealTourEnum | null;
   setTour: Dispatch<SetStateAction<AppealTourEnum | null>>;
 }

--- a/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
+++ b/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
@@ -12,7 +12,6 @@ import {
   ContactsType,
 } from 'src/components/Contacts/ContactsContext/ContactsContext';
 import { UserOptionFragment } from 'src/components/Shared/Filters/FilterPanel.generated';
-import { useContactPanel } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { useUrlFilters } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
 import { useGetIdsForMassSelectionQuery } from 'src/hooks/GetIdsForMassSelection.generated';
 import { useUpdateUserOptionMutation } from 'src/hooks/UserPreference.generated';
@@ -115,13 +114,7 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
     AppealStatusEnum.Asked,
   );
 
-  const {
-    openContactId: contactDetailsId,
-    openContact,
-    closePanel,
-  } = useContactPanel();
-  const { activeFilters, searchTerm, setSearchTerm, combinedFilters } =
-    useUrlFilters();
+  const { searchTerm, combinedFilters } = useUrlFilters();
 
   //User options for display view
   useEffect(() => {
@@ -208,8 +201,6 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
   } = useMassSelection(allContactIds);
   //#endregion
 
-  const { openContactId: contactId } = useContactPanel();
-
   const { data: filterData, loading: filtersLoading } = useContactFiltersQuery({
     variables: { accountListId: accountListId ?? '' },
     skip: !accountListId,
@@ -283,10 +274,6 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
     setFilterPanelOpen(!filterPanelOpen);
   };
 
-  const handleClearAll = () => {
-    setSearchTerm('');
-  };
-
   const savedFilters: UserOptionFragment[] = AppealsContextSavedFilters(
     filterData,
     accountListId,
@@ -294,14 +281,6 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
   //#endregion
 
   //#region User Actions
-  const setContactFocus = (id: string | undefined) => {
-    if (typeof id === 'string') {
-      openContact(id);
-    } else {
-      closePanel();
-    }
-  };
-
   const handleViewModeChange = (_, view: string) => {
     setViewMode(view as TableViewModeEnum);
     updateOptions(view);
@@ -355,7 +334,6 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
     <AppealsContext.Provider
       value={{
         accountListId: accountListId ?? '',
-        contactId: contactId,
         contactsQueryResult: contactsQueryResult,
         selectionType: selectionType,
         isRowChecked: isRowChecked,
@@ -366,14 +344,10 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
         filterData: filterData,
         filtersLoading: filtersLoading,
         toggleFilterPanel: toggleFilterPanel,
-        handleClearAll: handleClearAll,
         savedFilters: savedFilters,
-        setContactFocus: setContactFocus,
         handleViewModeChange: handleViewModeChange,
         filterPanelOpen: filterPanelOpen,
         setFilterPanelOpen: setFilterPanelOpen,
-        contactDetailsOpen: typeof contactDetailsId === 'string',
-        contactDetailsId: contactDetailsId,
         viewMode: viewMode,
         setViewMode: setViewMode,
         selectedIds: ids,

--- a/src/components/Tool/Appeal/Flow/ContactFlowRow/ContactFlowRow.tsx
+++ b/src/components/Tool/Appeal/Flow/ContactFlowRow/ContactFlowRow.tsx
@@ -21,6 +21,7 @@ import {
 } from 'src/components/Contacts/ContactFlow/ContactFlowRow/ContactFlowRow';
 import { StarContactIconButton } from 'src/components/Contacts/StarContactIconButton/StarContactIconButton';
 import { useGetPledgeOrDonation } from 'src/components/Tool/Appeal/Shared/useGetPledgeOrDonation/useGetPledgeOrDonation';
+import { useContactPanel } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { StatusEnum } from 'src/graphql/types.generated';
 import { useLocalizedConstants } from 'src/hooks/useLocalizedConstants';
 import theme from 'src/theme';
@@ -100,8 +101,8 @@ export const ContactFlowRow: React.FC<Props> = ({
     appealId,
     isRowChecked: isChecked,
     toggleSelectionById: onContactCheckToggle,
-    getContactUrl,
   } = React.useContext(AppealsContext) as AppealsType;
+  const { buildContactUrl } = useContactPanel();
   const [createPledgeModalOpen, setPledgeModalOpen] = useState(false);
   const [deletePledgeModalOpen, setDeletePledgeModalOpen] = useState(false);
 
@@ -153,8 +154,6 @@ export const ContactFlowRow: React.FC<Props> = ({
 
   const isExcludedContact = appealStatus === AppealStatusEnum.Excluded;
 
-  const contactUrl = getContactUrl(id).contactUrl;
-
   return (
     <>
       <ContainerBox isDragging={isDragging} ref={drag}>
@@ -173,7 +172,7 @@ export const ContactFlowRow: React.FC<Props> = ({
                 size="small"
               />
               <Box display="flex" flexDirection="column" ml={1} draggable>
-                <ContactLink component={NextLink} href={contactUrl}>
+                <ContactLink component={NextLink} href={buildContactUrl(id)}>
                   {name}
                 </ContactLink>
                 <Typography variant="body2">

--- a/src/components/Tool/Appeal/InitialPage/Appeal.tsx
+++ b/src/components/Tool/Appeal/InitialPage/Appeal.tsx
@@ -105,7 +105,7 @@ const Appeal = ({
               className={classes.nameLink}
             >
               <NextLink
-                href={`/accountLists/${accountListId}/tools/appeals/appeal/${id}/list`}
+                href={`/accountLists/${accountListId}/tools/appeals/appeal/${id}`}
                 scroll={false}
               >
                 {name}

--- a/src/components/Tool/Appeal/List/ContactRow/ContactRow.test.tsx
+++ b/src/components/Tool/Appeal/List/ContactRow/ContactRow.test.tsx
@@ -24,14 +24,16 @@ const accountListId = 'account-list-1';
 const appealId = 'appealId';
 
 const router = {
-  query: { accountListId },
+  pathname:
+    '/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]]',
+  query: {
+    accountListId,
+    appealId: [appealId, 'list'],
+  },
   isReady: true,
 };
-const contactUrl = `/accountLists/${accountListId}/tools/appeals/${appealId}/${defaultContact.id}`;
+const contactUrl = `/accountLists/${accountListId}/tools/appeals/appeal/${appealId}/list/${defaultContact.id}`;
 
-const getContactUrl = jest.fn().mockReturnValue({
-  contactUrl,
-});
 const contactDetailsOpen = true;
 const toggleSelectionById = jest.fn();
 const isRowChecked = jest.fn();
@@ -56,7 +58,6 @@ const Components = ({
                 value={
                   {
                     appealId,
-                    getContactUrl,
                     isRowChecked,
                     contactDetailsOpen,
                     toggleSelectionById,

--- a/src/components/Tool/Appeal/List/ContactRow/ContactRow.tsx
+++ b/src/components/Tool/Appeal/List/ContactRow/ContactRow.tsx
@@ -92,7 +92,7 @@ export const ContactRow: React.FC<Props> = ({
     isRowChecked: isChecked,
     toggleSelectionById: onContactCheckToggle,
   } = React.useContext(AppealsContext) as AppealsType;
-  const { isOpen: contactDetailsOpen, buildContactUrl } = useContactPanel();
+  const { isOpen: contactPanelOpen, buildContactUrl } = useContactPanel();
   const [createPledgeModalOpen, setPledgeModalOpen] = useState(false);
   const [deletePledgeModalOpen, setDeletePledgeModalOpen] = useState(false);
   const [addExcludedContactModalOpen, setAddExcludedContactModalOpen] =
@@ -211,7 +211,7 @@ export const ContactRow: React.FC<Props> = ({
             <Box
               display="flex"
               alignItems="center"
-              justifyContent={contactDetailsOpen ? 'flex-end' : undefined}
+              justifyContent={contactPanelOpen ? 'flex-end' : undefined}
             >
               <Box
                 display="flex"

--- a/src/components/Tool/Appeal/List/ContactRow/ContactRow.tsx
+++ b/src/components/Tool/Appeal/List/ContactRow/ContactRow.tsx
@@ -20,6 +20,7 @@ import {
 } from 'src/components/Contacts/ContactRow/ContactRow';
 import { preloadContactsRightPanel } from 'src/components/Contacts/ContactsRightPanel/DynamicContactsRightPanel';
 import { useGetPledgeOrDonation } from 'src/components/Tool/Appeal/Shared/useGetPledgeOrDonation/useGetPledgeOrDonation';
+import { useContactPanel } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import theme from 'src/theme';
 import {
   AppealStatusEnum,
@@ -89,10 +90,9 @@ export const ContactRow: React.FC<Props> = ({
   const {
     appealId,
     isRowChecked: isChecked,
-    contactDetailsOpen,
-    getContactUrl,
     toggleSelectionById: onContactCheckToggle,
   } = React.useContext(AppealsContext) as AppealsType;
+  const { isOpen: contactDetailsOpen, buildContactUrl } = useContactPanel();
   const [createPledgeModalOpen, setPledgeModalOpen] = useState(false);
   const [deletePledgeModalOpen, setDeletePledgeModalOpen] = useState(false);
   const [addExcludedContactModalOpen, setAddExcludedContactModalOpen] =
@@ -103,8 +103,6 @@ export const ContactRow: React.FC<Props> = ({
     excludedContacts,
     contactId: contact.id,
   });
-
-  const contactUrl = getContactUrl(contact.id).contactUrl;
 
   const { id: contactId, name } = contact;
 
@@ -145,7 +143,7 @@ export const ContactRow: React.FC<Props> = ({
     <>
       <ListButton
         component={NextLink}
-        href={contactUrl}
+        href={buildContactUrl(contact.id)}
         scroll={false}
         prefetch={false}
         shallow

--- a/src/components/Tool/Appeal/List/ContactsList/ContactsList.tsx
+++ b/src/components/Tool/Appeal/List/ContactsList/ContactsList.tsx
@@ -7,6 +7,7 @@ import { InfiniteList } from 'src/components/InfiniteList/InfiniteList';
 import { navBarHeight } from 'src/components/Layouts/Primary/Primary';
 import NullState from 'src/components/Shared/Filters/NullState/NullState';
 import { headerHeight } from 'src/components/Shared/Header/ListHeader';
+import { useContactPanel } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { useUrlFilters } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
 import theme from 'src/theme';
 import {
@@ -56,8 +57,8 @@ export const ContactsList: React.FC<ContactsListProps> = ({
     tour,
     contactsQueryResult,
     listAppealStatus: appealStatus,
-    contactDetailsOpen,
   } = React.useContext(AppealsContext) as AppealsType;
+  const { isOpen: contactPanelOpen } = useContactPanel();
   const { activeFilters } = useUrlFilters();
 
   const { data, loading, fetchMore } = contactsQueryResult;
@@ -140,7 +141,7 @@ export const ContactsList: React.FC<ContactsListProps> = ({
           xs={isExcludedContact ? 4 : 6}
           className={classes.givingHeader}
         >
-          <Box justifyContent={contactDetailsOpen ? 'flex-end' : undefined}>
+          <Box justifyContent={contactPanelOpen ? 'flex-end' : undefined}>
             <Box>
               <Typography variant="subtitle1" fontWeight={800}>
                 {columnName}

--- a/src/components/common/ContactPanelProvider/ContactPanelProvider.test.tsx
+++ b/src/components/common/ContactPanelProvider/ContactPanelProvider.test.tsx
@@ -12,44 +12,56 @@ const newContactId = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
 
 describe('splitContactIdParam', () => {
   it('should handle contactId is undefined', () => {
-    expect(splitContactIdParam(undefined)).toEqual({
+    expect(splitContactIdParam(undefined, 0)).toEqual({
       prefix: [],
       contactId: undefined,
     });
   });
 
   it('should handle contactId is a string', () => {
-    expect(splitContactIdParam(contactId)).toEqual({
+    expect(splitContactIdParam(contactId, 0)).toEqual({
       prefix: [],
       contactId: undefined,
     });
   });
 
   it('should handle contactId is an empty array', () => {
-    expect(splitContactIdParam([])).toEqual({
+    expect(splitContactIdParam([], 0)).toEqual({
       prefix: [],
       contactId: undefined,
     });
   });
 
   it('should handle contactId is not a UUID', () => {
-    expect(splitContactIdParam(['flows'])).toEqual({
+    expect(splitContactIdParam(['flows'], 0)).toEqual({
       prefix: ['flows'],
       contactId: undefined,
     });
   });
 
   it('should handle contactId is a UUID', () => {
-    expect(splitContactIdParam([contactId])).toEqual({
+    expect(splitContactIdParam([contactId], 0)).toEqual({
       prefix: [],
       contactId,
     });
   });
 
   it('should handle contactId is an array ending with a UUID', () => {
-    expect(splitContactIdParam(['flows', contactId])).toEqual({
+    expect(splitContactIdParam(['flows', contactId], 0)).toEqual({
       prefix: ['flows'],
       contactId,
+    });
+  });
+
+  it('should handle custom prefix length', () => {
+    expect(splitContactIdParam([contactId], 1)).toEqual({
+      prefix: [contactId],
+      contactId: undefined,
+    });
+
+    expect(splitContactIdParam([contactId, newContactId], 1)).toEqual({
+      prefix: [contactId],
+      contactId: newContactId,
     });
   });
 });

--- a/src/components/common/ContactPanelProvider/ContactPanelProvider.tsx
+++ b/src/components/common/ContactPanelProvider/ContactPanelProvider.tsx
@@ -15,21 +15,16 @@ const uuidRegex =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
- * Split a contact id query param into the prefix and the contact id. For example, a contact id
- * param value of `['map', '00000000-0000-0000-0000-000000000000']` would be split into
- * `{ prefix: ['map'], contactId: '00000000-0000-0000-0000-000000000000' }`.
+ * Extract the contact id from a query param
  *
  * @param paramValue The contact id query param from the router
  * @param prefixMinLength The minimum length of the prefix section
- * @returns The prefix and contact id from the query param
+ * @returns The contact id from the query param
  */
-export const splitContactIdParam = (
+export const extractContactId = (
   paramValue: ParsedUrlQuery[string],
   prefixMinLength: number,
-): {
-  prefix: string[];
-  contactId: string | undefined;
-} => {
+): string | undefined => {
   // The contact id param is always an array because it corresponds to a router segment like
   // `[[...contactId]]`. The array can contain multiple elements, for example, on the contacts page
   // for routes like ".../contacts/map/:contactId". Regardless of the number of elements in the
@@ -39,18 +34,21 @@ export const splitContactIdParam = (
   // more examples.
 
   if (!Array.isArray(paramValue)) {
-    return { prefix: [], contactId: undefined };
+    return undefined;
+  }
+
+  // The contact id must not be part of the first `prefixMinLength` items
+  if (paramValue.length <= prefixMinLength) {
+    return undefined;
   }
 
   // The contact id is the last item in the query param array, but it must be a UUID, not 'map', for
-  // example. Also, it must not be part of the first `prefixMinLength` items. The prefix is the rest
-  // of the param value, e.g. ['map'].
-  const contactId =
-    paramValue.length > prefixMinLength ? paramValue.at(-1) : undefined;
+  // example.
+  const contactId = paramValue.slice(prefixMinLength).at(-1);
   if (typeof contactId === 'string' && uuidRegex.test(contactId)) {
-    return { prefix: paramValue.slice(0, -1), contactId };
+    return contactId;
   } else {
-    return { prefix: paramValue, contactId: undefined };
+    return undefined;
   }
 };
 
@@ -96,6 +94,8 @@ export interface ContactPanelProviderProps {
   /**
    * The initial part of the contact id param before the contact id. It is `['map']` in the contacts
    * map view, for example.
+   *
+   * **IMPORTANT**: If provided, the prefix must be stable across renders.
    */
   contactIdPrefix?: string[];
 
@@ -112,7 +112,7 @@ export interface ContactPanelProviderProps {
 
 export const ContactPanelProvider: React.FC<ContactPanelProviderProps> = ({
   contactIdParam = 'contactId',
-  contactIdPrefix: manualContactIdPrefix,
+  contactIdPrefix,
   prefixMinLength = 0,
   children,
 }) => {
@@ -125,8 +125,8 @@ export const ContactPanelProvider: React.FC<ContactPanelProviderProps> = ({
     [JSON.stringify(router.query[contactIdParam])],
   );
 
-  const { prefix: urlContactIdPrefix, contactId: urlContactId } = useMemo(
-    () => splitContactIdParam(contactIdParamValue, prefixMinLength),
+  const urlContactId = useMemo(
+    () => extractContactId(contactIdParamValue, prefixMinLength),
     [contactIdParamValue, prefixMinLength],
   );
 
@@ -137,23 +137,19 @@ export const ContactPanelProvider: React.FC<ContactPanelProviderProps> = ({
     setContactId(urlContactId);
   }, [contactIdParamValue]);
 
-  const contactIdPrefix = useMemo(
-    () => manualContactIdPrefix ?? urlContactIdPrefix,
-    [manualContactIdPrefix, contactIdParamValue],
-  );
-
   // Update the URL when the prefix changes
   useEffect(() => {
     updateContactAndUrl(contactId);
-    // Memoize by the JSON string to ensure stability when the prefix changes to an equivalent array
-  }, [JSON.stringify(contactIdPrefix)]);
+  }, [contactIdPrefix]);
 
   const buildContactUrl = useCallback(
     (newContactId: string | undefined): UrlObject => {
-      const newContactIdParamValue =
-        typeof newContactId === 'string'
-          ? [...contactIdPrefix, newContactId]
-          : contactIdPrefix;
+      const newContactIdParamValue = contactIdPrefix
+        ? [...contactIdPrefix]
+        : [];
+      if (typeof newContactId === 'string') {
+        newContactIdParamValue.push(newContactId);
+      }
 
       const newQuery = {
         ...router.query,


### PR DESCRIPTION
## Description

Refactor appeals to use the new `ContactPanelProvider` and `UrlFiltersProvider` context providers.

The most significant changes were to parsing the current state from the URL and loading/updating the view mode.

MPDX-8667

## Testing

* Test 1
  * Click on an appeals from the appeals list
  * Check that you are redirected to the list or flows page based on your user preference
* Test 2
  * In the contacts view, change your view to maps
  * Click on an appeals from the appeals list
  * Check that you are redirected to the flows page
* Test 3
  * Manually navigate to a URL like `/accountLists/:accountListId/tools/appeals/appeal/:appealId/list` (note the `/list` at the end)
  * Check that you are taken to the list page and that it doesn't change
* Test 4
  * Manually navigate to a URL like `/accountLists/:accountListId/tools/appeals/appeal/:appealId/flows` (note the `/flows` at the end)
  * Check that you are taken to the flows page and that it doesn't change
* Test 5
  * Click on an appeals from the appeals list
  * Change the view mode
  * Go back to the appeals list
  * Click on an appeal again
  * Check that the view mode was persisted
  * Go to the contacts view
  * Check that the view mode was persisted there to

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
