### PR TITLE
MPDX-9327 - Add error handling to duplicate request mutation in CurrentBoardApproved

### DIFF
--- a/src/components/Reports/MinisterHousingAllowance/MinisterHousingAllowance.tsx
+++ b/src/components/Reports/MinisterHousingAllowance/MinisterHousingAllowance.tsx
@@ -181,7 +181,10 @@ export const MinisterHousingAllowanceReport = () => {
               )}
               {showPreviousRequests && (
                 <Stack direction="column" width={mainContentWidth} mt={4}>
-                  <CurrentBoardApproved request={previousApprovedRequest} />
+                  <CurrentBoardApproved
+                    request={previousApprovedRequest}
+                    hasOpenRequest={isCurrentRequestPending}
+                  />
                 </Stack>
               )}
             </>

--- a/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.test.tsx
+++ b/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.test.tsx
@@ -41,6 +41,7 @@ interface TestComponentProps {
   mocks?: DeepPartial<{
     DuplicateMinistryHousingAllowanceRequest: DuplicateMinistryHousingAllowanceRequestMutation;
   }>;
+  hasOpenRequest?: boolean;
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({
@@ -48,6 +49,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
   request,
   router = {},
   mocks,
+  hasOpenRequest,
 }) => {
   const approvedMHARequest = request ?? {
     ...mockMHARequest,
@@ -73,7 +75,10 @@ const TestComponent: React.FC<TestComponentProps> = ({
           <MinisterHousingAllowanceContext.Provider
             value={contextValue as ContextType}
           >
-            <CurrentBoardApproved request={approvedMHARequest} />
+            <CurrentBoardApproved
+              request={approvedMHARequest}
+              hasOpenRequest={hasOpenRequest}
+            />
           </MinisterHousingAllowanceContext.Provider>
         </GqlMockedProvider>
       </TestRouter>
@@ -184,5 +189,14 @@ describe('CurrentBoardApproved Component', () => {
         `/accountLists/account-list-1/reports/housingAllowance/${newRequestId}?mode=edit`,
       );
     });
+  });
+
+  it('should hide Update Current MHA button when there is an open request', () => {
+    const { queryByText, getByText } = render(
+      <TestComponent hasOpenRequest />,
+    );
+
+    expect(getByText('View Current MHA')).toBeInTheDocument();
+    expect(queryByText('Update Current MHA')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.test.tsx
+++ b/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.test.tsx
@@ -192,9 +192,7 @@ describe('CurrentBoardApproved Component', () => {
   });
 
   it('should hide Update Current MHA button when there is an open request', () => {
-    const { queryByText, getByText } = render(
-      <TestComponent hasOpenRequest />,
-    );
+    const { queryByText, getByText } = render(<TestComponent hasOpenRequest />);
 
     expect(getByText('View Current MHA')).toBeInTheDocument();
     expect(queryByText('Update Current MHA')).not.toBeInTheDocument();

--- a/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.test.tsx
+++ b/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.test.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { GraphQLError } from 'graphql';
+import { DeepPartial } from 'ts-essentials';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from 'src/theme';
-import { DuplicateMinistryHousingAllowanceRequestMutation } from '../MinisterHousingAllowance.generated';
+import {
+  DuplicateMinistryHousingAllowanceRequestDocument,
+  DuplicateMinistryHousingAllowanceRequestMutation,
+} from '../MinisterHousingAllowance.generated';
 import {
   ContextType,
   HcmData,
@@ -17,19 +23,40 @@ import { CurrentBoardApproved } from './CurrentBoardApproved';
 const newRequestId = 'new-request-id';
 const mutationSpy = jest.fn();
 const mockPush = jest.fn();
+
+const singleContext: Partial<ContextType> = {
+  isMarried: false,
+  preferredName: 'John',
+  spousePreferredName: '',
+  userHcmData: {
+    staffInfo: {
+      personNumber: '000123456',
+    },
+  } as unknown as HcmData,
+  spouseHcmData: null,
+};
+
 interface TestComponentProps {
-  contextValue: Partial<ContextType>;
+  contextValue?: Partial<ContextType>;
+  request?: typeof mockMHARequest;
   router?: {
     push?: jest.Mock;
     query?: { accountListId?: string };
   };
+  mocks?: DeepPartial<{
+    DuplicateMinistryHousingAllowanceRequest: DuplicateMinistryHousingAllowanceRequestMutation;
+  }>;
+  errorMocks?: MockedResponse[];
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({
-  contextValue,
+  contextValue = singleContext,
+  request,
   router = {},
+  mocks,
+  errorMocks,
 }) => {
-  const approvedMHARequest = {
+  const approvedMHARequest = request ?? {
     ...mockMHARequest,
     updatedAt: '2022-12-01',
     requestAttributes: {
@@ -41,20 +68,29 @@ const TestComponent: React.FC<TestComponentProps> = ({
     },
   };
 
+  const content = (
+    <MinisterHousingAllowanceContext.Provider
+      value={contextValue as ContextType}
+    >
+      <CurrentBoardApproved request={approvedMHARequest} />
+    </MinisterHousingAllowanceContext.Provider>
+  );
+
   return (
     <ThemeProvider theme={theme}>
       <TestRouter router={router}>
-        <GqlMockedProvider<{
-          DuplicateMinistryHousingAllowanceRequest: DuplicateMinistryHousingAllowanceRequestMutation;
-        }>
-          onCall={mutationSpy}
-        >
-          <MinisterHousingAllowanceContext.Provider
-            value={contextValue as ContextType}
+        {errorMocks ? (
+          <MockedProvider mocks={errorMocks}>{content}</MockedProvider>
+        ) : (
+          <GqlMockedProvider<{
+            DuplicateMinistryHousingAllowanceRequest: DuplicateMinistryHousingAllowanceRequestMutation;
+          }>
+            mocks={mocks}
+            onCall={mutationSpy}
           >
-            <CurrentBoardApproved request={approvedMHARequest} />
-          </MinisterHousingAllowanceContext.Provider>
-        </GqlMockedProvider>
+            {content}
+          </GqlMockedProvider>
+        )}
       </TestRouter>
     </ThemeProvider>
   );
@@ -105,19 +141,7 @@ describe('CurrentBoardApproved Component', () => {
 
   it('should render correctly for single person', () => {
     const { queryByText, queryByRole, getAllByText } = render(
-      <TestComponent
-        contextValue={{
-          isMarried: false,
-          preferredName: 'John',
-          spousePreferredName: '',
-          userHcmData: {
-            staffInfo: {
-              personNumber: '000123456',
-            },
-          } as unknown as HcmData,
-          spouseHcmData: null,
-        }}
-      />,
+      <TestComponent />,
     );
 
     expect(queryByText('Current Board Approved MHA')).toBeInTheDocument();
@@ -141,42 +165,19 @@ describe('CurrentBoardApproved Component', () => {
 
   it('should navigate to edit page with new requestId after duplicate mutation', async () => {
     const { getByText } = render(
-      <ThemeProvider theme={theme}>
-        <TestRouter router={{ push: mockPush }}>
-          <GqlMockedProvider<{
-            DuplicateMinistryHousingAllowanceRequest: DuplicateMinistryHousingAllowanceRequestMutation;
-          }>
-            mocks={{
-              DuplicateMinistryHousingAllowanceRequest: {
-                duplicateMinistryHousingAllowanceRequest: {
-                  ministryHousingAllowanceRequest: {
-                    id: newRequestId,
-                  },
-                },
+      <TestComponent
+        request={mockMHARequest}
+        router={{ push: mockPush }}
+        mocks={{
+          DuplicateMinistryHousingAllowanceRequest: {
+            duplicateMinistryHousingAllowanceRequest: {
+              ministryHousingAllowanceRequest: {
+                id: newRequestId,
               },
-            }}
-            onCall={mutationSpy}
-          >
-            <MinisterHousingAllowanceContext.Provider
-              value={
-                {
-                  isMarried: false,
-                  preferredName: 'John',
-                  spousePreferredName: '',
-                  userHcmData: {
-                    staffInfo: {
-                      personNumber: '000123456',
-                    },
-                  } as unknown as HcmData,
-                  spouseHcmData: null,
-                } as ContextType
-              }
-            >
-              <CurrentBoardApproved request={mockMHARequest} />
-            </MinisterHousingAllowanceContext.Provider>
-          </GqlMockedProvider>
-        </TestRouter>
-      </ThemeProvider>,
+            },
+          },
+        }}
+      />,
     );
 
     const updateButton = getByText('Update Current MHA');
@@ -197,6 +198,41 @@ describe('CurrentBoardApproved Component', () => {
       expect(mockPush).toHaveBeenCalledWith(
         `/accountLists/account-list-1/reports/housingAllowance/${newRequestId}?mode=edit`,
       );
+    });
+  });
+
+  it('should handle duplicate mutation error gracefully without throwing', async () => {
+    const { getByText } = render(
+      <TestComponent
+        request={mockMHARequest}
+        router={{ push: mockPush }}
+        errorMocks={[
+          {
+            request: {
+              query: DuplicateMinistryHousingAllowanceRequestDocument,
+              variables: {
+                input: {
+                  requestId: '1',
+                },
+              },
+            },
+            result: {
+              errors: [
+                new GraphQLError(
+                  'You already have an open request. Please complete or delete it before duplicating this MHA request.',
+                ),
+              ],
+            },
+          },
+        ]}
+      />,
+    );
+
+    const updateButton = getByText('Update Current MHA');
+    userEvent.click(updateButton);
+
+    await waitFor(() => {
+      expect(mockPush).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.test.tsx
+++ b/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.test.tsx
@@ -185,5 +185,4 @@ describe('CurrentBoardApproved Component', () => {
       );
     });
   });
-
 });

--- a/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.test.tsx
+++ b/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.test.tsx
@@ -1,17 +1,12 @@
 import React from 'react';
-import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { GraphQLError } from 'graphql';
 import { DeepPartial } from 'ts-essentials';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from 'src/theme';
-import {
-  DuplicateMinistryHousingAllowanceRequestDocument,
-  DuplicateMinistryHousingAllowanceRequestMutation,
-} from '../MinisterHousingAllowance.generated';
+import { DuplicateMinistryHousingAllowanceRequestMutation } from '../MinisterHousingAllowance.generated';
 import {
   ContextType,
   HcmData,
@@ -46,7 +41,6 @@ interface TestComponentProps {
   mocks?: DeepPartial<{
     DuplicateMinistryHousingAllowanceRequest: DuplicateMinistryHousingAllowanceRequestMutation;
   }>;
-  errorMocks?: MockedResponse[];
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({
@@ -54,7 +48,6 @@ const TestComponent: React.FC<TestComponentProps> = ({
   request,
   router = {},
   mocks,
-  errorMocks,
 }) => {
   const approvedMHARequest = request ?? {
     ...mockMHARequest,
@@ -68,29 +61,21 @@ const TestComponent: React.FC<TestComponentProps> = ({
     },
   };
 
-  const content = (
-    <MinisterHousingAllowanceContext.Provider
-      value={contextValue as ContextType}
-    >
-      <CurrentBoardApproved request={approvedMHARequest} />
-    </MinisterHousingAllowanceContext.Provider>
-  );
-
   return (
     <ThemeProvider theme={theme}>
       <TestRouter router={router}>
-        {errorMocks ? (
-          <MockedProvider mocks={errorMocks}>{content}</MockedProvider>
-        ) : (
-          <GqlMockedProvider<{
-            DuplicateMinistryHousingAllowanceRequest: DuplicateMinistryHousingAllowanceRequestMutation;
-          }>
-            mocks={mocks}
-            onCall={mutationSpy}
+        <GqlMockedProvider<{
+          DuplicateMinistryHousingAllowanceRequest: DuplicateMinistryHousingAllowanceRequestMutation;
+        }>
+          mocks={mocks}
+          onCall={mutationSpy}
+        >
+          <MinisterHousingAllowanceContext.Provider
+            value={contextValue as ContextType}
           >
-            {content}
-          </GqlMockedProvider>
-        )}
+            <CurrentBoardApproved request={approvedMHARequest} />
+          </MinisterHousingAllowanceContext.Provider>
+        </GqlMockedProvider>
       </TestRouter>
     </ThemeProvider>
   );
@@ -201,38 +186,4 @@ describe('CurrentBoardApproved Component', () => {
     });
   });
 
-  it('should handle duplicate mutation error gracefully without throwing', async () => {
-    const { getByText } = render(
-      <TestComponent
-        request={mockMHARequest}
-        router={{ push: mockPush }}
-        errorMocks={[
-          {
-            request: {
-              query: DuplicateMinistryHousingAllowanceRequestDocument,
-              variables: {
-                input: {
-                  requestId: '1',
-                },
-              },
-            },
-            result: {
-              errors: [
-                new GraphQLError(
-                  'You already have an open request. Please complete or delete it before duplicating this MHA request.',
-                ),
-              ],
-            },
-          },
-        ]}
-      />,
-    );
-
-    const updateButton = getByText('Update Current MHA');
-    userEvent.click(updateButton);
-
-    await waitFor(() => {
-      expect(mockPush).not.toHaveBeenCalled();
-    });
-  });
 });

--- a/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.tsx
+++ b/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.tsx
@@ -68,6 +68,8 @@ export const CurrentBoardApproved: React.FC<CurrentBoardApprovedProps> = ({
           router.push(getRequestUrl(accountListId, newRequestId, 'edit'));
         }
       },
+      // Prevents unhandled promise rejection
+      onError: () => {},
     });
   };
 

--- a/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.tsx
+++ b/src/components/Reports/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.tsx
@@ -24,10 +24,12 @@ import { MHARequest } from './types';
 
 interface CurrentBoardApprovedProps {
   request: MHARequest | null;
+  hasOpenRequest?: boolean;
 }
 
 export const CurrentBoardApproved: React.FC<CurrentBoardApprovedProps> = ({
   request,
+  hasOpenRequest = false,
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
@@ -68,8 +70,6 @@ export const CurrentBoardApproved: React.FC<CurrentBoardApprovedProps> = ({
           router.push(getRequestUrl(accountListId, newRequestId, 'edit'));
         }
       },
-      // Prevents unhandled promise rejection
-      onError: () => {},
     });
   };
 
@@ -92,6 +92,7 @@ export const CurrentBoardApproved: React.FC<CurrentBoardApprovedProps> = ({
       linkOne={viewLink}
       linkTwoText={t('Update Current MHA')}
       handleLinkTwo={handleDuplicateRequest}
+      hideLinkTwoButton={hasOpenRequest}
       isRequest={false}
       handlePrint={handlePrint}
       handleConfirmCancel={() => {}}


### PR DESCRIPTION
## Description

This prevents an unhandled runtime error and leads to better UI behavior for users.
Issue:
- If a new request is open (a user has a request that they are editing but have not submitted), and they go back to edit their already submitted request via Update Current MHA, a runtime error occurs.
Solution:
- Handle the error gracefully by using Apollo's onError callback. Apollo provides a Snackbar for the error in `client.ts`

Error: 
```
Error: You already have an open request. Please complete or delete it before duplicating this MHA request.
```

Future considerations: Possibly refactor to avoid the use of onCompleted and onError altogether. 

[Jira ticket](https://jira.cru.org/browse/MPDX-9327) 

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `reports/housingAllowance`
- Create a new request and edit it. Do not submit it.
- Go back to the Housing Allowance dashboard.
- Select 'Update Current MHA'
- Ensure that the snackbar is shown and the error is properly handled. 

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
