### PR TITLE
MPDX-9387 and MPDX-9400 - Allow international phone numbers (7–15 digits)

### DIFF
--- a/src/lib/yupHelpers.test.ts
+++ b/src/lib/yupHelpers.test.ts
@@ -1,0 +1,62 @@
+import i18n from './i18n';
+import { phoneNumber } from './yupHelpers';
+
+const schema = phoneNumber(i18n.t);
+
+describe('phoneNumber validation', () => {
+  it('accepts a US number with country code', () => {
+    expect(schema.validateSync('11234567890')).toBe('11234567890');
+  });
+
+  it('accepts trunk prefix (example is a UK numbers starting with 0)', () => {
+    expect(schema.validateSync('01234567890')).toBe('01234567890');
+  });
+
+  it('accepts a number with dashes', () => {
+    expect(schema.validateSync('123-456-7890')).toBe('123-456-7890');
+  });
+
+  it('accepts a number with parentheses and spaces', () => {
+    expect(schema.validateSync('(123) 456 7890')).toBe('(123) 456 7890');
+  });
+
+  it('accepts a number with plus prefix', () => {
+    expect(schema.validateSync('+447911123456')).toBe('+447911123456');
+  });
+
+  it('accepts the shortest international number (7 digits)', () => {
+    expect(schema.validateSync('1234567')).toBe('1234567');
+  });
+
+  it('accepts the max E.164 length (15 digits)', () => {
+    expect(schema.validateSync('123456789012345')).toBe('123456789012345');
+  });
+
+  it('rejects a number that is too short (6 digits)', () => {
+    expect(() => schema.validateSync('123456')).toThrow();
+  });
+
+  it('rejects a number that is too long (16 digits)', () => {
+    expect(() => schema.validateSync('1234567890123456')).toThrow();
+  });
+
+  it('rejects an empty string', () => {
+    expect(() => schema.validateSync('')).toThrow();
+  });
+
+  it('rejects only non-digit characters', () => {
+    expect(() => schema.validateSync('+-() ')).toThrow();
+  });
+
+  it('rejects alphabetical characters', () => {
+    expect(() => schema.validateSync('abcdefghij')).toThrow();
+  });
+
+  it('rejects numbers mixed with letters', () => {
+    expect(() => schema.validateSync('123abc4567')).toThrow();
+  });
+
+  it('rejects special characters', () => {
+    expect(() => schema.validateSync('123@456#7890')).toThrow();
+  });
+});

--- a/src/lib/yupHelpers.ts
+++ b/src/lib/yupHelpers.ts
@@ -2,13 +2,19 @@ import { DateTime } from 'luxon';
 import { TFunction } from 'react-i18next';
 import * as yup from 'yup';
 
+/**
+ * Validation for phone numbers that satisfy these conditions:
+ * - May include digits, spaces, parentheses, plus signs, and hyphens
+ * - Cannot contain letters or other special characters
+ * - Must contain between 7 and 15 digits (after removing non-digit characters)
+ */
 export const phoneNumber = (t: TFunction) =>
   yup.string().test('is-phone-number', t('Invalid phone number'), (val) => {
     if (!val) {
       return false;
     }
     const cleaned = val.replace(/\D/g, '');
-    return /^1?\d{10}$/.test(cleaned);
+    return !/[^\d+() -]/.test(val) && /^\d{7,15}$/.test(cleaned);
   });
 
 export const dateTime = () =>


### PR DESCRIPTION
## Description

Allow phone numbers between lengths 7 and 15 to support international numbers, E.164 standard and trunk prefixes. Remove requirement that the area code is US only.

[MPDX-9400](https://jira.cru.org/browse/MPDX-9400)
[MPDX-9387](https://jira.cru.org/browse/MPDX-9387)

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to the different reports
- Enter a phone number wherever applicable
- Check that the validation on the phone works for unique phones (e.g. numbers of length 11 starting with a 0). 

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
