### PR TITLE
[HS-1419450] Load salary organization coaching answer set

### DIFF
--- a/pages/api/Schema/CoachingAnswerSets/coachingAnswerSets.graphql
+++ b/pages/api/Schema/CoachingAnswerSets/coachingAnswerSets.graphql
@@ -1,6 +1,7 @@
 extend type Query {
   coachingAnswerSets(
     accountListId: ID!
+    organizationId: ID
     completed: Boolean
   ): [CoachingAnswerSet!]!
 

--- a/pages/api/Schema/CoachingAnswerSets/resolvers.ts
+++ b/pages/api/Schema/CoachingAnswerSets/resolvers.ts
@@ -4,11 +4,12 @@ const CoachingAnswerSetsResolvers: Resolvers = {
   Query: {
     coachingAnswerSets: (
       _source,
-      { accountListId, completed },
+      { accountListId, organizationId, completed },
       { dataSources },
     ) => {
       return dataSources.mpdxRestApi.getCoachingAnswerSets(
         accountListId,
+        organizationId,
         completed,
         true,
       );

--- a/pages/api/graphql-rest.page.ts
+++ b/pages/api/graphql-rest.page.ts
@@ -328,16 +328,20 @@ class MpdxRestApi extends RESTDataSource {
 
   async getCoachingAnswerSets(
     accountListId: string,
+    organizationId: string | null | undefined,
     completed: boolean | null | undefined,
     multiple: boolean,
   ) {
-    const response = await this.get(
-      `coaching/answer_sets?filter[account_list_id]=${accountListId}&filter[completed]=${
-        completed ?? false
-      }${
-        multiple ? '' : '&filter[limit]=1'
-      }&include=answers,questions&sort=-completed_at`,
-    );
+    const response = await this.get(`coaching/answer_sets`, {
+      params: {
+        'filter[account_list_id]': accountListId,
+        'filter[organization_id]': organizationId ?? undefined,
+        'filter[completed]': (completed ?? false).toString(),
+        'filter[limit]': multiple ? '1' : undefined,
+        include: 'answers,questions',
+        sort: '-completed_at',
+      },
+    });
     return getCoachingAnswerSets(response);
   }
 
@@ -348,6 +352,7 @@ class MpdxRestApi extends RESTDataSource {
     // Try to find the first incomplete answer set
     const [answerSet] = await this.getCoachingAnswerSets(
       accountListId,
+      organizationId,
       false,
       false,
     );

--- a/src/components/Coaching/CoachingDetail/WeeklyReport/WeeklyReport.graphql
+++ b/src/components/Coaching/CoachingDetail/WeeklyReport/WeeklyReport.graphql
@@ -17,3 +17,10 @@ query WeeklyReports($accountListId: ID!, $organizationId: ID) {
     completedAt
   }
 }
+
+query AccountListOrganization($accountListId: ID!) {
+  accountList(id: $accountListId) {
+    id
+    salaryOrganizationId
+  }
+}

--- a/src/components/Coaching/CoachingDetail/WeeklyReport/WeeklyReport.graphql
+++ b/src/components/Coaching/CoachingDetail/WeeklyReport/WeeklyReport.graphql
@@ -1,5 +1,9 @@
-query WeeklyReports($accountListId: ID!) {
-  coachingAnswerSets(accountListId: $accountListId, completed: true) {
+query WeeklyReports($accountListId: ID!, $organizationId: ID) {
+  coachingAnswerSets(
+    accountListId: $accountListId
+    organizationId: $organizationId
+    completed: true
+  ) {
     id
     answers {
       id

--- a/src/components/Coaching/CoachingDetail/WeeklyReport/WeeklyReport.test.tsx
+++ b/src/components/Coaching/CoachingDetail/WeeklyReport/WeeklyReport.test.tsx
@@ -72,7 +72,7 @@ describe('WeeklyReport', () => {
       const completed = getByTestId('CompletedText');
 
       expect(next).toBeDisabled();
-      expect(previous).not.toBeDisabled();
+      await waitFor(() => expect(previous).not.toBeDisabled());
       expect(completed).toHaveTextContent('Nov 1');
 
       userEvent.click(previous);

--- a/src/components/Coaching/CoachingDetail/WeeklyReport/WeeklyReport.tsx
+++ b/src/components/Coaching/CoachingDetail/WeeklyReport/WeeklyReport.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import AnimatedCard from 'src/components/AnimatedCard';
 import { MultilineSkeleton } from 'src/components/Shared/MultilineSkeleton';
 import { useLocale } from 'src/hooks/useLocale';
+import { useOrganizationId } from 'src/hooks/useOrganizationId';
 import { dateFormat, dateFormatWithoutYear } from 'src/lib/intlFormat';
 import { useWeeklyReportsQuery } from './WeeklyReport.generated';
 
@@ -71,11 +72,12 @@ export const WeeklyReport: React.FC<WeeklyReportProps> = ({
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
+  const organizationId = useOrganizationId();
 
   const [reportIndex, setReportIndex] = useState(0);
 
   const { data, loading } = useWeeklyReportsQuery({
-    variables: { accountListId },
+    variables: { accountListId, organizationId },
   });
   const reports = data?.coachingAnswerSets ?? [];
   const report = reports[reportIndex];

--- a/src/components/Coaching/CoachingDetail/WeeklyReport/WeeklyReport.tsx
+++ b/src/components/Coaching/CoachingDetail/WeeklyReport/WeeklyReport.tsx
@@ -13,9 +13,11 @@ import { useTranslation } from 'react-i18next';
 import AnimatedCard from 'src/components/AnimatedCard';
 import { MultilineSkeleton } from 'src/components/Shared/MultilineSkeleton';
 import { useLocale } from 'src/hooks/useLocale';
-import { useOrganizationId } from 'src/hooks/useOrganizationId';
 import { dateFormat, dateFormatWithoutYear } from 'src/lib/intlFormat';
-import { useWeeklyReportsQuery } from './WeeklyReport.generated';
+import {
+  useAccountListOrganizationQuery,
+  useWeeklyReportsQuery,
+} from './WeeklyReport.generated';
 
 const Header = styled(Typography)(({ theme }) => ({
   display: 'flex',
@@ -72,12 +74,19 @@ export const WeeklyReport: React.FC<WeeklyReportProps> = ({
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
-  const organizationId = useOrganizationId();
+  const { data: organizationData, loading: organizationLoading } =
+    useAccountListOrganizationQuery({
+      variables: { accountListId },
+    });
 
   const [reportIndex, setReportIndex] = useState(0);
 
   const { data, loading } = useWeeklyReportsQuery({
-    variables: { accountListId, organizationId },
+    variables: {
+      accountListId,
+      organizationId: organizationData?.accountList.salaryOrganizationId,
+    },
+    skip: !organizationData,
   });
   const reports = data?.coachingAnswerSets ?? [];
   const report = reports[reportIndex];
@@ -136,7 +145,7 @@ export const WeeklyReport: React.FC<WeeklyReportProps> = ({
         }
       />
       <ContentContainer>
-        {loading ? (
+        {loading || organizationLoading ? (
           <MultilineSkeleton lines={4} height={80} />
         ) : reports.length === 0 ? (
           t('No completed reports found')

--- a/src/components/Dashboard/ThisWeek/WeeklyActivity/WeeklyReportModal/WeeklyReportModal.graphql
+++ b/src/components/Dashboard/ThisWeek/WeeklyActivity/WeeklyReportModal/WeeklyReportModal.graphql
@@ -6,13 +6,6 @@ fragment WeeklyReportCoachingQuestion on CoachingQuestion {
   responseOptions
 }
 
-query AccountListOrganization($accountListId: ID!) {
-  accountList(id: $accountListId) {
-    id
-    salaryOrganizationId
-  }
-}
-
 query CurrentCoachingAnswerSet($accountListId: ID!, $organizationId: ID!) {
   currentCoachingAnswerSet(
     accountListId: $accountListId


### PR DESCRIPTION
## Description

A HelpScout user is having trouble seeing their current coaching answer set. The UI is blindly loading the most-recent answer set, which is pulling their empty answer set from Germany Cru. The UI needs to pass in an organizationId filter to only pull the current answer set from their salary organization.

[HS-1419450](https://secure.helpscout.net/conversation/3026279923/1419450/)

Depends on CruGlobal/mpdx_api#2978.

## Testing

* Go to an account with coaching answer sets set up (you can impersonate me if you need one)
* Verify that the current coaching answer set loads by checking that the "Fill out weekly report" button is present on the dashboard.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
