### PR TITLE
[no-Jira] Reduce `yarn gql` retry attempts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           command: yarn gql
           timeout_minutes: 1
           retry_wait_seconds: 60
-          max_attempts: 5
+          max_attempts: 2
       - name: 🧪 Test (chunk ${{ matrix.chunk }})
         run: yarn test:coverage --ci --shard ${{ matrix.chunk }}
       - name: Codecov
@@ -62,7 +62,7 @@ jobs:
           command: yarn gql
           timeout_minutes: 1
           retry_wait_seconds: 60
-          max_attempts: 5
+          max_attempts: 2
       - name: 💨 ESLint
         run: yarn lint:ci
 
@@ -84,7 +84,7 @@ jobs:
           command: yarn gql
           timeout_minutes: 1
           retry_wait_seconds: 60
-          max_attempts: 5
+          max_attempts: 2
       - name: ✅ TypeScript lint
         run: yarn lint:ts
 
@@ -149,7 +149,7 @@ jobs:
           command: yarn gql
           timeout_minutes: 1
           retry_wait_seconds: 60
-          max_attempts: 5
+          max_attempts: 2
       - name: Build Next.js app
         run: yarn build
         env:


### PR DESCRIPTION
## Description

Reduce the number of attempts to retry `gql codegen`. My experience is that if it fails once, it will usually fail all 5 times for some reason. Retrying 5 times make it take longer before the job fails and I can rerun it.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
