### PR TITLE
[no-Jira] Add initial GitHub Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,6 +8,7 @@ MPDX is a Next.js 15 React application built with TypeScript using pages router.
 
 - **Frontend**: Next.js v15, React, Material UI v5, TypeScript
 - **Data Loading**: Apollo Client GraphQL
+- **Forms**: Formik and yup for validation
 - **Testing**: Jest, React Testing Library v13
 - **Internationalization**: react-i18next
 - **Code Quality**: ESLint, Prettier

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ MPDX is a Next.js 15 React application built with TypeScript using pages router.
 
 ## File Naming Conventions
 
-- React components: PascalCase (e.g., `ComponentName.tsx`) without default export
+- React components: PascalCase (e.g., `ComponentName.tsx`)
 - Pages: kebab-case with `.page.tsx` extension (e.g., `account-lists.page.tsx`)
 - Test files: Same name as the file being tested with `.test.tsx` extension
 - GraphQL files: PascalCase with `.graphql` extension not starting with `Get` or `Load`
@@ -27,3 +27,8 @@ MPDX is a Next.js 15 React application built with TypeScript using pages router.
 - `yarn lint` - Run ESLint linter
 - `yarn lint:ts` - Run TypeScript typechecking
 - `yarn prettier:write` - Run Prettier formatter
+
+## Guidelines
+
+- Always use named exports instead of default exports.
+- Always write the least amount of code possible. Avoid using unnecessary styles, variables, and test providers.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,29 @@
+# GitHub Copilot Instructions
+
+## Project Overview
+
+MPDX is a Next.js 15 React application built with TypeScript using pages router.
+
+## Technology Stack
+
+- **Frontend**: Next.js v15, React, Material UI v5, TypeScript
+- **Data Loading**: Apollo Client GraphQL
+- **Testing**: Jest, React Testing Library v13
+- **Internationalization**: react-i18next
+- **Code Quality**: ESLint, Prettier
+
+## File Naming Conventions
+
+- React components: PascalCase (e.g., `ComponentName.tsx`) without default export
+- Pages: kebab-case with `.page.tsx` extension (e.g., `account-lists.page.tsx`)
+- Test files: Same name as the file being tested with `.test.tsx` extension
+- GraphQL files: PascalCase with `.graphql` extension not starting with `Get` or `Load`
+
+## Commands
+
+- **Always use `yarn` for package management and running scripts**
+- `yarn test` - Run tests
+- `yarn test [file]` - Run tests for a single file
+- `yarn lint` - Run ESLint linter
+- `yarn lint:ts` - Run TypeScript typechecking
+- `yarn prettier:write` - Run Prettier formatter


### PR DESCRIPTION
## Description

Adds basic GitHub Copilot instructions. From my research, these instructions are included with every prompt, so they need to be as lean as possible to avoid filling up the context window. There's probably more we could add, but for now I'm adding instructions to correct behavior I've seen multiple times from GitHub Copilot:

* Using `npm` instead of `yarn`
* Using the wrong command to run `tsc`
* Creating components with a default export
* Adding `await` to `userEvent.click()` (that is correct in v14, but we are on v13)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
