### PR TITLE
[MPDX-9410] Show max allowable cap on step 3

### DIFF
--- a/.claude/rules/code-review.md
+++ b/.claude/rules/code-review.md
@@ -140,7 +140,7 @@ MPDX displays and calculates donation/partner-giving aggregations across dozens 
 
 **Focus areas:**
 
-- **Money is never a JavaScript `number` for arithmetic.** Check for floating-point arithmetic on money values — any `amount + amount`, `amount * rate`, or `.reduce` accumulating amounts must either (a) use a decimal library (if one is in use in the codebase), (b) round at the display boundary only, or (c) work in integer "cents" consistently. Never compare money values with `===` after arithmetic.
+- **Money is never a JavaScript `number` for arithmetic.** Check for floating-point arithmetic on money values — any `amount + amount`, `amount * rate`, or `.reduce` accumulating amounts must round at the display boundary.
 - **Currency mixing.** Donations arrive in multiple currencies; verify no code path sums `amount` (native currency) across rows with different `currencyCode`. Aggregations must use `convertedAmount` (or equivalent) in a single reporting currency.
 - **Rounding consistency.** Rounding should happen at the display boundary via `intlFormat` / `Intl.NumberFormat`, not sprinkled through calculation code. Flag any `.toFixed(n)` used inside aggregation logic.
 - **Missing/null amounts.** Donations, pledges, and goals may be `null` or `undefined`. Verify nullish handling (`?? 0`) is present where aggregations happen, and that `null` is not silently coerced to `0` where it should surface as "unknown."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,8 @@
       "source": {
         "source": "git",
         "url": "https://github.com/CruGlobal/claude-code-plugins.git"
-      }
+      },
+      "autoUpdate": true
     }
   }
 }

--- a/src/components/Reports/SalaryCalculator/403bSection/403bSection.test.tsx
+++ b/src/components/Reports/SalaryCalculator/403bSection/403bSection.test.tsx
@@ -16,6 +16,6 @@ describe('403bSection', () => {
 
     expect(await findByRole('cell', { name: '12.00%' })).toBeInTheDocument();
     expect(getByRole('cell', { name: '8.00%' })).toBeInTheDocument();
-    expect(getByRole('cell', { name: '$47' })).toBeInTheDocument();
+    expect(getByRole('cell', { name: '$47.00' })).toBeInTheDocument();
   });
 });

--- a/src/components/Reports/SalaryCalculator/403bSection/403bSection.test.tsx
+++ b/src/components/Reports/SalaryCalculator/403bSection/403bSection.test.tsx
@@ -1,21 +1,94 @@
-import { render } from '@testing-library/react';
-import { SalaryCalculatorTestWrapper } from '../SalaryCalculatorTestWrapper';
+import { render, waitFor } from '@testing-library/react';
+import {
+  SalaryCalculatorTestWrapper,
+  SalaryCalculatorTestWrapperProps,
+} from '../SalaryCalculatorTestWrapper';
 import { FourOhThreeBSection } from './403bSection';
 
