### PR TITLE
[No-Jira] Hide user confirmation modal

### DIFF
--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -59,11 +59,13 @@ const Dashboard = ({ data, accountListId }: Props): ReactElement => {
             exit="exit"
             variants={variants}
           >
-            <ConfirmUserGroupModal
-              open={openConfirmUserGroupModal}
-              handleClose={handleCloseConfirmUserGroupModal}
-              userType={data.user.userType}
-            />
+            {process.env.DISABLE_NEW_REPORTS !== 'true' && (
+              <ConfirmUserGroupModal
+                open={openConfirmUserGroupModal}
+                handleClose={handleCloseConfirmUserGroupModal}
+                userType={data.user.userType}
+              />
+            )}
 
             <Grid container spacing={3} alignItems="stretch">
               <Grid xs={12} sm={8} item>


### PR DESCRIPTION
## Description

We don't want to show the user confirmation modal just yet. Hide with the new feature flag.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
