### PR TITLE
MPDX-9451 - Scheduled maintenance: Disable autofocus rule in various components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -74,6 +74,7 @@ module.exports = {
     'react/jsx-no-useless-fragment': 'error',
     'react/prop-types': 'off',
     'react/react-in-jsx-scope': 'off',
+    'jsx-a11y/no-autofocus': 'off',
   },
   settings: {
     react: {

--- a/src/components/Settings/Accounts/InviteForm/InviteForm.tsx
+++ b/src/components/Settings/Accounts/InviteForm/InviteForm.tsx
@@ -136,7 +136,7 @@ export const InviteForm: React.FC<InviteFormProps> = ({ type }) => {
                 type="email"
                 name="email"
                 value={email}
-                autoFocus={true}
+                autoFocus
                 placeholder="person.to.share@cru.org"
                 onChange={handleChange}
               />

--- a/src/components/Settings/Accounts/InviteForm/InviteForm.tsx
+++ b/src/components/Settings/Accounts/InviteForm/InviteForm.tsx
@@ -136,7 +136,6 @@ export const InviteForm: React.FC<InviteFormProps> = ({ type }) => {
                 type="email"
                 name="email"
                 value={email}
-                // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus={true}
                 placeholder="person.to.share@cru.org"
                 onChange={handleChange}

--- a/src/components/Settings/Admin/ImpersonateUser/ImpersonateUserAccordion.tsx
+++ b/src/components/Settings/Admin/ImpersonateUser/ImpersonateUserAccordion.tsx
@@ -123,7 +123,6 @@ export const ImpersonateUserAccordion: React.FC<
                   type="email"
                   value={user}
                   disabled={isSubmitting}
-                  // eslint-disable-next-line jsx-a11y/no-autofocus
                   autoFocus={true}
                   name="user"
                   onChange={handleChange}

--- a/src/components/Settings/Admin/ImpersonateUser/ImpersonateUserAccordion.tsx
+++ b/src/components/Settings/Admin/ImpersonateUser/ImpersonateUserAccordion.tsx
@@ -123,7 +123,7 @@ export const ImpersonateUserAccordion: React.FC<
                   type="email"
                   value={user}
                   disabled={isSubmitting}
-                  autoFocus={true}
+                  autoFocus
                   name="user"
                   onChange={handleChange}
                 />

--- a/src/components/Settings/Admin/ResetAccount/ResetAccountAccordion.tsx
+++ b/src/components/Settings/Admin/ResetAccount/ResetAccountAccordion.tsx
@@ -112,7 +112,7 @@ export const ResetAccountAccordion: React.FC<
                   type="email"
                   value={user}
                   disabled={isSubmitting}
-                  autoFocus={true}
+                  autoFocus
                   onChange={handleChange('user')}
                 />
                 {errors.user && (

--- a/src/components/Settings/Admin/ResetAccount/ResetAccountAccordion.tsx
+++ b/src/components/Settings/Admin/ResetAccount/ResetAccountAccordion.tsx
@@ -112,7 +112,6 @@ export const ResetAccountAccordion: React.FC<
                   type="email"
                   value={user}
                   disabled={isSubmitting}
-                  // eslint-disable-next-line jsx-a11y/no-autofocus
                   autoFocus={true}
                   onChange={handleChange('user')}
                 />

--- a/src/components/Settings/Organization/AccountLists/AccountListRow/DeleteAccountConfirmModal.tsx
+++ b/src/components/Settings/Organization/AccountLists/AccountListRow/DeleteAccountConfirmModal.tsx
@@ -102,7 +102,6 @@ export const DeleteAccountConfirmModal: React.FC<
           </Typography>
           {t('Please explain the reason for deleting this account.')}
           <TextField
-            // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
             margin="dense"
             id={t('Reason')}

--- a/src/components/Settings/Organization/AccountLists/AccountListRow/DeleteUserConfirmModal.tsx
+++ b/src/components/Settings/Organization/AccountLists/AccountListRow/DeleteUserConfirmModal.tsx
@@ -93,7 +93,6 @@ export const DeleteUserConfirmModal: React.FC<DeleteUserConfirmModalProps> = ({
           </Typography>
           {t('Please explain the reason for deleting this user.')}
           <TextField
-            // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
             margin="dense"
             id={t('Reason')}

--- a/src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion.tsx
+++ b/src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion.tsx
@@ -133,7 +133,6 @@ export const ImpersonateUserAccordion: React.FC<
                   type="email"
                   value={user}
                   disabled={isSubmitting}
-                  // eslint-disable-next-line jsx-a11y/no-autofocus
                   autoFocus={true}
                   onChange={handleChange}
                   inputProps={{

--- a/src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion.tsx
+++ b/src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion.tsx
@@ -133,7 +133,7 @@ export const ImpersonateUserAccordion: React.FC<
                   type="email"
                   value={user}
                   disabled={isSubmitting}
-                  autoFocus={true}
+                  autoFocus
                   onChange={handleChange}
                   inputProps={{
                     'data-testid': 'impersonateUsername',

--- a/src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion.tsx
+++ b/src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion.tsx
@@ -356,7 +356,6 @@ export const ManageOrganizationAccessAccordion: React.FC<
                     type="email"
                     value={username}
                     disabled={isSubmitting}
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
                     autoFocus={true}
                     onChange={handleChange}
                     inputProps={{

--- a/src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion.tsx
+++ b/src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion.tsx
@@ -356,7 +356,7 @@ export const ManageOrganizationAccessAccordion: React.FC<
                     type="email"
                     value={username}
                     disabled={isSubmitting}
-                    autoFocus={true}
+                    autoFocus
                     onChange={handleChange}
                     inputProps={{
                       'data-testid': 'inviteUsername',

--- a/src/components/Settings/integrations/Organization/ConnectOrganization.tsx
+++ b/src/components/Settings/integrations/Organization/ConnectOrganization.tsx
@@ -276,7 +276,7 @@ export const ConnectOrganization: React.FC<ConnectOrganizationProps> = ({
                       label={t('Username')}
                       value={username}
                       disabled={isSubmitting}
-                      autoFocus={true}
+                      autoFocus
                       onChange={handleChange('username')}
                     />
                   </FieldWrapper>

--- a/src/components/Settings/integrations/Organization/ConnectOrganization.tsx
+++ b/src/components/Settings/integrations/Organization/ConnectOrganization.tsx
@@ -276,7 +276,6 @@ export const ConnectOrganization: React.FC<ConnectOrganizationProps> = ({
                       label={t('Username')}
                       value={username}
                       disabled={isSubmitting}
-                      // eslint-disable-next-line jsx-a11y/no-autofocus
                       autoFocus={true}
                       onChange={handleChange('username')}
                     />

--- a/src/components/Settings/integrations/Organization/Modals/OrganizationEditAccountModal.tsx
+++ b/src/components/Settings/integrations/Organization/Modals/OrganizationEditAccountModal.tsx
@@ -104,7 +104,6 @@ export const OrganizationEditAccountModal: React.FC<
                   label={t('Username')}
                   value={username}
                   disabled={isSubmitting}
-                  // eslint-disable-next-line jsx-a11y/no-autofocus
                   autoFocus={true}
                   onChange={handleChange('username')}
                 />

--- a/src/components/Settings/integrations/Organization/Modals/OrganizationEditAccountModal.tsx
+++ b/src/components/Settings/integrations/Organization/Modals/OrganizationEditAccountModal.tsx
@@ -104,7 +104,7 @@ export const OrganizationEditAccountModal: React.FC<
                   label={t('Username')}
                   value={username}
                   disabled={isSubmitting}
-                  autoFocus={true}
+                  autoFocus
                   onChange={handleChange('username')}
                 />
                 {errors.username && (

--- a/src/components/Settings/preferences/accordions/AccountNameAccordion/AccountNameAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/AccountNameAccordion/AccountNameAccordion.tsx
@@ -109,7 +109,6 @@ export const AccountNameAccordion: React.FC<AccountNameAccordionProps> = ({
                 error={!!errors.name}
                 helperText={errors.name && t('Account Name is required')}
                 name={'name'}
-                // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus
                 label={label}
                 sx={{ marginTop: 1 }}

--- a/src/components/Settings/preferences/accordions/HomeCountryAccordion/HomeCountryAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/HomeCountryAccordion/HomeCountryAccordion.tsx
@@ -131,7 +131,6 @@ export const HomeCountryAccordion: React.FC<HomeCountryAccordionProps> = ({
                     placeholder={label}
                     label={label}
                     sx={{ marginTop: 1 }}
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
                     autoFocus
                   />
                 )}

--- a/src/components/Settings/preferences/accordions/HourToSendNotificationsAccordion/HourToSendNotificationsAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/HourToSendNotificationsAccordion/HourToSendNotificationsAccordion.tsx
@@ -132,7 +132,6 @@ export const HourToSendNotificationsAccordion: React.FC<
                   <TextField
                     {...params}
                     placeholder={label}
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
                     autoFocus
                     label={label}
                     sx={{ marginTop: 1 }}

--- a/src/components/Settings/preferences/accordions/LocaleAccordion/LocaleAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/LocaleAccordion/LocaleAccordion.tsx
@@ -130,7 +130,6 @@ export const LocaleAccordion: React.FC<LocaleAccordionProps> = ({
                   <TextField
                     {...params}
                     placeholder={label}
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
                     autoFocus
                     label={label}
                     sx={{ marginTop: 1 }}

--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.tsx
@@ -127,7 +127,6 @@ export const MonthlyGoalAccordion: React.FC<MonthlyGoalAccordionProps> = ({
                 name="monthlyGoal"
                 error={!!errors.monthlyGoal}
                 helperText={errors.monthlyGoal && t('Monthly Goal is required')}
-                // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus
                 label={label}
                 sx={{ marginTop: 1 }}

--- a/src/components/Settings/preferences/accordions/MpdInfoAccordion/MpdInfoAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/MpdInfoAccordion/MpdInfoAccordion.tsx
@@ -149,7 +149,6 @@ export const MpdInfoAccordion: React.FC<MpdInfoAccordionProps> = ({
                   label={t('Start Date')}
                   value={activeMpdStartAt}
                   onChange={(date) => setFieldValue('activeMpdStartAt', date)}
-                  // eslint-disable-next-line jsx-a11y/no-autofocus
                   autoFocus
                 />
               </Grid>

--- a/src/components/Settings/preferences/accordions/TimeZoneAccordion/TimeZoneAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/TimeZoneAccordion/TimeZoneAccordion.tsx
@@ -119,7 +119,6 @@ export const TimeZoneAccordion: React.FC<TimeZoneAccordionProps> = ({
                     placeholder={label}
                     label={label}
                     sx={{ marginTop: 1 }}
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
                     autoFocus
                   />
                 )}

--- a/src/components/Tool/Appeal/Modals/EditAppealHeaderInfoModal/EditAppealHeaderInfoModal.tsx
+++ b/src/components/Tool/Appeal/Modals/EditAppealHeaderInfoModal/EditAppealHeaderInfoModal.tsx
@@ -120,7 +120,7 @@ export const EditAppealHeaderInfoModal: React.FC<
                     label={t('Name')}
                     value={name}
                     disabled={isSubmitting}
-                    autoFocus={true}
+                    autoFocus
                     onChange={handleChange}
                   />
                   <FormHelperText error={true} data-testid="nameError">

--- a/src/components/Tool/Appeal/Modals/EditAppealHeaderInfoModal/EditAppealHeaderInfoModal.tsx
+++ b/src/components/Tool/Appeal/Modals/EditAppealHeaderInfoModal/EditAppealHeaderInfoModal.tsx
@@ -120,7 +120,6 @@ export const EditAppealHeaderInfoModal: React.FC<
                     label={t('Name')}
                     value={name}
                     disabled={isSubmitting}
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
                     autoFocus={true}
                     onChange={handleChange}
                   />

--- a/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
@@ -262,7 +262,6 @@ export const PledgeModal: React.FC<PledgeModalProps> = ({
                               }}
                               id="amount-input"
                               error={!!errors.amount && touched.amount}
-                              // eslint-disable-next-line jsx-a11y/no-autofocus
                               autoFocus
                             />
                             <FormHelperText>


### PR DESCRIPTION
## Description

Removes jsx-a11y/no-autofocus ESLint rule from config.

We end up just disabling it everywhere we violate it. Unless we decide to stop using the autofocus prop, we should reduce noise in our code by making no-autofocus no longer error and removing the eslint-disable-next-line directives.

[MPDX-9451](https://jira.cru.org/browse/MPDX-9451) 

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Run the linter to ensure all is good, and ensure that all eslint-disable-next-line directives have been removed from the project.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
