### PR TITLE
MPDX-8807 Use staff account query in reports

### DIFF
--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.test.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.test.tsx
@@ -17,7 +17,7 @@ const title = 'MPGA Report';
 const mockData = {
   StaffAccount: {
     staffAccount: {
-      accountId: '12345',
+      id: '12345',
       name: 'Test Account',
     },
   },

--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.test.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.test.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from 'src/theme';
 import { MPGAIncomeExpensesReport } from './MPGAIncomeExpensesReport';
-import { ReportsStaffExpensesQuery } from './ReportsStaffExpenses.generated';
+import { StaffAccountQuery } from './ReportsStaffExpenses.generated';
 
 const mutationSpy = jest.fn();
 const onNavListToggle = jest.fn();
@@ -15,8 +15,8 @@ const onNavListToggle = jest.fn();
 const title = 'MPGA Report';
 
 const mockData = {
-  ReportsStaffExpenses: {
-    reportsStaffExpenses: {
+  StaffAccount: {
+    staffAccount: {
       accountId: '12345',
       name: 'Test Account',
     },
@@ -27,7 +27,7 @@ const TestComponent: React.FC = () => (
   <ThemeProvider theme={theme}>
     <LocalizationProvider dateAdapter={AdapterLuxon}>
       <GqlMockedProvider<{
-        ReportsStaffExpenses: ReportsStaffExpensesQuery;
+        StaffAccount: StaffAccountQuery;
       }>
         mocks={mockData}
         onCall={mutationSpy}

--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.test.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.test.tsx
@@ -6,8 +6,8 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from 'src/theme';
+import { StaffAccountQuery } from '../StaffAccount.generated';
 import { MPGAIncomeExpensesReport } from './MPGAIncomeExpensesReport';
-import { StaffAccountQuery } from './ReportsStaffExpenses.generated';
 
 const mutationSpy = jest.fn();
 const onNavListToggle = jest.fn();

--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
@@ -16,6 +16,7 @@ import {
 import { useFilteredFunds } from 'src/hooks/useFilteredFunds';
 import { useGetLastTwelveMonths } from 'src/hooks/useGetLastTwelveMonths';
 import { useLocale } from 'src/hooks/useLocale';
+import { useStaffAccountQuery } from '../StaffAccount.generated';
 import {
   SimplePrintOnly,
   SimpleScreenOnly,
@@ -25,10 +26,7 @@ import { PrintOnlyReport } from './DisplayModes/PrintOnlyReport';
 import { ScreenOnlyReport } from './DisplayModes/ScreenOnlyReport';
 import { FundTypes } from './Helper/MPGAReportEnum';
 import { convertMonths } from './Helper/convertMonths';
-import {
-  useReportsStaffExpensesQuery,
-  useStaffAccountQuery,
-} from './ReportsStaffExpenses.generated';
+import { useReportsStaffExpensesQuery } from './ReportsStaffExpenses.generated';
 import { TotalsProvider } from './TotalsContext/TotalsContext';
 import { AllData } from './mockData';
 import { PrintOnly, StyledHeaderBox } from './styledComponents';
@@ -55,9 +53,7 @@ export const MPGAIncomeExpensesReport: React.FC<
   const start = convertMonths(last12Months[0], locale);
   const end = DateTime.now().toISODate();
 
-  const { data: staffAccountData } = useStaffAccountQuery({
-    variables: {},
-  });
+  const { data: staffAccountData } = useStaffAccountQuery();
 
   const { data: reportData } = useReportsStaffExpensesQuery({
     variables: {

--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
@@ -25,7 +25,10 @@ import { PrintOnlyReport } from './DisplayModes/PrintOnlyReport';
 import { ScreenOnlyReport } from './DisplayModes/ScreenOnlyReport';
 import { FundTypes } from './Helper/MPGAReportEnum';
 import { convertMonths } from './Helper/convertMonths';
-import { useReportsStaffExpensesQuery } from './ReportsStaffExpenses.generated';
+import {
+  useReportsStaffExpensesQuery,
+  useStaffAccountQuery,
+} from './ReportsStaffExpenses.generated';
 import { TotalsProvider } from './TotalsContext/TotalsContext';
 import { AllData } from './mockData';
 import { PrintOnly, StyledHeaderBox } from './styledComponents';
@@ -51,6 +54,10 @@ export const MPGAIncomeExpensesReport: React.FC<
 
   const start = convertMonths(last12Months[0], locale);
   const end = DateTime.now().toISODate();
+
+  const { data: staffAccountData } = useStaffAccountQuery({
+    variables: {},
+  });
 
   const { data: reportData } = useReportsStaffExpensesQuery({
     variables: {
@@ -122,9 +129,9 @@ export const MPGAIncomeExpensesReport: React.FC<
               </SimpleScreenOnly>
             </StyledHeaderBox>
             <Box display="flex" flexDirection="row" gap={3} mb={2}>
-              <Typography>{reportData?.reportsStaffExpenses.name}</Typography>
+              <Typography>{staffAccountData?.staffAccount?.name}</Typography>
               <Typography>
-                {reportData?.reportsStaffExpenses.accountId}
+                {staffAccountData?.staffAccount?.accountId}
               </Typography>
             </Box>
           </Container>

--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
@@ -126,9 +126,7 @@ export const MPGAIncomeExpensesReport: React.FC<
             </StyledHeaderBox>
             <Box display="flex" flexDirection="row" gap={3} mb={2}>
               <Typography>{staffAccountData?.staffAccount?.name}</Typography>
-              <Typography>
-                {staffAccountData?.staffAccount?.accountId}
-              </Typography>
+              <Typography>{staffAccountData?.staffAccount?.id}</Typography>
             </Box>
           </Container>
         </Box>

--- a/src/components/Reports/MPGAIncomeExpensesReport/ReportsStaffExpenses.graphql
+++ b/src/components/Reports/MPGAIncomeExpensesReport/ReportsStaffExpenses.graphql
@@ -1,3 +1,11 @@
+query StaffAccount {
+  staffAccount {
+    accountId
+    name
+    status
+  }
+}
+
 query ReportsStaffExpenses(
   $fundTypes: [String!]
   $startMonth: ISO8601Date
@@ -8,7 +16,6 @@ query ReportsStaffExpenses(
     startMonth: $startMonth
     endMonth: $endMonth
   ) {
-    accountId
     funds {
       categories {
         averagePerMonth
@@ -31,7 +38,5 @@ query ReportsStaffExpenses(
       fundType
       total
     }
-    name
-    status
   }
 }

--- a/src/components/Reports/MPGAIncomeExpensesReport/ReportsStaffExpenses.graphql
+++ b/src/components/Reports/MPGAIncomeExpensesReport/ReportsStaffExpenses.graphql
@@ -1,11 +1,3 @@
-query StaffAccount {
-  staffAccount {
-    accountId
-    name
-    status
-  }
-}
-
 query ReportsStaffExpenses(
   $fundTypes: [String!]
   $startMonth: ISO8601Date

--- a/src/components/Reports/SavingsFundTransfer/IntroPage/IntroPage.tsx
+++ b/src/components/Reports/SavingsFundTransfer/IntroPage/IntroPage.tsx
@@ -17,6 +17,7 @@ import {
   HeaderTypeEnum,
   MultiPageHeader,
 } from 'src/components/Shared/MultiPageLayout/MultiPageHeader';
+import { useAccountListId } from 'src/hooks/useAccountListId';
 import {
   StaffSavingFundContext,
   StaffSavingFundType,
@@ -37,10 +38,11 @@ export const SavingsFundTransfer: React.FC<SavingsFundTransferProps> = ({
   title,
 }) => {
   const { t } = useTranslation();
-  const { accountListId, isNavListOpen, onNavListToggle } = useContext(
+  const { isNavListOpen, onNavListToggle } = useContext(
     StaffSavingFundContext,
   ) as StaffSavingFundType;
 
+  const accountListId = useAccountListId();
   const transferLink = `/accountLists/${accountListId}/reports/staffSavingFund/transfers`;
 
   return (

--- a/src/components/Reports/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
+++ b/src/components/Reports/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
@@ -22,7 +22,7 @@ const onNavListToggle = jest.fn();
 const mockStaffAccount = {
   StaffAccount: {
     staffAccount: {
-      accountId: '12345',
+      id: '12345',
       name: 'Test Account',
     },
   },
@@ -99,7 +99,7 @@ describe('TransfersPage', () => {
       await findByText(mockStaffAccount.StaffAccount.staffAccount.name),
     ).toBeInTheDocument();
     expect(
-      await findByText(mockStaffAccount.StaffAccount.staffAccount.accountId),
+      await findByText(mockStaffAccount.StaffAccount.staffAccount.id),
     ).toBeInTheDocument();
   });
 

--- a/src/components/Reports/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
+++ b/src/components/Reports/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
@@ -28,13 +28,6 @@ const mockStaffAccount = {
   },
 };
 
-const router = {
-  query: {
-    accountListId: mockStaffAccount.StaffAccount.staffAccount.accountId,
-  },
-  isReady: true,
-};
-
 const MockStaffSavingFundProvider = ({
   children,
 }: {
@@ -69,7 +62,7 @@ const Components = ({
   <SnackbarProvider>
     <ThemeProvider theme={theme}>
       <LocalizationProvider dateAdapter={AdapterLuxon}>
-        <TestRouter router={router}>
+        <TestRouter>
           <I18nextProvider i18n={i18n}>
             <GqlMockedProvider<{
               StaffAccount: StaffAccountQuery;

--- a/src/components/Reports/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
+++ b/src/components/Reports/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
@@ -15,6 +15,7 @@ import {
   MultiPageHeader,
 } from 'src/components/Shared/MultiPageLayout/MultiPageHeader';
 import theme from 'src/theme';
+import { useStaffAccountQuery } from '../../StaffAccount.generated';
 import {
   StaffSavingFundContext,
   StaffSavingFundType,
@@ -52,6 +53,8 @@ export const TransfersPage: React.FC<TransfersPageProps> = ({ title }) => {
   const { isNavListOpen, onNavListToggle } = useContext(
     StaffSavingFundContext,
   ) as StaffSavingFundType;
+
+  const { data: staffAccountData } = useStaffAccountQuery();
 
   const handlePrint = () => window.print();
 
@@ -122,8 +125,10 @@ export const TransfersPage: React.FC<TransfersPageProps> = ({ title }) => {
                 mb: 2,
               }}
             >
-              <Typography>{mockData.accountName}</Typography>
-              <Typography>{mockData.accountListId}</Typography>
+              <Typography>{staffAccountData?.staffAccount?.name}</Typography>
+              <Typography>
+                {staffAccountData?.staffAccount?.accountId}
+              </Typography>
             </Box>
             <Box
               display="flex"

--- a/src/components/Reports/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
+++ b/src/components/Reports/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
@@ -126,9 +126,7 @@ export const TransfersPage: React.FC<TransfersPageProps> = ({ title }) => {
               }}
             >
               <Typography>{staffAccountData?.staffAccount?.name}</Typography>
-              <Typography>
-                {staffAccountData?.staffAccount?.accountId}
-              </Typography>
+              <Typography>{staffAccountData?.staffAccount?.id}</Typography>
             </Box>
             <Box
               display="flex"

--- a/src/components/Reports/SavingsFundTransfer/mockData.ts
+++ b/src/components/Reports/SavingsFundTransfer/mockData.ts
@@ -42,15 +42,11 @@ export interface TransferHistory {
 }
 
 interface MockData {
-  accountListId: string;
-  accountName: string;
   funds: Fund[];
   history: TransferHistory[];
 }
 
 export const mockData: MockData = {
-  accountListId: '123456789',
-  accountName: 'Test Account',
   funds: [
     {
       accountId: 'staffAccount',

--- a/src/components/Reports/StaffAccount.graphql
+++ b/src/components/Reports/StaffAccount.graphql
@@ -1,6 +1,6 @@
 query StaffAccount {
   staffAccount {
-    accountId
+    id
     name
     status
   }

--- a/src/components/Reports/StaffAccount.graphql
+++ b/src/components/Reports/StaffAccount.graphql
@@ -1,0 +1,7 @@
+query StaffAccount {
+  staffAccount {
+    accountId
+    name
+    status
+  }
+}

--- a/src/components/Reports/StaffSavingFund/StaffSavingFundContext.tsx
+++ b/src/components/Reports/StaffSavingFund/StaffSavingFundContext.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { useAccountListId } from 'src/hooks/useAccountListId';
 
 export type StaffSavingFundType = {
   accountListId?: string;
@@ -16,7 +15,6 @@ interface Props {
 }
 
 export const StaffSavingFundProvider: React.FC<Props> = ({ children }) => {
-  const accountListId = useAccountListId();
   const [isNavListOpen, setIsNavListOpen] = useState(false);
 
   const onNavListToggle = useCallback(() => {
@@ -25,11 +23,10 @@ export const StaffSavingFundProvider: React.FC<Props> = ({ children }) => {
 
   const contextValue = useMemo(
     () => ({
-      accountListId,
       isNavListOpen,
       onNavListToggle,
     }),
-    [accountListId, isNavListOpen, onNavListToggle],
+    [isNavListOpen, onNavListToggle],
   );
 
   return (

--- a/src/components/Reports/StaffSavingFund/StaffSavingFundContext.tsx
+++ b/src/components/Reports/StaffSavingFund/StaffSavingFundContext.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
 export type StaffSavingFundType = {
+  accountListId?: string;
   isNavListOpen: boolean;
   onNavListToggle: () => void;
 };

--- a/src/components/Reports/StaffSavingFund/StaffSavingFundContext.tsx
+++ b/src/components/Reports/StaffSavingFund/StaffSavingFundContext.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
 export type StaffSavingFundType = {
-  accountListId?: string;
   isNavListOpen: boolean;
   onNavListToggle: () => void;
 };

--- a/src/components/Reports/StaffSavingFund/StaffSavingFundLayout.tsx
+++ b/src/components/Reports/StaffSavingFund/StaffSavingFundLayout.tsx
@@ -40,7 +40,7 @@ export const StaffSavingFundLayout: React.FC<StaffSavingFundLayoutProps> = ({
       <Head>
         <title>{`${pageTitle}`}</title>
       </Head>
-      {staffAccountData?.staffAccount?.accountId ? (
+      {staffAccountData?.staffAccount?.id ? (
         <StaffSavingFundPageWrapper>
           <SidePanelsLayout
             isScrollBox={false}

--- a/src/components/Reports/StaffSavingFund/StaffSavingFundLayout.tsx
+++ b/src/components/Reports/StaffSavingFund/StaffSavingFundLayout.tsx
@@ -8,6 +8,7 @@ import {
   MultiPageMenu,
   NavTypeEnum,
 } from 'src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu';
+import { useStaffAccountQuery } from '../StaffAccount.generated';
 import {
   StaffSavingFundContext,
   StaffSavingFundType,
@@ -28,16 +29,18 @@ export const StaffSavingFundLayout: React.FC<StaffSavingFundLayoutProps> = ({
   selectedMenuId,
   children,
 }) => {
-  const { accountListId, isNavListOpen, onNavListToggle } = useContext(
+  const { isNavListOpen, onNavListToggle } = useContext(
     StaffSavingFundContext,
   ) as StaffSavingFundType;
+
+  const { data: staffAccountData } = useStaffAccountQuery();
 
   return (
     <>
       <Head>
         <title>{`${pageTitle}`}</title>
       </Head>
-      {accountListId ? (
+      {staffAccountData?.staffAccount?.accountId ? (
         <StaffSavingFundPageWrapper>
           <SidePanelsLayout
             isScrollBox={false}

--- a/src/hooks/useFilteredFunds.test.ts
+++ b/src/hooks/useFilteredFunds.test.ts
@@ -4,9 +4,6 @@ import { useFilteredFunds } from './useFilteredFunds';
 
 const mockData: ReportsStaffExpensesQuery = {
   reportsStaffExpenses: {
-    accountId: '123',
-    name: 'Example Report',
-    status: 'active',
     funds: [
       {
         categories: [


### PR DESCRIPTION
## Description

`staffAccount` is a query that will return a staff account's **id**, **name**, and **status**. This query will be used to fetch this information instead of pulling it from the report queries. This PR will address the MPGA Monthly Income Expenses and Savings Fund Transfer reports. It should also include updating the Staff Expenses report, however, that is in a separate PR.

Staff Expenses: [#1375](https://github.com/CruGlobal/mpdx-react/pull/1375) 

**Waiting for PR to merge**
Depends on: [MPDX-8801](https://github.com/CruGlobal/mpdx_api/pull/2995)

Urls:
MPGA: `/reports/mpgaIncomeExpenses`
Savings Fund: `/reports/staffSavingFund`

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [ ] I have requested a review from another person on the project
