### PR TITLE
MPDX 8825 subcategory right panels

### DIFF
--- a/src/components/Reports/GoalCalculator/GoalCalculatorTestWrapper.tsx
+++ b/src/components/Reports/GoalCalculator/GoalCalculatorTestWrapper.tsx
@@ -4,7 +4,10 @@ import { SnackbarProvider } from 'notistack';
 import { DeepPartial } from 'ts-essentials';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import { PrimaryBudgetCategoryEnum } from 'src/graphql/types.generated';
+import {
+  PrimaryBudgetCategoryEnum,
+  SubBudgetCategoryEnum,
+} from 'src/graphql/types.generated';
 import theme from 'src/theme';
 import { GoalCalculationQuery } from './Shared/GoalCalculation.generated';
 import { GoalCalculatorProvider } from './Shared/GoalCalculatorContext';
@@ -19,24 +22,56 @@ export const goalCalculationMock = {
     ministryFamily: {
       primaryBudgetCategories: [
         {
+          id: 'category-ministry',
           label: 'Ministry & Medical Mileage',
           category: PrimaryBudgetCategoryEnum.MinistryAndMedicalMileage,
+          directInput: 0,
+          subBudgetCategories: [],
         },
         {
+          id: 'category-transfers',
           label: 'Account Transfers',
           category: PrimaryBudgetCategoryEnum.AccountTransfers,
+          directInput: 0,
+          subBudgetCategories: [],
+        },
+        {
+          id: 'category-1',
+          label: 'Internet & Mobile',
+          category: PrimaryBudgetCategoryEnum.Utilities,
+          directInput: null, // null means Line Item mode, which shows subcategories
+          subBudgetCategories: [
+            {
+              id: 'sub-1',
+              label: 'Internet',
+              amount: 60,
+              category: SubBudgetCategoryEnum.UtilitiesInternet,
+            },
+            {
+              id: 'sub-2',
+              label: 'Phone/Mobile',
+              amount: 40,
+              category: SubBudgetCategoryEnum.UtilitiesPhoneMobile,
+            },
+          ],
         },
       ],
     },
     specialFamily: {
       primaryBudgetCategories: [
         {
+          id: 'category-special',
           label: 'Special Income',
           category: PrimaryBudgetCategoryEnum.SpecialIncome,
+          directInput: 0,
+          subBudgetCategories: [],
         },
         {
+          id: 'category-goal',
           label: 'One Time Goal',
           category: PrimaryBudgetCategoryEnum.OneTimeGoal,
+          directInput: 0,
+          subBudgetCategories: [],
         },
       ],
     },

--- a/src/components/Reports/GoalCalculator/RightPanels/SubUtilitiesPanel.tsx
+++ b/src/components/Reports/GoalCalculator/RightPanels/SubUtilitiesPanel.tsx
@@ -3,15 +3,13 @@ import { Alert } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { RightPanel } from './RightPanel';
 
-export const UtilitiesPanel: React.FC = () => {
+export const SubUtilitiesPanel: React.FC = () => {
   const { t } = useTranslation();
 
   return (
-    <RightPanel title={t('Utilities')}>
+    <RightPanel title={t('Internet and Mobile Expenses')}>
       <Alert severity="warning">
-        {t(
-          'For mobile phone and internet expenses, only include the portion not reimbursed as a ministry expense.',
-        )}
+        {t('Only the portion not reimbursed as ministry expense.')}
       </Alert>
     </RightPanel>
   );

--- a/src/components/Reports/GoalCalculator/RightPanels/rightPanels.tsx
+++ b/src/components/Reports/GoalCalculator/RightPanels/rightPanels.tsx
@@ -1,22 +1,35 @@
 import React from 'react';
-import { PrimaryBudgetCategoryEnum } from 'src/graphql/types.generated';
+import {
+  PrimaryBudgetCategoryEnum,
+  SubBudgetCategoryEnum,
+} from 'src/graphql/types.generated';
 import { MedicalPanel } from './MedicalPanel';
 import { MileagePanel } from './MileagePanel';
 import { SavingsPanel } from './SavingsPanel';
-import { UtilitiesPanel } from './UtilitiesPanel';
+import { SubUtilitiesPanel } from './SubUtilitiesPanel';
 
 export const getPrimaryCategoryRightPanel = (
   category: PrimaryBudgetCategoryEnum,
 ) => {
   switch (category) {
-    case PrimaryBudgetCategoryEnum.Saving:
-      return <SavingsPanel />;
-    case PrimaryBudgetCategoryEnum.Utilities:
-      return <UtilitiesPanel />;
     case PrimaryBudgetCategoryEnum.Medical:
       return <MedicalPanel />;
     case PrimaryBudgetCategoryEnum.MinistryAndMedicalMileage:
       return <MileagePanel />;
+    default:
+      return null;
+  }
+};
+
+export const getSubCategoryRightPanel = (
+  subCategory: SubBudgetCategoryEnum,
+) => {
+  switch (subCategory) {
+    case SubBudgetCategoryEnum.UtilitiesInternet:
+    case SubBudgetCategoryEnum.UtilitiesPhoneMobile:
+      return <SubUtilitiesPanel />;
+    case SubBudgetCategoryEnum.SavingEmergencyFund:
+      return <SavingsPanel />;
     default:
       return null;
   }

--- a/src/components/Reports/GoalCalculator/SharedComponents/GoalCalculatorGrid/GoalCalculatorGrid.tsx
+++ b/src/components/Reports/GoalCalculator/SharedComponents/GoalCalculatorGrid/GoalCalculatorGrid.tsx
@@ -3,6 +3,7 @@ import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import DoNotDisturbAltIcon from '@mui/icons-material/DoNotDisturbAlt';
 import FunctionsIcon from '@mui/icons-material/Functions';
+import InfoIcon from '@mui/icons-material/Info';
 import ViewHeadlineIcon from '@mui/icons-material/ViewHeadline';
 import {
   Box,
@@ -10,6 +11,7 @@ import {
   ButtonGroup,
   Card,
   FormHelperText,
+  IconButton,
   TextField,
   Typography,
   styled,
@@ -22,12 +24,17 @@ import {
 } from '@mui/x-data-grid';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { SubBudgetCategoryEnum } from 'src/graphql/types.generated';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useDebouncedCallback } from 'src/hooks/useDebounce';
 import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat } from 'src/lib/intlFormat';
-import { getPrimaryCategoryRightPanel } from '../../RightPanels/rightPanels';
+import {
+  getPrimaryCategoryRightPanel,
+  getSubCategoryRightPanel,
+} from '../../RightPanels/rightPanels';
 import { BudgetFamilyFragment } from '../../Shared/GoalCalculation.generated';
+import { useGoalCalculator } from '../../Shared/GoalCalculatorContext';
 import { GoalCalculatorSection } from '../../Shared/GoalCalculatorSection';
 import {
   UpdateSubBudgetCategoriesFragment,
@@ -83,6 +90,7 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
   const locale = useLocale();
   const { label: categoryName } = category;
   const accountListId = useAccountListId() ?? '';
+  const { setRightPanelContent } = useGoalCalculator();
 
   const gridData = useMemo(
     () =>
@@ -91,6 +99,7 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
         label: subCategory.label,
         amount: subCategory.amount,
         canDelete: !subCategory.category,
+        category: subCategory.category,
       })),
     [category.subBudgetCategories],
   );
@@ -338,14 +347,26 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
   };
 
   const renderLabelCell = (params: GridRenderCellParams) => {
-    const cellKey = `${params.id}-label`;
-    const hasError = cellErrors[cellKey];
+    const rowCategory = params.row.category as SubBudgetCategoryEnum | null;
+    const rightPanelContent = rowCategory
+      ? getSubCategoryRightPanel(rowCategory)
+      : null;
 
-    if (hasError) {
-      return <ErrorCell title={hasError}>{params.value}</ErrorCell>;
-    }
+    const content = (
+      <Box sx={{ display: 'flex', gap: 1 }}>
+        <span>{params.value}</span>
+        {rightPanelContent && (
+          <IconButton
+            onClick={() => setRightPanelContent(rightPanelContent)}
+            aria-label={t('Show additional info')}
+          >
+            <InfoIcon fontSize="small" />
+          </IconButton>
+        )}
+      </Box>
+    );
 
-    return params.value;
+    return content;
   };
 
   const renderAmountCell = (params: GridRenderCellParams) => {


### PR DESCRIPTION

## Description
Jira ticket available [here]([MPDX-8825](https://jira.cru.org/browse/MPDX-8825))

A couple of subcategory line items have right panel help text. Consult the Google Sheet, but I see "Total Saving > Emergency Fund", "Total Utilities > Phone/Mobile", and "Total Utilities > Internet". We need to add an icon to those categories in the DataGrid, that opens up help text in a right panel.

I would add a `getSubCategoryRightPanel` method like we already have for `
getPrimaryCategoryRightPanel` to make it easy to define the sub category help text all in one place.

MPDX-8825

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