-const mutationSpy = jest.fn();
-
-const TestComponent: React.FC = () => (
-  <SalaryCalculatorTestWrapper onCall={mutationSpy}>
+const TestComponent: React.FC<SalaryCalculatorTestWrapperProps> = (props) => (
+  <SalaryCalculatorTestWrapper
+    hcmUser={{
+      fourOThreeB: { maximumContributionLimit: 10001 },
+    }}
+    hcmSpouse={{
+      fourOThreeB: { maximumContributionLimit: 20001 },
+    }}
+    {...props}
+  >
     <FourOhThreeBSection />
   </SalaryCalculatorTestWrapper>
 );
 
 describe('403bSection', () => {
-  it('should render retirement contribution percentages', async () => {
-    const { findByRole, getByRole } = render(<TestComponent />);
+  describe('married', () => {
+    it('should render table headers', async () => {
+      const { getAllByRole } = render(<TestComponent />);
 
-    expect(await findByRole('cell', { name: '12.00%' })).toBeInTheDocument();
-    expect(getByRole('cell', { name: '8.00%' })).toBeInTheDocument();
-    expect(getByRole('cell', { name: '$47.00' })).toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          getAllByRole('columnheader').map((cell) => cell.textContent),
+        ).toEqual(['Category', 'John', 'Jane']),
+      );
+
+      await waitFor(() =>
+        expect(
+          getAllByRole('rowheader').map((cell) => cell.textContent),
+        ).toEqual([
+          'Current Tax-Deferred Contribution Percent',
+          'Current Roth 403(b) Contribution Percent',
+          'Maximum Contribution Limit',
+        ]),
+      );
+    });
+
+    it('should render table cells with formatted values', async () => {
+      const { getAllByRole } = render(<TestComponent />);
+
+      const expectedCells = [
+        ['5.00%', '8.00%'],
+        ['12.00%', '10.00%'],
+        ['$10,001.00', '$20,001.00'],
+      ].flat();
+
+      await waitFor(() =>
+        expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
+          expectedCells,
+        ),
+      );
+    });
+  });
+
+  describe('single', () => {
+    it('should render table headers', async () => {
+      const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
+
+      await waitFor(() =>
+        expect(
+          getAllByRole('columnheader').map((cell) => cell.textContent),
+        ).toEqual(['Category', 'John']),
+      );
+
+      await waitFor(() =>
+        expect(
+          getAllByRole('rowheader').map((cell) => cell.textContent),
+        ).toEqual([
+          'Current Tax-Deferred Contribution Percent',
+          'Current Roth 403(b) Contribution Percent',
+          'Maximum Contribution Limit',
+        ]),
+      );
+    });
+
+    it('should render table cells with formatted values', async () => {
+      const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
+
+      const expectedCells = ['5.00%', '12.00%', '$10,001.00'];
+
+      await waitFor(() =>
+        expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
+          expectedCells,
+        ),
+      );
+    });
   });
 });

--- a/src/components/Reports/SalaryCalculator/403bSection/403bSection.tsx
+++ b/src/components/Reports/SalaryCalculator/403bSection/403bSection.tsx
@@ -12,14 +12,12 @@ import {
 import { Stack } from '@mui/system';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSalaryCalculator } from '../SalaryCalculatorContext/SalaryCalculatorContext';
