### PR TITLE
[no-Jira] Remove nesting of SidePanelsLayout in goal calculator

### DIFF
--- a/src/components/Layouts/SidePanelsLayout.tsx
+++ b/src/components/Layouts/SidePanelsLayout.tsx
@@ -132,7 +132,11 @@ export const SidePanelsLayout: FC<SidePanelsLayoutProps> = ({
           >
             {leftOpen && leftPanel}
           </LeftPanelWrapper>
-          <ExpandingContent component="main" open={leftOpen}>
+          <ExpandingContent
+            component="main"
+            sx={{ display: 'flex', flexDirection: 'column' }}
+            open={leftOpen}
+          >
             {mainContent}
           </ExpandingContent>
         </CollapsibleWrapper>

--- a/src/components/Layouts/SidePanelsLayout.tsx
+++ b/src/components/Layouts/SidePanelsLayout.tsx
@@ -14,14 +14,11 @@ interface ToolbarMixin extends CSSProperties {
 interface FullHeightBoxProps {
   isScrollable?: boolean;
   headerHeight: number | string;
-  leftPanelAbsolutePosition?: boolean;
 }
 
 const FullHeightBox = styled(Box, {
   shouldForwardProp: (prop) =>
-    prop !== 'headerHeight' &&
-    prop !== 'isScrollable' &&
-    prop !== 'leftPanelAbsolutePosition',
+    prop !== 'headerHeight' && prop !== 'isScrollable',
 })<FullHeightBoxProps>(({ theme, headerHeight, isScrollable = false }) => {
   const toolbar = theme.mixins.toolbar as ToolbarMixin;
   return {
@@ -54,20 +51,18 @@ const ExpandingContent = styled(Box)(({ open }: { open: boolean }) => ({
   overflowX: 'hidden',
 }));
 
-const LeftPanelWrapper = styled(FullHeightBox)(
-  ({ theme, leftPanelAbsolutePosition }) => ({
-    flexShrink: 0,
-    borderRight: `1px solid ${theme.palette.cruGrayLight.main}`,
-    left: 0,
+const LeftPanelWrapper = styled(FullHeightBox)(({ theme }) => ({
+  flexShrink: 0,
+  borderRight: `1px solid ${theme.palette.cruGrayLight.main}`,
+  left: 0,
+  background: theme.palette.common.white,
+  [theme.breakpoints.down('md')]: {
+    transition: 'transform ease-in-out 225ms',
     background: theme.palette.common.white,
-    [theme.breakpoints.down('md')]: {
-      transition: 'transform ease-in-out 225ms',
-      background: theme.palette.common.white,
-      position: leftPanelAbsolutePosition ? 'absolute' : 'relative',
-      zIndex: 720, // Must be higher than RightPanelWrapper
-    },
-  }),
-);
+    position: 'absolute',
+    zIndex: 720, // Must be higher than RightPanelWrapper
+  },
+}));
 
 const RightPanelWrapper = styled(FullHeightBox)(({ theme, headerHeight }) => {
   const toolbar = theme.mixins.toolbar as ToolbarMixin;
@@ -100,7 +95,6 @@ interface SidePanelsLayoutProps {
   mainContent: ReactElement;
   rightPanel?: ReactElement;
   rightWidth?: string;
-  leftPanelAbsolutePosition?: boolean;
   rightOpen?: boolean;
 
   // The height of any extra header that the right panel should be under, not including the root navbar
@@ -115,7 +109,6 @@ export const SidePanelsLayout: FC<SidePanelsLayoutProps> = ({
   mainContent,
   rightPanel,
   rightWidth,
-  leftPanelAbsolutePosition = true,
   rightOpen = false,
   headerHeight = '0px',
 }) => {
@@ -132,7 +125,6 @@ export const SidePanelsLayout: FC<SidePanelsLayoutProps> = ({
             aria-labelledby="left-panel-header"
             width={leftWidth}
             flexBasis={leftWidth}
-            leftPanelAbsolutePosition={leftPanelAbsolutePosition}
             headerHeight="0px"
             isScrollable={isScrollBox}
             style={{ transform: leftOpen ? 'none' : 'translate(-100%)' }}

--- a/src/components/Reports/GoalCalculator/GoalCalculator.tsx
+++ b/src/components/Reports/GoalCalculator/GoalCalculator.tsx
@@ -21,14 +21,6 @@ import {
 } from 'src/components/Shared/MultiPageLayout/MultiPageHeader';
 import { useGoalCalculator } from './Shared/GoalCalculatorContext';
 
-const StyledCategoryIconButton = styled(IconButton)<{ selected: boolean }>(
-  ({ theme, selected }) => ({
-    color: selected
-      ? theme.palette.mpdxBlue.main
-      : theme.palette.cruGrayDark.main,
-  }),
-);
-
 const StyledCategoryTitle = styled(Typography)(({ theme }) => ({
   marginBottom: 0,
   marginTop: theme.spacing(1),
@@ -46,15 +38,6 @@ const StyledStepListItemIcon = styled(ListItemIcon)(({ theme }) => ({
   minWidth: 'auto',
   marginRight: theme.spacing(0.5),
 }));
-
-const StyledStepIcon = styled('div')<{ selected: boolean }>(
-  ({ theme, selected }) => ({
-    fontSize: '1rem',
-    color: selected
-      ? theme.palette.mpdxBlue.main
-      : theme.palette.cruGrayDark.main,
-  }),
-);
 
 const StyledToolbar = styled(Toolbar)(({ theme }) => ({
   paddingLeft: theme.spacing(2),
@@ -102,13 +85,18 @@ export const GoalCalculator: React.FC<GoalCalculatorProps> = ({
       <Stack direction="row" flex={1}>
         <Stack direction="column">
           {categories.map((category) => (
-            <StyledCategoryIconButton
+            <IconButton
               key={category.id}
+              sx={(theme) => ({
+                color:
+                  selectedCategoryID === category.id
+                    ? theme.palette.mpdxBlue.main
+                    : theme.palette.cruGrayDark.main,
+              })}
               onClick={() => handleCategoryChange(category.id)}
-              selected={selectedCategoryID === category.id}
             >
               {category.icon}
-            </StyledCategoryIconButton>
+            </IconButton>
           ))}
         </Stack>
         <Divider orientation="vertical" flexItem />
@@ -120,19 +108,27 @@ export const GoalCalculator: React.FC<GoalCalculatorProps> = ({
           <List disablePadding>
             {categorySteps?.map((step) => {
               const { id, title } = step;
+              const selected = selectedStepID === id;
               return (
                 <StyledStepListItemButton
                   key={id}
                   onClick={() => handleStepChange(id)}
                 >
                   <StyledStepListItemIcon>
-                    <StyledStepIcon selected={selectedStepID === id}>
-                      {selectedStepID === id ? (
+                    <Box
+                      sx={(theme) => ({
+                        fontSize: '1rem',
+                        color: selected
+                          ? theme.palette.mpdxBlue.main
+                          : theme.palette.cruGrayDark.main,
+                      })}
+                    >
+                      {selected ? (
                         <CircleIcon sx={{ fontSize: '1rem' }} />
                       ) : (
                         <RadioButtonUncheckedIcon sx={{ fontSize: '1rem' }} />
                       )}
-                    </StyledStepIcon>
+                    </Box>
                   </StyledStepListItemIcon>
                   <ListItemText
                     primary={title}

--- a/src/components/Reports/GoalCalculator/GoalCalculator.tsx
+++ b/src/components/Reports/GoalCalculator/GoalCalculator.tsx
@@ -29,10 +29,6 @@ const StyledCategoryIconButton = styled(IconButton)<{ selected: boolean }>(
   }),
 );
 
-const StyledVerticalDivider = styled(Divider)({
-  height: '100vh',
-});
-
 const StyledCategoryTitle = styled(Typography)(({ theme }) => ({
   marginBottom: 0,
   marginTop: theme.spacing(1),
@@ -103,7 +99,7 @@ export const GoalCalculator: React.FC<GoalCalculatorProps> = ({
         title={t('Goal Calculator')}
         headerType={HeaderTypeEnum.Report}
       />
-      <Stack direction="row">
+      <Stack direction="row" flex={1}>
         <Stack direction="column">
           {categories.map((category) => (
             <StyledCategoryIconButton
@@ -115,7 +111,7 @@ export const GoalCalculator: React.FC<GoalCalculatorProps> = ({
             </StyledCategoryIconButton>
           ))}
         </Stack>
-        <StyledVerticalDivider orientation="vertical" flexItem />
+        <Divider orientation="vertical" flexItem />
         <Box width={240}>
           <StyledCategoryTitle variant="h6">
             {categoryTitle || t('Goal Calculator')}
@@ -147,7 +143,7 @@ export const GoalCalculator: React.FC<GoalCalculatorProps> = ({
             })}
           </List>
         </Box>
-        <StyledVerticalDivider orientation="vertical" flexItem />
+        <Divider orientation="vertical" flexItem />
         <Box flex={1}>
           <StyledToolbar disableGutters>
             <StyledTitle variant="h6">

--- a/src/components/Reports/GoalCalculator/GoalCalculator.tsx
+++ b/src/components/Reports/GoalCalculator/GoalCalculator.tsx
@@ -3,19 +3,18 @@ import CircleIcon from '@mui/icons-material/Circle';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import {
   Box,
-  Container,
   Divider,
   IconButton,
   List,
   ListItemButton,
   ListItemIcon,
   ListItemText,
+  Stack,
   Toolbar,
   Typography,
   styled,
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
 import {
   HeaderTypeEnum,
   MultiPageHeader,
@@ -61,10 +60,6 @@ const StyledStepIcon = styled('div')<{ selected: boolean }>(
   }),
 );
 
-const StyledMainContent = styled(Box)(({ theme }) => ({
-  padding: theme.spacing(1),
-}));
-
 const StyledToolbar = styled(Toolbar)(({ theme }) => ({
   paddingLeft: theme.spacing(2),
 }));
@@ -101,98 +96,77 @@ export const GoalCalculator: React.FC<GoalCalculatorProps> = ({
   const { title: stepTitle, component: stepComponent } = currentStep || {};
 
   return (
-    <Box>
+    <>
       <MultiPageHeader
         isNavListOpen={isNavListOpen}
         onNavListToggle={onNavListToggle}
         title={t('Goal Calculator')}
         headerType={HeaderTypeEnum.Report}
       />
+      <Stack direction="row">
+        <Stack direction="column">
+          {categories.map((category) => (
+            <StyledCategoryIconButton
+              key={category.id}
+              onClick={() => handleCategoryChange(category.id)}
+              selected={selectedCategoryID === category.id}
+            >
+              {category.icon}
+            </StyledCategoryIconButton>
+          ))}
+        </Stack>
+        <StyledVerticalDivider orientation="vertical" flexItem />
+        <Box width={240}>
+          <StyledCategoryTitle variant="h6">
+            {categoryTitle || t('Goal Calculator')}
+          </StyledCategoryTitle>
 
-      <SidePanelsLayout
-        isScrollBox={true}
-        leftPanelAbsolutePosition={false}
-        leftPanel={
-          <Box>
-            <Box display="flex">
-              <Box flex={1}>
-                <List>
-                  {categories.map((category) => (
-                    <StyledCategoryIconButton
-                      key={category.id}
-                      onClick={() => handleCategoryChange(category.id)}
-                      selected={selectedCategoryID === category.id}
-                    >
-                      {category.icon}
-                    </StyledCategoryIconButton>
-                  ))}
-                </List>
-              </Box>
-              <StyledVerticalDivider orientation="vertical" flexItem />
-
-              <Container disableGutters>
-                <Box flex={1}>
-                  <StyledCategoryTitle variant="h6">
-                    {categoryTitle || t('Goal Calculator')}
-                  </StyledCategoryTitle>
-
-                  <List disablePadding>
-                    {categorySteps?.map((step) => {
-                      const { id, title } = step;
-                      return (
-                        <StyledStepListItemButton
-                          key={id}
-                          onClick={() => handleStepChange(id)}
-                        >
-                          <StyledStepListItemIcon>
-                            <StyledStepIcon selected={selectedStepID === id}>
-                              {selectedStepID === id ? (
-                                <CircleIcon sx={{ fontSize: '1rem' }} />
-                              ) : (
-                                <RadioButtonUncheckedIcon
-                                  sx={{ fontSize: '1rem' }}
-                                />
-                              )}
-                            </StyledStepIcon>
-                          </StyledStepListItemIcon>
-                          <ListItemText
-                            primary={title}
-                            primaryTypographyProps={{ variant: 'body2' }}
-                          />
-                        </StyledStepListItemButton>
-                      );
-                    })}
-                  </List>
-                </Box>
-              </Container>
-            </Box>
-          </Box>
-        }
-        leftOpen={true}
-        leftWidth="290px"
-        mainContent={
-          <StyledMainContent>
-            <Container>
-              <StyledToolbar disableGutters>
-                <StyledTitle variant="h6">
-                  {stepTitle || t('Goal Calculator')}
-                </StyledTitle>
-              </StyledToolbar>
-              <Box>
-                {stepComponent || (
-                  <StyledDefaultContent>
-                    <Typography variant="body1">
-                      {t(
-                        'Please select a step from the left panel to view its content.',
+          <List disablePadding>
+            {categorySteps?.map((step) => {
+              const { id, title } = step;
+              return (
+                <StyledStepListItemButton
+                  key={id}
+                  onClick={() => handleStepChange(id)}
+                >
+                  <StyledStepListItemIcon>
+                    <StyledStepIcon selected={selectedStepID === id}>
+                      {selectedStepID === id ? (
+                        <CircleIcon sx={{ fontSize: '1rem' }} />
+                      ) : (
+                        <RadioButtonUncheckedIcon sx={{ fontSize: '1rem' }} />
                       )}
-                    </Typography>
-                  </StyledDefaultContent>
-                )}
-              </Box>
-            </Container>
-          </StyledMainContent>
-        }
-      />
-    </Box>
+                    </StyledStepIcon>
+                  </StyledStepListItemIcon>
+                  <ListItemText
+                    primary={title}
+                    primaryTypographyProps={{ variant: 'body2' }}
+                  />
+                </StyledStepListItemButton>
+              );
+            })}
+          </List>
+        </Box>
+        <StyledVerticalDivider orientation="vertical" flexItem />
+        <Box flex={1}>
+          <StyledToolbar disableGutters>
+            <StyledTitle variant="h6">
+              {stepTitle || t('Goal Calculator')}
+            </StyledTitle>
+          </StyledToolbar>
+          <Box>
+            {stepComponent || (
+              <StyledDefaultContent>
+                <Typography variant="body1">
+                  {t(
+                    'Please select a step from the left panel to view its content.',
+                  )}
+                </Typography>
+              </StyledDefaultContent>
+            )}
+          </Box>
+        </Box>
+      </Stack>
+    </>
   );
 };


### PR DESCRIPTION
## Description

This PR creates the goal calculator layout without needing to have `<SidePanelsLayout>` nested inside of another `<SidePanelsLayout>`. I also simplified a few of the components and styles.

I also added vertical flexbox layout to the `<main>` component so that pages can set `flex: 1` on their content to make them fill all available space.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
