### PR TITLE
MPDX-9444 - Designation Support Calc: Pull 403b contribution from HCM

### DIFF
--- a/src/components/Reports/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
+++ b/src/components/Reports/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
@@ -6,6 +6,7 @@ import { SnackbarProvider } from 'notistack';
 import { DeepPartial } from 'ts-essentials';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider, gqlMock } from '__tests__/util/graphqlMocking';
+import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import {
   DesignationSupportSalaryType,
   DesignationSupportStatus,
@@ -18,6 +19,11 @@ import {
   PdsGoalCalculationsQuery,
   PdsGoalCalculationsQueryVariables,
 } from './GoalsList/PdsGoalCalculations.generated';
+import {
+  HcmUserDocument,
+  HcmUserQuery,
+  HcmUserQueryVariables,
+} from './Shared/HCM.generated';
 import { PdsGoalCalculatorProvider } from './Shared/PdsGoalCalculatorContext';
 
 const calculationsDefault = gqlMock<
@@ -50,11 +56,32 @@ export type PdsGoalCalculationMock = DeepPartial<
   PdsGoalCalculationQuery['designationSupportCalculation']
 >;
 
+const hcmUserDefault = gqlMock<HcmUserQuery, HcmUserQueryVariables>(
+  HcmUserDocument,
+  {
+    mocks: {
+      hcm: [
+        {
+          fourOThreeB: {
+            currentTaxDeferredContributionPercentage: 0,
+            currentRothContributionPercentage: 0,
+          },
+        },
+      ],
+    },
+  },
+);
+
+export type HcmUserMock = DeepPartial<HcmUserQuery['hcm'][number]>;
+export type GetUserMock = DeepPartial<GetUserQuery>;
+
 export interface PdsGoalCalculatorTestWrapperProps {
   children?: React.ReactNode;
   withProvider?: boolean;
   calculationsMock?: PdsGoalCalculationsMock;
   calculationMock?: PdsGoalCalculationMock;
+  hcmUserMock?: HcmUserMock | null;
+  userMock?: GetUserMock;
   onCall?: MockLinkCallHandler;
   router?: React.ComponentProps<typeof TestRouter>['router'];
 }
@@ -66,6 +93,8 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
   withProvider = true,
   calculationsMock,
   calculationMock,
+  hcmUserMock,
+  userMock,
   onCall,
   router,
 }) => {
@@ -82,6 +111,8 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
             PdsGoalCalculations: PdsGoalCalculationsQuery;
             PdsGoalCalculation: PdsGoalCalculationQuery;
             GoalCalculatorConstants: GoalCalculatorConstantsQuery;
+            HcmUser: HcmUserQuery;
+            GetUser: GetUserQuery;
           }>
             mocks={{
               PdsGoalCalculations: {
@@ -98,6 +129,13 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
                     },
                   }
                 : {}),
