### PR TITLE
MPDX-8668 - AccountListAutocomplete(s)

### DIFF
--- a/pages/accountLists/[accountListId]/settings/preferences.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/preferences.page.tsx
@@ -195,8 +195,7 @@ const Preferences: React.FC = () => {
               handleAccordionChange={setExpandedAccordion}
               expandedAccordion={expandedAccordion}
               data={personalPreferencesData}
-              accountListId={accountListId}
-              defaultAccountList={
+              defaultAccountListId={
                 personalPreferencesData?.user?.defaultAccountList || ''
               }
               disabled={onSetupTour}

--- a/pages/setup/account.page.tsx
+++ b/pages/setup/account.page.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { makeGetServerSideProps } from 'pages/api/utils/pagePropsHelpers';
-import { AccountListAutocomplete } from 'src/common/Autocompletes/AccountListAutocomplete';
+import { AccountListAutocomplete } from 'src/common/Autocompletes/AccountListAutocomplete/AccountListAutocomplete';
 import {
   UpdateUserDefaultAccountDocument,
   UpdateUserDefaultAccountMutation,
@@ -69,11 +69,6 @@ const AccountPage: React.FC<PageProps> = ({ accountListOptions }) => {
           onChange={(_, value) => setDefaultAccountList(value)}
           value={defaultAccountList}
           options={accountListOptions?.accountLists.nodes || []}
-          getOptionLabel={(defaultAccountList): string =>
-            accountListOptions?.accountLists.nodes.find(
-              (accountListId) => accountListId === defaultAccountList,
-            )?.name ?? ''
-          }
           textFieldProps={{
             label: t('Account'),
           }}

--- a/pages/setup/account.page.tsx
+++ b/pages/setup/account.page.tsx
@@ -1,8 +1,8 @@
 import Head from 'next/head';
 import React, { useState } from 'react';
-import { Autocomplete, TextField } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { makeGetServerSideProps } from 'pages/api/utils/pagePropsHelpers';
+import { AccountListAutocomplete } from 'src/common/Autocompletes/AccountListAutocomplete';
 import {
   UpdateUserDefaultAccountDocument,
   UpdateUserDefaultAccountMutation,
@@ -19,8 +19,8 @@ import {
   AccountListOptionsQuery,
 } from './Account.generated';
 
-type AccountList = AccountListOptionsQuery['accountLists']['nodes'][number];
-
+export type AccountList =
+  AccountListOptionsQuery['accountLists']['nodes'][number];
 interface PageProps {
   accountListOptions: AccountListOptionsQuery;
 }
@@ -65,16 +65,18 @@ const AccountPage: React.FC<PageProps> = ({ accountListOptions }) => {
           'Which account would you like to see by default when you open {{appName}}?',
           { appName },
         )}
-        <Autocomplete
-          autoHighlight
-          value={defaultAccountList}
+        <AccountListAutocomplete
           onChange={(_, value) => setDefaultAccountList(value)}
-          options={accountListOptions.accountLists.nodes}
-          getOptionLabel={(accountList) => accountList.name ?? ''}
-          fullWidth
-          renderInput={(params) => (
-            <TextField {...params} label={t('Account')} />
-          )}
+          value={defaultAccountList}
+          options={accountListOptions?.accountLists.nodes || []}
+          getOptionLabel={(defaultAccountList): string =>
+            accountListOptions?.accountLists.nodes.find(
+              (accountListId) => accountListId === defaultAccountList,
+            )?.name ?? ''
+          }
+          textFieldProps={{
+            label: t('Account'),
+          }}
         />
         <LargeButton
           variant="contained"
@@ -99,7 +101,7 @@ export const getServerSideProps = makeGetServerSideProps<PageProps>(
 
     if (accountListOptions.accountLists.nodes.length === 1) {
       // The user has exactly one account list, so set it as the default and go to preferences
-      const defaultAccountListId = accountListOptions.accountLists.nodes[0].id;
+      const defaultAccountList = accountListOptions.accountLists.nodes[0].id;
       try {
         await ssrClient.mutate<
           UpdateUserDefaultAccountMutation,
@@ -109,14 +111,14 @@ export const getServerSideProps = makeGetServerSideProps<PageProps>(
           variables: {
             input: {
               attributes: {
-                defaultAccountList: defaultAccountListId,
+                defaultAccountList: defaultAccountList,
               },
             },
           },
         });
         return {
           redirect: {
-            destination: `/accountLists/${defaultAccountListId}/settings/preferences`,
+            destination: `/accountLists/${defaultAccountList}/settings/preferences`,
             permanent: false,
           },
         };

--- a/pages/setup/account.page.tsx
+++ b/pages/setup/account.page.tsx
@@ -2,7 +2,10 @@ import Head from 'next/head';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { makeGetServerSideProps } from 'pages/api/utils/pagePropsHelpers';
-import { AccountListAutocomplete } from 'src/common/Autocompletes/AccountListAutocomplete/AccountListAutocomplete';
+import {
+  AccountListAutocomplete,
+  AccountListOption,
+} from 'src/common/Autocompletes/AccountListAutocomplete/AccountListAutocomplete';
 import {
   UpdateUserDefaultAccountDocument,
   UpdateUserDefaultAccountMutation,
@@ -19,8 +22,6 @@ import {
   AccountListOptionsQuery,
 } from './Account.generated';
 
-export type AccountList =
-  AccountListOptionsQuery['accountLists']['nodes'][number];
 interface PageProps {
   accountListOptions: AccountListOptionsQuery;
 }
@@ -36,7 +37,7 @@ const AccountPage: React.FC<PageProps> = ({ accountListOptions }) => {
     useUpdateUserDefaultAccountMutation();
 
   const [defaultAccountList, setDefaultAccountList] =
-    useState<AccountList | null>(null);
+    useState<AccountListOption | null>(null);
 
   const handleSave = async () => {
     if (!defaultAccountList) {
@@ -106,7 +107,7 @@ export const getServerSideProps = makeGetServerSideProps<PageProps>(
           variables: {
             input: {
               attributes: {
-                defaultAccountList: defaultAccountList,
+                defaultAccountList,
               },
             },
           },

--- a/src/common/Autocompletes/AccountListAutocomplete.tsx
+++ b/src/common/Autocompletes/AccountListAutocomplete.tsx
@@ -8,13 +8,13 @@ import {
 import { AccountListOptionsQuery } from 'pages/setup/Account.generated';
 // import { AccountList } from 'src/graphql/types.generated';
 
-export type AccountList =
+export type AccountListOption =
   AccountListOptionsQuery['accountLists']['nodes'][number];
 
 interface AccountListAutocompleteProps
-  extends Partial<AutocompleteProps<AccountList, false, boolean, false>> {
+  extends Partial<AutocompleteProps<AccountListOption, false, boolean, false>> {
   textFieldProps?: Partial<TextFieldProps>;
-  options: AccountList[];
+  options: AccountListOption[];
 }
 
 export const AccountListAutocomplete: React.FC<
@@ -26,7 +26,9 @@ export const AccountListAutocomplete: React.FC<
       autoHighlight
       {...props}
       options={options || []}
-      getOptionLabel={(account: AccountList): string => account?.name ?? ''}
+      getOptionLabel={(account: AccountListOption): string =>
+        account?.name ?? ''
+      }
       renderInput={(params) => <TextField {...params} {...textFieldProps} />}
     />
   );

--- a/src/common/Autocompletes/AccountListAutocomplete.tsx
+++ b/src/common/Autocompletes/AccountListAutocomplete.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {
+  Autocomplete,
+  AutocompleteProps,
+  TextField,
+  TextFieldProps,
+} from '@mui/material';
+import { AccountListOptionsQuery } from 'pages/setup/Account.generated';
+// import { AccountList } from 'src/graphql/types.generated';
+
+export type AccountList =
+  AccountListOptionsQuery['accountLists']['nodes'][number];
+
+interface AccountListAutocompleteProps
+  extends Partial<AutocompleteProps<AccountList, false, boolean, false>> {
+  textFieldProps?: Partial<TextFieldProps>;
+  options: AccountList[];
+}
+
+export const AccountListAutocomplete: React.FC<
+  AccountListAutocompleteProps
+> = ({ textFieldProps, options, ...props }) => {
+  return (
+    <Autocomplete
+      fullWidth
+      autoHighlight
+      {...props}
+      options={options || []}
+      getOptionLabel={(account: AccountList): string => account?.name ?? ''}
+      renderInput={(params) => <TextField {...params} {...textFieldProps} />}
+    />
+  );
+};

--- a/src/common/Autocompletes/AccountListAutocomplete/AccountListAutocomplete.test.tsx
+++ b/src/common/Autocompletes/AccountListAutocomplete/AccountListAutocomplete.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import theme from 'src/theme';
+import { AccountListAutocomplete } from './AccountListAutocomplete';
+
+const setFieldValue = jest.fn();
+
+const mockAccounts = [
+  { id: 'account-1', name: 'John Doe Ministry Account' },
+  { id: 'account-2', name: 'Jane Smith Support Account' },
+  { id: 'account-3', name: 'Global Missions Fund' },
+  { id: 'account-4', name: 'Local Church Partnership' },
+  { id: 'account-5', name: 'Student Ministry Account' },
+];
+
+describe('AccountListAutocomplete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the selected account', () => {
+    const { getByRole } = render(
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <ThemeProvider theme={theme}>
+          <AccountListAutocomplete
+            options={mockAccounts}
+            value={mockAccounts[0]}
+            onChange={(_, value) => {
+              setFieldValue(value);
+            }}
+          />
+        </ThemeProvider>
+      </LocalizationProvider>,
+    );
+    expect(getByRole('combobox')).toHaveDisplayValue(
+      'John Doe Ministry Account',
+    );
+  });
+
+  it('changes the selected account', async () => {
+    const { getByRole, findByRole } = render(
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <ThemeProvider theme={theme}>
+          <AccountListAutocomplete
+            options={mockAccounts}
+            value={mockAccounts[0]}
+            onChange={(_, value) => {
+              setFieldValue(value);
+            }}
+          />
+        </ThemeProvider>
+      </LocalizationProvider>,
+    );
+
+    expect(getByRole('combobox')).toHaveDisplayValue(
+      'John Doe Ministry Account',
+    );
+    userEvent.click(getByRole('combobox'));
+    userEvent.click(
+      await findByRole('option', {
+        name: 'Jane Smith Support Account',
+      }),
+    );
+    expect(setFieldValue).toHaveBeenCalledWith(mockAccounts[1]);
+  });
+
+  it('filters accounts based on input', async () => {
+    const { getByRole, findAllByRole, queryByRole } = render(
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <ThemeProvider theme={theme}>
+          <AccountListAutocomplete
+            options={mockAccounts}
+            value={null}
+            onChange={setFieldValue}
+          />
+        </ThemeProvider>
+      </LocalizationProvider>,
+    );
+
+    const combobox = getByRole('combobox');
+    userEvent.type(combobox, 'Ministry');
+
+    const options = await findAllByRole('option');
+    // "John Doe Ministry Account" and "Student Ministry Account"
+    expect(options).toHaveLength(2);
+
+    expect(
+      getByRole('option', { name: 'John Doe Ministry Account' }),
+    ).toBeInTheDocument();
+
+    expect(
+      getByRole('option', { name: 'Student Ministry Account' }),
+    ).toBeInTheDocument();
+
+    expect(
+      queryByRole('option', { name: 'Global Missions Fund' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('handles empty account list', () => {
+    const { getByRole } = render(
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <ThemeProvider theme={theme}>
+          <AccountListAutocomplete
+            options={[]}
+            value={null}
+            onChange={setFieldValue}
+          />
+        </ThemeProvider>
+      </LocalizationProvider>,
+    );
+
+    expect(getByRole('combobox')).toHaveValue('');
+  });
+
+  it('handles invalid account ID', () => {
+    const { getByRole } = render(
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <ThemeProvider theme={theme}>
+          <AccountListAutocomplete
+            options={mockAccounts}
+            value={{ id: '', name: '' }}
+            onChange={setFieldValue}
+          />
+        </ThemeProvider>
+      </LocalizationProvider>,
+    );
+
+    expect(getByRole('combobox')).toHaveValue('');
+  });
+});

--- a/src/common/Autocompletes/AccountListAutocomplete/AccountListAutocomplete.tsx
+++ b/src/common/Autocompletes/AccountListAutocomplete/AccountListAutocomplete.tsx
@@ -6,7 +6,6 @@ import {
   TextFieldProps,
 } from '@mui/material';
 import { AccountListOptionsQuery } from 'pages/setup/Account.generated';
-// import { AccountList } from 'src/graphql/types.generated';
 
 export type AccountListOption =
   AccountListOptionsQuery['accountLists']['nodes'][number];
@@ -19,13 +18,12 @@ interface AccountListAutocompleteProps
 
 export const AccountListAutocomplete: React.FC<
   AccountListAutocompleteProps
-> = ({ textFieldProps, options, ...props }) => {
+> = ({ textFieldProps, ...props }) => {
   return (
     <Autocomplete
       fullWidth
       autoHighlight
       {...props}
-      options={options || []}
       getOptionLabel={(account: AccountListOption): string =>
         account?.name ?? ''
       }

--- a/src/common/Autocompletes/AccountListAutocomplete/AccountListAutocomplete.tsx
+++ b/src/common/Autocompletes/AccountListAutocomplete/AccountListAutocomplete.tsx
@@ -5,10 +5,9 @@ import {
   TextField,
   TextFieldProps,
 } from '@mui/material';
-import { AccountListOptionsQuery } from 'pages/setup/Account.generated';
+import { AccountList } from 'src/graphql/types.generated';
 
-export type AccountListOption =
-  AccountListOptionsQuery['accountLists']['nodes'][number];
+export type AccountListOption = Pick<AccountList, 'id' | 'name'>;
 
 interface AccountListAutocompleteProps
   extends Partial<AutocompleteProps<AccountListOption, false, boolean, false>> {

--- a/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.test.tsx
@@ -34,7 +34,7 @@ const mutationSpy = jest.fn();
 const mockData = {
   user: {
     id: '1',
-    defaultAccountList: '1',
+    defaultAccountListId: '1',
     preferences: {
       id: '1',
       timeZone: 'us',
@@ -62,12 +62,12 @@ const mockData = {
 };
 
 interface ComponentsProps {
-  defaultAccountList: string;
+  defaultAccountListId: string;
   expandedAccordion: PreferenceAccordion | null;
 }
 
 const Components: React.FC<ComponentsProps> = ({
-  defaultAccountList,
+  defaultAccountListId,
   expandedAccordion,
 }) => (
   <SnackbarProvider>
@@ -78,8 +78,7 @@ const Components: React.FC<ComponentsProps> = ({
             handleAccordionChange={handleAccordionChange}
             expandedAccordion={expandedAccordion}
             data={mockData}
-            accountListId={accountListId}
-            defaultAccountList={defaultAccountList}
+            defaultAccountListId={defaultAccountListId}
           />
         </GqlMockedProvider>
       </ThemeProvider>
@@ -96,7 +95,7 @@ describe('Default Account Accordion', () => {
   it('should render accordion closed', () => {
     const { getByText, queryByRole } = render(
       <Components
-        defaultAccountList={'cbe2fe56-1525-4aee-8320-1ca7ccf09703'}
+        defaultAccountListId={'cbe2fe56-1525-4aee-8320-1ca7ccf09703'}
         expandedAccordion={null}
       />,
     );
@@ -111,7 +110,7 @@ describe('Default Account Accordion', () => {
 
     const { getByRole } = render(
       <Components
-        defaultAccountList={value}
+        defaultAccountListId={value}
         expandedAccordion={PreferenceAccordion.DefaultAccount}
       />,
     );
@@ -126,7 +125,7 @@ describe('Default Account Accordion', () => {
   it('Saves the input', async () => {
     const { getByRole, getByText } = render(
       <Components
-        defaultAccountList={'cbe2fe56-1525-4aee-8320-1ca7ccf09703'}
+        defaultAccountListId={'cbe2fe56-1525-4aee-8320-1ca7ccf09703'}
         expandedAccordion={PreferenceAccordion.DefaultAccount}
       />,
     );

--- a/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.tsx
@@ -6,7 +6,7 @@ import * as yup from 'yup';
 import {
   AccountListAutocomplete,
   AccountListOption,
-} from 'src/common/Autocompletes/AccountListAutocomplete';
+} from 'src/common/Autocompletes/AccountListAutocomplete/AccountListAutocomplete';
 import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
@@ -26,7 +26,7 @@ interface DefaultAccountAccordionProps
 const preferencesSchema = yup.object({
   defaultAccountListOption: yup
     .object({
-      id: yup.string(),
+      id: yup.string().required(),
       name: yup.string(),
     })
     .required(),

--- a/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.tsx
@@ -1,14 +1,16 @@
-import React, { ReactElement, useMemo } from 'react';
-import { Autocomplete, TextField } from '@mui/material';
+import React, { ReactElement } from 'react';
 import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import {
+  AccountListAutocomplete,
+  AccountListOption,
+} from 'src/common/Autocompletes/AccountListAutocomplete';
 import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { AccordionItem } from 'src/components/Shared/Forms/Accordions/AccordionItem';
 import { FieldWrapper } from 'src/components/Shared/Forms/FieldWrapper';
 import { FormWrapper } from 'src/components/Shared/Forms/FormWrapper';
-import { User } from 'src/graphql/types.generated';
 import useGetAppSettings from 'src/hooks/useGetAppSettings';
 import { AccordionProps } from '../../../accordionHelper';
 import { GetPersonalPreferencesQuery } from '../../GetPersonalPreferences.generated';
@@ -17,15 +19,18 @@ import { useUpdateUserDefaultAccountMutation } from './UpdateDefaultAccount.gene
 interface DefaultAccountAccordionProps
   extends AccordionProps<PreferenceAccordion> {
   data: GetPersonalPreferencesQuery | undefined;
-  accountListId: string;
-  defaultAccountList: string;
+  defaultAccountListId: string;
   disabled?: boolean;
 }
 
-const preferencesSchema: yup.ObjectSchema<Pick<User, 'defaultAccountList'>> =
-  yup.object({
-    defaultAccountList: yup.string().required(),
-  });
+const preferencesSchema = yup.object({
+  defaultAccountListOption: yup
+    .object({
+      id: yup.string(),
+      name: yup.string(),
+    })
+    .required(),
+});
 
 export const DefaultAccountAccordion: React.FC<
   DefaultAccountAccordionProps
@@ -33,7 +38,7 @@ export const DefaultAccountAccordion: React.FC<
   handleAccordionChange,
   expandedAccordion,
   data,
-  defaultAccountList,
+  defaultAccountListId,
   disabled,
 }) => {
   const { t } = useTranslation();
@@ -43,18 +48,14 @@ export const DefaultAccountAccordion: React.FC<
 
   const label = t('Default Account');
   const accounts = data?.accountLists?.nodes || [];
-
-  const selectedAccount = useMemo(
-    () => accounts.find(({ id }) => id === defaultAccountList)?.name ?? '',
-    [accounts, defaultAccountList],
-  );
-
-  const onSubmit = async (attributes: Pick<User, 'defaultAccountList'>) => {
+  const onSubmit = async (attributes: {
+    defaultAccountListOption: AccountListOption | null;
+  }) => {
     await updateUserDefaultAccount({
       variables: {
         input: {
           attributes: {
-            defaultAccountList: attributes.defaultAccountList,
+            defaultAccountList: attributes?.defaultAccountListOption?.id,
           },
         },
       },
@@ -73,31 +74,32 @@ export const DefaultAccountAccordion: React.FC<
   };
 
   return (
-    <AccordionItem
-      accordion={PreferenceAccordion.DefaultAccount}
-      onAccordionChange={handleAccordionChange}
-      expandedAccordion={expandedAccordion}
-      label={label}
-      value={selectedAccount}
-      fullWidth
-      disabled={disabled}
+    <Formik
+      initialValues={{
+        defaultAccountListOption:
+          accounts.find(({ id }) => id === defaultAccountListId) || null,
+      }}
+      validationSchema={preferencesSchema}
+      onSubmit={onSubmit}
+      enableReinitialize
+      validateOnMount
     >
-      <Formik
-        initialValues={{
-          defaultAccountList: defaultAccountList,
-        }}
-        validationSchema={preferencesSchema}
-        onSubmit={onSubmit}
-        enableReinitialize
-        validateOnMount
-      >
-        {({
-          values: { defaultAccountList },
-          handleSubmit,
-          setFieldValue,
-          isSubmitting,
-          isValid,
-        }): ReactElement => (
+      {({
+        values: { defaultAccountListOption: currentSelection },
+        handleSubmit,
+        setFieldValue,
+        isSubmitting,
+        isValid,
+      }): ReactElement => (
+        <AccordionItem
+          accordion={PreferenceAccordion.DefaultAccount}
+          onAccordionChange={handleAccordionChange}
+          expandedAccordion={expandedAccordion}
+          label={label}
+          value={currentSelection?.name || ''}
+          fullWidth
+          disabled={disabled}
+        >
           <FormWrapper
             onSubmit={handleSubmit}
             isValid={isValid}
@@ -109,34 +111,24 @@ export const DefaultAccountAccordion: React.FC<
                 { appName },
               )}
             >
-              <Autocomplete
+              <AccountListAutocomplete
                 disabled={isSubmitting}
-                autoHighlight
-                value={defaultAccountList}
+                value={currentSelection}
                 onChange={(_, value) => {
-                  setFieldValue('defaultAccountList', value);
+                  setFieldValue('defaultAccountListOption', value);
                 }}
-                options={accounts.map((account) => account.id) || []}
-                getOptionLabel={(defaultAccountList): string =>
-                  accounts.find(({ id }) => id === defaultAccountList)?.name ??
-                  ''
-                }
-                fullWidth
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    placeholder={label}
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
-                    autoFocus
-                    label={label}
-                    sx={{ marginTop: 1 }}
-                  />
-                )}
+                options={accounts}
+                textFieldProps={{
+                  placeholder: label,
+                  autoFocus: true,
+                  label: label,
+                  sx: { marginTop: 1 },
+                }}
               />
             </FieldWrapper>
           </FormWrapper>
-        )}
-      </Formik>
-    </AccordionItem>
+        </AccordionItem>
+      )}
+    </Formik>
   );
 };

--- a/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useMemo } from 'react';
 import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
@@ -48,6 +48,12 @@ export const DefaultAccountAccordion: React.FC<
 
   const label = t('Default Account');
   const accounts = data?.accountLists?.nodes || [];
+
+  const selectedAccount = useMemo(
+    () => accounts.find(({ id }) => id === defaultAccountListId)?.name ?? '',
+    [accounts, defaultAccountListId],
+  );
+
   const onSubmit = async (attributes: {
     defaultAccountListOption: AccountListOption | null;
   }) => {
@@ -96,7 +102,7 @@ export const DefaultAccountAccordion: React.FC<
           onAccordionChange={handleAccordionChange}
           expandedAccordion={expandedAccordion}
           label={label}
-          value={currentSelection?.name || ''}
+          value={selectedAccount}
           fullWidth
           disabled={disabled}
         >


### PR DESCRIPTION
## Description

[Jira ticket](https://jira.cru.org/secure/RapidBoard.jspa?rapidView=3&view=detail&selectedIssue=MPDX-8668#)

- Extracts DefaultAccountAutocomplete into a reusable, shared component. 
- Modifies DefaultAccountAccordion and account.page.tsx to use this shared component.
- Types of the props being passed in deferred in DefaultAccountAccordion and account.page.tsx when passed into the initial Autocomplete, so they were changed to match in each file.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
