### PR TITLE
[no-Jira] Revert "Install yarn manually"

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -26,7 +26,7 @@ frontend:
         # Install git-lfs and pull down the files
         - export PATH=$PATH:$(pwd)/bin && git-lfs install
         - export PATH=$PATH:$(pwd)/bin && git-lfs pull
-        # install dependencies
+        # Install npm dependencies
         - yarn config set nodeLinker node-modules
         - yarn -v
         - yarn

--- a/amplify.yml
+++ b/amplify.yml
@@ -26,11 +26,7 @@ frontend:
         # Install git-lfs and pull down the files
         - export PATH=$PATH:$(pwd)/bin && git-lfs install
         - export PATH=$PATH:$(pwd)/bin && git-lfs pull
-        # Install dependencies
-        # Installing yarn manually shouldn't be necessary, but the automatic
-        # `npm install -g --quiet @aws-amplify/cli bower cypress grunt-cli hugo-extended vuepress yarn`
-        # command is failing as of 7/23/2025. In the future, we may be able to remove this line.
-        - npm install -g yarn
+        # install dependencies
         - yarn config set nodeLinker node-modules
         - yarn -v
         - yarn


### PR DESCRIPTION
## Description

This reverts commit 459fff393fdfc08cc3cf2a4773eb6eef4937c1d8.

The workaround in #1374 was necessary because npm removed the `stylus` package, but has since restored it: https://www.bleepingcomputer.com/news/security/npm-accidentally-removes-stylus-package-breaks-builds-and-pipelines/. The workaround is no longer necessary.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
