### PR TITLE
MPDX-9449 - Add saving status and mutation tracking to PdsGoalCalculator

### DIFF
--- a/pages/accountLists/[accountListId]/reports/pdsGoalCalculator/[pdsGoalId].page.test.tsx
+++ b/pages/accountLists/[accountListId]/reports/pdsGoalCalculator/[pdsGoalId].page.test.tsx
@@ -1,8 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react';
 import { blockImpersonatingNonDevelopers } from 'pages/api/utils/pagePropsHelpers';
-import { getServerSideProps } from './[pdsGoalId].page';
+import { PdsGoalCalculatorTestWrapper } from 'src/components/Reports/PdsGoalCalculator/PdsGoalCalculatorTestWrapper';
+import { PdsGoalCalculatorPage, getServerSideProps } from './[pdsGoalId].page';
 
 describe('[pdsGoalId] page', () => {
   it('uses blockImpersonatingNonDevelopers for server-side props', () => {
     expect(getServerSideProps).toBe(blockImpersonatingNonDevelopers);
+  });
+
+  it('renders Saving indicator', async () => {
+    const { findByText } = render(
+      <PdsGoalCalculatorTestWrapper withProvider={false}>
+        <PdsGoalCalculatorPage />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    expect(await findByText(/Last saved/)).toBeInTheDocument();
   });
 });

--- a/pages/accountLists/[accountListId]/reports/pdsGoalCalculator/[pdsGoalId].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/pdsGoalCalculator/[pdsGoalId].page.tsx
@@ -12,6 +12,7 @@ import {
   PdsGoalCalculatorProvider,
   usePdsGoalCalculator,
 } from 'src/components/Reports/PdsGoalCalculator/Shared/PdsGoalCalculatorContext';
+import { SavingStatus } from 'src/components/Reports/Shared/CalculationReports/SavingStatus/SavingStatus';
 import {
   HeaderTypeEnum,
   MultiPageHeader,
@@ -54,7 +55,13 @@ const PdsGoalCalculatorContent: React.FC<PdsGoalCalculatorContentProps> = ({
   designationAccounts,
   setDesignationAccounts,
 }) => {
-  const { rightPanelContent, closeRightPanel } = usePdsGoalCalculator();
+  const {
+    rightPanelContent,
+    closeRightPanel,
+    calculation,
+    calculationLoading,
+    isMutating,
+  } = usePdsGoalCalculator();
   const { t } = useTranslation();
 
   const rightPanel = (
@@ -96,6 +103,14 @@ const PdsGoalCalculatorContent: React.FC<PdsGoalCalculatorContentProps> = ({
             isNavListOpen={isNavListOpen}
             onNavListToggle={onNavListToggle}
             title={t('Paid with Designation Support Goal Calculator')}
+            rightExtra={
+              <SavingStatus
+                loading={calculationLoading}
+                hasData={!!calculation}
+                isMutating={isMutating}
+                lastSavedAt={calculation?.updatedAt ?? null}
+              />
+            }
             headerType={HeaderTypeEnum.Report}
           />
           <PdsGoalCalculator />
@@ -107,7 +122,7 @@ const PdsGoalCalculatorContent: React.FC<PdsGoalCalculatorContentProps> = ({
   );
 };
 
-const PdsGoalCalculatorPage: React.FC = () => {
+export const PdsGoalCalculatorPage: React.FC = () => {
   const { t } = useTranslation();
   const { appName } = useGetAppSettings();
   const accountListId = useAccountListId();

--- a/src/components/Reports/PdsGoalCalculator/Shared/Autosave/useSaveField.ts
+++ b/src/components/Reports/PdsGoalCalculator/Shared/Autosave/useSaveField.ts
@@ -4,7 +4,7 @@ import { DesignationSupportCalculationUpdateInput } from 'src/graphql/types.gene
 import { useUpdatePdsGoalCalculationMutation } from '../../GoalsList/PdsGoalCalculations.generated';
 
 export const useSaveField = () => {
-  const { calculation } = usePdsGoalCalculator();
+  const { calculation, trackMutation } = usePdsGoalCalculator();
   const [updatePdsGoalCalculation] = useUpdatePdsGoalCalculationMutation();
 
   const saveField = useCallback(
@@ -20,25 +20,26 @@ export const useSaveField = () => {
         return;
       }
 
-      return updatePdsGoalCalculation({
-        variables: {
-          attributes: {
-            id: calculation.id,
-            ...attributes,
-          },
-        },
-        optimisticResponse: {
-          updateDesignationSupportCalculation: {
-            __typename: 'DesignationSupportCalculationUpdateMutationPayload',
-            designationSupportCalculation: {
-              ...calculation,
+      return trackMutation(
+        updatePdsGoalCalculation({
+          variables: {
+            attributes: {
+              id: calculation.id,
               ...attributes,
             },
           },
-        },
-      });
+          optimisticResponse: {
+            updateDesignationSupportCalculation: {
+              designationSupportCalculation: {
+                ...calculation,
+                ...attributes,
+              },
+            },
+          },
+        }),
+      );
     },
-    [calculation, updatePdsGoalCalculation],
+    [calculation, trackMutation, updatePdsGoalCalculation],
   );
 
   return saveField;

--- a/src/components/Reports/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import React, { createContext, useCallback, useMemo, useState } from 'react';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
+import { useTrackMutation } from 'src/hooks/useTrackMutation';
 import {
   PdsGoalCalculationFieldsFragment,
   usePdsGoalCalculationQuery,
@@ -16,8 +17,12 @@ export type PdsGoalCalculatorType = {
 
   calculation?: PdsGoalCalculationFieldsFragment;
   calculationLoading: boolean;
-
   hcmUser?: HcmUserQuery['hcm'][number];
+
+  /** Whether any mutations are currently in progress */
+  isMutating: boolean;
+  /** Call with the mutation promise to track the start and end of mutations */
+  trackMutation: <T>(mutation: Promise<T>) => Promise<T>;
 
   rightPanelContent: React.ReactNode;
   setRightPanelContent: (content: React.ReactNode) => void;
@@ -71,6 +76,7 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
   const [rightPanelContent, setRightPanelContent] =
     useState<React.ReactNode>(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(true);
+  const { trackMutation, isMutating } = useTrackMutation();
 
   const currentStep = steps[stepIndex];
 
@@ -115,6 +121,8 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
       stepIndex,
       calculation,
       calculationLoading,
+      isMutating,
+      trackMutation,
       hcmUser,
       rightPanelContent,
       isDrawerOpen,
@@ -132,6 +140,8 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
       stepIndex,
       calculation,
       calculationLoading,
+      isMutating,
+      trackMutation,
       hcmUser,
       rightPanelContent,
       isDrawerOpen,


### PR DESCRIPTION
## Description

Track save mutations to display the autosave in the top right corner of the calculator.
[MPDX-9449](https://jira.cru.org/browse/MPDX-9449)

## Testing

- Go to `reports/pdsGoalCalculator`
- Make modifications to a goal and view the autosave functionality and determine if it's good.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
