### PR TITLE
[no-Jira] Upgrade prettier to v3

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -122,7 +122,7 @@ const RAW_RUNTIME_STATE =
           ["node-fetch", "npm:3.3.2"],\
           ["node-mocks-http", "virtual:9909ff5388c6b6a3a46f12eb37c0afb449fcd1eedb9f02d871bde711a076c929583f48ecc4b85fa6d71478b076104a25f83dee45bc69687a22f551c576d7595d#npm:1.16.2"],\
           ["notistack", "virtual:9909ff5388c6b6a3a46f12eb37c0afb449fcd1eedb9f02d871bde711a076c929583f48ecc4b85fa6d71478b076104a25f83dee45bc69687a22f551c576d7595d#npm:2.0.5"],\
-          ["prettier", "npm:2.7.1"],\
+          ["prettier", "npm:3.6.2"],\
           ["prop-types", "npm:15.8.1"],\
           ["puppeteer", "npm:24.4.0"],\
           ["react", "npm:18.2.0"],\
@@ -13923,7 +13923,7 @@ const RAW_RUNTIME_STATE =
           ["@types/prettier", null],\
           ["eslint", "npm:8.57.0"],\
           ["eslint-config-prettier", "virtual:9909ff5388c6b6a3a46f12eb37c0afb449fcd1eedb9f02d871bde711a076c929583f48ecc4b85fa6d71478b076104a25f83dee45bc69687a22f551c576d7595d#npm:8.5.0"],\
