### PR TITLE
[no-Jira] Rename categories to steps and vice-versa

### DIFF
--- a/pages/accountLists/[accountListId]/reports/goalCalculator/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/goalCalculator/[[...contactId]].page.tsx
@@ -53,8 +53,10 @@ const GoalCalculatorContent: React.FC<GoalCalculatorContentProps> = ({
   designationAccounts,
   setDesignationAccounts,
 }) => {
-  const { currentStep, isRightOpen, toggleRightPanel } = useGoalCalculator();
-  const { rightPanelComponent: rightPanelStepComponent } = currentStep || {};
+  const { currentCategory, isRightOpen, toggleRightPanel } =
+    useGoalCalculator();
+  const { rightPanelComponent: rightPanelStepComponent } =
+    currentCategory || {};
   const { t } = useTranslation();
 
   const rightPanel = (

--- a/src/components/Reports/GoalCalculator/CalculatorSettings/CalculatorSettings.tsx
+++ b/src/components/Reports/GoalCalculator/CalculatorSettings/CalculatorSettings.tsx
@@ -1,33 +1,33 @@
 import SettingsIcon from '@mui/icons-material/Settings';
 import { useTranslation } from 'react-i18next';
 import {
-  GoalCalculatorCategory,
   GoalCalculatorCategoryEnum,
+  GoalCalculatorStep,
   GoalCalculatorStepEnum,
 } from '../GoalCalculatorHelper';
 import { InformationStep } from './Steps/InformationStep/InformationStep';
 import { OneTimeGoalsStep } from './Steps/OneTimeGoalsStep/OneTimeGoalsStep';
 import { SpecialIncomeStep } from './Steps/SpecialIncomeStep/SpecialIncomeStep';
 
-export const useCalculatorSettings = (): GoalCalculatorCategory => {
+export const useCalculatorSettings = (): GoalCalculatorStep => {
   const { t } = useTranslation();
   return {
     title: t('Calculator Settings'),
-    id: GoalCalculatorCategoryEnum.CalculatorSettings,
+    id: GoalCalculatorStepEnum.CalculatorSettings,
     icon: <SettingsIcon />,
-    steps: [
+    categories: [
       {
-        id: GoalCalculatorStepEnum.Information,
+        id: GoalCalculatorCategoryEnum.Information,
         title: t('Information'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.SpecialIncome,
+        id: GoalCalculatorCategoryEnum.SpecialIncome,
         title: t('Special Income'),
         component: <SpecialIncomeStep />,
       },
       {
-        id: GoalCalculatorStepEnum.OneTimeGoals,
+        id: GoalCalculatorCategoryEnum.OneTimeGoals,
         title: t('One-time Goals'),
         component: <OneTimeGoalsStep />,
       },

--- a/src/components/Reports/GoalCalculator/GoalCalculator.tsx
+++ b/src/components/Reports/GoalCalculator/GoalCalculator.tsx
@@ -22,6 +22,7 @@ import {
   multiPageHeaderHeight,
 } from 'src/components/Shared/MultiPageLayout/MultiPageHeader';
 import theme from 'src/theme';
+import { GoalCalculatorStepEnum } from './GoalCalculatorHelper';
 import { useGoalCalculator } from './Shared/GoalCalculatorContext';
 
 const StyledCategoryTitle = styled(Typography)(({ theme }) => ({
@@ -109,37 +110,37 @@ export const GoalCalculator: React.FC<GoalCalculatorProps> = ({
   onNavListToggle,
 }) => {
   const {
-    categories,
-    currentCategory,
-    selectedCategoryId,
-    selectedStepId,
+    steps,
     currentStep,
     isRightOpen,
     isDrawerOpen,
-    handleCategoryChange,
-    handleStepChange,
+    selectedStepId,
+    selectedCategoryId,
+    currentCategory,
     toggleRightPanel,
     toggleDrawer,
     setDrawerOpen,
+    handleStepChange,
+    handleCategoryChange,
   } = useGoalCalculator();
   const { t } = useTranslation();
   const iconPanelWidth = theme.spacing(5);
 
-  const handleCategoryIconClick = (categoryId: typeof selectedCategoryId) => {
-    if (selectedCategoryId === categoryId) {
+  const handleStepIconClick = (stepId: GoalCalculatorStepEnum) => {
+    if (selectedStepId === stepId) {
       toggleDrawer();
     } else {
-      handleCategoryChange(categoryId);
+      handleStepChange(stepId);
       setDrawerOpen(true);
     }
   };
 
-  const { title: categoryTitle, steps: categorySteps } = currentCategory || {};
+  const { title: stepTitle, categories: stepCategories } = currentStep || {};
   const {
-    title: stepTitle,
+    title: categoryTitle,
     component: stepComponent,
     rightPanelComponent,
-  } = currentStep || {};
+  } = currentCategory || {};
 
   return (
     <>
@@ -151,13 +152,13 @@ export const GoalCalculator: React.FC<GoalCalculatorProps> = ({
       />
       <Stack direction="row" flex={1}>
         <Stack sx={{ width: iconPanelWidth }} direction="column">
-          {categories.map((category) => (
+          {steps?.map((step) => (
             <StyledCategoryIconButton
-              key={category.id}
-              selected={selectedCategoryId === category.id}
-              onClick={() => handleCategoryIconClick(category.id)}
+              key={step.id}
+              selected={selectedStepId === step.id}
+              onClick={() => handleStepIconClick(step.id)}
             >
-              {category.icon}
+              {step.icon}
             </StyledCategoryIconButton>
           ))}
         </Stack>
@@ -172,13 +173,13 @@ export const GoalCalculator: React.FC<GoalCalculatorProps> = ({
           </StyledCategoryTitle>
 
           <List disablePadding>
-            {categorySteps?.map((step) => {
-              const { id, title } = step;
-              const selected = selectedStepId === id;
+            {stepCategories?.map((category) => {
+              const { id, title } = category;
+              const selected = selectedCategoryId === id;
               return (
                 <StyledStepListItemButton
                   key={id}
-                  onClick={() => handleStepChange(id)}
+                  onClick={() => handleCategoryChange(id)}
                 >
                   <StyledStepListItemIcon>
                     <StyledStepIcon selected={selected}>

--- a/src/components/Reports/GoalCalculator/GoalCalculatorHelper.ts
+++ b/src/components/Reports/GoalCalculator/GoalCalculatorHelper.ts
@@ -1,25 +1,25 @@
-export interface GoalCalculatorCategoryStep {
-  id: GoalCalculatorStepEnum;
+export interface GoalCalculatorCategory {
+  id: GoalCalculatorCategoryEnum;
   title: string;
   component: JSX.Element;
   rightPanelComponent?: JSX.Element;
 }
 
-export interface GoalCalculatorCategory {
+export interface GoalCalculatorStep {
   title: string;
-  id: GoalCalculatorCategoryEnum;
-  steps: GoalCalculatorCategoryStep[];
+  id: GoalCalculatorStepEnum;
+  categories: GoalCalculatorCategory[];
   icon: JSX.Element;
 }
 
-export enum GoalCalculatorCategoryEnum {
+export enum GoalCalculatorStepEnum {
   CalculatorSettings = 'calculator-settings',
   MinistryExpenses = 'ministry-expenses',
   HouseholdExpenses = 'household-expenses',
   SummaryReport = 'summary-report',
 }
 
-export enum GoalCalculatorStepEnum {
+export enum GoalCalculatorCategoryEnum {
   // CalculatorSettings
   Settings = 'settings',
   Information = 'information',

--- a/src/components/Reports/GoalCalculator/HouseholdExpenses/HouseholdExpenses.tsx
+++ b/src/components/Reports/GoalCalculator/HouseholdExpenses/HouseholdExpenses.tsx
@@ -2,75 +2,75 @@ import HomeIcon from '@mui/icons-material/Home';
 import { useTranslation } from 'react-i18next';
 import { InformationStep } from '../CalculatorSettings/Steps/InformationStep/InformationStep';
 import {
-  GoalCalculatorCategory,
   GoalCalculatorCategoryEnum,
+  GoalCalculatorStep,
   GoalCalculatorStepEnum,
 } from '../GoalCalculatorHelper';
 
-export const useHouseholdExpenses = (): GoalCalculatorCategory => {
+export const useHouseholdExpenses = (): GoalCalculatorStep => {
   const { t } = useTranslation();
   return {
     title: t('Household Expenses'),
-    id: GoalCalculatorCategoryEnum.HouseholdExpenses,
+    id: GoalCalculatorStepEnum.HouseholdExpenses,
     icon: <HomeIcon />,
-    steps: [
+    categories: [
       {
-        id: GoalCalculatorStepEnum.Giving,
+        id: GoalCalculatorCategoryEnum.Giving,
         title: t('Giving'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Saving,
+        id: GoalCalculatorCategoryEnum.Saving,
         title: t('Saving'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Housing,
+        id: GoalCalculatorCategoryEnum.Housing,
         title: t('Housing'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Utilities,
+        id: GoalCalculatorCategoryEnum.Utilities,
         title: t('Utilities'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Insurance,
+        id: GoalCalculatorCategoryEnum.Insurance,
         title: t('Insurance'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Debt,
+        id: GoalCalculatorCategoryEnum.Debt,
         title: t('Debt'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Food,
+        id: GoalCalculatorCategoryEnum.Food,
         title: t('Food'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Clothing,
+        id: GoalCalculatorCategoryEnum.Clothing,
         title: t('Clothing'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Transportation,
+        id: GoalCalculatorCategoryEnum.Transportation,
         title: t('Transportation'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Medical,
+        id: GoalCalculatorCategoryEnum.Medical,
         title: t('Medical'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Recreational,
+        id: GoalCalculatorCategoryEnum.Recreational,
         title: t('Recreational'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Personal,
+        id: GoalCalculatorCategoryEnum.Personal,
         title: t('Personal'),
         component: <InformationStep />,
       },

--- a/src/components/Reports/GoalCalculator/MinistryExpenses/MinistryExpenses.tsx
+++ b/src/components/Reports/GoalCalculator/MinistryExpenses/MinistryExpenses.tsx
@@ -2,53 +2,53 @@ import ChurchIcon from '@mui/icons-material/Church';
 import { useTranslation } from 'react-i18next';
 import { InformationStep } from '../CalculatorSettings/Steps/InformationStep/InformationStep';
 import {
-  GoalCalculatorCategory,
   GoalCalculatorCategoryEnum,
+  GoalCalculatorStep,
   GoalCalculatorStepEnum,
 } from '../GoalCalculatorHelper';
 import { MileageStep } from './Steps/MileageStep/MileageStep';
 import { MileageStepRightPanelComponent } from './Steps/MileageStep/MileageStepRightPanelComponent/MileageStepRightPanelComponent';
 
-export const useMinistryExpenses = (): GoalCalculatorCategory => {
+export const useMinistryExpenses = (): GoalCalculatorStep => {
   const { t } = useTranslation();
   return {
     title: t('Ministry Expenses'),
-    id: GoalCalculatorCategoryEnum.MinistryExpenses,
+    id: GoalCalculatorStepEnum.MinistryExpenses,
     icon: <ChurchIcon />,
-    steps: [
+    categories: [
       {
-        id: GoalCalculatorStepEnum.Mileage,
+        id: GoalCalculatorCategoryEnum.Mileage,
         title: t('Mileage'),
         component: <MileageStep />,
         rightPanelComponent: <MileageStepRightPanelComponent />,
       },
       {
-        id: GoalCalculatorStepEnum.Medical,
+        id: GoalCalculatorCategoryEnum.Medical,
         title: t('Medical'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.MPD,
+        id: GoalCalculatorCategoryEnum.MPD,
         title: t('MPD'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Transfers,
+        id: GoalCalculatorCategoryEnum.Transfers,
         title: t('Transfers'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Technology,
+        id: GoalCalculatorCategoryEnum.Technology,
         title: t('Technology'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.SummerMissions,
+        id: GoalCalculatorCategoryEnum.SummerMissions,
         title: t('Summer Missions'),
         component: <InformationStep />,
       },
       {
-        id: GoalCalculatorStepEnum.Other,
+        id: GoalCalculatorCategoryEnum.Other,
         title: t('Other'),
         component: <InformationStep />,
       },

--- a/src/components/Reports/GoalCalculator/SummaryReport/SummaryReport.tsx
+++ b/src/components/Reports/GoalCalculator/SummaryReport/SummaryReport.tsx
@@ -2,20 +2,20 @@ import RequestQuoteIcon from '@mui/icons-material/RequestQuote';
 import { useTranslation } from 'react-i18next';
 import { InformationStep } from '../CalculatorSettings/Steps/InformationStep/InformationStep';
 import {
-  GoalCalculatorCategory,
   GoalCalculatorCategoryEnum,
+  GoalCalculatorStep,
   GoalCalculatorStepEnum,
 } from '../GoalCalculatorHelper';
 
-export const useSummaryReport = (): GoalCalculatorCategory => {
+export const useSummaryReport = (): GoalCalculatorStep => {
   const { t } = useTranslation();
   return {
     title: t('Summary Report'),
-    id: GoalCalculatorCategoryEnum.SummaryReport,
+    id: GoalCalculatorStepEnum.SummaryReport,
     icon: <RequestQuoteIcon />,
-    steps: [
+    categories: [
       {
-        id: GoalCalculatorStepEnum.Overview,
+        id: GoalCalculatorCategoryEnum.Overview,
         title: t('Overview'),
         component: <InformationStep />,
       },


### PR DESCRIPTION
## Description

In the new terminology, there are four Steps: Calculator Settings, Household Expenses, Ministry Expenses, and Summary Report. Categories are budget categories like Giving, Electricity, Mileage, etc. This PR updates the variable names and enums to reflect this.

@dr-bizz I'm asking Will to quickly review this because any other work not based on this will have merge conflicts. A lot of the logic in the context is being changed anyway when I start putting all categories on the same page, so if there's bugs and oversights, I'll be fixing them soon in another PR.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
