### PR TITLE
MPDX-9454 - Annual Reimbursable Expenses for PDS Calc

### DIFF
--- a/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/AnnualReimbursableSection.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/AnnualReimbursableSection.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
+import { AnnualReimbursableSection } from './AnnualReimbursableSection';
+import { editAmountCell } from './reimbursableExpensesTestUtils';
+
+const mutationSpy = jest.fn();
+
+const TestComponent: React.FC = () => (
+  <PdsGoalCalculatorTestWrapper
+    onCall={mutationSpy}
+    calculationMock={{
+      id: 'goal-1',
+      conferenceRetreatCosts: 600,
+      ministryTravelMeals: 300,
+      otherAnnualReimbursements: 100,
+    }}
+  >
+    <AnnualReimbursableSection />
+  </PdsGoalCalculatorTestWrapper>
+);
+
+describe('AnnualReimbursableSection', () => {
+  beforeEach(() => {
+    mutationSpy.mockClear();
+  });
+
+  it('renders the section heading and column headers', async () => {
+    const { findByRole, getByRole } = render(<TestComponent />);
+
+    expect(
+      await findByRole('heading', { name: 'Annual Reimbursable Expenses' }),
+    ).toBeInTheDocument();
+    expect(
+      getByRole('columnheader', { name: 'Expense Name' }),
+    ).toBeInTheDocument();
+    expect(getByRole('columnheader', { name: 'Amount' })).toBeInTheDocument();
+  });
+
+  it('renders a row for every annual field plus the subtotal', async () => {
+    const { findByRole, getAllByRole } = render(<TestComponent />);
+
+    await findByRole('gridcell', { name: 'Conference / Retreat Costs' });
+    // 1 header row + 3 field rows + 1 subtotal row
+    expect(getAllByRole('row')).toHaveLength(5);
+  });
+
+  it('renders the info tooltip icon with an accessible label', async () => {
+    const { findByLabelText } = render(<TestComponent />);
+
+    expect(
+      await findByLabelText(
+        'This annual amount will be divided by 12 when added to the total.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the annual subtotal from the calculation', async () => {
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() =>
+      expect(getByTestId('annual-subtotal')).toHaveTextContent('$1,000'),
+    );
+  });
+
+  it('autosaves an edit to Conference / Retreat Costs', async () => {
+    const { findByRole } = render(<TestComponent />);
+
+    await editAmountCell(findByRole, 'Conference / Retreat Costs', '800');
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation', {
+        attributes: { id: 'goal-1', conferenceRetreatCosts: 800 },
+      }),
+    );
+  });
+
+  it('autosaves an edit to Ministry Travel / Meals', async () => {
+    const { findByRole } = render(<TestComponent />);
+
+    await editAmountCell(findByRole, 'Ministry Travel / Meals', '450');
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation', {
+        attributes: { id: 'goal-1', ministryTravelMeals: 450 },
+      }),
+    );
+  });
+
+  it('autosaves an edit to Other Annual Reimbursements', async () => {
+    const { findByRole } = render(<TestComponent />);
+
+    await editAmountCell(findByRole, 'Other Annual Reimbursements', '75');
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation', {
+        attributes: { id: 'goal-1', otherAnnualReimbursements: 75 },
+      }),
+    );
+  });
+
+  it('shows an error and skips saving when a negative amount is entered', async () => {
+    const { findByRole } = render(<TestComponent />);
+
+    await editAmountCell(findByRole, 'Ministry Travel / Meals', '-10');
+
+    expect(await findByRole('alert')).toHaveTextContent(
+      'Amount must be positive',
+    );
+    expect(mutationSpy).not.toHaveGraphqlOperation('UpdatePdsGoalCalculation');
+  });
+});

