### PR TITLE
[no-Jira] Remove accountId argument from reportsStaffExpenses

### DIFF
--- a/pages/accountLists/[accountListId]/reports/mpgaIncomeExpenses/index.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/mpgaIncomeExpenses/index.page.tsx
@@ -51,7 +51,6 @@ const MPGAReportPage: React.FC = () => {
             leftWidth="290px"
             mainContent={
               <MPGAIncomeExpensesReport
-                accountId={'1000000001'}
                 isNavListOpen={isNavListOpen}
                 onNavListToggle={handleNavListToggle}
                 title={t('Ministry Partner Giving Analysis')}

--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.test.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.test.tsx
@@ -16,14 +16,12 @@ const title = 'MPGA Report';
 
 const mockData = {
   ReportsStaffExpenses: {
-    __typename: 'Query',
     reportsStaffExpenses: {
-      __typename: 'StaffExpenses',
       accountId: '12345',
       name: 'Test Account',
     },
   },
-} as const;
+};
 
 const TestComponent: React.FC = () => (
   <ThemeProvider theme={theme}>
@@ -35,7 +33,6 @@ const TestComponent: React.FC = () => (
         onCall={mutationSpy}
       >
         <MPGAIncomeExpensesReport
-          accountId="12345"
           onNavListToggle={onNavListToggle}
           isNavListOpen={true}
           title={title}

--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
@@ -31,7 +31,6 @@ import { AllData } from './mockData';
 import { PrintOnly, StyledHeaderBox } from './styledComponents';
 
 interface MPGAIncomeExpensesReportProps {
-  accountId: string;
   isNavListOpen: boolean;
   onNavListToggle: () => void;
   title: string;
@@ -39,7 +38,7 @@ interface MPGAIncomeExpensesReportProps {
 
 export const MPGAIncomeExpensesReport: React.FC<
   MPGAIncomeExpensesReportProps
-> = ({ accountId, title, isNavListOpen, onNavListToggle }) => {
+> = ({ title, isNavListOpen, onNavListToggle }) => {
   const { t } = useTranslation();
   const locale = useLocale();
   const currency = 'USD';
@@ -55,7 +54,6 @@ export const MPGAIncomeExpensesReport: React.FC<
 
   const { data: reportData } = useReportsStaffExpensesQuery({
     variables: {
-      accountId: accountId,
       fundTypes: [FundTypes.Primary],
       startMonth: start,
       endMonth: end,

--- a/src/components/Reports/MPGAIncomeExpensesReport/ReportsStaffExpenses.graphql
+++ b/src/components/Reports/MPGAIncomeExpensesReport/ReportsStaffExpenses.graphql
@@ -1,11 +1,9 @@
 query ReportsStaffExpenses(
-  $accountId: ID!
   $fundTypes: [String!]
   $startMonth: ISO8601Date
   $endMonth: ISO8601Date
 ) {
   reportsStaffExpenses(
-    accountId: $accountId
     fundTypes: $fundTypes
     startMonth: $startMonth
     endMonth: $endMonth


### PR DESCRIPTION
## Description

Remove the `accountId` argument from `reportsStaffExpenses`. Should be merged immediately after https://github.com/CruGlobal/mpdx_api/pull/2994.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
