### PR TITLE
[MPDX-9391] - Adds status bar for spouse

### DIFF
--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.test.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { render } from '@testing-library/react';
+import { FormikProvider, useFormik } from 'formik';
+import { I18nextProvider } from 'react-i18next';
+import i18n from 'src/lib/i18n';
+import theme from 'src/theme';
+import { CompleteFormValues } from '../../AdditionalSalaryRequest';
+import { useAdditionalSalaryRequest } from '../../Shared/AdditionalSalaryRequestContext';
+import { defaultCompleteFormValues } from '../../Shared/CompleteForm.mock';
+import { SplitCapSubContent } from './SplitCapSubContent';
+
+jest.mock('../../Shared/AdditionalSalaryRequestContext', () => ({
+  useAdditionalSalaryRequest: jest.fn(),
+}));
+
+const mockUseAdditionalSalaryRequest =
+  useAdditionalSalaryRequest as jest.MockedFunction<
+    typeof useAdditionalSalaryRequest
+  >;
+
+const FormikWrapper: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const formik = useFormik<CompleteFormValues>({
+    initialValues: { ...defaultCompleteFormValues },
+    onSubmit: jest.fn(),
+  });
+  return <FormikProvider value={formik}>{children}</FormikProvider>;
+};
+
+const setupContext = (opts: {
+  spouseCap: number | null;
+  spousePending?: number;
+  spouseGross?: number;
+}) => {
+  const { spouseCap, spousePending = 0, spouseGross = 40000 } = opts;
+  mockUseAdditionalSalaryRequest.mockReturnValue({
+    traditional403bPercentage: 0.12,
+    roth403bPercentage: 0.1,
+    user: { currentSalary: { grossSalaryAmount: 50000 } },
+    spouse:
+      spouseCap !== null
+        ? { currentSalary: { grossSalaryAmount: spouseGross } }
+        : undefined,
+    requestData: {
+      latestAdditionalSalaryRequest: {
+        calculations: { currentSalaryCap: 60000, pendingAsrAmount: 0 },
+        spouseCalculations:
+          spouseCap !== null
+            ? {
+                currentSalaryCap: spouseCap,
+                pendingAsrAmount: spousePending,
+              }
+            : null,
+      },
+    },
+  } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
+};
+
+const renderSplitCapSubContent = (spouseName = 'Jane') =>
+  render(
+    <ThemeProvider theme={theme}>
+      <I18nextProvider i18n={i18n}>
+        <FormikWrapper>
+          <SplitCapSubContent spouseName={spouseName} />
+        </FormikWrapper>
+      </I18nextProvider>
+    </ThemeProvider>,
+  );
+
+describe('SplitCapSubContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders existing copy with spouse name and Progressive Approvals link', () => {
+    setupContext({ spouseCap: 50000 });
+
+    const { getAllByText, getByText, getByRole } =
+      renderSplitCapSubContent('Jane');
+
+    expect(
+      getByText(/Please make adjustments to your request/),
+    ).toBeInTheDocument();
+    expect(getAllByText(/Jane/).length).toBeGreaterThan(0);
+    expect(
+      getByRole('link', { name: 'Progressive Approvals' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders status bar header with spouse salary and cap amounts', () => {
+    setupContext({
+      spouseCap: 50000,
+      spousePending: 2000,
+      spouseGross: 40000,
+    });
+
+    const { getByText } = renderSplitCapSubContent('Jane');
+
+    // spouse total = 40000 + 2000 = 42000, cap = 50000
+    expect(getByText("Jane's Salary / Max Allowable Salary")).toBeInTheDocument();
+    expect(getByText('$42,000.00 / $50,000.00')).toBeInTheDocument();
+  });
+
+  it('renders remaining amount in footer', () => {
+    setupContext({
+      spouseCap: 50000,
+      spousePending: 2000,
+      spouseGross: 40000,
+    });
+
+    const { getByText } = renderSplitCapSubContent('Jane');
+
+    expect(
+      getByText("Remaining in Jane's Max Allowable Salary"),
+    ).toBeInTheDocument();
+    expect(getByText('$8,000.00')).toBeInTheDocument();
+  });
+
+  it('renders progress bar with correct value', () => {
+    setupContext({
+      spouseCap: 50000,
+      spousePending: 2000,
+      spouseGross: 40000,
+    });
+
+    const { getByRole } = renderSplitCapSubContent('Jane');
+
+    const progressBar = getByRole('progressbar');
+    // 42000 / 50000 = 84%
+    expect(progressBar).toHaveAttribute('aria-valuenow', '84');
+  });
+
+  it('shows 100% bar and $0 remaining when spouse is at cap', () => {
+    setupContext({
+      spouseCap: 50000,
+      spousePending: 10000,
+      spouseGross: 40000,
+    });
+
+    const { getByText, getByRole } = renderSplitCapSubContent('Jane');
+
+    expect(getByText('$50,000.00 / $50,000.00')).toBeInTheDocument();
+    expect(getByText('$0.00')).toBeInTheDocument();
+    expect(getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  it('does not render the status bar when spouse cap is unavailable', () => {
+    setupContext({ spouseCap: null });
+
+    const { queryByRole, queryByText, getByText } =
+      renderSplitCapSubContent('Jane');
+
+    expect(
+      getByText(/Please make adjustments to your request/),
+    ).toBeInTheDocument();
+    expect(queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(
+      queryByText(/Max Allowable Salary/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.test.tsx
@@ -100,7 +100,9 @@ describe('SplitCapSubContent', () => {
     const { getByText } = renderSplitCapSubContent('Jane');
 
     // spouse total = 40000 + 2000 = 42000, cap = 50000
-    expect(getByText("Jane's Salary / Max Allowable Salary")).toBeInTheDocument();
+    expect(
+      getByText("Jane's Salary / Max Allowable Salary"),
+    ).toBeInTheDocument();
     expect(getByText('$42,000.00 / $50,000.00')).toBeInTheDocument();
   });
 
@@ -165,8 +167,6 @@ describe('SplitCapSubContent', () => {
       getByText(/Please make adjustments to your request/),
     ).toBeInTheDocument();
     expect(queryByRole('progressbar')).not.toBeInTheDocument();
-    expect(
-      queryByText(/Max Allowable Salary/),
-    ).not.toBeInTheDocument();
+    expect(queryByText(/Max Allowable Salary/)).not.toBeInTheDocument();
   });
 });

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.test.tsx
@@ -77,13 +77,14 @@ describe('SplitCapSubContent', () => {
   it('renders existing copy with spouse name and Progressive Approvals link', () => {
     setupContext({ spouseCap: 50000 });
 
-    const { getAllByText, getByText, getByRole } =
-      renderSplitCapSubContent('Jane');
+    const { getByText, getByRole } = renderSplitCapSubContent('Jane');
 
     expect(
       getByText(/Please make adjustments to your request/),
     ).toBeInTheDocument();
-    expect(getAllByText(/Jane/).length).toBeGreaterThan(0);
+    expect(
+      getByText(/separate request up to Jane's maximum allowable salary/),
+    ).toBeInTheDocument();
     expect(
       getByRole('link', { name: 'Progressive Approvals' }),
     ).toBeInTheDocument();
@@ -144,6 +145,14 @@ describe('SplitCapSubContent', () => {
     expect(getByText('$50,000.00 / $50,000.00')).toBeInTheDocument();
     expect(getByText('$0.00')).toBeInTheDocument();
     expect(getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  it('does not render status bar when spouse cap is 0', () => {
+    setupContext({ spouseCap: 0 });
+
+    const { queryByRole } = renderSplitCapSubContent('Jane');
+
+    expect(queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
   it('does not render the status bar when spouse cap is unavailable', () => {

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.tsx
@@ -19,30 +19,22 @@ export const SplitCapSubContent: React.FC<SplitCapSubContentProps> = ({
   const locale = useLocale();
   const currency = 'USD';
   const { values } = useFormikContext<CompleteFormValues>();
-  const {
-    spouseTotalAnnualSalary,
-    spouseIndividualCap,
-    spouseRemainingCap,
-  } = useSalaryCalculations({ values });
+  const { spouseCap } = useSalaryCalculations({ values });
 
-  const showBar =
-    spouseIndividualCap !== null &&
-    spouseIndividualCap > 0 &&
-    spouseTotalAnnualSalary !== null &&
-    spouseRemainingCap !== null;
+  const showBar = spouseCap !== null && spouseCap.individualCap > 0;
 
   const totalFormatted = showBar
-    ? currencyFormat(spouseTotalAnnualSalary, currency, locale, {
+    ? currencyFormat(spouseCap.totalAnnualSalary, currency, locale, {
         showTrailingZeros: true,
       })
     : '';
   const capFormatted = showBar
-    ? currencyFormat(spouseIndividualCap, currency, locale, {
+    ? currencyFormat(spouseCap.individualCap, currency, locale, {
         showTrailingZeros: true,
       })
     : '';
   const remainingFormatted = showBar
-    ? currencyFormat(spouseRemainingCap, currency, locale, {
+    ? currencyFormat(spouseCap.remainingCap, currency, locale, {
         showTrailingZeros: true,
       })
     : '';
@@ -50,7 +42,10 @@ export const SplitCapSubContent: React.FC<SplitCapSubContentProps> = ({
   const progressValue = showBar
     ? Math.min(
         100,
-        Math.max(0, (spouseTotalAnnualSalary / spouseIndividualCap) * 100),
+        Math.max(
+          0,
+          (spouseCap.totalAnnualSalary / spouseCap.individualCap) * 100,
+        ),
       )
     : 0;
 
@@ -77,26 +72,35 @@ export const SplitCapSubContent: React.FC<SplitCapSubContentProps> = ({
               mb: 1,
               display: 'flex',
               justifyContent: 'space-between',
+              flexWrap: 'wrap',
+              gap: 1,
             }}
           >
-            <Typography variant="body1">
+            <Typography variant="body1" id="spouse-salary-progress-label">
               {t("{{spouseName}}'s Salary / Max Allowable Salary", {
                 spouseName,
               })}
             </Typography>
-            <Typography>
-              {t('{{totalFormatted}} / {{capFormatted}}', {
-                totalFormatted,
-                capFormatted,
-              })}
-            </Typography>
+            <Typography>{`${totalFormatted} / ${capFormatted}`}</Typography>
           </Box>
           <LinearProgress
             variant="determinate"
             value={progressValue}
             color="primary"
+            aria-labelledby="spouse-salary-progress-label"
+            aria-valuetext={t('{{total}} of {{cap}}', {
+              total: totalFormatted,
+              cap: capFormatted,
+            })}
           />
-          <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              flexWrap: 'wrap',
+              gap: 1,
+            }}
+          >
             <Typography variant="body2" sx={{ mt: 1, color: 'text.secondary' }}>
               {t("Remaining in {{spouseName}}'s Max Allowable Salary", {
                 spouseName,

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.tsx
@@ -1,6 +1,12 @@
 import Link from 'next/link';
+import { Box, LinearProgress, Typography } from '@mui/material';
+import { useFormikContext } from 'formik';
 import { Trans, useTranslation } from 'react-i18next';
+import { useLocale } from 'src/hooks/useLocale';
+import { currencyFormat } from 'src/lib/intlFormat';
 import theme from 'src/theme';
+import { CompleteFormValues } from '../../AdditionalSalaryRequest';
+import { useSalaryCalculations } from '../../Shared/useSalaryCalculations';
 
 interface SplitCapSubContentProps {
   spouseName: string;
@@ -10,21 +16,98 @@ export const SplitCapSubContent: React.FC<SplitCapSubContentProps> = ({
   spouseName,
 }) => {
   const { t } = useTranslation();
+  const locale = useLocale();
+  const currency = 'USD';
+  const { values } = useFormikContext<CompleteFormValues>();
+  const {
+    spouseTotalAnnualSalary,
+    spouseIndividualCap,
+    spouseRemainingCap,
+  } = useSalaryCalculations({ values });
+
+  const showBar =
+    spouseIndividualCap !== null &&
+    spouseIndividualCap > 0 &&
+    spouseTotalAnnualSalary !== null &&
+    spouseRemainingCap !== null;
+
+  const totalFormatted = showBar
+    ? currencyFormat(spouseTotalAnnualSalary, currency, locale, {
+        showTrailingZeros: true,
+      })
+    : '';
+  const capFormatted = showBar
+    ? currencyFormat(spouseIndividualCap, currency, locale, {
+        showTrailingZeros: true,
+      })
+    : '';
+  const remainingFormatted = showBar
+    ? currencyFormat(spouseRemainingCap, currency, locale, {
+        showTrailingZeros: true,
+      })
+    : '';
+
+  const progressValue = showBar
+    ? Math.min(
+        100,
+        Math.max(0, (spouseTotalAnnualSalary / spouseIndividualCap) * 100),
+      )
+    : 0;
 
   return (
-    <Trans t={t} values={{ spouseName }} parent="span">
-      Please make adjustments to your request to continue. You may make a
-      separate request up to {spouseName}&apos;s maximum allowable salary if
-      desired. After using both you and {spouseName}&apos;s maximum allowable
-      salary, any additional requests can be submitted online but will require
-      approval through our{' '}
-      <Link
-        href="/"
-        style={{ display: 'inline', color: theme.palette.primary.main }}
-      >
-        Progressive Approvals
-      </Link>{' '}
-      process.
-    </Trans>
+    <>
+      <Trans t={t} values={{ spouseName }} parent="span">
+        Please make adjustments to your request to continue. You may make a
+        separate request up to {spouseName}&apos;s maximum allowable salary if
+        desired. After using both you and {spouseName}&apos;s maximum allowable
+        salary, any additional requests can be submitted online but will require
+        approval through our{' '}
+        <Link
+          href="/"
+          style={{ display: 'inline', color: theme.palette.primary.main }}
+        >
+          Progressive Approvals
+        </Link>{' '}
+        process.
+      </Trans>
+      {showBar && (
+        <Box sx={{ mt: 2 }}>
+          <Box
+            sx={{
+              mb: 1,
+              display: 'flex',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Typography variant="body1">
+              {t("{{spouseName}}'s Salary / Max Allowable Salary", {
+                spouseName,
+              })}
+            </Typography>
+            <Typography>
+              {t('{{totalFormatted}} / {{capFormatted}}', {
+                totalFormatted,
+                capFormatted,
+              })}
+            </Typography>
+          </Box>
+          <LinearProgress
+            variant="determinate"
+            value={progressValue}
+            color="primary"
+          />
+          <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+            <Typography variant="body2" sx={{ mt: 1, color: 'text.secondary' }}>
+              {t("Remaining in {{spouseName}}'s Max Allowable Salary", {
+                spouseName,
+              })}
+            </Typography>
+            <Typography variant="body2" sx={{ mt: 1, color: 'text.secondary' }}>
+              {remainingFormatted}
+            </Typography>
+          </Box>
+        </Box>
+      )}
+    </>
   );
 };

--- a/src/components/Reports/AdditionalSalaryRequest/Shared/useSalaryCalculations.test.ts
+++ b/src/components/Reports/AdditionalSalaryRequest/Shared/useSalaryCalculations.test.ts
@@ -709,4 +709,86 @@ describe('useSalaryCalculations', () => {
       expect(result.current.additionalApproval).toBe(true);
     });
   });
+
+  describe('spouse cap fields', () => {
+    it('returns spouse total, cap, and remaining when spouse has room', () => {
+      mockUseAdditionalSalaryRequest.mockReturnValue({
+        traditional403bPercentage: 0.12,
+        roth403bPercentage: 0.1,
+        user: { currentSalary: { grossSalaryAmount: 50000 } },
+        spouse: { currentSalary: { grossSalaryAmount: 40000 } },
+        requestData: {
+          latestAdditionalSalaryRequest: {
+            calculations: { currentSalaryCap: 60000 },
+            spouseCalculations: {
+              currentSalaryCap: 50000,
+              pendingAsrAmount: 2000,
+            },
+          },
+        },
+      } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
+
+      const values: CompleteFormValues = { ...baseValues };
+
+      const { result } = renderHook(() => useSalaryCalculations({ values }), {
+        wrapper: ({ children }) => FormikWrapper({ children, values }),
+      });
+
+      expect(result.current.spouseTotalAnnualSalary).toBe(42000); // 40000 + 2000
+      expect(result.current.spouseIndividualCap).toBe(50000);
+      expect(result.current.spouseRemainingCap).toBe(8000); // 50000 - 42000
+    });
+
+    it('clamps spouseRemainingCap at 0 when spouse total exceeds cap', () => {
+      mockUseAdditionalSalaryRequest.mockReturnValue({
+        traditional403bPercentage: 0.12,
+        roth403bPercentage: 0.1,
+        user: { currentSalary: { grossSalaryAmount: 50000 } },
+        spouse: { currentSalary: { grossSalaryAmount: 40000 } },
+        requestData: {
+          latestAdditionalSalaryRequest: {
+            calculations: { currentSalaryCap: 60000 },
+            spouseCalculations: {
+              currentSalaryCap: 50000,
+              pendingAsrAmount: 15000,
+            },
+          },
+        },
+      } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
+
+      const values: CompleteFormValues = { ...baseValues };
+
+      const { result } = renderHook(() => useSalaryCalculations({ values }), {
+        wrapper: ({ children }) => FormikWrapper({ children, values }),
+      });
+
+      expect(result.current.spouseTotalAnnualSalary).toBe(55000);
+      expect(result.current.spouseIndividualCap).toBe(50000);
+      expect(result.current.spouseRemainingCap).toBe(0);
+    });
+
+    it('returns null for all spouse fields when no spouse', () => {
+      mockUseAdditionalSalaryRequest.mockReturnValue({
+        traditional403bPercentage: 0.12,
+        roth403bPercentage: 0.1,
+        user: { currentSalary: { grossSalaryAmount: 50000 } },
+        spouse: undefined,
+        requestData: {
+          latestAdditionalSalaryRequest: {
+            calculations: { currentSalaryCap: 60000 },
+          },
+        },
+      } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
+
+      const values: CompleteFormValues = { ...baseValues };
+
+      const { result } = renderHook(() => useSalaryCalculations({ values }), {
+        wrapper: ({ children }) => FormikWrapper({ children, values }),
+      });
+
+      expect(result.current.spouseTotalAnnualSalary).toBeNull();
+      expect(result.current.spouseIndividualCap).toBeNull();
+      expect(result.current.spouseRemainingCap).toBeNull();
+    });
+  });
 });

--- a/src/components/Reports/AdditionalSalaryRequest/Shared/useSalaryCalculations.test.ts
+++ b/src/components/Reports/AdditionalSalaryRequest/Shared/useSalaryCalculations.test.ts
@@ -734,9 +734,11 @@ describe('useSalaryCalculations', () => {
         wrapper: ({ children }) => FormikWrapper({ children, values }),
       });
 
-      expect(result.current.spouseTotalAnnualSalary).toBe(42000); // 40000 + 2000
-      expect(result.current.spouseIndividualCap).toBe(50000);
-      expect(result.current.spouseRemainingCap).toBe(8000); // 50000 - 42000
+      expect(result.current.spouseCap).toEqual({
+        totalAnnualSalary: 42000, // 40000 + 2000
+        individualCap: 50000,
+        remainingCap: 8000, // 50000 - 42000
+      });
     });
 
     it('clamps spouseRemainingCap at 0 when spouse total exceeds cap', () => {
@@ -762,9 +764,11 @@ describe('useSalaryCalculations', () => {
         wrapper: ({ children }) => FormikWrapper({ children, values }),
       });
 
-      expect(result.current.spouseTotalAnnualSalary).toBe(55000);
-      expect(result.current.spouseIndividualCap).toBe(50000);
-      expect(result.current.spouseRemainingCap).toBe(0);
+      expect(result.current.spouseCap).toEqual({
+        totalAnnualSalary: 55000,
+        individualCap: 50000,
+        remainingCap: 0,
+      });
     });
 
     it('returns null for all spouse fields when no spouse', () => {
@@ -786,9 +790,7 @@ describe('useSalaryCalculations', () => {
         wrapper: ({ children }) => FormikWrapper({ children, values }),
       });
 
-      expect(result.current.spouseTotalAnnualSalary).toBeNull();
-      expect(result.current.spouseIndividualCap).toBeNull();
-      expect(result.current.spouseRemainingCap).toBeNull();
+      expect(result.current.spouseCap).toBeNull();
     });
   });
 });

--- a/src/components/Reports/AdditionalSalaryRequest/Shared/useSalaryCalculations.ts
+++ b/src/components/Reports/AdditionalSalaryRequest/Shared/useSalaryCalculations.ts
@@ -25,6 +25,12 @@ export interface SalaryCalculations {
   splitAsrType: 'user' | 'spouse' | null;
   /** `true` when the request requires additional approval */
   additionalApproval: boolean;
+  /** Spouse's gross annual salary + pending ASR amount. `null` when no spouse. */
+  spouseTotalAnnualSalary: number | null;
+  /** Spouse's individual salary cap. `null` when no spouse. */
+  spouseIndividualCap: number | null;
+  /** Spouse's remaining room under cap (cap - total, clamped at 0). `null` when no spouse. */
+  spouseRemainingCap: number | null;
 }
 export interface UseSalaryCalculationsProps {
   values: CompleteFormValues;
@@ -138,6 +144,11 @@ export const useSalaryCalculations = ({
       (exceedsCap && (!isMarried || spouseAtCap || spouseExceedsCap)) ||
       (userAtCap && isMarried && spouseExceedsCap);
 
+    const hasSpouseCap = isMarried && spouseIndividualCap !== null;
+    const spouseRemainingCap = hasSpouseCap
+      ? Math.max(0, spouseIndividualCap - spouseTotalAnnualSalary)
+      : null;
+
     return {
       total,
       calculatedTraditionalDeduction,
@@ -151,6 +162,9 @@ export const useSalaryCalculations = ({
       splitAsr,
       splitAsrType,
       additionalApproval,
+      spouseTotalAnnualSalary: hasSpouseCap ? spouseTotalAnnualSalary : null,
+      spouseIndividualCap: hasSpouseCap ? spouseIndividualCap : null,
+      spouseRemainingCap,
     };
   }, [
     values,

--- a/src/components/Reports/AdditionalSalaryRequest/Shared/useSalaryCalculations.ts
+++ b/src/components/Reports/AdditionalSalaryRequest/Shared/useSalaryCalculations.ts
@@ -25,12 +25,15 @@ export interface SalaryCalculations {
   splitAsrType: 'user' | 'spouse' | null;
   /** `true` when the request requires additional approval */
   additionalApproval: boolean;
-  /** Spouse's gross annual salary + pending ASR amount. `null` when no spouse. */
-  spouseTotalAnnualSalary: number | null;
-  /** Spouse's individual salary cap. `null` when no spouse. */
-  spouseIndividualCap: number | null;
-  /** Spouse's remaining room under cap (cap - total, clamped at 0). `null` when no spouse. */
-  spouseRemainingCap: number | null;
+  /** Spouse cap figures. `null` when no spouse; otherwise all three fields are present. */
+  spouseCap: {
+    /** Spouse's gross annual salary + pending ASR amount. */
+    totalAnnualSalary: number;
+    /** Spouse's individual salary cap. */
+    individualCap: number;
+    /** Spouse's remaining room under cap (cap - total, clamped at 0). */
+    remainingCap: number;
+  } | null;
 }
 export interface UseSalaryCalculationsProps {
   values: CompleteFormValues;
@@ -73,7 +76,7 @@ export const useSalaryCalculations = ({
     0;
   const spouseIndividualCap = spouse
     ? (requestData?.latestAdditionalSalaryRequest?.spouseCalculations
-        ?.currentSalaryCap ?? 0)
+        ?.currentSalaryCap ?? null)
     : null;
 
   const grossAnnualSalary = user?.currentSalary?.grossSalaryAmount ?? 0;
@@ -145,8 +148,15 @@ export const useSalaryCalculations = ({
       (userAtCap && isMarried && spouseExceedsCap);
 
     const hasSpouseCap = isMarried && spouseIndividualCap !== null;
-    const spouseRemainingCap = hasSpouseCap
-      ? Math.max(0, spouseIndividualCap - spouseTotalAnnualSalary)
+    const spouseCap = hasSpouseCap
+      ? {
+          totalAnnualSalary: spouseTotalAnnualSalary,
+          individualCap: spouseIndividualCap,
+          remainingCap: Math.max(
+            0,
+            spouseIndividualCap - spouseTotalAnnualSalary,
+          ),
+        }
       : null;
 
     return {
@@ -162,9 +172,7 @@ export const useSalaryCalculations = ({
       splitAsr,
       splitAsrType,
       additionalApproval,
-      spouseTotalAnnualSalary: hasSpouseCap ? spouseTotalAnnualSalary : null,
-      spouseIndividualCap: hasSpouseCap ? spouseIndividualCap : null,
-      spouseRemainingCap,
+      spouseCap,
     };
   }, [
     values,


### PR DESCRIPTION
## Description

When one spouse is over their cap but their spouse is under, we should show them their spouses ASR and how much room they have until their cap to show how they can submit it

This will likely show on the show "split funds with spouse" model

Jira ticket available [here](https://jira.cru.org/browse/MPDX-9391)

## Testing

- Impersonate Joel Hurdle
- Go to ASR page
- Add 10,000 to the first field
- Click submit
- Check the spouse bar shows

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