-          ["prettier", "npm:2.7.1"],\
+          ["prettier", "npm:3.6.2"],\
           ["prettier-linter-helpers", "npm:1.0.0"]\
         ],\
         "packagePeers": [\
@@ -19112,7 +19112,7 @@ const RAW_RUNTIME_STATE =
           ["node-fetch", "npm:3.3.2"],\
           ["node-mocks-http", "virtual:9909ff5388c6b6a3a46f12eb37c0afb449fcd1eedb9f02d871bde711a076c929583f48ecc4b85fa6d71478b076104a25f83dee45bc69687a22f551c576d7595d#npm:1.16.2"],\
           ["notistack", "virtual:9909ff5388c6b6a3a46f12eb37c0afb449fcd1eedb9f02d871bde711a076c929583f48ecc4b85fa6d71478b076104a25f83dee45bc69687a22f551c576d7595d#npm:2.0.5"],\
-          ["prettier", "npm:2.7.1"],\
+          ["prettier", "npm:3.6.2"],\
           ["prop-types", "npm:15.8.1"],\
           ["puppeteer", "npm:24.4.0"],\
           ["react", "npm:18.2.0"],\
@@ -20613,10 +20613,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["prettier", [\
-      ["npm:2.7.1", {\
-        "packageLocation": "./.yarn/cache/prettier-npm-2.7.1-d1f40f5e1a-9d29f81c1a.zip/node_modules/prettier/",\
+      ["npm:3.6.2", {\
+        "packageLocation": "./.yarn/unplugged/prettier-npm-3.6.2-2668152203/node_modules/prettier/",\
         "packageDependencies": [\
-          ["prettier", "npm:2.7.1"]\
+          ["prettier", "npm:3.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,3 @@
 module.exports = {
   singleQuote: true,
-  trailingComma: 'all',
 };

--- a/.yarn/cache/prettier-npm-2.7.1-d1f40f5e1a-9d29f81c1a.zip
+++ b/.yarn/cache/prettier-npm-2.7.1-d1f40f5e1a-9d29f81c1a.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f13646ff294a9430f9d759a71ea4cdd517e0518b120d473e218f908bcf9b4e35
-size 4004766

--- a/.yarn/cache/prettier-npm-3.6.2-2668152203-488cb2f2b9.zip
+++ b/.yarn/cache/prettier-npm-3.6.2-2668152203-488cb2f2b9.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ac793e3021df0197ea7dbd0226d97ca7fbc37f04fc040f881e6b1e4bd51abbc
+size 8467542

--- a/__tests__/util/setup.ts
+++ b/__tests__/util/setup.ts
@@ -57,7 +57,7 @@ window.document.createRange = (): Range =>
       nodeName: 'BODY',
       ownerDocument: document,
     } as unknown as Node,
-  } as unknown as Range);
+  }) as unknown as Range;
 
 Object.defineProperty(window, 'location', {
   value: { ...window.location, assign: jest.fn(), replace: jest.fn() },

--- a/lighthouse/lighthouse-auth.test.ts
+++ b/lighthouse/lighthouse-auth.test.ts
@@ -170,12 +170,10 @@ describe('Lighthouse Pre-Login Steps', () => {
       successfulTestMock();
 
       const badPerformanceResult = { ...successResult };
-      badPerformanceResult.lhr.audits[
-        'largest-contentful-paint'
-      ].numericValue = 2600;
-      badPerformanceResult.lhr.audits[
-        'cumulative-layout-shift'
-      ].numericValue = 0.3;
+      badPerformanceResult.lhr.audits['largest-contentful-paint'].numericValue =
+        2600;
+      badPerformanceResult.lhr.audits['cumulative-layout-shift'].numericValue =
+        0.3;
 
       mockLighthouse.default.mockImplementation(() => {
         return Promise.resolve(badPerformanceResult);

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "lint-staged": "^13.0.3",
     "next-compose-plugins": "^2.2.1",
     "node-mocks-http": "1.16.2",
-    "prettier": "^2.7.1",
+    "prettier": "^3.6.2",
     "puppeteer": "24.4.0",
     "ts-essentials": "^9.3.0",
     "typescript": "~5.6.3",

--- a/pages/_error.page.test.tsx
+++ b/pages/_error.page.test.tsx
@@ -14,7 +14,7 @@ const createContext = (requestStatusCode, errorStatusCode) =>
     req: { query: 'test' },
     res: { statusCode: requestStatusCode },
     err: { statusCode: errorStatusCode, message: 'Test Message' },
-  } as unknown as NextPageContext);
+  }) as unknown as NextPageContext;
 
 describe('Error Page', () => {
   describe('Status codes', () => {

--- a/pages/_error.page.tsx
+++ b/pages/_error.page.tsx
@@ -18,8 +18,8 @@ ErrorPage.getInitialProps = ({
   const statusCode: number = res?.statusCode
     ? res.statusCode
     : err?.statusCode
-    ? err.statusCode
-    : 404;
+      ? err.statusCode
+      : 404;
 
   if (!process.browser) {
     if (isRollBarEnabled) {

--- a/pages/accountLists/[accountListId]/contacts/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/contacts/[[...contactId]].page.tsx
@@ -35,8 +35,8 @@ const Contacts: React.FC = () => {
             viewMode === TableViewModeEnum.Flows
               ? t('Contact Flows')
               : viewMode === TableViewModeEnum.Map
-              ? t('Contacts Map')
-              : t('Contacts')
+                ? t('Contacts Map')
+                : t('Contacts')
           }`}
         </title>
       </Head>

--- a/pages/accountLists/[accountListId]/reports/partnerGivingAnalysis/[[...contactId]].page.test.tsx
+++ b/pages/accountLists/[accountListId]/reports/partnerGivingAnalysis/[[...contactId]].page.test.tsx
@@ -65,12 +65,14 @@ const TestingComponent: React.FC<TestingComponentProps> = ({
                 defaultSelection: '',
                 options: [
                   {
-                    name: 'Designation Account 1',
                     __typename: 'FilterOption' as const,
+                    name: 'Designation Account 1',
+                    value: 'designation-account-1',
                   },
                   {
-                    name: 'Designation Account 2',
                     __typename: 'FilterOption' as const,
+                    name: 'Designation Account 2',
+                    value: 'designation-account-2',
                   },
                 ],
               },
@@ -177,7 +179,7 @@ describe('partnerGivingAnalysis page', () => {
     await waitFor(() =>
       expect(replace.mock.lastCall[0].query).toEqual(
         expect.objectContaining({
-          filters: '{"designationAccountId":["Sandwich"]}',
+          filters: '{"designationAccountId":["designation-account-1"]}',
           searchTerm: 'John',
         }),
       ),

--- a/pages/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]].page.test.tsx
+++ b/pages/accountLists/[accountListId]/tools/appeals/appeal/[[...appealId]].page.test.tsx
@@ -7,6 +7,7 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 import { VirtuosoMockContext } from 'react-virtuoso';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { ContactFiltersQuery } from 'pages/accountLists/[accountListId]/contacts/Contacts.generated';
 import { ListHeaderCheckBoxState } from 'src/components/Shared/Header/ListHeader';
 import { AppealQuery } from 'src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealInfo.generated';
 import { ContactsQuery } from 'src/components/Tool/Appeal/AppealsContext/contacts.generated';
@@ -94,10 +95,17 @@ const Components = ({ router = defaultRouter }: { router?: object }) => (
   <ThemeProvider theme={theme}>
     <TestRouter router={router}>
       <DndProvider backend={HTML5Backend}>
-        <GqlMockedProvider<{ Contacts: ContactsQuery; Appeal: AppealQuery }>
+        <GqlMockedProvider<{
+          Contacts: ContactsQuery;
+          Appeal: AppealQuery;
+          ContactFilters: ContactFiltersQuery;
+        }>
           mocks={{
             Contacts: mockResponse,
             Appeal: mockAppealResponse,
+            ContactFilters: {
+              userOptions: [],
+            },
           }}
         >
           <VirtuosoMockContext.Provider
@@ -178,7 +186,7 @@ describe('Appeal navigation', () => {
   });
 
   it('should show flows detail appeal page and open filters', async () => {
-    const { queryByText, getByRole } = render(
+    const { queryByText, getByRole, findByRole } = render(
       <Components
         router={{
           ...defaultRouter,
@@ -209,13 +217,8 @@ describe('Appeal navigation', () => {
 
     userEvent.click(getByRole('img', { name: 'Toggle Filter Panel' }));
 
-    await waitFor(() => {
-      expect(
-        getByRole('complementary', { name: 'Filter' }),
-      ).toBeInTheDocument();
-      expect(
-        getByRole('heading', { name: 'See More Filters' }),
-      ).toBeInTheDocument();
-    });
+    expect(
+      await findByRole('complementary', { name: 'Filter' }),
+    ).toBeInTheDocument();
   });
 });

--- a/pages/api/auth/[...nextauth].page.ts
+++ b/pages/api/auth/[...nextauth].page.ts
@@ -288,8 +288,8 @@ const Auth = (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
           metadata instanceof Error
             ? metadata
             : metadata?.error instanceof Error
-            ? metadata?.error
-            : code;
+              ? metadata?.error
+              : code;
         const customData = { code, ...metadata };
         if (isRollBarEnabled) {
           rollbar.error(errorMsg, customData);

--- a/src/components/Coaching/AppealProgress/AppealProgress.tsx
+++ b/src/components/Coaching/AppealProgress/AppealProgress.tsx
@@ -51,8 +51,8 @@ export const AppealProgress = ({
           {loading
             ? ' '
             : isPrimary
-            ? t('Primary Appeal ') + currencyFormat(goal, currency, locale)
-            : goalText}
+              ? t('Primary Appeal ') + currencyFormat(goal, currency, locale)
+              : goalText}
         </Typography>
         <Typography>
           <MinimalSpacingTooltip title={t('Received')} placement="top" arrow>

--- a/src/components/Coaching/CoachingDetail/helpers.ts
+++ b/src/components/Coaching/CoachingDetail/helpers.ts
@@ -47,7 +47,7 @@ export const getMonthOrWeekDateRange = (
           DateTime.fromISO(endDate).toJSDate(),
         )
       : startDate
-      ? dateFormatMonthOnly(DateTime.fromISO(startDate), locale)
-      : null)
+        ? dateFormatMonthOnly(DateTime.fromISO(startDate), locale)
+        : null)
   );
 };

--- a/src/components/Contacts/ContactDetails/ContactDetailContext.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailContext.tsx
@@ -59,7 +59,8 @@ export const ContactDetailProvider: React.FC<Props> = ({ children }) => {
   const [editMailingModalOpen, setEditMailingModalOpen] = useState(false);
   const [selectedTabKey, setSelectedTabKey] = React.useState(
     query?.tab
-      ? ContactDetailTabEnum[query.tab.toString()] ?? ContactDetailTabEnum.Tasks
+      ? (ContactDetailTabEnum[query.tab.toString()] ??
+          ContactDetailTabEnum.Tasks)
       : ContactDetailTabEnum.Tasks,
   );
   const handleTabChange = useCallback(

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.tsx
@@ -217,12 +217,12 @@ export const EditContactOtherModal: React.FC<EditContactOtherModalProps> = ({
             },
           ]
         : selectedId
-        ? [
-            {
-              referredById: attributes.referredById,
-            },
-          ]
-        : [{}];
+          ? [
+              {
+                referredById: attributes.referredById,
+              },
+            ]
+          : [{}];
     await updateContactOther({
       variables: {
         accountListId,

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonModal.tsx
@@ -442,8 +442,8 @@ export const PersonModal: React.FC<PersonModalProps> = ({
         userProfile
           ? 'Edit Details'
           : person
-          ? t('Edit Person')
-          : t('Create Person')
+            ? t('Edit Person')
+            : t('Create Person')
       }
       size="md"
       handleClose={handleClose}

--- a/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/TaskDate/TaskDate.tsx
+++ b/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTaskRow/TaskDate/TaskDate.tsx
@@ -30,8 +30,8 @@ const DateText = styled(Typography, {
     color: isLate
       ? theme.palette.error.main
       : isComplete
-      ? theme.palette.text.secondary
-      : theme.palette.text.primary,
+        ? theme.palette.text.secondary
+        : theme.palette.text.primary,
     marginLeft: small ? theme.spacing(0.5) : theme.spacing(1),
   }),
 );

--- a/src/components/Contacts/ContactPartnershipStatus/ContactLateStatusLabel/ContactLateStatusLabel.tsx
+++ b/src/components/Contacts/ContactPartnershipStatus/ContactLateStatusLabel/ContactLateStatusLabel.tsx
@@ -50,12 +50,12 @@ export const ContactLateStatusLabel: React.FC<ContactLateStatusProps> = ({
           lateStatusEnum === ContactLateStatusEnum.OnTime
             ? theme.palette.mpdxGreen.main
             : lateStatusEnum === ContactLateStatusEnum.LateLessThirty
-            ? theme.palette.cruGrayMedium.main
-            : lateStatusEnum === ContactLateStatusEnum.LateMoreThirty
-            ? theme.palette.cruYellow.main
-            : lateStatusEnum === ContactLateStatusEnum.LateMoreSixty
-            ? theme.palette.error.main
-            : undefined,
+              ? theme.palette.cruGrayMedium.main
+              : lateStatusEnum === ContactLateStatusEnum.LateMoreThirty
+                ? theme.palette.cruYellow.main
+                : lateStatusEnum === ContactLateStatusEnum.LateMoreSixty
+                  ? theme.palette.error.main
+                  : undefined,
       }}
     >
       {isDetail ? lateStatusLabel : `(${lateStatusLabel})`}

--- a/src/components/Contacts/MassActions/Exports/exportRest.tsx
+++ b/src/components/Contacts/MassActions/Exports/exportRest.tsx
@@ -28,8 +28,8 @@ export const exportRest = async (
       fileType === 'csv'
         ? 'text/csv'
         : fileType === 'xlsx'
-        ? 'application/xlsx'
-        : 'text/pdf';
+          ? 'application/xlsx'
+          : 'text/pdf';
 
     const fields: RestExportFields = {
       type: 'export_logs',

--- a/src/components/Contacts/MassActions/RemoveTags/MassActionsRemoveTagsModal.test.tsx
+++ b/src/components/Contacts/MassActions/RemoveTags/MassActionsRemoveTagsModal.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from '../../../../theme';
+import { GetContactsForTagsQuery } from '../GetContactsForTags.generated';
 import { MassActionsRemoveTagsModal } from './MassActionsRemoveTagsModal';
 
 const mockEnqueue = jest.fn();
@@ -27,10 +28,19 @@ describe('MassActionsRemoveTagsModal', () => {
   it('Clicks on tag to remove it, then saves action', async () => {
     const mutationSpy = jest.fn();
     const handleClose = jest.fn();
-    const tagName = 'Circus';
+    const tagName = 'Family';
     const { getByText } = render(
       <ThemeProvider theme={theme}>
-        <GqlMockedProvider onCall={mutationSpy}>
+        <GqlMockedProvider<{ GetContactsForTags: GetContactsForTagsQuery }>
+          onCall={mutationSpy}
+          mocks={{
+            GetContactsForTags: {
+              contacts: {
+                nodes: [{ tagList: [tagName] }],
+              },
+            },
+          }}
+        >
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <SnackbarProvider>
               <MassActionsRemoveTagsModal

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateContact/CreateContact.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateContact/CreateContact.tsx
@@ -112,7 +112,7 @@ const CreateContact = ({
         const findFirstName = firstAndSpouseNames.split(/ (.*)/s, 2);
         people.push({
           firstName: findFirstName[0],
-          lastName: lastName ? lastName : findFirstName[1] ?? '',
+          lastName: lastName ? lastName : (findFirstName[1] ?? ''),
         });
       }
 

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateMultipleContacts/CreateMultipleContacts.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateMultipleContacts/CreateMultipleContacts.tsx
@@ -164,8 +164,8 @@ export const CreateMultipleContacts = ({
                     ? `${lastName}, ${firstName} and ${spouseName}`
                     : `${lastName}, ${firstName}`
                   : spouseName
-                  ? `${firstName} and ${spouseName}`
-                  : `${firstName}`,
+                    ? `${firstName} and ${spouseName}`
+                    : `${firstName}`,
                 contactReferralsToMe: referredById
                   ? [{ referredById }]
                   : undefined,

--- a/src/components/PageHeading/PageHeading.test.tsx
+++ b/src/components/PageHeading/PageHeading.test.tsx
@@ -27,7 +27,9 @@ describe('PageHeading', () => {
       <ThemeProvider theme={theme}>
         <PageHeading
           heading="test heading"
-          imgSrc={require(`../../images/drawkit/grape/drawkit-grape-pack-illustration-1.svg`)}
+          imgSrc={require(
+            `../../images/drawkit/grape/drawkit-grape-pack-illustration-1.svg`,
+          )}
           overlap={100}
           height={400}
         />

--- a/src/components/Reports/FinancialAccountsReport/AccountSummary/AccountSummaryHelper.ts
+++ b/src/components/Reports/FinancialAccountsReport/AccountSummary/AccountSummaryHelper.ts
@@ -63,6 +63,6 @@ export const formatNumber = (
   const number =
     typeof numberAsString === 'string'
       ? Number(numberAsString)
-      : numberAsString ?? 0;
+      : (numberAsString ?? 0);
   return Math.ceil(makeAbsolute ? Math.abs(number) : number);
 };

--- a/src/components/Reports/SavingsFundTransfer/BalanceCard/BalanceCard.tsx
+++ b/src/components/Reports/SavingsFundTransfer/BalanceCard/BalanceCard.tsx
@@ -37,14 +37,14 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
     fund.type === StaffSavingFundEnum.StaffAccount
       ? Wallet
       : fund.type === StaffSavingFundEnum.StaffConferenceSavings
-      ? Groups
-      : Savings;
+        ? Groups
+        : Savings;
   const iconBgColor =
     fund.type === StaffSavingFundEnum.StaffAccount
       ? staffAccountColor
       : fund.type === StaffSavingFundEnum.StaffConferenceSavings
-      ? staffConferenceSavingsColor
-      : staffSavingsColor;
+        ? staffConferenceSavingsColor
+        : staffSavingsColor;
 
   const handleTransferFrom = () => {
     handleOpenTransferModal({

--- a/src/components/Reports/SavingsFundTransfer/DownloadTable/downloadTable.tsx
+++ b/src/components/Reports/SavingsFundTransfer/DownloadTable/downloadTable.tsx
@@ -17,18 +17,18 @@ export const createTable = (
       transfer.transferFrom === StaffSavingFundEnum.StaffSavings
         ? 'Staff Savings'
         : transfer.transferFrom === StaffSavingFundEnum.StaffAccount
-        ? 'Staff Account'
-        : transfer.transferFrom === StaffSavingFundEnum.StaffConferenceSavings
-        ? 'Staff Conference Savings'
-        : transfer.transferFrom;
+          ? 'Staff Account'
+          : transfer.transferFrom === StaffSavingFundEnum.StaffConferenceSavings
+            ? 'Staff Conference Savings'
+            : transfer.transferFrom;
     const toFund =
       transfer.transferTo === StaffSavingFundEnum.StaffSavings
         ? 'Staff Savings'
         : transfer.transferTo === StaffSavingFundEnum.StaffAccount
-        ? 'Staff Account'
-        : transfer.transferTo === StaffSavingFundEnum.StaffConferenceSavings
-        ? 'Staff Conference Savings'
-        : transfer.transferTo;
+          ? 'Staff Account'
+          : transfer.transferTo === StaffSavingFundEnum.StaffConferenceSavings
+            ? 'Staff Conference Savings'
+            : transfer.transferTo;
     const schedule =
       transfer.schedule === ScheduleEnum.OneTime ? 'One Time' : 'Monthly';
     return [

--- a/src/components/Reports/SavingsFundTransfer/Table/PrintTable.tsx
+++ b/src/components/Reports/SavingsFundTransfer/Table/PrintTable.tsx
@@ -54,16 +54,16 @@ export const PrintTable: React.FC<PrintTableProps> = ({ transfers }) => {
                     {transfer.transferFrom === StaffSavingFundEnum.StaffAccount
                       ? 'Staff Account'
                       : transfer.transferFrom ===
-                        StaffSavingFundEnum.StaffSavings
-                      ? 'Staff Savings'
-                      : 'Staff Conference Savings'}
+                          StaffSavingFundEnum.StaffSavings
+                        ? 'Staff Savings'
+                        : 'Staff Conference Savings'}
                   </TableCell>
                   <TableCell>
                     {transfer.transferTo === StaffSavingFundEnum.StaffAccount
                       ? 'Staff Account'
                       : transfer.transferTo === StaffSavingFundEnum.StaffSavings
-                      ? 'Staff Savings'
-                      : 'Staff Conference Savings'}
+                        ? 'Staff Savings'
+                        : 'Staff Conference Savings'}
                   </TableCell>
                   <TableCell>
                     {transfer.amount?.toLocaleString(locale, {

--- a/src/components/Reports/SavingsFundTransfer/TransferModal/TransferModalSelect/TransferModalSelect.tsx
+++ b/src/components/Reports/SavingsFundTransfer/TransferModal/TransferModalSelect/TransferModalSelect.tsx
@@ -33,10 +33,10 @@ export const TransferModalSelect: React.FC<TransferModalSelectProps> = ({
             {fund.type === StaffSavingFundEnum.StaffAccount
               ? StaffAccount
               : fund.type === StaffSavingFundEnum.StaffSavings
-              ? StaffSavings
-              : fund.type === StaffSavingFundEnum.StaffConferenceSavings
-              ? StaffConferenceSavings
-              : null}{' '}
+                ? StaffSavings
+                : fund.type === StaffSavingFundEnum.StaffConferenceSavings
+                  ? StaffConferenceSavings
+                  : null}{' '}
             <b>{fund.name}</b>
           </Box>
         </MenuItem>

--- a/src/components/Settings/Organization/AccountLists/AccountListRow/AccountListCoachesOrUsers/AccountListCoachesOrUsers.tsx
+++ b/src/components/Settings/Organization/AccountLists/AccountListRow/AccountListCoachesOrUsers/AccountListCoachesOrUsers.tsx
@@ -56,8 +56,8 @@ export const AccountListCoachesOrUsers: React.FC<Props> = ({
           item.__typename === 'AccountListUsers'
             ? item.userEmailAddresses
             : item.__typename === 'OrganizationAccountListCoaches'
-            ? item.coachEmailAddresses
-            : [];
+              ? item.coachEmailAddresses
+              : [];
 
         return (
           <BorderBottomBox key={`designationAccounts-coaches-${idx}`}>

--- a/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
+++ b/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
@@ -297,8 +297,7 @@ describe('OrganizationAccordion', () => {
       const mutationSpy = jest.fn();
       mocks.GetUsersOrganizationsAccounts.userOrganizationAccounts[0].organization.apiClass =
         'DataServer';
-      mocks.GetUsersOrganizationsAccounts.userOrganizationAccounts[0].organization.oauth =
-        true;
+      mocks.GetUsersOrganizationsAccounts.userOrganizationAccounts[0].organization.oauth = true;
       const { getByText, queryByTestId } = render(
         <Components>
           <GqlMockedProvider<{

--- a/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.tsx
+++ b/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.tsx
@@ -130,32 +130,34 @@ export const PrayerlettersAccordion: React.FC<AccordionProps> = ({
           </StyledServicesButton>
         </>
       )}
-      {!loading && prayerlettersAccount && !prayerlettersAccount?.validToken && (
-        <>
-          <Alert severity="error">
-            {t(
-              'The link between {{appName}} and your prayerletters.com account stopped working. Click "Refresh prayerletters.com Account" to re-enable it.',
-              { appName },
-            )}
-          </Alert>
+      {!loading &&
+        prayerlettersAccount &&
+        !prayerlettersAccount?.validToken && (
+          <>
+            <Alert severity="error">
+              {t(
+                'The link between {{appName}} and your prayerletters.com account stopped working. Click "Refresh prayerletters.com Account" to re-enable it.',
+                { appName },
+              )}
+            </Alert>
 
-          <Box style={{ marginTop: '20px' }}>
-            <Button href={getOauthUrl()} variant="contained">
-              {t('Refresh prayerletters.com Account')}
-            </Button>
+            <Box style={{ marginTop: '20px' }}>
+              <Button href={getOauthUrl()} variant="contained">
+                {t('Refresh prayerletters.com Account')}
+              </Button>
 
-            <Button
-              onClick={() => setShowDeleteModal(true)}
-              variant="text"
-              color="error"
-              style={{ marginLeft: '15px' }}
-              disabled={isSaving}
-            >
-              {t('Disconnect')}
-            </Button>
-          </Box>
-        </>
-      )}
+              <Button
+                onClick={() => setShowDeleteModal(true)}
+                variant="text"
+                color="error"
+                style={{ marginLeft: '15px' }}
+                disabled={isSaving}
+              >
+                {t('Disconnect')}
+              </Button>
+            </Box>
+          </>
+        )}
       {!loading && prayerlettersAccount && prayerlettersAccount?.validToken && (
         <>
           <Alert severity="warning">

--- a/src/components/Settings/preferences/accordions/LocaleAccordion/LocaleAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/LocaleAccordion/LocaleAccordion.tsx
@@ -45,8 +45,8 @@ export const LocaleAccordion: React.FC<LocaleAccordionProps> = ({
     return thisLocale?.englishName && thisLocale?.nativeName
       ? `${thisLocale?.englishName} (${thisLocale?.nativeName})`
       : thisLocale?.englishName
-      ? thisLocale?.englishName
-      : '';
+        ? thisLocale?.englishName
+        : '';
   };
 
   const selectedLocale = useMemo(

--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
@@ -48,8 +48,8 @@ export const MonthlyGoalAccordion: React.FC<MonthlyGoalAccordionProps> = ({
     return monthlyGoal && locale && currency
       ? currencyFormat(monthlyGoal, currency, locale)
       : monthlyGoal
-      ? String(monthlyGoal)
-      : '';
+        ? String(monthlyGoal)
+        : '';
   }, [monthlyGoal, locale, currency]);
 
   const onSubmit = async (

--- a/src/components/Settings/preferences/accordions/MpdInfoAccordion/MpdInfoAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/MpdInfoAccordion/MpdInfoAccordion.tsx
@@ -89,8 +89,8 @@ export const MpdInfoAccordion: React.FC<MpdInfoAccordionProps> = ({
       activeMpdMonthlyGoal && activeMpdMonthlyGoal > 0 && currency && locale
         ? ' (' + currencyFormat(activeMpdMonthlyGoal, currency, locale) + ')'
         : activeMpdMonthlyGoal && activeMpdMonthlyGoal > 0
-        ? ' (' + activeMpdMonthlyGoal + ')'
-        : '';
+          ? ' (' + activeMpdMonthlyGoal + ')'
+          : '';
     const mpdStartDate = activeMpdStartAt
       ? dateFormat(DateTime.fromISO(activeMpdStartAt), locale) + ' - '
       : '';

--- a/src/components/Shared/Filters/FilterPanel.tsx
+++ b/src/components/Shared/Filters/FilterPanel.tsx
@@ -211,7 +211,7 @@ export const FilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
           ({
             name: snakeToCamel(key),
             value: parsedFilter[key],
-          } as { name: string; value: FilterKey }),
+          }) as { name: string; value: FilterKey },
       );
 
       const newFilter = filters.reduce<FilterInput>((acc, filter) => {

--- a/src/components/Shared/Header/ListHeader.tsx
+++ b/src/components/Shared/Header/ListHeader.tsx
@@ -189,7 +189,7 @@ export const ListHeader: React.FC<ListHeaderProps> = ({
             massDeselectAll={massDeselectAll}
             selectedIdCount={
               headerCheckboxState === ListHeaderCheckBoxState.Checked
-                ? totalItems ?? 0
+                ? (totalItems ?? 0)
                 : selectedIds.length
             }
           />

--- a/src/components/Shared/TagChip/TagChip.tsx
+++ b/src/components/Shared/TagChip/TagChip.tsx
@@ -14,22 +14,22 @@ export const TagChip = styled(Chip, {
     selectType === 'include'
       ? theme.palette.mpdxBlue.main
       : selectType === 'exclude'
-      ? theme.palette.error.main
-      : theme.palette.cruGrayMedium.main,
+        ? theme.palette.error.main
+        : theme.palette.cruGrayMedium.main,
   '&:focus': {
     backgroundColor:
       selectType === 'include'
         ? theme.palette.mpdxBlue.main
         : selectType === 'exclude'
-        ? theme.palette.error.main
-        : theme.palette.cruGrayMedium.main,
+          ? theme.palette.error.main
+          : theme.palette.cruGrayMedium.main,
   },
   '&:hover': {
     backgroundColor:
       selectType === 'include'
         ? theme.palette.mpdxBlue.main
         : selectType === 'exclude'
-        ? theme.palette.error.main
-        : '#777',
+          ? theme.palette.error.main
+          : '#777',
   },
 }));

--- a/src/components/Task/Modal/Form/Complete/TaskModalCompleteForm.tsx
+++ b/src/components/Task/Modal/Form/Complete/TaskModalCompleteForm.tsx
@@ -319,8 +319,8 @@ const TaskModalCompleteForm = ({
                   {numberOfContacts > 1
                     ? t('Contacts: ')
                     : numberOfContacts > 0
-                    ? t('Contact: ')
-                    : null}
+                      ? t('Contact: ')
+                      : null}
                 </Typography>
                 {task?.contacts.nodes.map((contact, index) => (
                   <Typography

--- a/src/components/Tool/Appeal/AppealDetails/AppealsDetailsPage.test.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealsDetailsPage.test.tsx
@@ -7,6 +7,7 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 import { VirtuosoMockContext } from 'react-virtuoso';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { ContactFiltersQuery } from 'pages/accountLists/[accountListId]/contacts/Contacts.generated';
 import { AppealsWrapper } from 'pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper';
 import { ListHeaderCheckBoxState } from 'src/components/Shared/Header/ListHeader';
 import { AppealQuery } from 'src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealInfo.generated';
@@ -97,10 +98,17 @@ const Components = ({ router = defaultRouter }: { router?: object }) => (
   <ThemeProvider theme={theme}>
     <TestRouter router={router}>
       <DndProvider backend={HTML5Backend}>
-        <GqlMockedProvider<{ Contacts: ContactsQuery; Appeal: AppealQuery }>
+        <GqlMockedProvider<{
+          Contacts: ContactsQuery;
+          Appeal: AppealQuery;
+          ContactFilters: ContactFiltersQuery;
+        }>
           mocks={{
             Contacts: mockResponse,
             Appeal: mockAppealResponse,
+            ContactFilters: {
+              userOptions: [],
+            },
           }}
         >
           <VirtuosoMockContext.Provider
@@ -217,20 +225,20 @@ describe('AppealsDetailsPage', () => {
       ).toBeInTheDocument();
 
       expect(
-        queryByRole('heading', { name: /see more filters/i }),
+        queryByRole('complementary', { name: 'Filter' }),
       ).not.toBeInTheDocument();
 
       userEvent.click(getByRole('img', { name: /toggle filter panel/i }));
 
       expect(
-        await findByRole('heading', { name: /see more filters/i }),
+        await findByRole('complementary', { name: 'Filter' }),
       ).toBeInTheDocument();
 
       userEvent.click(getByRole('img', { name: 'Close' }));
 
       await waitFor(() =>
         expect(
-          queryByRole('heading', { name: /see more filters/i }),
+          queryByRole('complementary', { name: 'Filter' }),
         ).not.toBeInTheDocument(),
       );
     });

--- a/src/components/Tool/Appeal/Modals/UpdateDonationsModal/UpdateDonationsModal.test.tsx
+++ b/src/components/Tool/Appeal/Modals/UpdateDonationsModal/UpdateDonationsModal.test.tsx
@@ -743,7 +743,7 @@ describe('UpdateDonationsModal', () => {
           ),
         );
 
-        expect(mutationSpy).toHaveGraphqlOperation('UpdateDonations', {
+        (expect(mutationSpy).toHaveGraphqlOperation('UpdateDonations', {
           input: {
             accountListId,
             attributes: [
@@ -758,7 +758,7 @@ describe('UpdateDonationsModal', () => {
             ],
           },
         }),
-          expect(handleClose).toHaveBeenCalled();
+          expect(handleClose).toHaveBeenCalled());
       });
     });
   });

--- a/src/components/Tool/Appeal/Shared/useGetPledgeOrDonation/useGetPledgeOrDonation.ts
+++ b/src/components/Tool/Appeal/Shared/useGetPledgeOrDonation/useGetPledgeOrDonation.ts
@@ -47,10 +47,11 @@ const formatPledgeOrDonation = ({
   const pledgeOrDonationDate =
     appealStatus === AppealStatusEnum.Asked ||
     appealStatus === AppealStatusEnum.Excluded
-      ? (dateOrFrequency && getLocalizedPledgeFrequency(dateOrFrequency)) ?? ''
+      ? ((dateOrFrequency && getLocalizedPledgeFrequency(dateOrFrequency)) ??
+        '')
       : dateOrFrequency
-      ? dateFormat(DateTime.fromISO(dateOrFrequency), locale)
-      : '';
+        ? dateFormat(DateTime.fromISO(dateOrFrequency), locale)
+        : '';
   return {
     amount: pledgeOrDonationAmount,
     dateOrFrequency: pledgeOrDonationDate,

--- a/src/components/Tool/FixCommitmentInfo/FixCommitmentInfo.test.tsx
+++ b/src/components/Tool/FixCommitmentInfo/FixCommitmentInfo.test.tsx
@@ -138,12 +138,12 @@ describe('FixCommitmentInfo', () => {
 
     userEvent.click((await findAllByTestId('confirmButton'))[0]);
 
-    expect(
+    (expect(
       await findByText(
         'Are you sure you wish to update the commitment info for Tester 1?',
       ),
     ).toBeInTheDocument(),
-      userEvent.click(getByText('Yes'));
+      userEvent.click(getByText('Yes')));
 
     await waitFor(() =>
       expect(queryByText('Tester 1')).not.toBeInTheDocument(),

--- a/src/components/Tool/FixEmailAddresses/FixEmailAddresses.tsx
+++ b/src/components/Tool/FixEmailAddresses/FixEmailAddresses.tsx
@@ -121,7 +121,7 @@ export const determineBulkDataToSend = (
               id: emailAddress.id,
               primary: emailAddress.id === primaryEmailAddress.id,
               validValues: true,
-            } as PersonEmailAddressInput),
+            }) as PersonEmailAddressInput,
         ),
       });
     }

--- a/src/components/Tool/FixMailingAddresses/Contact.tsx
+++ b/src/components/Tool/FixMailingAddresses/Contact.tsx
@@ -142,10 +142,13 @@ const Contact: React.FC<Props> = ({
   }, [addressesState]);
 
   const editableSources = useMemo(() => {
-    return addressesData?.reduce((acc, address) => {
-      acc[address.id] = isEditableSource(address.source);
-      return acc;
-    }, {} as Record<string, boolean>);
+    return addressesData?.reduce(
+      (acc, address) => {
+        acc[address.id] = isEditableSource(address.source);
+        return acc;
+      },
+      {} as Record<string, boolean>,
+    );
   }, [addressesData]);
 
   const handleConfirm = () => {

--- a/src/components/Tool/FixSendNewsletter/FixSendNewsletter.test.tsx
+++ b/src/components/Tool/FixSendNewsletter/FixSendNewsletter.test.tsx
@@ -303,9 +303,8 @@ describe('FixSendNewsletter', () => {
               cardinality++;
               return queryResult;
             },
-            MassActionsUpdateContacts: {
-              ...mockMassActionsUpdateContactsData.MassActionsUpdateContacts,
-            },
+            MassActionsUpdateContacts:
+              mockMassActionsUpdateContactsData.MassActionsUpdateContacts,
           }}
           onCall={mutationSpy}
         />,
@@ -321,28 +320,26 @@ describe('FixSendNewsletter', () => {
         );
       });
       await waitFor(() => {
-        expect(mutationSpy.mock.calls[1][0]).toMatchObject({
-          operation: {
-            operationName: 'MassActionsUpdateContacts',
-            variables: {
-              accountListId: 'account-id',
-              attributes: [
-                {
-                  id: 'contactId3',
-                  sendNewsletter: SendNewsletterEnum.None,
-                },
-                {
-                  id: 'contactId1',
-                  sendNewsletter: SendNewsletterEnum.Physical,
-                },
-                {
-                  id: 'contactId2',
-                  sendNewsletter: SendNewsletterEnum.Both,
-                },
-              ],
-            },
+        expect(mutationSpy).toHaveGraphqlOperation(
+          'MassActionsUpdateContacts',
+          {
+            accountListId: 'account-id',
+            attributes: [
+              {
+                id: 'contactId3',
+                sendNewsletter: SendNewsletterEnum.None,
+              },
+              {
+                id: 'contactId1',
+                sendNewsletter: SendNewsletterEnum.Physical,
+              },
+              {
+                id: 'contactId2',
+                sendNewsletter: SendNewsletterEnum.Both,
+              },
+            ],
           },
-        });
+        );
       });
     });
 

--- a/src/components/Tool/FixSendNewsletter/FixSendNewsletterMock.ts
+++ b/src/components/Tool/FixSendNewsletter/FixSendNewsletterMock.ts
@@ -1,4 +1,12 @@
-import { SendNewsletterEnum, StatusEnum } from 'src/graphql/types.generated';
+import { DeepPartial } from 'ts-essentials';
+import { MassActionsUpdateContactsMutation } from 'src/components/Contacts/MassActions/MassActionsUpdateContacts.generated';
+import {
+  ContactSourceEnum,
+  SendNewsletterEnum,
+  StatusEnum,
+} from 'src/graphql/types.generated';
+import { InvalidNewsletterQuery } from './InvalidNewsletter.generated';
+import { UpdateContactNewsletterMutation } from './UpdateNewsletter.generated';
 
 export const mpdxSourcedAddress = {
   id: '1',
@@ -53,7 +61,8 @@ export const mockInvalidNewslettersResponse = {
           id: 'contactId1',
           name: 'Baggins, Frodo',
           status: StatusEnum.PartnerPray,
-          source: 'MPDX',
+          sendNewsletter: SendNewsletterEnum.Physical,
+          source: ContactSourceEnum.Mpdx,
           primaryAddress: mpdxSourcedAddress,
           primaryPerson,
         },
@@ -61,7 +70,8 @@ export const mockInvalidNewslettersResponse = {
           id: 'contactId2',
           name: 'Gamgee, Samwise',
           status: StatusEnum.PartnerFinancial,
-          source: 'MPDX',
+          sendNewsletter: SendNewsletterEnum.Physical,
+          source: ContactSourceEnum.Mpdx,
           primaryAddress: emptyAddress,
           primaryPerson: emptyPerson,
         },
@@ -69,15 +79,16 @@ export const mockInvalidNewslettersResponse = {
           id: 'contactId3',
           name: 'Gollum, Smeagol',
           status: StatusEnum.NeverAsk,
-          source: 'MPDX',
+          sendNewsletter: SendNewsletterEnum.Physical,
+          source: ContactSourceEnum.Mpdx,
           primaryAddress: emptyAddress,
           primaryPerson: {
             deceased: true,
           },
         },
       ],
+      totalCount: 3,
     },
-    totalCount: 2,
     constant: {
       status: [
         { id: StatusEnum.PartnerPray, value: 'Partner - Pray' },
@@ -85,7 +96,7 @@ export const mockInvalidNewslettersResponse = {
         { id: StatusEnum.NeverAsk, value: 'Never Ask' },
       ],
     },
-  },
+  } satisfies DeepPartial<InvalidNewsletterQuery>,
 };
 
 export const mockUploadNewsletterChange = {
@@ -96,20 +107,13 @@ export const mockUploadNewsletterChange = {
         sendNewsletter: SendNewsletterEnum.Physical,
       },
     },
-  },
+  } satisfies DeepPartial<UpdateContactNewsletterMutation>,
 };
 
 export const mockMassActionsUpdateContactsData = {
   MassActionsUpdateContacts: {
-    updateContacts: [
-      {
-        id: 'contactId',
-        sendNewsletter: SendNewsletterEnum.Physical,
-      },
-      {
-        id: 'contactId2',
-        sendNewsletter: SendNewsletterEnum.Both,
-      },
-    ],
-  },
+    updateContacts: {
+      contacts: [{ id: 'contactId1' }, { id: 'contactId2' }],
+    },
+  } satisfies DeepPartial<MassActionsUpdateContactsMutation>,
 };

--- a/src/components/Tool/GoogleImport/GoogleImport.test.tsx
+++ b/src/components/Tool/GoogleImport/GoogleImport.test.tsx
@@ -253,10 +253,10 @@ describe('Google Import', () => {
       const contactGroupTagAutocomplete = getAllByRole(
         'combobox',
       )[0] as HTMLInputElement;
-      expect(await findByText(account2GroupTag)).toBeInTheDocument(),
-        userEvent.type(contactGroupTagAutocomplete, 'hello-world');
-      expect(contactGroupTagAutocomplete.value).toBe('hello-world'),
-        userEvent.type(contactGroupTagAutocomplete, '{enter}');
+      (expect(await findByText(account2GroupTag)).toBeInTheDocument(),
+        userEvent.type(contactGroupTagAutocomplete, 'hello-world'));
+      (expect(contactGroupTagAutocomplete.value).toBe('hello-world'),
+        userEvent.type(contactGroupTagAutocomplete, '{enter}'));
 
       //Add tags for all
       const allTagAutocomplete = getAllByRole(

--- a/src/components/Tool/MergeContacts/ContactPair.tsx
+++ b/src/components/Tool/MergeContacts/ContactPair.tsx
@@ -164,8 +164,8 @@ const ContactItem: React.FC<ContactItemProps> = ({
       selected
         ? classes.selectedBox
         : loser
-        ? classes.loserBox
-        : classes.unselectedBox
+          ? classes.loserBox
+          : classes.unselectedBox
     }`}
       onClick={() => updateState(side)}
     >
@@ -199,8 +199,8 @@ const ContactItem: React.FC<ContactItemProps> = ({
                 {isPersonType
                   ? `${contact.firstName} ${contact.lastName}`
                   : isContactType
-                  ? contact.name
-                  : null}
+                    ? contact.name
+                    : null}
               </InlineTypography>
             </Link>
             {selected && (

--- a/src/components/Tool/MergeContacts/mergeDuplicatesHelper.ts
+++ b/src/components/Tool/MergeContacts/mergeDuplicatesHelper.ts
@@ -121,8 +121,8 @@ export const bulkUpdateDuplicates = async (
           result.success && result?.successfulMerges
             ? result.successfulMerges
             : result.success
-            ? 1
-            : 0;
+              ? 1
+              : 0;
       });
       const totalDuplicatesAttempted =
         mergeActions.length + duplicatesToIgnore.length;

--- a/src/components/Welcome/Welcome.test.tsx
+++ b/src/components/Welcome/Welcome.test.tsx
@@ -25,7 +25,9 @@ describe('Welcome', () => {
         <Welcome
           title={<div data-testid="testTitle">test title</div>}
           subtitle={<div data-testid="testSubtitle">test subtitle</div>}
-          imgSrc={require(`../../images/drawkit/grape/drawkit-grape-pack-illustration-1.svg`)}
+          imgSrc={require(
+            `../../images/drawkit/grape/drawkit-grape-pack-illustration-1.svg`,
+          )}
         />
       </ThemeProvider>,
     );

--- a/src/components/common/SearchBox/SearchBox.tsx
+++ b/src/components/common/SearchBox/SearchBox.tsx
@@ -52,8 +52,8 @@ export const SearchBox: React.FC<SearchBoxProps> = ({
         toolTipText
           ? toolTipText
           : page === PageEnum.Task
-          ? t('Search by subject, tags, contact name, or comments')
-          : t('Search by name, phone, email, or partner #')
+            ? t('Search by subject, tags, contact name, or comments')
+            : t('Search by name, phone, email, or partner #')
       }
     >
       <SearchInput

--- a/src/hooks/useMassSelection.ts
+++ b/src/hooks/useMassSelection.ts
@@ -65,8 +65,8 @@ export const useMassSelection = (idsList: string[]): UseMassSelectionResult => {
       ids.length === 0
         ? ListHeaderCheckBoxState.Unchecked
         : ids.length === totalCount
-        ? ListHeaderCheckBoxState.Checked
-        : ListHeaderCheckBoxState.Partial,
+          ? ListHeaderCheckBoxState.Checked
+          : ListHeaderCheckBoxState.Partial,
     isRowChecked,
     deselectAll,
     toggleSelectAll,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14802,7 +14802,7 @@ __metadata:
     node-fetch: "npm:^3.3.2"
     node-mocks-http: "npm:1.16.2"
     notistack: "npm:^2.0.5"
-    prettier: "npm:^2.7.1"
+    prettier: "npm:^3.6.2"
     prop-types: "npm:^15.8.1"
     puppeteer: "npm:24.4.0"
     react: "npm:^18.2.0"
@@ -16099,12 +16099,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.7.1":
-  version: 2.7.1
-  resolution: "prettier@npm:2.7.1"
+"prettier@npm:^3.6.2":
+  version: 3.6.2
+  resolution: "prettier@npm:3.6.2"
   bin:
-    prettier: bin-prettier.js
-  checksum: 10/9d29f81c1a470efca6851cd926a3e132a8d9c9d290c3d084c917c1c5aad5c392551406cf6012c724a136bd15911ede5eadc255d121c2761813b33a541a9c34c6
+    prettier: bin/prettier.cjs
+  checksum: 10c0/488cb2f2b99ec13da1e50074912870217c11edaddedeadc649b1244c749d15ba94e846423d062e2c4c9ae683e2d65f754de28889ba06e697ac4f988d44f45812
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

I was trying to use the newish `satisfies` TypeScript operator on another PR and noticed that it messed up prettier. It appears to be because prettier wasn't new enough. This PR simply upgrades to prettier 3 and removes the `trailingComma` configuration because it defaults to `all` now. It seems that the main breaking change is how it formats nested ternaries.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