+              HcmUser: {
+                hcm:
+                  hcmUserMock === null
+                    ? []
+                    : [merge({}, hcmUserDefault.hcm[0], hcmUserMock)],
+              },
+              ...(userMock ? { GetUser: userMock } : {}),
               GoalCalculatorConstants: {
                 constant: {
                   mpdGoalBenefitsConstants: [],

--- a/src/components/Reports/PdsGoalCalculator/Setup/SetupStep.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/SetupStep.test.tsx
@@ -126,6 +126,71 @@ describe('SetupStep', () => {
     ).toBeDisabled();
   });
 
+  it('displays the sum of tax-deferred and Roth 403b contribution percentages', async () => {
+    const { findByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={fullTimeSalariedMock}
+        hcmUserMock={{
+          fourOThreeB: {
+            currentTaxDeferredContributionPercentage: 5,
+            currentRothContributionPercentage: 3,
+          },
+        }}
+      >
+        <SetupStep />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await waitFor(async () =>
+      expect(
+        await findByRole('textbox', {
+          name: '403b Contribution Percentage',
+        }),
+      ).toHaveValue('8'),
+    );
+  });
+
+  it('403b field is empty when hcm data has no 403b entry', async () => {
+    const { findByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={fullTimeSalariedMock}
+        hcmUserMock={null}
+      >
+        <SetupStep />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    expect(
+      await findByRole('textbox', {
+        name: '403b Contribution Percentage',
+      }),
+    ).toHaveValue('');
+  });
+
+  it('displays the logged-in user first name and avatar', async () => {
+    const { getByTestId, getByAltText } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={fullTimeSalariedMock}
+        userMock={{
+          user: {
+            firstName: 'Jane',
+            avatar: 'https://example.com/jane.png',
+          },
+        }}
+      >
+        <SetupStep />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await waitFor(() =>
+      expect(getByTestId('info-name-typography')).toHaveTextContent('Jane'),
+    );
+    expect(getByAltText('Jane')).toHaveAttribute(
+      'src',
+      'https://example.com/jane.png',
+    );
+  });
+
   it('Geographic Multiplier autocomplete renders', async () => {
     const { findByRole } = render(
       <PdsGoalCalculatorTestWrapper calculationMock={fullTimeSalariedMock}>

--- a/src/components/Reports/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo } from 'react';
 import {
   Autocomplete,
+  AutocompleteRenderInputParams,
+  Avatar,
   Box,
   Card,
   Divider,
@@ -12,8 +14,12 @@ import {
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
-import { CurrencyAdornment } from 'src/components/Reports/GoalCalculator/Shared/Adornments';
+import {
+  CurrencyAdornment,
+  PercentageAdornment,
+} from 'src/components/Reports/GoalCalculator/Shared/Adornments';
 import { AutosaveForm } from 'src/components/Shared/Autosave/AutosaveForm';
+import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import {
   DesignationSupportSalaryType,
   DesignationSupportStatus,
@@ -26,7 +32,13 @@ import { usePdsGoalCalculator } from '../Shared/PdsGoalCalculatorContext';
 export const SetupStep: React.FC = () => {
   const { t } = useTranslation();
   const theme = useTheme();
-  const { calculation } = usePdsGoalCalculator();
+  const { calculation, hcmUser } = usePdsGoalCalculator();
+  const { data: userData } = useGetUserQuery();
+  const fourOThreeB = hcmUser?.fourOThreeB;
+  const totalFourOThreeBContributionPercentage = fourOThreeB
+    ? (fourOThreeB.currentTaxDeferredContributionPercentage ?? 0) +
+      (fourOThreeB.currentRothContributionPercentage ?? 0)
+    : null;
 
   const schema = useMemo(
     () =>
@@ -89,6 +101,17 @@ export const SetupStep: React.FC = () => {
       </Box>
 
       <Card sx={{ padding: theme.spacing(3) }}>
+        <Box display="flex" alignItems="center" gap={1} mb={3}>
+          <Avatar
+            src={userData?.user.avatar}
+            alt={userData?.user.firstName ?? undefined}
+            variant="rounded"
+            sx={{ width: theme.spacing(4.5), height: theme.spacing(4.5) }}
+          />
+          <Typography data-testid="info-name-typography" variant="subtitle1">
+            {userData?.user.firstName}
+          </Typography>
+        </Box>
         <Grid container spacing={3}>
           <Grid item xs={12}>
             <AutosaveTextField
@@ -169,7 +192,13 @@ export const SetupStep: React.FC = () => {
               variant="outlined"
               label={t('403b Contribution Percentage')}
               disabled
-              helperText={t('Retrieved from Principal')}
+              value={totalFourOThreeBContributionPercentage ?? ''}
+              helperText={t(
+                'Retrieved from Principal. A combined percentage of your current tax deferred and Roth contributions.',
+              )}
+              InputProps={{
+                endAdornment: <PercentageAdornment />,
+              }}
             />
           </Grid>
 
@@ -177,12 +206,12 @@ export const SetupStep: React.FC = () => {
             <Autocomplete
               options={locations}
               value={calculation?.geographicLocation ?? 'None'}
-              onChange={(_, newValue) =>
+              onChange={(_, newValue: string | null) =>
                 saveField({ geographicLocation: newValue })
               }
               disabled={!calculation}
               size="small"
-              renderInput={(params) => (
+              renderInput={(params: AutocompleteRenderInputParams) => (
                 <TextField
                   {...params}
                   label={t('Geographic Multiplier')}

--- a/src/components/Reports/PdsGoalCalculator/Shared/HCM.graphql
+++ b/src/components/Reports/PdsGoalCalculator/Shared/HCM.graphql
@@ -1,0 +1,10 @@
+query HcmUser($effectiveDate: ISO8601Date) {
+  hcm(effectiveDate: $effectiveDate) {
+    fourOThreeB {
+      currentTaxDeferredContributionPercentage
+      currentRothContributionPercentage
+      maximumContributionLimit
+      fourOThreeBMakeUpLimitAmount
+    }
+  }
+}

--- a/src/components/Reports/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -7,6 +7,7 @@ import {
   usePdsGoalCalculationQuery,
 } from '../GoalsList/PdsGoalCalculations.generated';
 import { PdsGoalCalculatorStepEnum } from '../PdsGoalCalculatorHelper';
+import { HcmUserQuery, useHcmUserQuery } from './HCM.generated';
 import { PdsGoalCalculatorStep, useSteps } from './useSteps';
 
 export type PdsGoalCalculatorType = {
@@ -15,6 +16,8 @@ export type PdsGoalCalculatorType = {
 
   calculation?: PdsGoalCalculationFieldsFragment;
   calculationLoading: boolean;
+
+  hcmUser?: HcmUserQuery['hcm'][number];
 
   rightPanelContent: React.ReactNode;
   setRightPanelContent: (content: React.ReactNode) => void;
@@ -59,6 +62,9 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
       skip: !pdsGoalId,
     });
   const calculation = calculationData?.designationSupportCalculation;
+
+  const { data: hcmData } = useHcmUserQuery();
+  const hcmUser = hcmData?.hcm[0];
 
   const steps = useSteps();
   const [stepIndex, setStepIndex] = useState(0);
@@ -109,6 +115,7 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
       stepIndex,
       calculation,
       calculationLoading,
+      hcmUser,
       rightPanelContent,
       isDrawerOpen,
       handleStepChange,
@@ -125,6 +132,7 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
       stepIndex,
       calculation,
       calculationLoading,
+      hcmUser,
       rightPanelContent,
       isDrawerOpen,
       handleStepChange,


### PR DESCRIPTION
## Description

Pulls 403b contribution directly from HCM, sets it as an uneditable field. 
The drawback to pulling this value frontend side is an extra HCM call. The upside is this value isn't meant to be persisted, so it's not entirely appropriate to pull it API side and apply it to the DesignationSupportCalculation model.

While in this file, I also added the name and avatar display, to more closely match the GoalCalculator and help users understand that they are working with their own information.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `reports/pdsGoalCalculator`
- Open a goal or create a new one.
- Check that the 403b contribution is correctly pulled from HCM. 
- Check that the Name + Avatar box looks good.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
