### PR TITLE
[no-Jira] Install yarn manually

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -26,7 +26,11 @@ frontend:
         # Install git-lfs and pull down the files
         - export PATH=$PATH:$(pwd)/bin && git-lfs install
         - export PATH=$PATH:$(pwd)/bin && git-lfs pull
-        # install dependencies
+        # Install dependencies
+        # Installing yarn manually shouldn't be necessary, but the automatic
+        # `npm install -g --quiet @aws-amplify/cli bower cypress grunt-cli hugo-extended vuepress yarn`
+        # command is failing as of 7/23/2025. In the future, we may be able to remove this line.
+        - npm install -g yarn
         - yarn config set nodeLinker node-modules
         - yarn -v
         - yarn


### PR DESCRIPTION
## Description

Today (7/25/2025) all Amplify build started failing with the following error message:

```
npm install -g --quiet @aws-amplify/cli bower cypress grunt-cli hugo-extended vuepress yarn
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: stylus-loader@3.0.2
npm warn Found: stylus@undefined
npm warn node_modules/vuepress/node_modules/stylus
npm warn
npm warn Could not resolve dependency:
npm warn peer stylus@">=0.52.4" from stylus-loader@3.0.2
npm warn node_modules/vuepress/node_modules/stylus-loader
npm warn   stylus-loader@"^3.0.2" from @vuepress/theme-default@1.9.10
npm warn   node_modules/vuepress/node_modules/@vuepress/theme-default
npm error code ETARGET
npm error notarget No matching version found for stylus@^0.54.8.
npm error notarget In most cases you or one of your dependencies are requesting
npm error notarget a package version that doesn't exist.
```

Then it fails later on with `yarn: command not found` because `yarn` failed to be installed. There may be a way to resolve this, but to unblock development, I'm manually installing `yarn` in Amplify. A build completed successfully in `staging` with this fix.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
