### PR TITLE
MPDX-8680 - Fix Setup Tour Settings NavMenuIcon bug

### DIFF
--- a/src/components/Shared/MultiPageLayout/MultiPageHeader.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageHeader.tsx
@@ -85,7 +85,11 @@ export const MultiPageHeader: FC<MultiPageHeaderProps> = ({
         alignItems="center"
         sx={{ lineHeight: 1.1 }}
       >
-        <NavListButton panelOpen={isNavListOpen} onClick={onNavListToggle}>
+        <NavListButton
+          panelOpen={isNavListOpen}
+          onClick={onNavListToggle}
+          disabled={onSetupTour && headerType === HeaderTypeEnum.Settings}
+        >
           {headerType === HeaderTypeEnum.Report && (
             <NavFilterIcon
               titleAccess={titleAccess}


### PR DESCRIPTION
## Description
[Jira ticket](https://jira.cru.org/secure/RapidBoard.jspa?rapidView=3&view=detail&selectedIssue=MPDX-8680#)
- On the setup tour, the Settings NavMenuIcon in MultiPageHeader is invisible but still clickable, appearing as a bug to the users.
- To resolve, I disabled the Settings NavMenuIcon in the instance where the user is doing the setup tour. 
  - I assumed this is the correct behavior, as making it visible and clickable leads to strange behaviors (e.g. a user can finish the setup tour, go back to their preferences, and have to go through the setup tour non-linearly).


## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
