### PR TITLE
[HS-1431211] Turn Helpjuice article links into absolute URLs

### DIFF
--- a/src/components/Helpjuice/Helpjuice.test.tsx
+++ b/src/components/Helpjuice/Helpjuice.test.tsx
@@ -42,6 +42,26 @@ describe('Helpjuice', () => {
     ).toHaveAttribute('href', 'https://domain.helpjuice.com/article-2');
   });
 
+  it('makes links absolute URLs', async () => {
+    render(<Helpjuice />);
+
+    document
+      .getElementsByClassName('hj-swifty')[0]
+      .setAttribute('data-current-question-id', 'article-1');
+
+    expect(
+      await screen.findByRole('link', { name: 'Question Link' }),
+    ).toHaveAttribute('href', 'https://domain.helpjuice.com/question/123');
+    expect(screen.getByRole('link', { name: 'External Link' })).toHaveAttribute(
+      'href',
+      'https://google.com/',
+    );
+    expect(screen.getByRole('link', { name: 'Email Link' })).toHaveAttribute(
+      'href',
+      'mailto:test@example.com',
+    );
+  });
+
   it('does nothing if the element is missing', () => {
     document.body.innerHTML = '';
 

--- a/src/components/Helpjuice/Helpjuice.tsx
+++ b/src/components/Helpjuice/Helpjuice.tsx
@@ -61,11 +61,11 @@ export const Helpjuice: React.FC = () => {
 
       // Helpjuice renders links to questions as relative URLs, e.g. href="/question/123"
       // We need to turn them into absolute URLs so that they open correctly
-      for (const link of document.querySelectorAll('#article-content-body a')) {
+      for (const link of document.querySelectorAll(
+        '#article-content-body a[href^="/"]',
+      )) {
         const href = link.getAttribute('href');
-        if (href?.startsWith('/')) {
-          link.setAttribute('href', `${helpJuiceOrigin}${href}`);
-        }
+        link.setAttribute('href', `${helpJuiceOrigin}${href}`);
       }
     });
     // Watch for changes to the selected question

--- a/src/components/Helpjuice/Helpjuice.tsx
+++ b/src/components/Helpjuice/Helpjuice.tsx
@@ -37,7 +37,7 @@ export const Helpjuice: React.FC = () => {
   });
 
   // When a user clicks on an article in the beacon, make the title link to the article in a new
-  // tab on Helpjuice
+  // tab on Helpjuice and add the Helpjuice domain to links
   useEffect(() => {
     const helpJuiceOrigin = process.env.HELPJUICE_ORIGIN;
     const swiftyContainer = document.getElementsByClassName('hj-swifty')[0];
@@ -58,6 +58,15 @@ export const Helpjuice: React.FC = () => {
       link.setAttribute('target', '_blank');
       link.textContent = nameHeader.textContent;
       nameHeader.replaceChildren(link);
+
+      // Helpjuice renders links to questions as relative URLs, e.g. href="/question/123"
+      // We need to turn them into absolute URLs so that they open correctly
+      for (const link of document.querySelectorAll('#article-content-body a')) {
+        const href = link.getAttribute('href');
+        if (href?.startsWith('/')) {
+          link.setAttribute('href', `${helpJuiceOrigin}${href}`);
+        }
+      }
     });
     // Watch for changes to the selected question
     observer.observe(swiftyContainer, {

--- a/src/components/Helpjuice/widget.mock.ts
+++ b/src/components/Helpjuice/widget.mock.ts
@@ -11,6 +11,12 @@ export const widgetHTML = `<div class="hj-swifty">
         <div class="header">
           <h1 id="article-content-name" class="name">Article Name</h1>
         </div>
+        <div id="article-content-body" class="body">
+          <p>Article Body</p>
+          <a href="/question/123">Question Link</a>
+          <a href="https://google.com/">External Link</a>
+          <a href="mailto:test@example.com">Email Link</a>
+        </div>
       </div>
       <div id="helpjuice-widget-contact">
         <a id="helpjuice-contact-link">Contact Us</a>


### PR DESCRIPTION
## Description

The Helpjuice Swifty widget is rendering links to articles as relative URLs like `/question/123`. Clicking on them takes users to `https://mdpx.org/question/123`, which 404s.

We can work around this by adding the Helpjuice domain to those URLs.

## Testing

* Test 1
  * Open the Helpjuice widget
  * Click on the "The Contacts Tab" article
  * Scroll down and click on the "Contacts Views" link
  * Check that you are taken to HelpDucks and not to an MPDX page
* Test 2
  * Open the Helpjuice widget
  * Search for "MailChimp Sync" and click on that article
  * Check that the links to mailchimp.com and mpdx.org are left unchanged and open correctly

[HelpScout ticket](https://secure.helpscout.net/conversation/3042913312/1431211)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
