### PR TITLE
MPDX-8676 Expose clear filters

### DIFF
--- a/src/components/Reports/FinancialAccountsReport/Context/FinancialAccountsContext.tsx
+++ b/src/components/Reports/FinancialAccountsReport/Context/FinancialAccountsContext.tsx
@@ -36,7 +36,6 @@ export interface FinancialAccountType {
   setPanelOpen: Dispatch<SetStateAction<Panel | null>>;
   handleNavListToggle: () => void;
   handleFilterListToggle: () => void;
-  handleClearAll: () => void;
 }
 
 export const FinancialAccountContext =
@@ -79,10 +78,6 @@ export const FinancialAccountProvider: React.FC<
     setPanelOpen(panelOpen === Panel.Filters ? null : Panel.Filters);
   };
 
-  const handleClearAll = () => {
-    setSearchTerm('');
-  };
-
   const financialAccountQuery = useFinancialAccountQuery({
     variables: {
       accountListId,
@@ -113,7 +108,6 @@ export const FinancialAccountProvider: React.FC<
         handleFilterListToggle,
         panelOpen,
         setPanelOpen,
-        handleClearAll,
       }}
     >
       {children}

--- a/src/components/Shared/Filters/FilterPanel.tsx
+++ b/src/components/Shared/Filters/FilterPanel.tsx
@@ -134,7 +134,7 @@ export const FilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
   const {
     activeFilters: selectedFilters,
     setActiveFilters,
-    clearSearchTerm,
+    clearFilters,
   } = useUrlFilters();
 
   const updateSelectedFilter = (name: FilterKey, value?: FilterValue) => {
@@ -552,11 +552,6 @@ export const FilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
     setDeleteFilterModalOpen(true);
   };
 
-  const handleClearAllClick = () => {
-    clearSearchTerm();
-    clearSelectedFilter();
-  };
-
   const tagsFilters = useMemo(() => {
     const tags = filters.find(
       (filter) => filter?.filters[0]?.filterKey === 'tags',
@@ -615,7 +610,7 @@ export const FilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
                   marginInlineStart: theme.spacing(showSaveButton ? 2 : -1),
                 }}
                 disabled={noSelectedFilters}
-                onClick={handleClearAllClick}
+                onClick={clearFilters}
               >
                 {t('Clear All')}
               </LinkButton>

--- a/src/components/common/UrlFiltersProvider/UrlFiltersProvider.test.tsx
+++ b/src/components/common/UrlFiltersProvider/UrlFiltersProvider.test.tsx
@@ -129,24 +129,23 @@ describe('useUrlFilters', () => {
     });
   });
 
-  it('should clear the search term', async () => {
+  it('should clear the filters and search term', async () => {
     const { result } = renderHook(() => useUrlFilters(), {
       wrapper: Wrapper,
     });
 
     act(() => {
-      result.current.clearSearchTerm();
+      result.current.clearFilters();
     });
 
+    expect(result.current.activeFilters).toEqual({});
     expect(result.current.searchTerm).toBe('');
 
     await waitFor(() => {
       expect(replace).toHaveBeenCalledWith(
         {
           pathname,
-          query: {
-            filters: '{"key":"value"}',
-          },
+          query: {},
         },
         undefined,
         { shallow: true },

--- a/src/components/common/UrlFiltersProvider/UrlFiltersProvider.tsx
+++ b/src/components/common/UrlFiltersProvider/UrlFiltersProvider.tsx
@@ -28,7 +28,7 @@ export interface UrlFilters {
   setSearchTerm: (newSearchTerm: string) => void;
   starred: boolean;
   setStarred: (starred: boolean) => void;
-  clearSearchTerm: () => void;
+  clearFilters: () => void;
 }
 
 const UrlFiltersContext = createContext<UrlFilters | null>(null);
@@ -99,7 +99,8 @@ export const UrlFiltersProvider: React.FC<UrlFiltersProviderProps> = ({
 
   const setSearchTermDebounced = useDebouncedCallback(setSearchTerm, 500);
 
-  const clearSearchTerm = useCallback(() => {
+  const clearFilters = useCallback(() => {
+    setActiveFilters({});
     setSearchTerm('');
   }, []);
 
@@ -159,7 +160,7 @@ export const UrlFiltersProvider: React.FC<UrlFiltersProviderProps> = ({
       setSearchTerm: setSearchTermDebounced,
       starred,
       setStarred,
-      clearSearchTerm,
+      clearFilters,
       combinedFilters,
     }),
     [
@@ -168,7 +169,7 @@ export const UrlFiltersProvider: React.FC<UrlFiltersProviderProps> = ({
       searchTerm,
       setSearchTermDebounced,
       starred,
-      clearSearchTerm,
+      clearFilters,
       combinedFilters,
     ],
   );


### PR DESCRIPTION
## Description

In this PR, I replaced the `clearSearchTerm()` function with a new `clearFilters()` function in `UrlFiltersProvider.tsx`. This new function resets both the filters and search term stored in context, allowing multiple components to easily clear all search-related values with a single function call. I also updated all references to `clearSearchTerm()` in other files to use `clearFilters()` instead.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
