### PR TITLE
MPDX-8751 Fix dashboard monthly goal percentages

### DIFF
--- a/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
+++ b/src/components/Dashboard/MonthlyGoal/MonthlyGoal.tsx
@@ -20,6 +20,8 @@ import {
   currencyFormat,
   numberFormat,
   percentageFormat,
+  percentageFormatFloor,
+  roundPledgedBelow,
 } from '../../../lib/intlFormat';
 import AnimatedBox from '../../AnimatedBox';
 import AnimatedCard from '../../AnimatedCard';
@@ -71,6 +73,8 @@ const MonthlyGoal = ({
   const pledgedPercentage = pledged / goal;
   const belowGoal = goal - pledged;
   const belowGoalPercentage = belowGoal / goal;
+
+  const { pledgedPct, belowPct } = roundPledgedBelow(pledged, goal);
 
   return (
     <>
@@ -147,7 +151,7 @@ const MonthlyGoal = ({
                 ) : isNaN(receivedPercentage) ? (
                   '-'
                 ) : (
-                  percentageFormat(receivedPercentage, locale)
+                  percentageFormatFloor(receivedPercentage, locale)
                 )}
               </Typography>
               <Typography
@@ -177,7 +181,7 @@ const MonthlyGoal = ({
                 ) : isNaN(pledgedPercentage) ? (
                   '-'
                 ) : (
-                  percentageFormat(pledgedPercentage, locale)
+                  percentageFormat(pledgedPct, locale)
                 )}
               </Typography>
               <Typography
@@ -201,7 +205,7 @@ const MonthlyGoal = ({
                     variant="h5"
                     data-testid="MonthlyGoalTypographyBelowGoalPercentage"
                   >
-                    {percentageFormat(belowGoalPercentage, locale)}
+                    {percentageFormat(belowPct, locale)}
                   </Typography>
                   <Typography
                     component="small"
@@ -224,7 +228,7 @@ const MonthlyGoal = ({
                     ) : isNaN(belowGoalPercentage) ? (
                       '-'
                     ) : (
-                      percentageFormat(-belowGoalPercentage, locale)
+                      percentageFormat(-belowPct, locale)
                     )}
                   </Typography>
                   <Typography

--- a/src/lib/intlFormat.ts
+++ b/src/lib/intlFormat.ts
@@ -10,6 +10,26 @@ export const percentageFormat = (value: number, locale: string): string =>
     style: 'percent',
   }).format(Number.isFinite(value) ? value : 0);
 
+export const percentageFormatFloor = (value: number, locale: string): string =>
+  new Intl.NumberFormat(locale, {
+    style: 'percent',
+    roundingMode: 'floor',
+  }).format(Number.isFinite(value) ? value : 0);
+
+export function roundPledgedBelow(pledged: number, goal: number) {
+  if (goal <= 0) {
+    return { pledgedPct: 0, belowPct: 0 };
+  }
+
+  const pledgedPct = Math.max(0, Math.floor((pledged / goal) * 100));
+  const belowPct = pledgedPct <= 100 ? 100 - pledgedPct : 0;
+
+  return {
+    pledgedPct: pledgedPct / 100,
+    belowPct: belowPct / 100,
+  };
+}
+
 interface CurrencyFormatOptions {
   showTrailingZeros?: boolean;
 }


### PR DESCRIPTION
## Description

In a Helpscout ticket, it was brought to my attention that rounding to the nearest percentage caused confusion - even though the calculation was technically correct. To avoid this in the future, I have updated the percentage display logic to round down instead of rounding to the nearest whole number. This ensures that if a small amount remains before reaching a user's goal, the UI will still reflect percentage remaining rather than still left rather than displaying 100% pledged.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
