### PR TITLE
[MPDX-8798] Populate settings sidebar with special family categories

### DIFF
--- a/src/components/Reports/GoalCalculator/CalculatorSettings/SettingsSectionList.test.tsx
+++ b/src/components/Reports/GoalCalculator/CalculatorSettings/SettingsSectionList.test.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import { GoalCalculatorTestWrapper } from '../GoalCalculatorTestWrapper';
+import { SettingsSectionList } from './SettingsSectionList';
+
+describe('SettingsSectionList', () => {
+  it('renders correctly', async () => {
+    const { getByText, findByText } = render(
+      <GoalCalculatorTestWrapper>
+        <SettingsSectionList />
+      </GoalCalculatorTestWrapper>,
+    );
+
+    expect(getByText('Information')).toBeInTheDocument();
+    expect(await findByText('Special Income')).toBeInTheDocument();
+  });
+});

--- a/src/components/Reports/GoalCalculator/CalculatorSettings/SettingsSectionList.tsx
+++ b/src/components/Reports/GoalCalculator/CalculatorSettings/SettingsSectionList.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useGoalCalculator } from '../Shared/GoalCalculatorContext';
+import { getFamilySections } from '../Shared/familySections';
 import { SectionList } from '../SharedComponents/SectionList';
 
 export const SettingsSectionList: React.FC = () => {
   const { t } = useTranslation();
+  const {
+    goalCalculationResult: { data },
+  } = useGoalCalculator();
+  const specialFamily = data?.goalCalculation.specialFamily;
 
   const sections = [
     { title: t('Information'), complete: false },
-    { title: t('Special Income'), complete: false },
-    { title: t('One-time Goals'), complete: false },
+    ...(specialFamily ? getFamilySections(specialFamily) : []),
   ];
 
   return <SectionList sections={sections} />;

--- a/src/components/Reports/GoalCalculator/GoalCalculatorTestWrapper.tsx
+++ b/src/components/Reports/GoalCalculator/GoalCalculatorTestWrapper.tsx
@@ -28,6 +28,18 @@ export const goalCalculationMock = {
         },
       ],
     },
+    specialFamily: {
+      primaryBudgetCategories: [
+        {
+          label: 'Special Income',
+          category: PrimaryBudgetCategoryEnum.SpecialIncome,
+        },
+        {
+          label: 'One Time Goal',
+          category: PrimaryBudgetCategoryEnum.OneTimeGoal,
+        },
+      ],
+    },
   },
 } satisfies DeepPartial<GoalCalculationQuery>;
 

--- a/src/components/Reports/GoalCalculator/Shared/familySections.test.ts
+++ b/src/components/Reports/GoalCalculator/Shared/familySections.test.ts
@@ -2,7 +2,7 @@ import { gqlMock } from '__tests__/util/graphqlMocking';
 import {
   BudgetFamilyFragment,
   BudgetFamilyFragmentDoc,
-} from '../../Shared/GoalCalculation.generated';
+} from './GoalCalculation.generated';
 import { getFamilySections } from './familySections';
 
 describe('getFamilySections', () => {

--- a/src/components/Reports/GoalCalculator/Shared/familySections.ts
+++ b/src/components/Reports/GoalCalculator/Shared/familySections.ts
@@ -1,5 +1,5 @@
-import { BudgetFamilyFragment } from '../../Shared/GoalCalculation.generated';
-import { SectionItem } from '../SectionList';
+import { SectionItem } from '../SharedComponents/SectionList';
+import { BudgetFamilyFragment } from './GoalCalculation.generated';
 
 export const getFamilySections = (
   budgetFamily: BudgetFamilyFragment,

--- a/src/components/Reports/GoalCalculator/SharedComponents/ExpensesStep/ExpensesStep.tsx
+++ b/src/components/Reports/GoalCalculator/SharedComponents/ExpensesStep/ExpensesStep.tsx
@@ -3,10 +3,10 @@ import { getPrimaryCategoryRightPanel } from '../../RightPanels/rightPanels';
 import { BudgetFamilyFragment } from '../../Shared/GoalCalculation.generated';
 import { GoalCalculatorLayout } from '../../Shared/GoalCalculatorLayout';
 import { GoalCalculatorSection } from '../../Shared/GoalCalculatorSection';
+import { getFamilySections } from '../../Shared/familySections';
 import { GoalCalculatorGrid } from '../GoalCalculatorGrid/GoalCalculatorGrid';
 import { SectionList } from '../SectionList';
 import { SectionPage } from '../SectionPage';
-import { getFamilySections } from './familySections';
 
 interface ExpensesStepProps {
   instructions: React.ReactNode;


### PR DESCRIPTION
## Description

Instead of using a static list, populate the settings sidebar with the categories in the "special" family. #1421 has already updated the settings page to render the tables for the special family's categories.

MPDX-8798

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
