### PR TITLE
[MPDX-8719] Add ministry expenses instructions

### DIFF
--- a/src/components/Reports/GoalCalculator/MinistryExpenses/MinistryExpenses.tsx
+++ b/src/components/Reports/GoalCalculator/MinistryExpenses/MinistryExpenses.tsx
@@ -1,5 +1,6 @@
 import ChurchIcon from '@mui/icons-material/Church';
-import { useTranslation } from 'react-i18next';
+import { Link } from '@mui/material';
+import { Trans, useTranslation } from 'react-i18next';
 import { InformationStep } from '../CalculatorSettings/Steps/InformationStep/InformationStep';
 import {
   GoalCalculatorCategoryEnum,
@@ -12,8 +13,23 @@ import { MileageStepRightPanelComponent } from './Steps/MileageStep/MileageStepR
 export const useMinistryExpenses = (): GoalCalculatorStep => {
   const { t } = useTranslation();
   return {
-    title: t('Ministry Expenses'),
     id: GoalCalculatorStepEnum.MinistryExpenses,
+    title: t('Ministry Expenses'),
+    instructions: (
+      <Trans t={t}>
+        Enter amounts for the following categories of reimbursable and ministry
+        expenses. The{' '}
+        <Link href="https://staffweb.cru.org/mpd-donations/my-donations/mpga.html">
+          MPGA tool on StaffWeb
+        </Link>{' '}
+        can show you your averages in some of these categories. If you did not
+        take full reimbursements for the entire year, or if your reimbursements
+        were abnormally high (e.g. you had a surgery or bought a new computer),
+        or low (e.g. no summer mission), you will want to adjust the averages
+        from the MPGA to reflect an average year. Click the link above, go to
+        the Income/Expenses tab, and look under the Ministry Expenses section.
+      </Trans>
+    ),
     icon: <ChurchIcon />,
     categories: [
       {


### PR DESCRIPTION
## Description

Add instructions to the ministry expenses step. The instructions reference the StaffWeb MPGA report for now. Once the MPDX income/expenses report is built out, we can link to that report instead.

I haven't used `Trans` like this before, but it's a much simpler way to render translated blocks of text containing formatting or links. When you run `yarn extract` the translation key looks like this: `Enter amounts for the following categories of reimbursable and ministry expenses. The <2>MPGA tool on StaffWeb</2> can show you your averages in some of these categories. ...` When rendering, `Trans` works some magic to populate the `<2>` section with the actual `Link` component! 🤯

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
