### PR TITLE
MPDX-9417 - Updates text to 'Current Gross Salary'

### DIFF
--- a/src/components/Reports/SalaryCalculator/Landing/useLandingData.ts
+++ b/src/components/Reports/SalaryCalculator/Landing/useLandingData.ts
@@ -220,7 +220,7 @@ export const useLandingData = (): LandingData => {
         spouse: getLocalizedTaxStatus(spouse?.staffInfo.secaStatus, t),
       },
       {
-        category: t('Gross Salary'),
+        category: t('Current Gross Salary'),
         user: salaryData.currentGrossSalary
           ? currencyFormat(salaryData.currentGrossSalary, 'USD', locale, {
               showTrailingZeros: true,
@@ -232,11 +232,11 @@ export const useLandingData = (): LandingData => {
             })
           : '-',
         tooltip: t(
-          'Gross Salary includes MHA, 403(b), SECA, and taxes if applicable.',
+          'Current Gross Salary includes MHA, 403(b), SECA, and taxes if applicable.',
         ),
       },
       {
-        category: t('Current MHA (Included in Gross Salary)'),
+        category: t('Current MHA (Included in Current Gross Salary)'),
         user: currencyFormat(salaryData.takenMha, 'USD', locale, {
           showTrailingZeros: true,
         }),

--- a/src/components/Reports/SalaryCalculator/Shared/SalaryInformationCard.test.tsx
+++ b/src/components/Reports/SalaryCalculator/Shared/SalaryInformationCard.test.tsx
@@ -46,9 +46,9 @@ describe('SalaryInformationCard', () => {
       ['Tax-deferred 403(b) Contribution', '5%', '6%'],
       ['Roth 403(b) Contribution', '12%', '10%'],
       ['Security (SECA/FICA) Status', 'Subject to SECA', 'Subject to SECA'],
-      ['Gross Salary', '$55,000.00', '$10,000.00'],
+      ['Current Gross Salary', '$55,000.00', '$10,000.00'],
       [
-        'Current MHA (Included in Gross Salary)',
+        'Current MHA (Included in Current Gross Salary)',
         '$10,000.00View MHA Form',
         '$12,000.00',
       ],


### PR DESCRIPTION
## Description

Change wording from Gross Salary to "Current Gross Salary".  This change is required on Information Page. Not entirely sure which report this is referencing, I'm assuming it's Salary Calculator as "Gross Salary" could be confusing here.

Jira ticket available [here](https://jira.cru.org/browse/MPDX-9417)

## Testing

- Go to Salary Calculator
- Under Current Salary Information, check the second line from the bottom says, "Current Gross Salary" rather then "Gross Salary"
-  Check the tooltip for "Current Gross Salary" references "Current Gross Salary" as well

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