--- a/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/AnnualReimbursableSection.tsx
+++ b/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/AnnualReimbursableSection.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { usePdsGoalCalculator } from '../Shared/PdsGoalCalculatorContext';
+import {
+  ReimbursableExpensesGrid,
+  ReimbursableField,
+} from './ReimbursableExpensesGrid';
+import { calculateReimbursableTotals } from './reimbursableExpenses';
+
+export const AnnualReimbursableSection: React.FC = () => {
+  const { t } = useTranslation();
+  const { calculation } = usePdsGoalCalculator();
+
+  const annualSubtotal = calculation
+    ? calculateReimbursableTotals(calculation).annualSubtotal
+    : 0;
+
+  const fields: ReimbursableField[] = [
+    {
+      fieldName: 'conferenceRetreatCosts',
+      label: t('Conference / Retreat Costs'),
+    },
+    { fieldName: 'ministryTravelMeals', label: t('Ministry Travel / Meals') },
+    {
+      fieldName: 'otherAnnualReimbursements',
+      label: t('Other Annual Reimbursements'),
+    },
+  ];
+
+  return (
+    <ReimbursableExpensesGrid
+      title={t('Annual Reimbursable Expenses')}
+      titleTooltip={t(
+        'This annual amount will be divided by 12 when added to the total.',
+      )}
+      fields={fields}
+      subtotalLabel={t('Subtotal Annual')}
+      subtotalValue={annualSubtotal}
+      subtotalTestId="annual-subtotal"
+    />
+  );
+};

--- a/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import {
   MpdGoalMiscConstantCategoryEnum,
   MpdGoalMiscConstantLabelEnum,
 } from 'src/graphql/types.generated';
 import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
 import { MonthlyReimbursableSection } from './MonthlyReimbursableSection';
+import { editAmountCell } from './reimbursableExpensesTestUtils';
 
 const mutationSpy = jest.fn();
 
@@ -40,19 +40,6 @@ const TestComponent: React.FC = () => (
     <MonthlyReimbursableSection />
   </PdsGoalCalculatorTestWrapper>
 );
