### PR TITLE
MPDX-8685 Update helper text in all forms

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/PartnerAccounts/ContactDetailsPartnerAccounts.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/PartnerAccounts/ContactDetailsPartnerAccounts.tsx
@@ -8,6 +8,7 @@ import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 import { ActionButton } from 'src/components/common/Modal/ActionButtons/ActionButtons';
+import i18n from 'src/lib/i18n';
 import { ContactDetailsTabDocument } from '../ContactDetailsTab.generated';
 import { useUpdateContactOtherMutation } from '../Other/EditContactOtherModal/EditContactOther.generated';
 import { ContactDetailLoadingPlaceHolder } from '../StyledComponents';
@@ -18,7 +19,7 @@ import {
 import { useDeleteDonorAccountMutation } from './DeleteDonorAccount.generated';
 
 const newPartnerAccountSchema = yup.object({
-  accountNumber: yup.string().required(),
+  accountNumber: yup.string().required(i18n.t('Account Number is required')),
 });
 
 type Attributes = yup.InferType<typeof newPartnerAccountSchema>;
@@ -158,11 +159,7 @@ export const ContactDetailsPartnerAccounts: React.FC<
                 onBlur={handleBlur}
                 inputProps={{ 'aria-label': t('Account Number') }}
                 error={!!errors.accountNumber && touched.accountNumber}
-                helperText={
-                  errors.accountNumber &&
-                  touched.accountNumber &&
-                  t('Field is required')
-                }
+                helperText={touched.accountNumber ? errors.accountNumber : ''}
                 required
               />
               <IconButton

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonEmail/PersonEmailItem.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonEmail/PersonEmailItem.tsx
@@ -111,6 +111,7 @@ export const PersonEmailItem: React.FC<Props> = ({
               getIn(errors, `emailAddresses.${index}`).email
             }
             fullWidth
+            required
           />
         </Grid>
         <Grid item xs={12} sm={6} md={2}>

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonName/PersonName.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonName/PersonName.tsx
@@ -125,11 +125,19 @@ export const PersonName: React.FC<PersonNameProps> = ({
           </Grid>
           <Grid item xs={12} sm={6}>
             <TextField
+              name="lastName"
               label={t('Last Name')}
               value={lastName}
               onChange={handleChange('lastName')}
               inputProps={{ 'aria-label': t('Last Name') }}
               fullWidth
+              onBlur={handleBlur}
+              error={touched.lastName && !!errors.lastName}
+              helperText={
+                touched.lastName &&
+                errors.lastName &&
+                t('Last Name is required')
+              }
               required
             />
           </Grid>

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonSocials/PersonSocials.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonSocials/PersonSocials.tsx
@@ -92,7 +92,7 @@ export const PersonSocial: React.FC<PersonSocialProps> = ({ formikProps }) => {
                     error={getIn(errors, `facebookAccounts.${index}`)}
                     helperText={
                       getIn(errors, `facebookAccounts.${index}`) &&
-                      t('Field is required')
+                      t('Username/URL is required')
                     }
                     fullWidth
                   />
@@ -149,7 +149,7 @@ export const PersonSocial: React.FC<PersonSocialProps> = ({ formikProps }) => {
                     error={getIn(errors, `twitterAccounts.${index}`)}
                     helperText={
                       getIn(errors, `twitterAccounts.${index}`) &&
-                      t('Field is required')
+                      t('Username/URL is required')
                     }
                     fullWidth
                   />
@@ -206,7 +206,7 @@ export const PersonSocial: React.FC<PersonSocialProps> = ({ formikProps }) => {
                     error={getIn(errors, `linkedinAccounts.${index}`)}
                     helperText={
                       getIn(errors, `linkedinAccounts.${index}`) &&
-                      t('Field is required')
+                      t('Username/URL is required')
                     }
                     fullWidth
                   />
@@ -266,7 +266,7 @@ export const PersonSocial: React.FC<PersonSocialProps> = ({ formikProps }) => {
                       error={getIn(errors, `websites.${index}`)}
                       helperText={
                         getIn(errors, `websites.${index}`) &&
-                        t('Field is required')
+                        t('Username/URL is required')
                       }
                       disabled={!!account.destroy}
                       fullWidth
@@ -331,7 +331,7 @@ export const PersonSocial: React.FC<PersonSocialProps> = ({ formikProps }) => {
                         error={getIn(errors, `newSocials.${index}`)}
                         helperText={
                           getIn(errors, `newSocials.${index}`) &&
-                          t('Field is required')
+                          t('Username/URL is required')
                         }
                         disabled={!!social.destroy}
                         fullWidth

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/personModalHelper.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/personModalHelper.tsx
@@ -22,7 +22,7 @@ export const getPersonSchema = (
 ): GetPersonSchemaReturnedValues => {
   const personSchema = yup.object({
     firstName: yup.string().required(),
-    lastName: yup.string().nullable(),
+    lastName: yup.string().required(),
     title: yup.string().nullable(),
     suffix: yup.string().nullable(),
     phoneNumbers: yup.array().of(
@@ -34,7 +34,7 @@ export const getPersonSchema = (
             then: (schema) => schema.nullable(),
             otherwise: (schema) =>
               schema
-                .required(t('This field is required'))
+                .required(t('Phone Number is required'))
                 .nullable()
                 .test(
                   'is-phone-number',
@@ -54,7 +54,7 @@ export const getPersonSchema = (
         email: yup
           .string()
           .email(t('Invalid email address'))
-          .required(t('This field is required')),
+          .required(t('Email is required')),
         destroy: yup.boolean().default(false),
         primary: yup.boolean().default(false),
         historic: yup.boolean().default(false),

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.test.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.test.tsx
@@ -79,7 +79,7 @@ describe('LogNewsletter', () => {
       expect(getByText('Log Newsletter')).toBeInTheDocument();
 
       userEvent.click(getByText('Save'));
-      expect(await findByText('Field is required')).toBeInTheDocument();
+      expect(await findByText('Subject is required')).toBeInTheDocument();
 
       userEvent.type(getByLabelText('Subject'), accountListId);
       await waitFor(() => expect(getByText('Save')).not.toBeDisabled());
@@ -105,7 +105,7 @@ describe('LogNewsletter', () => {
       expect(getByText('Log Newsletter')).toBeInTheDocument();
 
       userEvent.click(getByText('Save'));
-      expect(await findByText('Field is required')).toBeInTheDocument();
+      expect(await findByText('Subject is required')).toBeInTheDocument();
 
       userEvent.type(getByLabelText('Subject'), accountListId);
       await waitFor(() => expect(getByText('Save')).not.toBeDisabled());
@@ -132,7 +132,7 @@ describe('LogNewsletter', () => {
       expect(getByText('Log Newsletter')).toBeInTheDocument();
 
       userEvent.click(getByText('Save'));
-      expect(await findByText('Field is required')).toBeInTheDocument();
+      expect(await findByText('Subject is required')).toBeInTheDocument();
 
       userEvent.type(getByLabelText('Subject'), accountListId);
       await waitFor(() => expect(getByText('Save')).not.toBeDisabled());
@@ -167,7 +167,7 @@ describe('LogNewsletter', () => {
       expect(getByText('Log Newsletter')).toBeInTheDocument();
 
       userEvent.click(getByText('Save'));
-      expect(await findByText('Field is required')).toBeInTheDocument();
+      expect(await findByText('Subject is required')).toBeInTheDocument();
 
       userEvent.type(getByLabelText('Subject'), accountListId);
       await waitFor(() => expect(getByText('Save')).not.toBeDisabled());

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/LogNewsLetter/LogNewsletter.tsx
@@ -183,7 +183,7 @@ const LogNewsletter = ({
                     helperText={
                       errors.subject &&
                       touched.subject &&
-                      t('Field is required')
+                      t('Subject is required')
                     }
                     variant="outlined"
                     required

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateContact/CreateContact.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateContact/CreateContact.test.tsx
@@ -74,7 +74,9 @@ describe('CreateContact', () => {
       );
 
       userEvent.click(getByText('Save'));
-      expect(await findByText('Field is required')).toBeInTheDocument();
+      expect(
+        await findByText('At least one name is required'),
+      ).toBeInTheDocument();
       userEvent.type(
         getByRole('textbox', { hidden: true, name: 'Name' }),
         name,
@@ -121,7 +123,9 @@ describe('CreateContact', () => {
       );
 
       userEvent.click(getByText('Save'));
-      expect(await findByText('Field is required')).toBeInTheDocument();
+      expect(
+        await findByText('At least one name is required'),
+      ).toBeInTheDocument();
       userEvent.type(
         getByRole('textbox', { hidden: true, name: 'Name' }),
         name,

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateContact/CreateContact.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateContact/CreateContact.tsx
@@ -175,7 +175,9 @@ const CreateContact = ({
                     inputProps={{ 'aria-label': t('Name') }}
                     error={!!errors.name && touched.name}
                     helperText={
-                      errors.name && touched.name && t('Field is required')
+                      errors.name &&
+                      touched.name &&
+                      t('At least one name is required')
                     }
                     variant="outlined"
                     required

--- a/src/components/Settings/Accounts/MergeForm/MergeForm.tsx
+++ b/src/components/Settings/Accounts/MergeForm/MergeForm.tsx
@@ -209,7 +209,7 @@ export const MergeForm: React.FC<MergeFormProps> = ({ isSpouse }) => {
                         </Select>
                         {errors.selectedAccountId && (
                           <FormHelperText error={true}>
-                            {t('This field is required')}
+                            {t('Account is required')}
                           </FormHelperText>
                         )}
                       </FieldWrapper>
@@ -289,7 +289,7 @@ export const MergeForm: React.FC<MergeFormProps> = ({ isSpouse }) => {
                     />
                     {errors.accept && (
                       <FormHelperText error={true}>
-                        {t('This field is required')}
+                        {t('You must accept before proceeding')}
                       </FormHelperText>
                     )}
                   </FieldWrapper>

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
@@ -219,7 +219,7 @@ describe('EditGoogleAccountModal', () => {
 
     userEvent.click(getByRole('button', { name: /update/i }));
     await waitFor(() =>
-      expect(getByText(/this field is required/i)).toBeInTheDocument(),
+      expect(getByText(/a calendar is required/i)).toBeInTheDocument(),
     );
     userEvent.click(getByRole('combobox'));
     userEvent.click(
@@ -229,7 +229,7 @@ describe('EditGoogleAccountModal', () => {
     );
 
     await waitFor(() =>
-      expect(queryByRole(/this field is required/i)).not.toBeInTheDocument(),
+      expect(queryByRole(/a calendar is required/i)).not.toBeInTheDocument(),
     );
     await waitFor(() =>
       expect(getByRole('button', { name: /update/i })).not.toBeDisabled(),

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleIntegrationForm.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleIntegrationForm.tsx
@@ -205,7 +205,7 @@ export const EditGoogleIntegrationForm: React.FC<
                   </Select>
                   {errors.calendarId && (
                     <FormHelperText error={true}>
-                      {t('This field is required')}
+                      {t('A calendar is required')}
                     </FormHelperText>
                   )}
                 </Box>

--- a/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.tsx
+++ b/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.tsx
@@ -271,7 +271,7 @@ export const MailchimpAccordion: React.FC<AccordionProps> = ({
                       </Select>
                       {errors.primaryListId && (
                         <FormHelperText error={true}>
-                          {t('This field is required')}
+                          {t('A list is required')}
                         </FormHelperText>
                       )}
                       <StyledFormControlLabel

--- a/src/components/Task/Modal/Form/Inputs/ActivityTypeAutocomplete/ActivityTypeAutocomplete.tsx
+++ b/src/components/Task/Modal/Form/Inputs/ActivityTypeAutocomplete/ActivityTypeAutocomplete.tsx
@@ -64,7 +64,7 @@ export const ActivityTypeAutocomplete: React.FC<ActivityTypeProps> = ({
           helperText={
             errors?.activityType &&
             touched?.activityType &&
-            t('Field is required')
+            t('Action is required')
           }
         />
       )}

--- a/src/components/Task/Modal/Form/Inputs/TaskPhaseAutocomplete/TaskPhaseAutocomplete.tsx
+++ b/src/components/Task/Modal/Form/Inputs/TaskPhaseAutocomplete/TaskPhaseAutocomplete.tsx
@@ -49,7 +49,9 @@ export const TaskPhaseAutocomplete: React.FC<TaskPhaseProps> = ({
           label={label || t('Task Type')}
           error={!!errors?.taskPhase && Boolean(touched?.taskPhase)}
           helperText={
-            errors?.taskPhase && touched?.taskPhase && t('Field is required')
+            errors?.taskPhase &&
+            touched?.taskPhase &&
+            t('Task Type is required')
           }
         />
       )}

--- a/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.tsx
+++ b/src/components/Task/Modal/Form/LogForm/TaskModalLogForm.tsx
@@ -40,6 +40,7 @@ import useTaskModal from 'src/hooks/useTaskModal';
 import { useUpdateTasksQueries } from 'src/hooks/useUpdateTasksQueries';
 import { dispatch } from 'src/lib/analytics';
 import { nullableDateTime } from 'src/lib/formikHelpers';
+import i18n from 'src/lib/i18n';
 import { getValueFromIdValue } from 'src/utils/phases/getValueFromIdValue';
 import { inPersonActivityTypes } from 'src/utils/phases/taskActivityTypes';
 import { DateTimeFieldPair } from '../../../../common/DateTimePickers/DateTimeFieldPair';
@@ -74,7 +75,7 @@ import { possibleResults } from '../possibleResults';
 const taskSchema = yup.object({
   taskPhase: yup.mixed<PhaseEnum>().required(),
   activityType: yup.mixed<ActivityTypeEnum>().required(),
-  subject: yup.string().required(),
+  subject: yup.string().required(i18n.t('Task Name is required')),
   contactIds: yup.array().of(yup.string().required()).default([]),
   completedAt: nullableDateTime(),
   userId: yup.string().nullable(),
@@ -423,9 +424,7 @@ const TaskModalLogForm = ({
                   multiline
                   inputProps={{ 'aria-label': t('Subject') }}
                   error={!!errors.subject && touched.subject}
-                  helperText={
-                    errors.subject && touched.subject && t('Field is required')
-                  }
+                  helperText={touched.subject ? errors.subject : ''}
                   required
                 />
               </Grid>

--- a/src/components/Task/Modal/Form/TaskModalForm.test.tsx
+++ b/src/components/Task/Modal/Form/TaskModalForm.test.tsx
@@ -106,7 +106,7 @@ describe('TaskModalForm', () => {
 
     userEvent.click(getByRole('button', { name: 'Save' }));
     expect(onClose).not.toHaveBeenCalled();
-    expect(await findByText('Field is required')).toBeInTheDocument();
+    expect(await findByText('Task Name is required')).toBeInTheDocument();
     await waitFor(() => expect(onClose).not.toHaveBeenCalled());
   });
 

--- a/src/components/Task/Modal/Form/TaskModalForm.tsx
+++ b/src/components/Task/Modal/Form/TaskModalForm.tsx
@@ -513,7 +513,9 @@ const TaskModalForm = ({
                   inputProps={{ 'aria-label': t('Subject') }}
                   error={!!errors.subject && touched.subject}
                   helperText={
-                    errors.subject && touched.subject && t('Field is required')
+                    errors.subject &&
+                    touched.subject &&
+                    t('Task Name is required')
                   }
                   required
                 />

--- a/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
@@ -304,7 +304,7 @@ export const PledgeModal: React.FC<PledgeModalProps> = ({
                       )}
                       {errors.amountCurrency && (
                         <FormHelperText error={true}>
-                          {t('This field is required')}
+                          {t('Currency is required')}
                         </FormHelperText>
                       )}
                     </FormControl>

--- a/src/components/Tool/FixPhoneNumbers/Contact.test.tsx
+++ b/src/components/Tool/FixPhoneNumbers/Contact.test.tsx
@@ -179,7 +179,7 @@ describe('Fix PhoneNumber Contact', () => {
       const addButton = getByTestId('addButton-contactTestId');
       expect(addButton).toBeDisabled();
 
-      expect(await findByText('This field is required')).toBeVisible();
+      expect(await findByText('Phone Number is required')).toBeVisible();
     });
 
     it('should show an error message if there is an invalid number', async () => {

--- a/src/components/Tool/FixPhoneNumbers/Contact.tsx
+++ b/src/components/Tool/FixPhoneNumbers/Contact.tsx
@@ -172,7 +172,7 @@ const Contact: React.FC<Props> = ({ person, submitAll, accountListId }) => {
               t('This field is not a valid phone number'),
               (val) => typeof val === 'string' && /\d/.test(val),
             )
-            .required(t('This field is required')),
+            .required(t('Phone Number is required')),
           primary: yup.bool(),
         }),
       )

--- a/src/components/Tool/FixPhoneNumbers/PhoneNumberValidationForm.tsx
+++ b/src/components/Tool/FixPhoneNumbers/PhoneNumberValidationForm.tsx
@@ -76,7 +76,7 @@ const PhoneValidationForm = ({
         t('This field is not a valid phone number'),
         (val) => typeof val === 'string' && /\d/.test(val),
       )
-      .required(t('This field is required')),
+      .required(t('Phone Number is required')),
     isPrimary: yup.bool().default(false),
     updatedAt: yup.string(),
     source: yup.string(),


### PR DESCRIPTION
## Description

In OKR #41, I refactored autocompletes into a shared component to increase reusability and improve the overall codebase. During this process, I discovered that many form fields were not consistent with the error validation helper texts used in the shared components. To maintain consistency throughout MPDX, I reviewed each form and updated instances of the generic "Field is required" message to use the specific field name (e.g., "Email is required"). This improves user experience by making validation messages clearer.

I also fixed a few bugs in the fields themselves. For example, in `personModalHelper.tsx`, the email field displayed "Email is required" but was missing the asterisk. Additionally, when creating or editing a person, the last name field showed an asterisk (indicating it was required) but did not display an error message if the field was empty. I addressed both of these issues.

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
