### PR TITLE
[no-Jira] Run prettier on ignored gql codegen files

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -53,5 +53,5 @@ generates:
       - ./extractRootFields.js
 hooks:
   afterAllFileWrite:
-    - prettier --write
+    - prettier --write --ignore-path=""
     - node deleteStaleFiles.mjs

--- a/src/components/Tool/FixSendNewsletter/FixSendNewsletter.test.tsx
+++ b/src/components/Tool/FixSendNewsletter/FixSendNewsletter.test.tsx
@@ -277,32 +277,11 @@ describe('FixSendNewsletter', () => {
     });
 
     it('should successfully update all the contacts', async () => {
-      let cardinality = 0;
       const mutationSpy = jest.fn();
       const { getAllByRole, getByRole, queryByRole, getByText } = render(
         <TestComponent
           mocks={{
-            InvalidNewsletter: () => {
-              let queryResult;
-              if (cardinality === 0) {
-                queryResult = {
-                  ...mockInvalidNewslettersResponse.InvalidNewsletter,
-                };
-              } else {
-                queryResult = {
-                  contacts: {
-                    nodes: [
-                      {
-                        ...mockInvalidNewslettersResponse.InvalidNewsletter
-                          .contacts.nodes[2],
-                      },
-                    ],
-                  },
-                };
-              }
-              cardinality++;
-              return queryResult;
-            },
+            InvalidNewsletter: mockInvalidNewslettersResponse.InvalidNewsletter,
             MassActionsUpdateContacts:
               mockMassActionsUpdateContactsData.MassActionsUpdateContacts,
           }}

--- a/src/components/Tool/FixSendNewsletter/FixSendNewsletter.test.tsx
+++ b/src/components/Tool/FixSendNewsletter/FixSendNewsletter.test.tsx
@@ -327,7 +327,7 @@ describe('FixSendNewsletter', () => {
             attributes: [
               {
                 id: 'contactId3',
-                sendNewsletter: SendNewsletterEnum.None,
+                sendNewsletter: SendNewsletterEnum.Email,
               },
               {
                 id: 'contactId1',


### PR DESCRIPTION
## Description

I noticed that upgrading prettier to v3 in #1420 stopped formatting our files generated by gql-codegen. v3 apparently respects `.prettierignore` even when paths are manually specified. We have to disable `.prettierignore` by passing `--ignore-path=""`.

## Testing

* Run `yarn gql`
* Find any `.generated.ts` file
* Check whether it has been  has been formatted with `prettier` (a missing trailing newline is evidence that it was **not** formatted)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