-
-const editAmountCell = async (
-  findByRole: ReturnType<typeof render>['findByRole'],
-  rowLabel: string,
-  newValue: string,
-) => {
-  const row = await findByRole('row', { name: new RegExp(rowLabel) });
-  userEvent.dblClick(row.querySelector('[data-field="amount"]')!);
-  const input = await findByRole('spinbutton');
-  userEvent.clear(input);
-  userEvent.type(input, newValue);
-  userEvent.tab();
-};
 
 describe('MonthlyReimbursableSection', () => {
   it('renders the section heading and column headers', async () => {

--- a/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.tsx
+++ b/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.tsx
@@ -1,5 +1,14 @@
 import React, { useState } from 'react';
-import { Box, Card, FormHelperText, Typography, styled } from '@mui/material';
+import InfoIcon from '@mui/icons-material/Info';
+import {
+  Box,
+  Card,
+  FormHelperText,
+  Stack,
+  Tooltip,
+  Typography,
+  styled,
+} from '@mui/material';
 import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { useTranslation } from 'react-i18next';
 import { BaseGrid } from 'src/components/Reports/GoalCalculator/SharedComponents/GoalCalculatorGrid/BaseGrid';
@@ -25,6 +34,7 @@ interface ReimbursableRow {
 
 interface ReimbursableExpensesGridProps {
   title: string;
+  titleTooltip?: string;
   fields: ReimbursableField[];
   subtotalLabel: string;
   subtotalValue: number;
@@ -46,7 +56,14 @@ const ErrorCell = styled(Box)(({ theme }) => ({
 
 export const ReimbursableExpensesGrid: React.FC<
   ReimbursableExpensesGridProps
-> = ({ title, fields, subtotalLabel, subtotalValue, subtotalTestId }) => {
+> = ({
+  title,
+  titleTooltip,
+  fields,
+  subtotalLabel,
+  subtotalValue,
+  subtotalTestId,
+}) => {
   const { t } = useTranslation();
   const locale = useLocale();
   const { calculation } = usePdsGoalCalculator();
@@ -145,9 +162,14 @@ export const ReimbursableExpensesGrid: React.FC<
 
   return (
     <>
-      <Typography variant="h6" pb={2}>
-        {title}
-      </Typography>
+      <Stack direction="row" alignItems="center" gap={0.5} pb={2}>
+        <Typography variant="h6">{title}</Typography>
+        {titleTooltip && (
+          <Tooltip title={titleTooltip}>
+            <InfoIcon color="action" aria-label={titleTooltip} />
+          </Tooltip>
+        )}
+      </Stack>
       <StyledCard>
         <BaseGrid
           rows={rows}

--- a/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesStep.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesStep.test.tsx
@@ -4,7 +4,7 @@ import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
 import { ReimbursableExpensesStep } from './ReimbursableExpensesStep';
 
 describe('ReimbursableExpensesStep', () => {
-  it('renders the monthly reimbursable section', async () => {
+  it('renders the monthly, annual, and total reimbursable sections', async () => {
     const { findByRole } = render(
       <PdsGoalCalculatorTestWrapper calculationMock={{ id: 'goal-1' }}>
         <ReimbursableExpensesStep />
@@ -13,6 +13,12 @@ describe('ReimbursableExpensesStep', () => {
 
     expect(
       await findByRole('heading', { name: 'Monthly Reimbursable Expenses' }),
+    ).toBeInTheDocument();
+    expect(
+      await findByRole('heading', { name: 'Annual Reimbursable Expenses' }),
+    ).toBeInTheDocument();
+    expect(
+      await findByRole('heading', { name: 'Total Reimbursable Expenses' }),
     ).toBeInTheDocument();
   });
 });

--- a/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesStep.tsx
+++ b/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesStep.tsx
@@ -1,6 +1,18 @@
 import React from 'react';
+import { Divider } from '@mui/material';
+import { AnnualReimbursableSection } from './AnnualReimbursableSection';
 import { MonthlyReimbursableSection } from './MonthlyReimbursableSection';
+import { TotalReimbursableSection } from './TotalReimbursableSection';
 
 export const ReimbursableExpensesStep: React.FC = () => {
-  return <MonthlyReimbursableSection />;
+  return (
+    <>
+      <MonthlyReimbursableSection />
+      <Divider sx={{ mx: -4, my: 4 }} />
+      <AnnualReimbursableSection />
+      <Divider sx={{ mx: -4, my: 4 }} />
+      <TotalReimbursableSection />
+      <Divider sx={{ mx: -4, my: 4 }} />
+    </>
+  );
 };

--- a/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/TotalReimbursableSection.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/TotalReimbursableSection.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
+import { TotalReimbursableSection } from './TotalReimbursableSection';
+
+interface Props {
+  monthlyCellPhone?: number;
+  annualConference?: number;
+}
+
+const TestComponent: React.FC<Props> = ({
+  monthlyCellPhone = 0,
+  annualConference = 0,
+}) => (
+  <PdsGoalCalculatorTestWrapper
+    calculationMock={{
+      id: 'goal-1',
+      ministryCellPhone: monthlyCellPhone,
+      ministryInternet: 0,
+      mpdNewsletter: 0,
+      mpdMiscellaneous: 0,
+      accountTransfers: 0,
+      otherMonthlyReimbursements: 0,
+      conferenceRetreatCosts: annualConference,
+      ministryTravelMeals: 0,
+      otherAnnualReimbursements: 0,
+    }}
+  >
+    <TotalReimbursableSection />
+  </PdsGoalCalculatorTestWrapper>
+);
+
+describe('TotalReimbursableSection', () => {
+  it('renders the heading', async () => {
+    const { findByRole } = render(<TestComponent />);
+
+    expect(
+      await findByRole('heading', { name: 'Total Reimbursable Expenses' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the info icon with an accessible label', async () => {
+    const { findByLabelText } = render(<TestComponent />);
+
+    expect(
+      await findByLabelText('Total reimbursable information'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a tooltip describing the $300 minimum floor on hover', async () => {
+    const { findByLabelText, findByRole } = render(<TestComponent />);
+
+    userEvent.hover(await findByLabelText('Total reimbursable information'));
+
+    expect(await findByRole('tooltip')).toHaveTextContent(
+      'The total is the greater of the $300 minimum or your calculated amount.',
+    );
+  });
+
+  it('applies the $300 floor when the calculated amount is below it', async () => {
+    const { getByTestId } = render(
+      <TestComponent monthlyCellPhone={100} annualConference={0} />,
+    );
+
+    await waitFor(() =>
+      expect(getByTestId('reimbursable-total')).toHaveTextContent('$300'),
+    );
+  });
+
+  it('uses the calculated amount when it exceeds the floor', async () => {
+    // monthly 500 + annual 1200/12 = 600 → above the $300 floor
+    const { getByTestId } = render(
+      <TestComponent monthlyCellPhone={500} annualConference={1200} />,
+    );
+
+    await waitFor(() =>
+      expect(getByTestId('reimbursable-total')).toHaveTextContent('$600'),
+    );
+  });
+});

--- a/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/TotalReimbursableSection.tsx
+++ b/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/TotalReimbursableSection.tsx
@@ -1,0 +1,63 @@
+import InfoIcon from '@mui/icons-material/Info';
+import {
+  Card,
+  CardContent,
+  Stack,
+  Tooltip,
+  Typography,
+  styled,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useLocale } from 'src/hooks/useLocale';
+import { currencyFormat } from 'src/lib/intlFormat';
+import { usePdsGoalCalculator } from '../Shared/PdsGoalCalculatorContext';
+import {
+  REIMBURSABLE_FLOOR,
+  calculateReimbursableTotals,
+} from './reimbursableExpenses';
+
+const AmountTypography = styled(Typography)(({ theme }) => ({
+  fontSize: '2.5rem',
+  fontWeight: 'bold',
+  color: theme.palette.mpdxBlue.main,
+}));
+
+export const TotalReimbursableSection: React.FC = () => {
+  const { t } = useTranslation();
+  const locale = useLocale();
+  const { calculation } = usePdsGoalCalculator();
+
+  if (!calculation) {
+    return null;
+  }
+
+  const { total } = calculateReimbursableTotals(calculation);
+
+  return (
+    <Card>
+      <CardContent>
+        <Stack direction="row" alignItems="center" gap={0.5}>
+          <Typography variant="h6">
+            {t('Total Reimbursable Expenses')}
+          </Typography>
+          <Tooltip
+            title={t(
+              'The total is the greater of the {{floor}} minimum or your calculated amount.',
+              {
+                floor: currencyFormat(REIMBURSABLE_FLOOR, 'USD', locale),
+              },
+            )}
+          >
+            <InfoIcon
+              color="action"
+              aria-label={t('Total reimbursable information')}
+            />
+          </Tooltip>
+        </Stack>
+        <AmountTypography data-testid="reimbursable-total">
+          {currencyFormat(total, 'USD', locale)}
+        </AmountTypography>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/reimbursableExpensesTestUtils.ts
+++ b/src/components/Reports/PdsGoalCalculator/ReimbursableExpenses/reimbursableExpensesTestUtils.ts
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+export const editAmountCell = async (
+  findByRole: ReturnType<typeof render>['findByRole'],
+  rowLabel: string,
+  newValue: string,
+) => {
+  const row = await findByRole('row', { name: new RegExp(rowLabel) });
+  userEvent.dblClick(row.querySelector('[data-field="amount"]')!);
+  const input = await findByRole('spinbutton');
+  userEvent.clear(input);
+  userEvent.type(input, newValue);
+  userEvent.tab();
+};

--- a/src/components/Reports/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -18,7 +18,6 @@ import {
   CurrencyAdornment,
   PercentageAdornment,
 } from 'src/components/Reports/GoalCalculator/Shared/Adornments';
-import { AutosaveForm } from 'src/components/Shared/Autosave/AutosaveForm';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import {
   DesignationSupportSalaryType,
@@ -78,7 +77,7 @@ export const SetupStep: React.FC = () => {
     : t('Enter hourly rate');
 
   return (
-    <AutosaveForm>
+    <>
       <Box pb={4}>
         <Typography variant="h6">{t('Settings')}</Typography>
         <Typography pt={1}>
@@ -222,6 +221,6 @@ export const SetupStep: React.FC = () => {
           </Grid>
         </Grid>
       </Card>
-    </AutosaveForm>
+    </>
   );
 };


### PR DESCRIPTION
## Description

- Replaced stub text with a Card showing the grand total in large bold type, pulled via calculateReimbursableTotals from usePdsGoalCalculator. Added a filled info icon + tooltip explaining the total is the greater of the $300 minimum or the calculated amount.
- Added a filled info icon + tooltip next to the title explaining the annual amount is divided by 12 for the total.
- Added an optional titleTooltip prop that renders an InfoIcon + Tooltip next to the title.
- Removed the unused AutosaveForm wrapper in SetupStep (no consumer of allValid in the PDS flow).

[MPDX-9454](https://jira.cru.org/browse/MPDX-9454)

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `reports/pdsGoalCalculator`
- Create or view a calculation
- Go to the Reimbursable Expenses section
- Determine that the Annual Expenses section totals correctly, autosaves, and applies to the overall total.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
