### PR TITLE
MPDX-9446 - Order Goal List goals by updatedAt

### DIFF
--- a/src/components/Reports/PdsGoalCalculator/GoalsList/PdsGoalsList.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/GoalsList/PdsGoalsList.test.tsx
@@ -77,6 +77,28 @@ describe('PdsGoalsList', () => {
     );
   });
 
+  it('displays goals sorted by most recently updated', async () => {
+    const { findAllByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        withProvider={false}
+        calculationsMock={{
+          nodes: [
+            { name: 'Oldest', updatedAt: '2024-01-01T00:00:00Z' },
+            { name: 'Newest', updatedAt: '2024-03-01T00:00:00Z' },
+            { name: 'Middle', updatedAt: '2024-02-01T00:00:00Z' },
+          ],
+        }}
+      >
+        <PdsGoalsList />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    const headings = await findAllByRole('heading', { level: 6 });
+    expect(headings[0]).toHaveTextContent('Newest');
+    expect(headings[1]).toHaveTextContent('Middle');
+    expect(headings[2]).toHaveTextContent('Oldest');
+  });
+
   it('calls delete mutation when a goal is deleted', async () => {
     const { findByRole } = render(
       <PdsGoalCalculatorTestWrapper

--- a/src/components/Reports/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
+++ b/src/components/Reports/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
@@ -35,7 +35,9 @@ export const PdsGoalsList: React.FC = () => {
   const [createPdsGoalCalculation] = useCreatePdsGoalCalculationMutation();
   const [deletePdsGoalCalculation] = useDeletePdsGoalCalculationMutation();
 
-  const goals = data?.designationSupportCalculations.nodes;
+  const goals = data?.designationSupportCalculations.nodes
+    .slice()
+    .sort((goalA, goalB) => goalB.updatedAt.localeCompare(goalA.updatedAt));
 
   const handleDeleteGoal = async (id: string) => {
     await deletePdsGoalCalculation({


### PR DESCRIPTION
## Description

Sorts PDS goals by updatedAt in the PDS Goals List. Could have been done API side, but this matches the behavior of GoalCalculator and so I went this route.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `reports/pdsGoalCalculator`
- Create some goals
- Update the goals (not currently possible UI side but will be soon)
- Check that the most recently updated goals go to the start of the list.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
