### PR TITLE
[No Jira] - Add trigger for ai-review-auto-approve workflow

### DIFF
--- a/.claude/rules/code-review.md
+++ b/.claude/rules/code-review.md
@@ -320,3 +320,24 @@ Directories and file patterns the agent should not search or flag findings again
 - `**/*.snap` — Jest snapshot files
 - `.github/ISSUE_TEMPLATE/**`
 - `docs/**` — repo documentation (unless changes are in-scope for the review)
+
+## Post-Review Auto-Approve Trigger
+
+**After posting the review to GitHub**, if ALL of these conditions are met,trigger the auto-approve workflow:
+
+- The review was posted to GitHub (not terminal-only)
+- Risk level is LOW or MEDIUM
+- Verdict is CLEAN or APPROVED_WITH_SUGGESTIONS
+
+```bash
+BRANCH=$(gh pr view ${PR_NUM} --json headRefName --jq '.headRefName')
+if [ -n "$BRANCH" ]; then
+  gh workflow run ai-review-auto-approve.yml -f head_branch="${BRANCH}" \
+    && echo "Triggered auto-approve workflow for branch ${BRANCH}" \
+    || echo "WARNING: Failed to trigger auto-approve workflow"
+else
+  echo "WARNING: Could not determine branch name, skipping auto-approve trigger"
+fi
+```
+
+Do NOT trigger the workflow if any condition is not met (e.g., BLOCKERS_FOUND verdict or HIGH/CRITICAL risk). The auto-approve workflow does NOT check CI status — CI is enforced by the repo's branch protection rules (CI must pass before merging).


### PR DESCRIPTION
## Description

- Add a "Post-Review Auto-Approve Trigger" section to `.claude/rules/code-review.md`
- Instructs the AI review agent to automatically trigger the `ai-review-auto-approve.yml` workflow after posting a review to GitHub, when the risk level is LOW/MEDIUM and the verdict is CLEAN or APPROVED_WITH_SUGGESTIONS
- Prevents auto-approve from triggering on HIGH/CRITICAL risk or BLOCKERS_FOUND verdicts

## Testing

- Run `/quality:agent-review` on a low-risk PR and verify the auto-approve workflow is triggered after the review is posted
- Run `/quality:agent-review` on a high-risk PR and verify the auto-approve workflow is NOT triggered
- Verify the workflow uses the correct branch name from `gh pr view`

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history