### PR TITLE
[MPDX-9404] - Show board approval message for ASR over-cap with board cap exception

### DIFF
--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.test.tsx
@@ -64,6 +64,8 @@ describe('CapSubContent', () => {
     const { getByText, queryByText } = renderCapSubContent();
 
     expect(getByText(/Progressive Approvals/)).toBeInTheDocument();
+    expect(getByText(/Division Head/)).toBeInTheDocument();
+    expect(getByText(/1-2 weeks/)).toBeInTheDocument();
     expect(
       queryByText(/You have a Board approved Maximum Allowable Salary/),
     ).not.toBeInTheDocument();

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { render } from '@testing-library/react';
+import { FormikProvider, useFormik } from 'formik';
+import { I18nextProvider } from 'react-i18next';
+import i18n from 'src/lib/i18n';
+import theme from 'src/theme';
+import { CompleteFormValues } from '../../AdditionalSalaryRequest';
+import { useAdditionalSalaryRequest } from '../../Shared/AdditionalSalaryRequestContext';
+import { defaultCompleteFormValues } from '../../Shared/CompleteForm.mock';
+import { CapSubContent } from './CapSubContent';
+
+jest.mock('../../Shared/AdditionalSalaryRequestContext', () => ({
+  useAdditionalSalaryRequest: jest.fn(),
+}));
+
+const mockUseAdditionalSalaryRequest =
+  useAdditionalSalaryRequest as jest.MockedFunction<
+    typeof useAdditionalSalaryRequest
+  >;
+
+const FormikWrapper: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const formik = useFormik<CompleteFormValues>({
+    initialValues: {
+      ...defaultCompleteFormValues,
+      totalAdditionalSalaryRequested: '5000',
+    },
+    onSubmit: jest.fn(),
+  });
+  return <FormikProvider value={formik}>{children}</FormikProvider>;
+};
+
+const renderCapSubContent = () =>
+  render(
+    <ThemeProvider theme={theme}>
+      <I18nextProvider i18n={i18n}>
+        <FormikWrapper>
+          <CapSubContent />
+        </FormikWrapper>
+      </I18nextProvider>
+    </ThemeProvider>,
+  );
+
+describe('CapSubContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders Progressive Approvals messaging when hasBoardCapException is false', () => {
+    mockUseAdditionalSalaryRequest.mockReturnValue({
+      hasBoardCapException: false,
+      requestData: {
+        latestAdditionalSalaryRequest: {
+          progressiveApprovalTier: {
+            approver: 'Division Head',
+            approvalTimeframe: '1-2 weeks',
+          },
+        },
+      },
+    } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
+
+    const { getByText, queryByText } = renderCapSubContent();
+
+    expect(getByText(/Progressive Approvals/)).toBeInTheDocument();
+    expect(
+      queryByText(/You have a Board approved Maximum Allowable Salary/),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders board cap exception messaging when hasBoardCapException is true', () => {
+    mockUseAdditionalSalaryRequest.mockReturnValue({
+      hasBoardCapException: true,
+      requestData: {
+        latestAdditionalSalaryRequest: {
+          progressiveApprovalTier: null,
+        },
+      },
+    } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
+
+    const { getByText, queryByText } = renderCapSubContent();
+
+    expect(
+      getByText(/You have a Board approved Maximum Allowable Salary/),
+    ).toBeInTheDocument();
+    expect(
+      getByText(/Additional Salary Request exceeds that amount/),
+    ).toBeInTheDocument();
+    expect(queryByText(/Progressive Approvals/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.test.tsx
@@ -69,7 +69,7 @@ describe('CapSubContent', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders board cap exception messaging when hasBoardCapException is true', () => {
+  it('renders nothing when hasBoardCapException is true (message is carried by getCapOverrides)', () => {
     mockUseAdditionalSalaryRequest.mockReturnValue({
       hasBoardCapException: true,
       requestData: {
@@ -79,14 +79,12 @@ describe('CapSubContent', () => {
       },
     } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
 
-    const { getByText, queryByText } = renderCapSubContent();
+    const { container, queryByText } = renderCapSubContent();
 
+    expect(container).toBeEmptyDOMElement();
     expect(
-      getByText(/You have a Board approved Maximum Allowable Salary/),
-    ).toBeInTheDocument();
-    expect(
-      getByText(/Additional Salary Request exceeds that amount/),
-    ).toBeInTheDocument();
+      queryByText(/You have a Board approved Maximum Allowable Salary/),
+    ).not.toBeInTheDocument();
     expect(queryByText(/Progressive Approvals/)).not.toBeInTheDocument();
   });
 });

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.tsx
@@ -21,13 +21,7 @@ export const CapSubContent: React.FC = () => {
   const { values } = useFormikContext<CompleteFormValues>();
 
   if (hasBoardCapException) {
-    return (
-      <span>
-        {t(
-          "You have a Board approved Maximum Allowable Salary (CAP) and your Additional Salary Request exceeds that amount. As a result we need to get their approval for this request. We'll forward your request to them and get back to you with their decision.",
-        )}
-      </span>
-    );
+    return null;
   }
 
   return (

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.tsx
@@ -14,11 +14,21 @@ export const CapSubContent: React.FC = () => {
   const { t } = useTranslation();
   const locale = useLocale();
   const currency = 'USD';
-  const { requestData } = useAdditionalSalaryRequest();
+  const { requestData, hasBoardCapException } = useAdditionalSalaryRequest();
   const progressiveApprovalTier =
     requestData?.latestAdditionalSalaryRequest?.progressiveApprovalTier;
 
   const { values } = useFormikContext<CompleteFormValues>();
+
+  if (hasBoardCapException) {
+    return (
+      <span>
+        {t(
+          "You have a Board approved Maximum Allowable Salary (CAP) and your Additional Salary Request exceeds that amount. As a result we need to get their approval for this request. We'll forward your request to them and get back to you with their decision.",
+        )}
+      </span>
+    );
+  }
 
   return (
     <>

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/getCapOverrides.test.ts
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/getCapOverrides.test.ts
@@ -1,0 +1,46 @@
+import { getCapOverrides } from './getCapOverrides';
+
+const t = ((key: string) => key) as unknown as Parameters<
+  typeof getCapOverrides
+>[4];
+
+describe('getCapOverrides', () => {
+  it('returns undefined title/content when not exceeding cap', () => {
+    const result = getCapOverrides(false, false, false, false, t);
+    expect(result.title).toBeUndefined();
+    expect(result.content).toBeUndefined();
+  });
+
+  it('returns split-asr messaging when splitAsr is true', () => {
+    const result = getCapOverrides(true, false, false, false, t);
+    expect(result.title).toMatch(/exceeds your remaining allowable salary/);
+  });
+
+  it('returns Progressive Approvals messaging when exceeds cap without board exception', () => {
+    const result = getCapOverrides(false, false, true, false, t);
+    expect(result.title).toMatch(/requires additional approval/);
+    expect(result.content).toMatch(/exceed your Maximum Allowable Salary/);
+  });
+
+  it('returns board-approval messaging when exceeds cap with board exception', () => {
+    const result = getCapOverrides(false, false, true, true, t);
+    expect(result.title).toMatch(/Board approval/);
+    expect(result.content).toMatch(
+      /You have a Board approved Maximum Allowable Salary/,
+    );
+    expect(result.content).toMatch(/Additional Salary Request exceeds/);
+  });
+
+  it('board exception takes precedence over additionalApproval branch', () => {
+    const result = getCapOverrides(false, true, false, true, t);
+    expect(result.content).toMatch(
+      /You have a Board approved Maximum Allowable Salary/,
+    );
+  });
+
+  it('board exception does not apply when user is not exceeding cap', () => {
+    const result = getCapOverrides(false, false, false, true, t);
+    expect(result.title).toBeUndefined();
+    expect(result.content).toBeUndefined();
+  });
+});

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/getCapOverrides.test.ts
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/getCapOverrides.test.ts
@@ -2,28 +2,60 @@ import { getCapOverrides } from './getCapOverrides';
 
 const t = ((key: string) => key) as unknown as Parameters<
   typeof getCapOverrides
->[4];
+>[1];
 
 describe('getCapOverrides', () => {
   it('returns undefined title/content when not exceeding cap', () => {
-    const result = getCapOverrides(false, false, false, false, t);
+    const result = getCapOverrides(
+      {
+        splitAsr: false,
+        additionalApproval: false,
+        exceedsCap: false,
+        hasBoardCapException: false,
+      },
+      t,
+    );
     expect(result.title).toBeUndefined();
     expect(result.content).toBeUndefined();
   });
 
   it('returns split-asr messaging when splitAsr is true', () => {
-    const result = getCapOverrides(true, false, false, false, t);
+    const result = getCapOverrides(
+      {
+        splitAsr: true,
+        additionalApproval: false,
+        exceedsCap: false,
+        hasBoardCapException: false,
+      },
+      t,
+    );
     expect(result.title).toMatch(/exceeds your remaining allowable salary/);
   });
 
   it('returns Progressive Approvals messaging when exceeds cap without board exception', () => {
-    const result = getCapOverrides(false, false, true, false, t);
+    const result = getCapOverrides(
+      {
+        splitAsr: false,
+        additionalApproval: false,
+        exceedsCap: true,
+        hasBoardCapException: false,
+      },
+      t,
+    );
     expect(result.title).toMatch(/requires additional approval/);
     expect(result.content).toMatch(/exceed your Maximum Allowable Salary/);
   });
 
   it('returns board-approval messaging when exceeds cap with board exception', () => {
-    const result = getCapOverrides(false, false, true, true, t);
+    const result = getCapOverrides(
+      {
+        splitAsr: false,
+        additionalApproval: false,
+        exceedsCap: true,
+        hasBoardCapException: true,
+      },
+      t,
+    );
     expect(result.title).toMatch(/Board approval/);
     expect(result.content).toMatch(
       /You have a Board approved Maximum Allowable Salary/,
@@ -32,14 +64,30 @@ describe('getCapOverrides', () => {
   });
 
   it('board exception takes precedence over additionalApproval branch', () => {
-    const result = getCapOverrides(false, true, false, true, t);
+    const result = getCapOverrides(
+      {
+        splitAsr: false,
+        additionalApproval: true,
+        exceedsCap: false,
+        hasBoardCapException: true,
+      },
+      t,
+    );
     expect(result.content).toMatch(
       /You have a Board approved Maximum Allowable Salary/,
     );
   });
 
   it('board exception does not apply when user is not exceeding cap', () => {
-    const result = getCapOverrides(false, false, false, true, t);
+    const result = getCapOverrides(
+      {
+        splitAsr: false,
+        additionalApproval: false,
+        exceedsCap: false,
+        hasBoardCapException: true,
+      },
+      t,
+    );
     expect(result.title).toBeUndefined();
     expect(result.content).toBeUndefined();
   });

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/getCapOverrides.ts
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/getCapOverrides.ts
@@ -4,6 +4,7 @@ export const getCapOverrides = (
   splitAsr: boolean,
   additionalApproval: boolean,
   exceedsCap: boolean,
+  hasBoardCapException: boolean,
   t: TFunction,
 ) => {
   if (splitAsr) {
@@ -16,6 +17,17 @@ export const getCapOverrides = (
   }
 
   if (additionalApproval || exceedsCap) {
+    if (hasBoardCapException) {
+      return {
+        title: t(
+          'Your request requires Board approval. Please review the information below to continue.',
+        ),
+        content: t(
+          "You have a Board approved Maximum Allowable Salary (CAP) and your Additional Salary Request exceeds that amount. As a result we need to get their approval for this request. We'll forward your request to them and get back to you with their decision.",
+        ),
+      };
+    }
+
     return {
       title: t(
         'Your request requires additional approval. Please fill in the information below to continue.',

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/getCapOverrides.ts
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/getCapOverrides.ts
@@ -1,10 +1,19 @@
 import { TFunction } from 'i18next';
 
+interface CapOverridesOptions {
+  splitAsr: boolean;
+  additionalApproval: boolean;
+  exceedsCap: boolean;
+  hasBoardCapException: boolean;
+}
+
 export const getCapOverrides = (
-  splitAsr: boolean,
-  additionalApproval: boolean,
-  exceedsCap: boolean,
-  hasBoardCapException: boolean,
+  {
+    splitAsr,
+    additionalApproval,
+    exceedsCap,
+    hasBoardCapException,
+  }: CapOverridesOptions,
   t: TFunction,
 ) => {
   if (splitAsr) {

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/RequestPage.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/RequestPage.test.tsx
@@ -778,12 +778,10 @@ describe('RequestPage', () => {
       const submitButton = await findByRole('button', { name: /submit/i });
       userEvent.click(submitButton);
 
-      // The board cap text appears in both the modal's bold contentTitle
-      // (from overrideContent) and the CapSubContent span (from overrideSubContent)
       const matches = await findAllByText(
         /You have a Board approved Maximum Allowable Salary/,
       );
-      expect(matches.length).toBeGreaterThanOrEqual(2);
+      expect(matches).toHaveLength(1);
     });
   });
 });

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/RequestPage.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/RequestPage.test.tsx
@@ -783,5 +783,47 @@ describe('RequestPage', () => {
       );
       expect(matches).toHaveLength(1);
     });
+
+    it('shows normal submit modal when user has board cap exception but does not exceed cap', async () => {
+      mockUseAdditionalSalaryRequest.mockReturnValue({
+        ...boardCapContextValue,
+        requestData: {
+          latestAdditionalSalaryRequest: {
+            ...boardCapContextValue.requestData.latestAdditionalSalaryRequest,
+            calculations: {
+              ...boardCapContextValue.requestData.latestAdditionalSalaryRequest
+                .calculations,
+              currentSalaryCap: 100000,
+            },
+          },
+        },
+      } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
+
+      const underCapValues: CompleteFormValues = {
+        ...defaultCompleteFormValues,
+        currentYearSalaryNotReceived: '500',
+        totalAdditionalSalaryRequested: '500',
+        phoneNumber: '555-123-4567',
+        emailAddress: 'test@example.com',
+        electionType403b: ElectionType403bEnum.None,
+      };
+
+      const { findByRole, findByText, queryByText } = render(
+        <TestWrapper initialValues={underCapValues} />,
+      );
+
+      const submitButton = await findByRole('button', { name: /submit/i });
+      userEvent.click(submitButton);
+
+      expect(
+        await findByText(
+          'Are you ready to submit your Additional Salary Request?',
+        ),
+      ).toBeInTheDocument();
+      expect(queryByText(/requires Board approval/)).not.toBeInTheDocument();
+      expect(
+        queryByText(/You have a Board approved Maximum Allowable Salary/),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/RequestPage.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/RequestPage.test.tsx
@@ -8,7 +8,10 @@ import { I18nextProvider } from 'react-i18next';
 import * as yup from 'yup';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import { AsrStatusEnum } from 'src/graphql/types.generated';
+import {
+  AsrStatusEnum,
+  ElectionType403bEnum,
+} from 'src/graphql/types.generated';
 import i18n from 'src/lib/i18n';
 import { amount, phoneNumber } from 'src/lib/yupHelpers';
 import theme from 'src/theme';
@@ -100,6 +103,7 @@ const defaultMockContextValue = {
   setIsNewAsr: jest.fn(),
   isSpouse: false,
   hasSpouse: false,
+  hasBoardCapException: false,
 };
 
 const router = {
@@ -711,5 +715,75 @@ describe('RequestPage', () => {
 
     const backLink = queryByRole('link', { name: /back to dashboard/i });
     expect(backLink).not.toBeInTheDocument();
+  });
+
+  describe('board cap exception', () => {
+    const boardCapContextValue = {
+      ...defaultMockContextValue,
+      currentIndex: mockSteps.length - 2,
+      currentStep: AdditionalSalaryRequestSectionEnum.CompleteForm,
+      hasBoardCapException: true,
+      requestData: {
+        latestAdditionalSalaryRequest: {
+          id: 'asr-1',
+          status: AsrStatusEnum.InProgress,
+          calculations: {
+            currentSalaryCap: 10000,
+            combinedCap: null,
+            staffAccountBalance: 999999,
+            pendingAsrAmount: 0,
+          },
+          progressiveApprovalTier: null,
+        },
+      },
+    };
+
+    const overCapInitialValues: CompleteFormValues = {
+      ...defaultCompleteFormValues,
+      currentYearSalaryNotReceived: '20000',
+      totalAdditionalSalaryRequested: '20000',
+      phoneNumber: '555-123-4567',
+      emailAddress: 'test@example.com',
+      electionType403b: ElectionType403bEnum.None,
+    };
+
+    it('shows board approval title in submit modal when user has board cap exception and exceeds cap', async () => {
+      mockUseAdditionalSalaryRequest.mockReturnValue(
+        boardCapContextValue as unknown as ReturnType<
+          typeof useAdditionalSalaryRequest
+        >,
+      );
+
+      const { findByRole, findByText } = render(
+        <TestWrapper initialValues={overCapInitialValues} />,
+      );
+
+      const submitButton = await findByRole('button', { name: /submit/i });
+      userEvent.click(submitButton);
+
+      expect(await findByText(/requires Board approval/)).toBeInTheDocument();
+    });
+
+    it('shows board cap sub-content in submit modal when user has board cap exception and exceeds cap', async () => {
+      mockUseAdditionalSalaryRequest.mockReturnValue(
+        boardCapContextValue as unknown as ReturnType<
+          typeof useAdditionalSalaryRequest
+        >,
+      );
+
+      const { findByRole, findAllByText } = render(
+        <TestWrapper initialValues={overCapInitialValues} />,
+      );
+
+      const submitButton = await findByRole('button', { name: /submit/i });
+      userEvent.click(submitButton);
+
+      // The board cap text appears in both the modal's bold contentTitle
+      // (from overrideContent) and the CapSubContent span (from overrideSubContent)
+      const matches = await findAllByText(
+        /You have a Board approved Maximum Allowable Salary/,
+      );
+      expect(matches.length).toBeGreaterThanOrEqual(2);
+    });
   });
 });

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/RequestPage.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/RequestPage.tsx
@@ -48,6 +48,7 @@ const MainContent: React.FC = () => {
     spouse,
     isSpouse,
     setIsNewAsr,
+    hasBoardCapException,
   } = useAdditionalSalaryRequest();
 
   const [createRequest, { loading: creatingRequest }] =
@@ -104,6 +105,7 @@ const MainContent: React.FC = () => {
     !!splitAsr,
     !!additionalApproval,
     exceedsCap,
+    hasBoardCapException,
     t,
   );
 
@@ -161,8 +163,9 @@ const MainContent: React.FC = () => {
                 additionalApproval={additionalApproval || exceedsCap}
                 splitAsr={splitAsr}
                 disableSubmit={
-                  (splitAsr && !!errors.additionalInfo) ||
-                  (exceedsCap && !!errors.additionalInfo)
+                  !hasBoardCapException &&
+                  ((splitAsr && !!errors.additionalInfo) ||
+                    (exceedsCap && !!errors.additionalInfo))
                 }
                 overrideNext={isFirstFormPage ? handleContinue : undefined}
               />

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/RequestPage.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/RequestPage.tsx
@@ -102,10 +102,12 @@ const MainContent: React.FC = () => {
   const isFormPage = !isFirstFormPage && !reviewPage;
 
   const { title: overrideTitle, content: overrideContent } = getCapOverrides(
-    !!splitAsr,
-    !!additionalApproval,
-    exceedsCap,
-    hasBoardCapException,
+    {
+      splitAsr: !!splitAsr,
+      additionalApproval: !!additionalApproval,
+      exceedsCap,
+      hasBoardCapException,
+    },
     t,
   );
 
@@ -163,9 +165,8 @@ const MainContent: React.FC = () => {
                 additionalApproval={additionalApproval || exceedsCap}
                 splitAsr={splitAsr}
                 disableSubmit={
-                  !hasBoardCapException &&
-                  ((splitAsr && !!errors.additionalInfo) ||
-                    (exceedsCap && !!errors.additionalInfo))
+                  (splitAsr && !!errors.additionalInfo) ||
+                  (exceedsCap && !!errors.additionalInfo)
                 }
                 overrideNext={isFirstFormPage ? handleContinue : undefined}
               />

--- a/src/components/Reports/AdditionalSalaryRequest/Shared/AdditionalSalaryRequestContext.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/Shared/AdditionalSalaryRequestContext.tsx
@@ -74,6 +74,7 @@ export type AdditionalSalaryRequestType = {
   setIsNewAsr: React.Dispatch<React.SetStateAction<boolean>>;
   isSpouse: boolean;
   hasSpouse: boolean;
+  hasBoardCapException: boolean;
   isPending: boolean;
   isApproved: boolean;
 };
@@ -210,6 +211,8 @@ export const AdditionalSalaryRequestProvider: React.FC<Props> = ({
       ? primaryPerson
       : spousePerson
     : undefined;
+  const hasBoardCapException =
+    user?.exceptionSalaryCap?.boardCapException ?? false;
 
   const salaryInfo = salaryInfoData?.salaryInfo;
   const isInternational = user?.staffInfo?.isInternational ?? false;
@@ -259,6 +262,7 @@ export const AdditionalSalaryRequestProvider: React.FC<Props> = ({
       setIsNewAsr,
       isSpouse,
       hasSpouse,
+      hasBoardCapException,
       isPending,
       isApproved,
     }),
@@ -295,6 +299,7 @@ export const AdditionalSalaryRequestProvider: React.FC<Props> = ({
       setIsNewAsr,
       isSpouse,
       hasSpouse,
+      hasBoardCapException,
       isPending,
       isApproved,
     ],

--- a/src/components/Reports/AdditionalSalaryRequest/Shared/AutoSave/AutosaveCustomTextField.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/Shared/AutoSave/AutosaveCustomTextField.test.tsx
@@ -82,6 +82,7 @@ const defaultMockContextValue: AdditionalSalaryRequestType = {
   setIsNewAsr: jest.fn(),
   isSpouse: false,
   hasSpouse: false,
+  hasBoardCapException: false,
   isPending: false,
   isApproved: false,
 };

--- a/src/components/Reports/AdditionalSalaryRequest/Shared/AutoSave/useSaveField.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/Shared/AutoSave/useSaveField.test.tsx
@@ -94,6 +94,7 @@ const defaultMockContextValue: AdditionalSalaryRequestType = {
   setIsNewAsr: jest.fn(),
   isSpouse: false,
   hasSpouse: false,
+  hasBoardCapException: false,
   isPending: false,
   isApproved: false,
 };

--- a/src/components/Reports/AdditionalSalaryRequest/Shared/useAdditionalSalaryRequestForm.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/Shared/useAdditionalSalaryRequestForm.test.tsx
@@ -102,6 +102,7 @@ const defaultMockContextValue: AdditionalSalaryRequestType = {
   setIsNewAsr: jest.fn(),
   isSpouse: false,
   hasSpouse: false,
+  hasBoardCapException: false,
   isPending: false,
   isApproved: false,
 };
@@ -483,6 +484,32 @@ describe('useAdditionalSalaryRequestForm', () => {
       expect(errors.additionalInfo).toBe(
         'Additional info is required for requests exceeding your cap.',
       );
+    });
+
+    it('should not require additional info when exceedsCap is true and user has board cap exception', async () => {
+      mockUseAdditionalSalaryRequest.mockReturnValue({
+        ...defaultMockContextValue,
+        hasBoardCapException: true,
+      });
+
+      const { result } = renderHook(
+        () =>
+          useAdditionalSalaryRequestForm({
+            ...defaultFormValues,
+            phoneNumber: '555-123-4567',
+            additionalSalaryWithinMax: '70000',
+          }),
+        {
+          wrapper: TestWrapper,
+        },
+      );
+
+      let errors: Record<string, string> = {};
+      await act(async () => {
+        errors = await result.current.validateForm();
+      });
+
+      expect(errors.additionalInfo).toBeUndefined();
     });
 
     it('should not show electionType403b error before submit', () => {

--- a/src/components/Reports/AdditionalSalaryRequest/Shared/useAdditionalSalaryRequestForm.ts
+++ b/src/components/Reports/AdditionalSalaryRequest/Shared/useAdditionalSalaryRequestForm.ts
@@ -81,6 +81,7 @@ export const useAdditionalSalaryRequestForm = (
     isInternational,
     requestId,
     isSpouse,
+    hasBoardCapException,
   } = useAdditionalSalaryRequest();
 
   const { primaryAccountBalance } = useFormUserInfo();
@@ -208,6 +209,9 @@ export const useAdditionalSalaryRequestForm = (
             'required-when-exceeds-cap',
             t('Additional info is required for requests exceeding your cap.'),
             function (value) {
+              if (hasBoardCapException) {
+                return true;
+              }
               const total = getTotal(this.parent as CompleteFormValues);
               if (total > 0) {
                 lastValidTotalRef.current = total;
@@ -228,7 +232,14 @@ export const useAdditionalSalaryRequestForm = (
             t('Please select how you would like to contribute to your 403(b).'),
           ),
       }),
-    [createCurrencyValidation, t, primaryAccountBalance, individualCap, locale],
+    [
+      createCurrencyValidation,
+      t,
+      primaryAccountBalance,
+      individualCap,
+      locale,
+      hasBoardCapException,
+    ],
   );
 
   const onSubmit = useCallback(

--- a/src/components/Reports/AdditionalSalaryRequest/SharedComponents/CurrentRequest.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/SharedComponents/CurrentRequest.test.tsx
@@ -103,6 +103,7 @@ const mockContextValue = {
   setIsNewAsr: jest.fn(),
   isSpouse: false,
   hasSpouse: false,
+  hasBoardCapException: false,
   isPending: true,
   isApproved: false,
 };

--- a/src/components/Reports/AdditionalSalaryRequest/SharedComponents/StepList.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/SharedComponents/StepList.test.tsx
@@ -74,6 +74,7 @@ const mockContextValue = {
   setIsNewAsr: jest.fn(),
   isSpouse: false,
   hasSpouse: false,
+  hasBoardCapException: false,
   isPending: false,
   isApproved: false,
 };

--- a/src/components/Reports/Shared/HcmData/HCMData.graphql
+++ b/src/components/Reports/Shared/HcmData/HCMData.graphql
@@ -34,6 +34,7 @@ query HcmData {
     exceptionSalaryCap {
       amount
       effectiveDate
+      boardCapException
     }
     fourOThreeB {
       currentRothContributionPercentage

--- a/src/components/Reports/Shared/HcmData/mockData.ts
+++ b/src/components/Reports/Shared/HcmData/mockData.ts
@@ -46,6 +46,7 @@ const noMhaAndNoException: HcmDataQuery['hcm'][number] = {
   exceptionSalaryCap: {
     amount: null,
     effectiveDate: null,
+    boardCapException: false,
   },
   fourOThreeB: {
     currentTaxDeferredContributionPercentage: 6,
@@ -113,4 +114,17 @@ export const marriedUserEligibleSpouseIneligible: HcmDataQuery['hcm'] = [
     ...ineligibleAndNoException,
     staffInfo: janeDoe,
   },
+];
+
+const noMhaWithBoardCapException: HcmDataQuery['hcm'][number] = {
+  ...noMhaAndNoException,
+  exceptionSalaryCap: {
+    amount: null,
+    effectiveDate: null,
+    boardCapException: true,
+  },
+};
+
+export const singleNoMhaWithBoardCapException: HcmDataQuery['hcm'] = [
+  noMhaWithBoardCapException,
 ];

--- a/src/components/Reports/Shared/HcmData/mockData.ts
+++ b/src/components/Reports/Shared/HcmData/mockData.ts
@@ -115,16 +115,3 @@ export const marriedUserEligibleSpouseIneligible: HcmDataQuery['hcm'] = [
     staffInfo: janeDoe,
   },
 ];
-
-const noMhaWithBoardCapException: HcmDataQuery['hcm'][number] = {
-  ...noMhaAndNoException,
-  exceptionSalaryCap: {
-    amount: null,
-    effectiveDate: null,
-    boardCapException: true,
-  },
-};
-
-export const singleNoMhaWithBoardCapException: HcmDataQuery['hcm'] = [
-  noMhaWithBoardCapException,
-];


### PR DESCRIPTION
## Description

- Users with a board cap exception whose Additional Salary Request would exceed their cap now see a "requires Board approval" message instead of the standard Progressive Approvals flow.
- The `additionalInfo` field is now optional for these users (they don't need to justify the over-cap request because the board has already approved their elevated cap).
- Added `boardCapException` to the shared `HcmData` GraphQL query (previously only consumed by the SalaryCalculator).
- Exposed `hasBoardCapException` through the ASR context so `getCapOverrides`, `CapSubContent`, and the Yup validation can branch on it.
- Related: MPDX-9404

## Testing

- Go to **Reports → Additional Salary Request** as a user with `exceptionSalaryCap.boardCapException: true`.
- Enter salary items totaling more than your Maximum Allowable Salary.
- Check that the banner title reads **"Your request requires Board approval..."** instead of the Progressive Approvals messaging.
- Click **Submit** and confirm the submit modal shows **"You have a Board approved Maximum Allowable Salary (CAP) and your Additional Salary Request exceeds that amount..."**
- Confirm the **Additional Info** field is not required (submit works with it empty).
- As a normal user (no board cap exception), verify the existing Progressive Approvals flow is unchanged when exceeding the cap.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code \`/pr-review\` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history