### PR TITLE
MPDX MPD Goal calculator move sidepanel

### DIFF
--- a/pages/accountLists/[accountListId]/reports/goalCalculator/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/goalCalculator/[[...contactId]].page.tsx
@@ -1,13 +1,18 @@
 import Head from 'next/head';
 import React, { useState } from 'react';
-import { Box } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { Box, IconButton, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
 import Loading from 'src/components/Loading';
 import { GoalCalculator } from 'src/components/Reports/GoalCalculator/GoalCalculator';
-import { GoalCalculatorProvider } from 'src/components/Reports/GoalCalculator/Shared/GoalCalculatorContext';
+import {
+  GoalCalculatorProvider,
+  useGoalCalculator,
+} from 'src/components/Reports/GoalCalculator/Shared/GoalCalculatorContext';
+import { multiPageHeaderHeight } from 'src/components/Shared/MultiPageLayout/MultiPageHeader';
 import {
   MultiPageMenu,
   NavTypeEnum,
@@ -18,6 +23,84 @@ import useGetAppSettings from 'src/hooks/useGetAppSettings';
 const GoalCalculatorPageWrapper = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.common.white,
 }));
+
+const RightPanelHeader = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: theme.spacing(1),
+  borderBottom: `1px solid ${theme.palette.cruGrayLight.main}`,
+}));
+
+const RightPanelTitle = styled(Typography)({
+  fontSize: '0.875rem',
+});
+
+const RightPanelContent = styled(Box)({
+  // Content wrapper for right panel
+});
+
+interface GoalCalculatorContentProps {
+  isNavListOpen: boolean;
+  onNavListToggle: () => void;
+  designationAccounts: string[];
+  setDesignationAccounts: (accounts: string[]) => void;
+}
+
+const GoalCalculatorContent: React.FC<GoalCalculatorContentProps> = ({
+  isNavListOpen,
+  onNavListToggle,
+  designationAccounts,
+  setDesignationAccounts,
+}) => {
+  const { currentStep, isRightOpen, toggleRightPanel } = useGoalCalculator();
+  const { rightPanelComponent: rightPanelStepComponent } = currentStep || {};
+  const { t } = useTranslation();
+
+  const rightPanel = (
+    <>
+      <RightPanelHeader>
+        <RightPanelTitle variant="h6">{t('Details')}</RightPanelTitle>
+        <IconButton
+          size="small"
+          onClick={() => toggleRightPanel()}
+          aria-label={t('Close Panel')}
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </RightPanelHeader>
+      <RightPanelContent>{rightPanelStepComponent}</RightPanelContent>
+    </>
+  );
+
+  return (
+    <SidePanelsLayout
+      isScrollBox={false}
+      leftPanel={
+        <MultiPageMenu
+          isOpen={isNavListOpen}
+          selectedId="goalCalculation"
+          onClose={onNavListToggle}
+          designationAccounts={designationAccounts}
+          setDesignationAccounts={setDesignationAccounts}
+          navType={NavTypeEnum.Reports}
+        />
+      }
+      leftOpen={isNavListOpen}
+      leftWidth="290px"
+      rightWidth="290px"
+      headerHeight={multiPageHeaderHeight}
+      mainContent={
+        <GoalCalculator
+          isNavListOpen={isNavListOpen}
+          onNavListToggle={onNavListToggle}
+        />
+      }
+      rightPanel={rightPanel}
+      rightOpen={isRightOpen && !!rightPanelStepComponent}
+    />
+  );
+};
 
 const GoalCalculatorPage: React.FC = () => {
   const { t } = useTranslation();
@@ -37,29 +120,14 @@ const GoalCalculatorPage: React.FC = () => {
       </Head>
       {accountListId ? (
         <GoalCalculatorPageWrapper>
-          <SidePanelsLayout
-            isScrollBox={false}
-            leftPanel={
-              <MultiPageMenu
-                isOpen={isNavListOpen}
-                selectedId="goalCalculation"
-                onClose={handleNavListToggle}
-                designationAccounts={designationAccounts}
-                setDesignationAccounts={setDesignationAccounts}
-                navType={NavTypeEnum.Reports}
-              />
-            }
-            leftOpen={isNavListOpen}
-            leftWidth="290px"
-            mainContent={
-              <GoalCalculatorProvider>
-                <GoalCalculator
-                  isNavListOpen={isNavListOpen}
-                  onNavListToggle={handleNavListToggle}
-                />
-              </GoalCalculatorProvider>
-            }
-          />
+          <GoalCalculatorProvider>
+            <GoalCalculatorContent
+              isNavListOpen={isNavListOpen}
+              onNavListToggle={handleNavListToggle}
+              designationAccounts={designationAccounts}
+              setDesignationAccounts={setDesignationAccounts}
+            />
+          </GoalCalculatorProvider>
         </GoalCalculatorPageWrapper>
       ) : (
         <Loading loading />

--- a/src/components/Reports/GoalCalculator/MinistryExpenses/MinistryExpenses.tsx
+++ b/src/components/Reports/GoalCalculator/MinistryExpenses/MinistryExpenses.tsx
@@ -7,6 +7,7 @@ import {
   GoalCalculatorStepEnum,
 } from '../GoalCalculatorHelper';
 import { MileageStep } from './Steps/MileageStep/MileageStep';
+import { MileageStepRightPanelComponent } from './Steps/MileageStep/MileageStepRightPanelComponent/MileageStepRightPanelComponent';
 
 export const useMinistryExpenses = (): GoalCalculatorCategory => {
   const { t } = useTranslation();
@@ -19,6 +20,7 @@ export const useMinistryExpenses = (): GoalCalculatorCategory => {
         id: GoalCalculatorStepEnum.Mileage,
         title: t('Mileage'),
         component: <MileageStep />,
+        rightPanelComponent: <MileageStepRightPanelComponent />,
       },
       {
         id: GoalCalculatorStepEnum.Medical,

--- a/src/components/Reports/GoalCalculator/MinistryExpenses/Steps/MileageStep/MileageStepRightPanelComponent/MileageStepRightPanelComponent.tsx
+++ b/src/components/Reports/GoalCalculator/MinistryExpenses/Steps/MileageStep/MileageStepRightPanelComponent/MileageStepRightPanelComponent.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useGoalCalculator } from 'src/components/Reports/GoalCalculator/Shared/GoalCalculatorContext';
+
+export const MileageStepRightPanelComponent: React.FC = () => {
+  const { t } = useTranslation();
+  const { toggleRightPanel } = useGoalCalculator();
+
+  return (
+    <Box sx={{ padding: '16px' }}>
+      <Typography variant="h6" gutterBottom>
+        {t('Mileage Step')}
+      </Typography>
+
+      <Button
+        variant="outlined"
+        onClick={toggleRightPanel}
+        sx={{ marginTop: '16px' }}
+      >
+        {t('Close Panel')}
+      </Button>
+    </Box>
+  );
+};

--- a/src/components/Reports/GoalCalculator/Shared/GoalCalculatorContext.tsx
+++ b/src/components/Reports/GoalCalculator/Shared/GoalCalculatorContext.tsx
@@ -18,9 +18,14 @@ export type GoalCalculatorType = {
   selectedStepId: GoalCalculatorStepEnum;
   currentCategory?: GoalCalculatorCategory;
   currentStep?: GoalCalculatorCategoryStep;
+  isRightOpen: boolean;
+  isDrawerOpen: boolean;
   handleCategoryChange: (categoryId: GoalCalculatorCategoryEnum) => void;
   handleStepChange: (stepId: GoalCalculatorStepEnum) => void;
   handleContinue: () => void;
+  toggleRightPanel: () => void;
+  toggleDrawer: () => void;
+  setDrawerOpen: (open: boolean) => void;
 };
 
 const GoalCalculatorContext = React.createContext<GoalCalculatorType | null>(
@@ -60,6 +65,8 @@ export const GoalCalculatorProvider: React.FC<Props> = ({ children }) => {
   const [selectedStepId, setSelectedStepId] = useState<GoalCalculatorStepEnum>(
     GoalCalculatorStepEnum.Information,
   );
+  const [isRightOpen, setIsRightOpen] = useState<boolean>(false);
+  const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(true);
 
   const currentCategory = useMemo(
     () => categories.find((cat) => cat.id === selectedCategoryId),
@@ -142,6 +149,17 @@ export const GoalCalculatorProvider: React.FC<Props> = ({ children }) => {
     t,
   ]);
 
+  const toggleRightPanel = useCallback(() => {
+    setIsRightOpen((prev) => !prev);
+  }, []);
+
+  const toggleDrawer = useCallback(() => {
+    setIsDrawerOpen((prev) => !prev);
+  }, []);
+
+  const setDrawerOpen = useCallback((open: boolean) => {
+    setIsDrawerOpen(open);
+  }, []);
   const contextValue: GoalCalculatorType = useMemo(
     () => ({
       categories,
@@ -149,18 +167,28 @@ export const GoalCalculatorProvider: React.FC<Props> = ({ children }) => {
       selectedStepId,
       currentCategory,
       currentStep,
+      isRightOpen,
+      isDrawerOpen,
       handleCategoryChange,
       handleStepChange,
       handleContinue,
+      toggleRightPanel,
+      toggleDrawer,
+      setDrawerOpen,
     }),
     [
       selectedCategoryId,
       selectedStepId,
       currentCategory,
       currentStep,
+      isRightOpen,
+      isDrawerOpen,
       handleCategoryChange,
       handleStepChange,
       handleContinue,
+      toggleRightPanel,
+      toggleDrawer,
+      setDrawerOpen,
     ],
   );
 


### PR DESCRIPTION


## Description

I moved sidePanelsLayout directly into GoalCalculator as some significant changes needed to be made to allow for the side icon row, the left step (or anchor) panel and the right information panel to all work correctly. This PR should address these issues. If you would like to see the right panel working you will need to add `rightPanelComponent` to one of the "Steps" and a component that you want rendered there.

Side note, initially this PR aimed to address some of UI changes needed for "Mileage" but it sounds like this will need to be discussed a little more before going in a specific direction.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
