### PR TITLE
[MPDX-8720] Add household expenses instructions

### DIFF
--- a/pages/accountLists/[accountListId]/reports/goalCalculator/index.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/goalCalculator/index.page.tsx
@@ -36,9 +36,9 @@ const RightPanelTitle = styled(Typography)({
   fontSize: '0.875rem',
 });
 
-const RightPanelContent = styled(Box)({
-  // Content wrapper for right panel
-});
+const RightPanelContent = styled('div')(({ theme }) => ({
+  margin: theme.spacing(2),
+}));
 
 interface GoalCalculatorContentProps {
   isNavListOpen: boolean;

--- a/src/components/Reports/GoalCalculator/GoalCalculator.test.tsx
+++ b/src/components/Reports/GoalCalculator/GoalCalculator.test.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect } from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { render, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SnackbarProvider } from 'notistack';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import theme from 'src/theme';
+import { GoalCalculator } from './GoalCalculator';
+import { GoalCalculatorStepEnum } from './GoalCalculatorHelper';
+import {
+  GoalCalculatorProvider,
+  useGoalCalculator,
+} from './Shared/GoalCalculatorContext';
+
+interface InitializeContextProps {
+  selectedStepId: GoalCalculatorStepEnum;
+}
+
+/**
+ * This component is only for use in tests. It makes it simpler to open a specific step within
+ * tests. It also extracts state from the context, like the right panel contents, and renders it
+ * in the page so that tests can query and assert the state of the context.
+ */
+const ContextHelper: React.FC<InitializeContextProps> = ({
+  selectedStepId,
+}) => {
+  const { handleStepChange, rightPanelContent } = useGoalCalculator();
+
+  useEffect(() => {
+    handleStepChange(selectedStepId);
+  }, []);
+
+  return <aside aria-label="Right Panel">{rightPanelContent}</aside>;
+};
+
+interface TestComponentProps {
+  selectedStepId?: GoalCalculatorStepEnum;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({
+  selectedStepId = GoalCalculatorStepEnum.MinistryExpenses,
+}) => (
+  <ThemeProvider theme={theme}>
+    <SnackbarProvider>
+      <GqlMockedProvider>
+        <GoalCalculatorProvider>
+          <ContextHelper selectedStepId={selectedStepId} />
+          <GoalCalculator isNavListOpen={false} onNavListToggle={jest.fn()} />
+        </GoalCalculatorProvider>
+      </GqlMockedProvider>
+    </SnackbarProvider>
+  </ThemeProvider>
+);
+
+describe('GoalCalculator', () => {
+  it('renders the step title and instructions', () => {
+    const { getByRole } = render(
+      <TestComponent
+        selectedStepId={GoalCalculatorStepEnum.HouseholdExpenses}
+      />,
+    );
+
+    expect(
+      getByRole('heading', { name: 'Household Expenses' }),
+    ).toBeInTheDocument();
+
+    expect(
+      getByRole('heading', { name: 'Enter your monthly budget' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders right panel components', () => {
+    const { getByRole } = render(<TestComponent />);
+    const heading = getByRole('heading', { name: 'Mileage' });
+    userEvent.click(
+      within(heading).getByRole('button', {
+        name: 'Show additional info',
+      }),
+    );
+
+    expect(
+      getByRole('complementary', { name: 'Right Panel' }),
+    ).toHaveTextContent('Mileage Expenses');
+  });
+
+  it('does not show info icon for categories without right panel content', () => {
+    const { getByRole } = render(<TestComponent />);
+    const heading = getByRole('heading', { name: 'Transfers' });
+    expect(within(heading).queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Reports/GoalCalculator/GoalCalculator.tsx
+++ b/src/components/Reports/GoalCalculator/GoalCalculator.tsx
@@ -113,7 +113,11 @@ export const GoalCalculator: React.FC<GoalCalculatorProps> = ({
     }
   };
 
-  const { title: stepTitle, categories } = currentStep || {};
+  const {
+    title: stepTitle,
+    instructions: stepInstructions,
+    categories,
+  } = currentStep || {};
 
   return (
     <>
@@ -185,6 +189,9 @@ export const GoalCalculator: React.FC<GoalCalculatorProps> = ({
         {isDrawerOpen && <Divider orientation="vertical" flexItem />}
         <Divider orientation="vertical" flexItem />
         <CategoriesStack flex={1} spacing={4} divider={<Divider />}>
+          {stepInstructions && (
+            <CategoryContainer>{stepInstructions}</CategoryContainer>
+          )}
           {categories?.map((category) => {
             const rightPanelContent = category.rightPanelComponent;
             return (

--- a/src/components/Reports/GoalCalculator/GoalCalculatorHelper.ts
+++ b/src/components/Reports/GoalCalculator/GoalCalculatorHelper.ts
@@ -6,8 +6,9 @@ export interface GoalCalculatorCategory {
 }
 
 export interface GoalCalculatorStep {
-  title: string;
   id: GoalCalculatorStepEnum;
+  title: string;
+  instructions?: JSX.Element;
   categories: GoalCalculatorCategory[];
   icon: JSX.Element;
 }

--- a/src/components/Reports/GoalCalculator/HouseholdExpenses/HouseholdExpenses.tsx
+++ b/src/components/Reports/GoalCalculator/HouseholdExpenses/HouseholdExpenses.tsx
@@ -1,4 +1,5 @@
 import HomeIcon from '@mui/icons-material/Home';
+import { Link, Typography, styled } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { InformationStep } from '../CalculatorSettings/Steps/InformationStep/InformationStep';
 import {
@@ -7,11 +8,34 @@ import {
   GoalCalculatorStepEnum,
 } from '../GoalCalculatorHelper';
 
+const InstructionsWrapper = styled('div')(({ theme }) => ({
+  '.MuiTypography-root': {
+    marginBottom: theme.spacing(1),
+  },
+}));
+
 export const useHouseholdExpenses = (): GoalCalculatorStep => {
   const { t } = useTranslation();
   return {
-    title: t('Household Expenses'),
     id: GoalCalculatorStepEnum.HouseholdExpenses,
+    title: t('Household Expenses'),
+    instructions: (
+      <InstructionsWrapper>
+        <Typography variant="h6">{t('Enter your monthly budget')}</Typography>
+        <Typography variant="body2">
+          {t(
+            'You may choose to skip entering your budget below if you know the net cash you need each month.',
+          )}
+        </Typography>
+        <Typography variant="body2">
+          {t('For additional guidance, check out')}{' '}
+          <Link href="https://www.ramseysolutions.com/budgeting/useful-forms">
+            {t('these resources from Ramsey Solutions')}
+          </Link>
+          .
+        </Typography>
+      </InstructionsWrapper>
+    ),
     icon: <HomeIcon />,
     categories: [
       {

--- a/src/components/Reports/GoalCalculator/HouseholdExpenses/HouseholdExpenses.tsx
+++ b/src/components/Reports/GoalCalculator/HouseholdExpenses/HouseholdExpenses.tsx
@@ -1,5 +1,5 @@
 import HomeIcon from '@mui/icons-material/Home';
-import { Link, Typography, styled } from '@mui/material';
+import { Alert, Link, Typography, styled } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { InformationStep } from '../CalculatorSettings/Steps/InformationStep/InformationStep';
 import {
@@ -87,6 +87,18 @@ export const useHouseholdExpenses = (): GoalCalculatorStep => {
         id: GoalCalculatorCategoryEnum.Medical,
         title: t('Medical'),
         component: <InformationStep />,
+        rightPanelComponent: (
+          <>
+            <Typography variant="h6" gutterBottom>
+              {t('Medical Expenses')}
+            </Typography>
+            <Alert severity="warning">
+              {t(
+                'Only include medical expenses that are not reimbursable through your staff account.',
+              )}
+            </Alert>
+          </>
+        ),
       },
       {
         id: GoalCalculatorCategoryEnum.Recreational,

--- a/src/components/Reports/GoalCalculator/HouseholdExpenses/HouseholdExpenses.tsx
+++ b/src/components/Reports/GoalCalculator/HouseholdExpenses/HouseholdExpenses.tsx
@@ -14,6 +14,10 @@ const InstructionsWrapper = styled('div')(({ theme }) => ({
   },
 }));
 
+const MonthlySavingsTable = styled('table')({
+  width: '100%',
+});
+
 export const useHouseholdExpenses = (): GoalCalculatorStep => {
   const { t } = useTranslation();
   return {
@@ -47,6 +51,29 @@ export const useHouseholdExpenses = (): GoalCalculatorStep => {
         id: GoalCalculatorCategoryEnum.Saving,
         title: t('Saving'),
         component: <InformationStep />,
+        rightPanelComponent: (
+          <>
+            <Typography variant="h6" gutterBottom>
+              {t('Emergency Savings Guide')}
+            </Typography>
+            <MonthlySavingsTable>
+              <tbody>
+                <tr>
+                  <td>{t('Individuals')}</td>
+                  <td>$50/{t('month')}</td>
+                </tr>
+                <tr>
+                  <td>{t('Couples')}</td>
+                  <td>$100/{t('month')}</td>
+                </tr>
+                <tr>
+                  <td>{t('With kids')}</td>
+                  <td>$150/{t('month')}</td>
+                </tr>
+              </tbody>
+            </MonthlySavingsTable>
+          </>
+        ),
       },
       {
         id: GoalCalculatorCategoryEnum.Housing,
@@ -57,6 +84,18 @@ export const useHouseholdExpenses = (): GoalCalculatorStep => {
         id: GoalCalculatorCategoryEnum.Utilities,
         title: t('Utilities'),
         component: <InformationStep />,
+        rightPanelComponent: (
+          <>
+            <Typography variant="h6" gutterBottom>
+              {t('Utilities')}
+            </Typography>
+            <Alert severity="warning">
+              {t(
+                'For mobile phone and internet expenses, only include the portion not reimbursed as a ministry expense.',
+              )}
+            </Alert>
+          </>
+        ),
       },
       {
         id: GoalCalculatorCategoryEnum.Insurance,

--- a/src/components/Reports/GoalCalculator/MinistryExpenses/Steps/MileageStep/MileageStepRightPanelComponent/MileageStepRightPanelComponent.tsx
+++ b/src/components/Reports/GoalCalculator/MinistryExpenses/Steps/MileageStep/MileageStepRightPanelComponent/MileageStepRightPanelComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Button, Typography } from '@mui/material';
+import { Button, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useGoalCalculator } from 'src/components/Reports/GoalCalculator/Shared/GoalCalculatorContext';
 
@@ -8,9 +8,9 @@ export const MileageStepRightPanelComponent: React.FC = () => {
   const { closeRightPanel } = useGoalCalculator();
 
   return (
-    <Box sx={{ padding: '16px' }}>
+    <>
       <Typography variant="h6" gutterBottom>
-        {t('Mileage Step')}
+        {t('Mileage Expenses')}
       </Typography>
 
       <Button
@@ -20,6 +20,6 @@ export const MileageStepRightPanelComponent: React.FC = () => {
       >
         {t('Close Panel')}
       </Button>
-    </Box>
+    </>
   );
 };

--- a/src/components/Reports/GoalCalculator/Shared/GoalCalculatorContext.tsx
+++ b/src/components/Reports/GoalCalculator/Shared/GoalCalculatorContext.tsx
@@ -54,8 +54,8 @@ export const GoalCalculatorProvider: React.FC<Props> = ({ children }) => {
   // Static categories - no memoization to avoid React queue issues
   const steps = [
     useCalculatorSettings(),
-    useHouseholdExpenses(),
     useMinistryExpenses(),
+    useHouseholdExpenses(),
     useSummaryReport(),
   ];
 


### PR DESCRIPTION
## Description

Start instructions for household expenses to the top of the form and right panels for specific categories. Also, I started writing some tests for `GoalCalculator`. We need more, but I have the scaffolding for more and wrote tests for the new functionality I added. I also corrected the order of the household expenses and ministry expenses icons in the left sidebar.

MPDX-8720

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