-import {
-  FormattedTableCell,
-  StepCard,
-  StepTableHead,
-} from '../Shared/StepCard';
+import { StepCard, StepTableHead } from '../Shared/StepCard';
+import { useFormatters } from '../Shared/useFormatters';
 
 export const FourOhThreeBSection: React.FC = () => {
   const { t } = useTranslation();
+  const { formatCurrency, formatPercentage } = useFormatters();
   const { hcmUser, hcmSpouse } = useSalaryCalculator();
 
   const user = hcmUser?.fourOThreeB;
@@ -53,39 +51,43 @@ export const FourOhThreeBSection: React.FC = () => {
                 <TableCell component="th" scope="row">
                   {t('Current Tax-Deferred Contribution Percent')}
                 </TableCell>
-                <FormattedTableCell
-                  percentage
-                  value={user?.currentTaxDeferredContributionPercentage}
-                />
+                <TableCell>
+                  {formatPercentage(
+                    user?.currentTaxDeferredContributionPercentage,
+                  )}
+                </TableCell>
                 {spouse && (
-                  <FormattedTableCell
-                    percentage
-                    value={spouse.currentTaxDeferredContributionPercentage}
-                  />
+                  <TableCell>
+                    {formatPercentage(
+                      spouse.currentTaxDeferredContributionPercentage,
+                    )}
+                  </TableCell>
                 )}
               </TableRow>
               <TableRow>
                 <TableCell component="th" scope="row">
                   {t('Current Roth 403(b) Contribution Percent')}
                 </TableCell>
-                <FormattedTableCell
-                  percentage
-                  value={user?.currentRothContributionPercentage}
-                />
+                <TableCell>
+                  {formatPercentage(user?.currentRothContributionPercentage)}
+                </TableCell>
                 {spouse && (
-                  <FormattedTableCell
-                    percentage
-                    value={spouse.currentRothContributionPercentage}
-                  />
+                  <TableCell>
+                    {formatPercentage(spouse.currentRothContributionPercentage)}
+                  </TableCell>
                 )}
               </TableRow>
               <TableRow>
                 <TableCell component="th" scope="row">
                   {t('Maximum Contribution Limit')}
                 </TableCell>
-                <FormattedTableCell value={user?.maximumContributionLimit} />
+                <TableCell>
+                  {formatCurrency(user?.maximumContributionLimit)}
+                </TableCell>
                 {spouse && (
-                  <FormattedTableCell value={spouse.maximumContributionLimit} />
+                  <TableCell>
+                    {formatCurrency(spouse.maximumContributionLimit)}
+                  </TableCell>
                 )}
               </TableRow>
             </TableBody>

--- a/src/components/Reports/SalaryCalculator/SalaryCalculation/ApprovalProcessCard/ApprovalProcessCard.test.tsx
+++ b/src/components/Reports/SalaryCalculator/SalaryCalculation/ApprovalProcessCard/ApprovalProcessCard.test.tsx
@@ -72,7 +72,30 @@ If this is correct, please provide reasoning for why Jane's Salary should exceed
   });
 
   describe('combined over cap', () => {
-    it('renders status message and textfield', async () => {
+    it('renders single status message and textfield', async () => {
+      const { getByRole, getByTestId } = render(
+        <TestComponent
+          salaryRequestMock={{
+            calculations: { requestedGross: 100_000 },
+            spouseCalculations: null,
+            progressiveApprovalTier: {
+              tier: ProgressiveApprovalTierEnum.VicePresident,
+            },
+          }}
+        />,
+      );
+
+      await waitFor(() =>
+        expect(getByTestId('ApprovalProcessCard-status')).toHaveTextContent(
+          'Since you are requesting above your Maximum Allowable Salary, you will need to provide the information below.',
+        ),
+      );
+      expect(
+        getByRole('textbox', { name: 'Additional info' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders married status message', async () => {
       const { getByRole, getByTestId } = render(
         <TestComponent
           salaryRequestMock={{

--- a/src/components/Reports/SalaryCalculator/SalaryCalculation/ApprovalProcessCard/ApprovalProcessCard.tsx
+++ b/src/components/Reports/SalaryCalculator/SalaryCalculation/ApprovalProcessCard/ApprovalProcessCard.tsx
@@ -60,11 +60,16 @@ export const ApprovalProcessCard: React.FC = () => {
               {{ cap: overCapPerson?.effectiveCap }} for division head approval
               below.
             </Trans>
-          ) : (
+          ) : spouseName ? (
             <Trans t={t}>
               Since you are requesting above {{ spouse: spouseName }}&apos;s and
               your combined Maximum Allowable Salary, you will need to provide
               the information below.
+            </Trans>
+          ) : (
+            <Trans t={t}>
+              Since you are requesting above your Maximum Allowable Salary, you
+              will need to provide the information below.
             </Trans>
           )}
         </Typography>

--- a/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.test.tsx
+++ b/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.test.tsx
@@ -79,9 +79,9 @@ As you set your salary level, the amount you receive should reflect the amount o
       const { getAllByRole } = render(<TestComponent />);
 
       const expectedCells = [
-        ['$10,001', '$20,001'],
-        ['$10,003', '$20,003'],
-        ['$10,004', '$20,004'],
+        ['$10,001.00', '$20,001.00'],
+        ['$10,003.00', '$20,003.00'],
+        ['$10,004.00', '$20,004.00'],
       ].flat();
 
       await waitFor(() =>
@@ -134,7 +134,7 @@ As you set your salary level, the amount you receive should reflect the amount o
     it('should render table cells with formatted currency', async () => {
       const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
 
-      const expectedCells = [['$10,001'], ['$10,003'], ['$10,004']].flat();
+      const expectedCells = ['$10,001.00', '$10,003.00', '$10,004.00'];
 
       await waitFor(() =>
         expect(

--- a/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.test.tsx
+++ b/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { DeepPartial } from 'ts-essentials';
+import { SalaryCalculationQuery } from '../../SalaryCalculatorContext/SalaryCalculation.generated';
+import {
+  SalaryCalculatorTestWrapper,
+  SalaryCalculatorTestWrapperProps,
+} from '../../SalaryCalculatorTestWrapper';
+import { RequestedSalaryCard } from './RequestedSalaryCard';
+
+const defaultSalaryMock: DeepPartial<SalaryCalculationQuery['salaryRequest']> =
+  {
+    calculations: {
+      minimumRequiredSalary: 10002,
+      minimumRequestedSalary: 10003,
+      effectiveCap: 10004,
+    },
+    spouseCalculations: {
+      minimumRequiredSalary: 20002,
+      minimumRequestedSalary: 20003,
+      effectiveCap: 20004,
+    },
+  };
+
+const TestComponent: React.FC<SalaryCalculatorTestWrapperProps> = (props) => (
+  <SalaryCalculatorTestWrapper
+    salaryRequestMock={defaultSalaryMock}
+    hcmUser={{
+      currentSalary: { grossSalaryAmount: 10001 },
+    }}
+    hcmSpouse={{
+      currentSalary: { grossSalaryAmount: 20001 },
+    }}
+    {...props}
+  >
+    <RequestedSalaryCard />
+  </SalaryCalculatorTestWrapper>
+);
+
+describe('RequestedSalaryCard', () => {
+  describe('married', () => {
+    it('should render explanation message', async () => {
+      const { getByTestId } = render(<TestComponent />);
+
+      await waitFor(() =>
+        expect(getByTestId('RequestedSalaryCard-message')).toHaveTextContent(
+          "Below, enter the annual salary amount you would like to request. \
+This salary level includes taxes (local, state, and federal) and Minister's Housing Allowance. \
+It does not include either Social Security (SECA) or 403b. They will be added in later. \
+Because of IRS and Cru requirements, the lowest salary you can request is $10,003.00 (MHA + $10,002.00 - SECA) for John \
+and $20,003.00 (MHA + $20,002.00 - SECA) for Jane. \
+As you set your salary level, the amount you receive should reflect the amount of time you work in ministry.",
+        ),
+      );
+    });
+
+    it('should render table headers', async () => {
+      const { getAllByRole } = render(<TestComponent />);
+
+      await waitFor(() =>
+        expect(
+          getAllByRole('columnheader').map((cell) => cell.textContent),
+        ).toEqual(['Category', 'John', 'Jane']),
+      );
+
+      await waitFor(() =>
+        expect(
+          getAllByRole('rowheader').map((cell) => cell.textContent),
+        ).toEqual([
+          'Current Salary',
+          'Minimum Salary',
+          'Maximum Allowable Salary (CAP)',
+          'Requested Salary',
+        ]),
+      );
+    });
+
+    it('should render table cells with formatted currency', async () => {
+      const { getAllByRole } = render(<TestComponent />);
+
+      const expectedCells = [
+        ['$10,001', '$20,001'],
+        ['$10,003', '$20,003'],
+        ['$10,004', '$20,004'],
+      ].flat();
+
+      await waitFor(() =>
+        expect(
+          getAllByRole('cell')
+            // Skip the two inputs
+            .slice(0, -2)
+            .map((cell) => cell.textContent),
+        ).toEqual(expectedCells),
+      );
+    });
+  });
+
+  describe('single', () => {
+    it('should render explanation message', async () => {
+      const { getByTestId } = render(<TestComponent hasSpouse={false} />);
+
+      await waitFor(() =>
+        expect(getByTestId('RequestedSalaryCard-message')).toHaveTextContent(
+          "Below, enter the annual salary amount you would like to request. \
+This salary level includes taxes (local, state, and federal) and Minister's Housing Allowance. \
+It does not include either Social Security (SECA) or 403b. They will be added in later. \
+Because of IRS and Cru requirements, the lowest salary you can request is $10,003.00 (MHA + $10,002.00 - SECA). \
+As you set your salary level, the amount you receive should reflect the amount of time you work in ministry.",
+        ),
+      );
+    });
+
+    it('should render table headers', async () => {
+      const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
+
+      await waitFor(() =>
+        expect(
+          getAllByRole('columnheader').map((cell) => cell.textContent),
+        ).toEqual(['Category', 'John']),
+      );
+
+      await waitFor(() =>
+        expect(
+          getAllByRole('rowheader').map((cell) => cell.textContent),
+        ).toEqual([
+          'Current Salary',
+          'Minimum Salary',
+          'Maximum Allowable Salary (CAP)',
+          'Requested Salary',
+        ]),
+      );
+    });
+
+    it('should render table cells with formatted currency', async () => {
+      const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
+
+      const expectedCells = [['$10,001'], ['$10,003'], ['$10,004']].flat();
+
+      await waitFor(() =>
+        expect(
+          getAllByRole('cell')
+            // Skip the one input
+            .slice(0, -1)
+            .map((cell) => cell.textContent),
+        ).toEqual(expectedCells),
+      );
+    });
+  });
+});

--- a/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.tsx
+++ b/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.tsx
@@ -10,16 +10,16 @@ import {
 } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
 import * as yup from 'yup';
-import { useLocale } from 'src/hooks/useLocale';
-import { currencyFormat } from 'src/lib/intlFormat';
 import { amount } from 'src/lib/yupHelpers';
 import { AutosaveTextField } from '../../Autosave/AutosaveTextField';
+import { CalculationFieldsFragment } from '../../SalaryCalculatorContext/SalaryCalculation.generated';
 import { useSalaryCalculator } from '../../SalaryCalculatorContext/SalaryCalculatorContext';
 import {
   FormattedTableCell,
   StepCard,
   StepTableHead,
 } from '../../Shared/StepCard';
+import { useFormatters } from '../../Shared/useFormatters';
 
 export const RequestedSalaryCard: React.FC = () => {
   const { t } = useTranslation();
@@ -28,27 +28,24 @@ export const RequestedSalaryCard: React.FC = () => {
     hcmUser,
     hcmSpouse,
   } = useSalaryCalculator();
-  const locale = useLocale();
+  const { formatCurrency } = useFormatters();
 
   const minimumSalaryValue =
-    salaryCalculation?.calculations.minimumRequestedSalary ?? 0;
+    salaryCalculation?.calculations.minimumRequestedSalary;
   const spouseMinimumSalaryValue =
-    salaryCalculation?.spouseCalculations?.minimumRequestedSalary ?? 0;
+    salaryCalculation?.spouseCalculations?.minimumRequestedSalary;
 
-  const formula = t('MHA + {{ min }} - SECA', {
-    min: currencyFormat(
-      salaryCalculation?.calculations.minimumRequiredSalary ?? 0,
-      'USD',
-      locale,
-    ),
-  });
+  const minimumSalary = formatCurrency(minimumSalaryValue);
+  const spouseMinimumSalary = formatCurrency(spouseMinimumSalaryValue);
 
-  const minimumSalary = currencyFormat(minimumSalaryValue, 'USD', locale);
-  const spouseMinimumSalary = currencyFormat(
-    spouseMinimumSalaryValue,
-    'USD',
-    locale,
-  );
+  const renderFormula = (
+    calculations: CalculationFieldsFragment | null | undefined,
+  ) =>
+    t('MHA + {{ min }} - SECA', {
+      min: formatCurrency(calculations?.minimumRequiredSalary),
+    });
+  const formula = renderFormula(salaryCalculation?.calculations);
+  const spouseFormula = renderFormula(salaryCalculation?.spouseCalculations);
 
   const schema = useMemo(
     () =>
@@ -91,15 +88,15 @@ export const RequestedSalaryCard: React.FC = () => {
           {hcmSpouse ? (
             <Trans t={t}>
               Because of IRS and Cru requirements, the lowest salary you can
-              request is {{ minimumSalary }} ({formula}) for{' '}
+              request is {{ minimumSalary }} ({{ formula }}) for{' '}
               {{ name: hcmUser?.staffInfo.preferredName }} and{' '}
-              {{ spouseMinimumSalary }} ({formula}) for{' '}
+              {{ spouseMinimumSalary }} ({{ formula: spouseFormula }}) for{' '}
               {{ spouseName: hcmSpouse?.staffInfo.preferredName }}.
             </Trans>
           ) : (
             <Trans t={t}>
               Because of IRS and Cru requirements, the lowest salary you can
-              request is {{ minimumSalary }} ({formula}).
+              request is {{ minimumSalary }} ({{ formula }}).
             </Trans>
           )}{' '}
           <Trans t={t}>

--- a/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.tsx
+++ b/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.tsx
@@ -78,7 +78,7 @@ export const RequestedSalaryCard: React.FC = () => {
     <StepCard>
       <CardHeader title={t('Requested Salary')} />
       <CardContent>
-        <Typography variant="body1">
+        <Typography variant="body1" data-testid="RequestedSalaryCard-message">
           <Trans t={t}>
             Below, enter the annual salary amount you would like to request.
             This salary level includes taxes (local, state, and federal) and
@@ -90,7 +90,7 @@ export const RequestedSalaryCard: React.FC = () => {
               Because of IRS and Cru requirements, the lowest salary you can
               request is {{ minimumSalary }} ({{ formula }}) for{' '}
               {{ name: hcmUser?.staffInfo.preferredName }} and{' '}
-              {{ spouseMinimumSalary }} ({{ formula: spouseFormula }}) for{' '}
+              {{ spouseMinimumSalary }} ({{ spouseFormula }}) for{' '}
               {{ spouseName: hcmSpouse?.staffInfo.preferredName }}.
             </Trans>
           ) : (
@@ -124,11 +124,25 @@ export const RequestedSalaryCard: React.FC = () => {
 
             <TableRow>
               <TableCell component="th" scope="row">
-                {t('Salary Minimum')}
+                {t('Minimum Salary')}
               </TableCell>
               <FormattedTableCell value={minimumSalaryValue} />
               {hcmSpouse && (
                 <FormattedTableCell value={spouseMinimumSalaryValue} />
+              )}
+            </TableRow>
+
+            <TableRow>
+              <TableCell component="th" scope="row">
+                {t('Maximum Allowable Salary (CAP)')}
+              </TableCell>
+              <FormattedTableCell
+                value={salaryCalculation?.calculations.effectiveCap}
+              />
+              {hcmSpouse && (
+                <FormattedTableCell
+                  value={salaryCalculation?.spouseCalculations?.effectiveCap}
+                />
               )}
             </TableRow>
 

--- a/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.tsx
+++ b/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.tsx
@@ -14,11 +14,7 @@ import { amount } from 'src/lib/yupHelpers';
 import { AutosaveTextField } from '../../Autosave/AutosaveTextField';
 import { CalculationFieldsFragment } from '../../SalaryCalculatorContext/SalaryCalculation.generated';
 import { useSalaryCalculator } from '../../SalaryCalculatorContext/SalaryCalculatorContext';
-import {
-  FormattedTableCell,
-  StepCard,
-  StepTableHead,
-} from '../../Shared/StepCard';
+import { StepCard, StepTableHead } from '../../Shared/StepCard';
 import { useFormatters } from '../../Shared/useFormatters';
 
 export const RequestedSalaryCard: React.FC = () => {
@@ -112,13 +108,13 @@ export const RequestedSalaryCard: React.FC = () => {
               <TableCell component="th" scope="row">
                 {t('Current Salary')}
               </TableCell>
-              <FormattedTableCell
-                value={hcmUser?.currentSalary.grossSalaryAmount}
-              />
+              <TableCell>
+                {formatCurrency(hcmUser?.currentSalary.grossSalaryAmount)}
+              </TableCell>
               {hcmSpouse && (
-                <FormattedTableCell
-                  value={hcmSpouse.currentSalary.grossSalaryAmount}
-                />
+                <TableCell>
+                  {formatCurrency(hcmSpouse.currentSalary.grossSalaryAmount)}
+                </TableCell>
               )}
             </TableRow>
 
@@ -126,9 +122,11 @@ export const RequestedSalaryCard: React.FC = () => {
               <TableCell component="th" scope="row">
                 {t('Minimum Salary')}
               </TableCell>
-              <FormattedTableCell value={minimumSalaryValue} />
+              <TableCell>{formatCurrency(minimumSalaryValue)}</TableCell>
               {hcmSpouse && (
-                <FormattedTableCell value={spouseMinimumSalaryValue} />
+                <TableCell>
+                  {formatCurrency(spouseMinimumSalaryValue)}
+                </TableCell>
               )}
             </TableRow>
 
@@ -136,13 +134,15 @@ export const RequestedSalaryCard: React.FC = () => {
               <TableCell component="th" scope="row">
                 {t('Maximum Allowable Salary (CAP)')}
               </TableCell>
-              <FormattedTableCell
-                value={salaryCalculation?.calculations.effectiveCap}
-              />
+              <TableCell>
+                {formatCurrency(salaryCalculation?.calculations.effectiveCap)}
+              </TableCell>
               {hcmSpouse && (
-                <FormattedTableCell
-                  value={salaryCalculation?.spouseCalculations?.effectiveCap}
-                />
+                <TableCell>
+                  {formatCurrency(
+                    salaryCalculation?.spouseCalculations?.effectiveCap,
+                  )}
+                </TableCell>
               )}
             </TableRow>
 

--- a/src/components/Reports/SalaryCalculator/SalaryCalculatorTestWrapper.tsx
+++ b/src/components/Reports/SalaryCalculator/SalaryCalculatorTestWrapper.tsx
@@ -1,11 +1,13 @@
 import { ThemeProvider } from '@emotion/react';
 import { MockLinkCallHandler } from 'graphql-ergonomock/dist/apollo/MockLink';
 import { merge } from 'lodash';
+import { I18nextProvider } from 'react-i18next';
 import { DeepPartial } from 'ts-essentials';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider, gqlMock } from '__tests__/util/graphqlMocking';
 import { SalaryRequestStatusEnum } from 'src/graphql/types.generated';
 import { GoalCalculatorConstantsQuery } from 'src/hooks/goalCalculatorConstants.generated';
+import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { PayrollDatesQuery } from './EffectiveDateStep/PayrollDates.generated';
 import {
@@ -111,61 +113,63 @@ export const SalaryCalculatorTestWrapper: React.FC<
   const hcmSpouseMerged = merge({}, hcmSpouseMock, hcmSpouse);
   return (
     <ThemeProvider theme={theme}>
-      <TestRouter
-        router={{
-          query: {
-            accountListId: 'account-list-1',
-            calculationId: 'salary-request-1',
-            ...(editing ? {} : { mode: 'view' }),
-          },
-        }}
-      >
-        <GqlMockedProvider<{
-          Hcm: HcmQuery;
-          PayrollDates: PayrollDatesQuery;
-          SalaryCalculation: SalaryCalculationQuery;
-          GoalCalculatorConstants: GoalCalculatorConstantsQuery;
-        }>
-          mocks={{
-            PayrollDates: {
-              payrollDates,
-            },
-            GoalCalculatorConstants: {
-              constant: {
-                mpdGoalGeographicConstants: [
-                  { location: 'Atlanta, GA' },
-                  { location: 'Miami, FL' },
-                ],
-              },
-            },
-            Hcm: {
-              hcm: hasSpouse
-                ? [hcmUserMerged, hcmSpouseMerged]
-                : [hcmUserMerged],
-            },
-            SalaryCalculation: {
-              salaryRequest: merge(
-                {
-                  id: 'salary-request-1',
-                  status: SalaryRequestStatusEnum.InProgress,
-                  effectiveDate: '2025-01-01',
-                  calculations: {
-                    hardCap: 80000,
-                    exceptionCap: null,
-                    combinedCap: 125000,
-                  },
-                  progressiveApprovalTier: null,
-                } satisfies SalaryRequestMock,
-                salaryRequestMock,
-                hasSpouse ? undefined : { spouseCalculations: null },
-              ),
+      <I18nextProvider i18n={i18n}>
+        <TestRouter
+          router={{
+            query: {
+              accountListId: 'account-list-1',
+              calculationId: 'salary-request-1',
+              ...(editing ? {} : { mode: 'view' }),
             },
           }}
-          onCall={onCall}
         >
-          <SalaryCalculatorProvider>{children}</SalaryCalculatorProvider>
-        </GqlMockedProvider>
-      </TestRouter>
+          <GqlMockedProvider<{
+            Hcm: HcmQuery;
+            PayrollDates: PayrollDatesQuery;
+            SalaryCalculation: SalaryCalculationQuery;
+            GoalCalculatorConstants: GoalCalculatorConstantsQuery;
+          }>
+            mocks={{
+              PayrollDates: {
+                payrollDates,
+              },
+              GoalCalculatorConstants: {
+                constant: {
+                  mpdGoalGeographicConstants: [
+                    { location: 'Atlanta, GA' },
+                    { location: 'Miami, FL' },
+                  ],
+                },
+              },
+              Hcm: {
+                hcm: hasSpouse
+                  ? [hcmUserMerged, hcmSpouseMerged]
+                  : [hcmUserMerged],
+              },
+              SalaryCalculation: {
+                salaryRequest: merge(
+                  {
+                    id: 'salary-request-1',
+                    status: SalaryRequestStatusEnum.InProgress,
+                    effectiveDate: '2025-01-01',
+                    calculations: {
+                      hardCap: 80000,
+                      exceptionCap: null,
+                      combinedCap: 125000,
+                    },
+                    progressiveApprovalTier: null,
+                  } satisfies SalaryRequestMock,
+                  salaryRequestMock,
+                  hasSpouse ? undefined : { spouseCalculations: null },
+                ),
+              },
+            }}
+            onCall={onCall}
+          >
+            <SalaryCalculatorProvider>{children}</SalaryCalculatorProvider>
+          </GqlMockedProvider>
+        </TestRouter>
+      </I18nextProvider>
     </ThemeProvider>
   );
 };

--- a/src/components/Reports/SalaryCalculator/Shared/StepCard.tsx
+++ b/src/components/Reports/SalaryCalculator/Shared/StepCard.tsx
@@ -1,15 +1,6 @@
 import React from 'react';
-import {
-  Card,
-  TableCell,
-  TableCellProps,
-  TableHead,
-  TableRow,
-  styled,
-} from '@mui/material';
+import { Card, TableCell, TableHead, TableRow, styled } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { useLocale } from 'src/hooks/useLocale';
-import { currencyFormat, percentageFormat } from 'src/lib/intlFormat';
 import { useSalaryCalculator } from '../SalaryCalculatorContext/SalaryCalculatorContext';
 
 export const StepCard = styled(Card)(({ theme }) => ({
@@ -39,31 +30,6 @@ export const StepCard = styled(Card)(({ theme }) => ({
     padding: theme.spacing(2),
   },
 }));
-
-interface FormattedTableCellProps extends Omit<TableCellProps, 'children'> {
-  value: React.ReactNode;
-  percentage?: boolean;
-}
-
-export const FormattedTableCell: React.FC<FormattedTableCellProps> = ({
-  value,
-  percentage,
-  ...props
-}) => {
-  const locale = useLocale();
-  const formattedValue =
-    typeof value === 'number'
-      ? percentage
-        ? percentageFormat(value / 100, locale, {
-            fractionDigits: 2,
-          })
-        : currencyFormat(value, 'USD', locale, {
-            fractionDigits: 0,
-          })
-      : value;
-
-  return <TableCell {...props}>{formattedValue}</TableCell>;
-};
 
 export const StepTableHead: React.FC = () => {
   const { t } = useTranslation();

--- a/src/components/Reports/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.test.tsx
+++ b/src/components/Reports/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.test.tsx
@@ -60,9 +60,11 @@ describe('MaxAllowableSection', () => {
         />,
       );
 
-      expect(await findByRole('cell', { name: '$50,000' })).toBeInTheDocument();
+      expect(
+        await findByRole('cell', { name: '$50,000.00' }),
+      ).toBeInTheDocument();
       await waitFor(() =>
-        expect(getByRole('cell', { name: '$60,000' })).toBeInTheDocument(),
+        expect(getByRole('cell', { name: '$60,000.00' })).toBeInTheDocument(),
       );
       expect(queryByRole('checkbox')).not.toBeInTheDocument();
     });
@@ -168,7 +170,9 @@ describe('MaxAllowableSection', () => {
       <TestComponent salaryRequestMock={{ splitCapRequired: false }} />,
     );
 
-    expect(await findByRole('cell', { name: '$75,000' })).toBeInTheDocument();
+    expect(
+      await findByRole('cell', { name: '$75,000.00' }),
+    ).toBeInTheDocument();
     expect(queryByRole('checkbox')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Reports/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.tsx
+++ b/src/components/Reports/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.tsx
@@ -21,15 +21,13 @@ import { amount } from 'src/lib/yupHelpers';
 import { AutosaveCheckbox } from '../../Autosave/AutosaveCheckbox';
 import { AutosaveTextField } from '../../Autosave/AutosaveTextField';
 import { useSalaryCalculator } from '../../SalaryCalculatorContext/SalaryCalculatorContext';
-import {
-  FormattedTableCell,
-  StepCard,
-  StepTableHead,
-} from '../../Shared/StepCard';
+import { StepCard, StepTableHead } from '../../Shared/StepCard';
+import { useFormatters } from '../../Shared/useFormatters';
 
 export const MaxAllowableStep: React.FC = () => {
   const { t } = useTranslation();
   const locale = useLocale();
+  const { formatCurrency } = useFormatters();
   const {
     calculation: salaryCalculation,
     hcmUser,
@@ -206,9 +204,13 @@ export const MaxAllowableStep: React.FC = () => {
             <StepTableHead />
             <TableBody>
               <TableRow>
-                <FormattedTableCell value={t('Maximum Allowable Salary')} />
-                <FormattedTableCell value={effectiveCap} />
-                {hcmSpouse && <FormattedTableCell value={spouseEffectiveCap} />}
+                <TableCell component="th" scope="row">
+                  {t('Maximum Allowable Salary')}
+                </TableCell>
+                <TableCell>{formatCurrency(effectiveCap)}</TableCell>
+                {hcmSpouse && (
+                  <TableCell>{formatCurrency(spouseEffectiveCap)}</TableCell>
+                )}
               </TableRow>
             </TableBody>
           </Table>


### PR DESCRIPTION
## Description

Show the user their max cap on step 3 where they are inputting their requested salary.

Also, improves formatting of the "Requested Salary" table and fixes the spouse's minimum salary formula.

MPDX-9410

## Testing

- Impersonate brooke.butler@athletesinaction.org
- Go to step 3
- Check that the "Maximum Allowable Salary (CAP)" row shows in the table

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
