### PR TITLE
[no-Jira] Make "Staging API" run codegen against the staging API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,22 @@ on:
   push:
     branches: [main]
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
   workflow_dispatch:
 
 env:
-  # Use production API for codegen to make sure production is compatible with the code to be merged
-  API_URL: 'https://api.mpdx.org/graphql'
-  SITE_URL: 'http://stage.mpdx.org'
+  # Normally, we want to use production API for codegen to make sure production is compatible with
+  # the code to be merged. However, sometimes GraphQL queries or mutations are only available in
+  # staging and haven't been merged to production yet. In that case, we still want CI to run, but
+  # we don't want to let the PR be merged yet. If the "Staging API" label is added to the PR, we
+  # run codegen against the staging API instead of the production API and block the PR from merging.
+  API_URL: ${{ contains(github.event.pull_request.labels.*.name, 'Staging API') && 'https://api.stage.mpdx.org/graphql' || 'https://api.mpdx.org/graphql' }}
+  SITE_URL: http://stage.mpdx.org
 
 jobs:
   test:
@@ -161,3 +171,11 @@ jobs:
         env:
           # This secret is automatically injected by GitHub
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  staging-api-block:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Staging API')
+    steps:
+      - run: |
+          echo "PR cannot be merged until Staging API label is removed"
+          exit 1


### PR DESCRIPTION
## Description

It is common for UI PRs to be dependent on an API PR that is in staging, but not in production. In CI, our GraphQL codegen tasks target production to ensure that we don't merge code that depends on GraphQL APIs not yet available in staging. But when the API PR is still in staging, that makes all of our CI checks fail immediately before we get a chance to see whether our tests pass or whether the PR has lint errors.

This PR introduces a "Staging API" label for PRs that are using GraphQL APIs only available in staging. It makes CI run GraphQL codegen against the staging GraphQL API so we can see if our tests pass, but it also prevents those PRs from merging with the Staging API label. Once the API PR is in production, developers should remove the "Staging API" to unblock merging.

**Important note**: before this PR merges, we will need to make the "Staging API Protection Check" check required in Terraform to ensure that PRs with the "Staging API" label don't merge to production

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels. (_Add the label "On Staging" to get the branch automatically merged into staging._)
- [x] I have requested a review from another person on the project
