### PR TITLE
[No Jira] - Fix bug showing 'Thank You' page when deleting a request

### DIFF
--- a/src/components/Reports/AdditionalSalaryRequest/SharedComponents/CurrentRequest.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/SharedComponents/CurrentRequest.test.tsx
@@ -301,6 +301,6 @@ describe('CurrentRequest', () => {
     const confirmButton = getByRole('button', { name: /yes, cancel/i });
     userEvent.click(confirmButton);
 
-    expect(mockHandleDeleteRequest).toHaveBeenCalledWith('request-123', true);
+    expect(mockHandleDeleteRequest).toHaveBeenCalledWith('request-123', false);
   });
 });

--- a/src/components/Reports/AdditionalSalaryRequest/SharedComponents/CurrentRequest.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/SharedComponents/CurrentRequest.tsx
@@ -71,7 +71,7 @@ export const CurrentRequest: React.FC<CurrentRequestProps> = ({ request }) => {
       isRequest={true}
       disableCancel={isApproved}
       handlePrint={handlePrint}
-      handleConfirmCancel={() => handleDeleteRequest(id, true)}
+      handleConfirmCancel={() => handleDeleteRequest(id, false)}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column' }}>
         <Typography


### PR DESCRIPTION
## Description

When deleting a submitted request, it redirected the user to the "Thank You" page. This fix should now bring the user back to the start form page.

## Testing

- Go to ASR
- Submit a request
- Reload page
- Click Delete Request from the ASR list
- Ensure you are taken to the "Continue" page rather then the "Thank You" page

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
