### PR TITLE
[No Jira] - Add spouse switch button to EditForm name card

### DIFF
--- a/src/components/Reports/AdditionalSalaryRequest/FormVersions/Edit/EditForm.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/FormVersions/Edit/EditForm.tsx
@@ -14,6 +14,7 @@ import { NetAdditionalSalary } from '../../CompleteForm/NetAdditionalSalary/NetA
 import { useAdditionalSalaryRequest } from '../../Shared/AdditionalSalaryRequestContext';
 import { useFormUserInfo } from '../../Shared/useFormUserInfo';
 import { useSalaryCalculations } from '../../Shared/useSalaryCalculations';
+import { SpouseComponent } from '../../SharedComponents/SpouseComponent';
 import { ValidationAlert } from '../../SharedComponents/ValidationAlert';
 import { ApprovalProcess } from '../../SubmitModalAccordions/ApprovalProcess/ApprovalProcess';
 import { TotalSalaryRequested } from '../../SubmitModalAccordions/TotalSalaryRequested/TotalSalaryRequested';
@@ -40,6 +41,7 @@ export const EditForm: React.FC = () => {
         amountOne={primaryAccountBalance}
         titleTwo={t('Your Maximum Allowable Salary (CAP)')}
         amountTwo={individualCap}
+        spouseComponent={<SpouseComponent />}
         showContent
       />
       <Typography variant="body1" paragraph>


### PR DESCRIPTION
## Description

- The EditForm (Edit Your Request) was missing the `SpouseComponent` on the `NameDisplay` card, so users couldn't switch to their spouse's ASR while editing
- Adds the same `spouseComponent` prop that already exists on `AboutForm` and `NewForm`

## Testing

- Go to the Additional Salary Request page
- Start editing an existing ASR (Edit Your Request step)
- Check that the "switch to spouse" link appears on the name card
- Verify clicking it switches to the spouse's ASR view

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history