### PR TITLE
No-Jira - Disable Continue on Setup Step until values filled by user

### DIFF
--- a/src/components/Reports/PdsGoalCalculator/PdsGoalCalculator.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/PdsGoalCalculator.test.tsx
@@ -1,7 +1,22 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
+import {
+  DesignationSupportSalaryType,
+  DesignationSupportStatus,
+} from 'src/graphql/types.generated';
 import { PdsGoalCalculator } from './PdsGoalCalculator';
 import { PdsGoalCalculatorTestWrapper } from './PdsGoalCalculatorTestWrapper';
+
+const completeSetupMock = {
+  id: 'goal-1',
+  name: 'Test Goal',
+  status: DesignationSupportStatus.FullTime,
+  salaryOrHourly: DesignationSupportSalaryType.Salaried,
+  payRate: 50000,
+  hoursWorkedPerWeek: null,
+  benefits: 1500,
+  geographicLocation: 'Orlando, FL',
+};
 
 describe('PdsGoalCalculator', () => {
   it('renders the setup step by default', () => {
@@ -14,5 +29,42 @@ describe('PdsGoalCalculator', () => {
     expect(
       getByRole('heading', { level: 6, name: 'Calculator Setup' }),
     ).toBeInTheDocument();
+  });
+
+  it('disables Continue on Setup step when a required field is missing', async () => {
+    const { findByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={{ ...completeSetupMock, name: '' }}
+      >
+        <PdsGoalCalculator />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    const continueButton = await findByRole('button', { name: /continue/i });
+    await waitFor(() => expect(continueButton).toBeDisabled());
+  });
+
+  it('disables Continue on Setup step when geographicLocation is not set', async () => {
+    const { findByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={{ ...completeSetupMock, geographicLocation: null }}
+      >
+        <PdsGoalCalculator />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    const continueButton = await findByRole('button', { name: /continue/i });
+    await waitFor(() => expect(continueButton).toBeDisabled());
+  });
+
+  it('enables Continue on Setup step when all required fields are filled', async () => {
+    const { findByRole } = render(
+      <PdsGoalCalculatorTestWrapper calculationMock={completeSetupMock}>
+        <PdsGoalCalculator />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    const continueButton = await findByRole('button', { name: /continue/i });
+    await waitFor(() => expect(continueButton).toBeEnabled());
   });
 });

--- a/src/components/Reports/PdsGoalCalculator/PdsGoalCalculator.tsx
+++ b/src/components/Reports/PdsGoalCalculator/PdsGoalCalculator.tsx
@@ -42,7 +42,7 @@ const StepContent: React.FC = () => {
           formTitle={currentStep.title}
           handleNextStep={handleContinue}
           handlePreviousStep={handlePreviousStep}
-          isValid={allValid}
+          disableNext={!allValid}
         />
       )}
     </>

--- a/src/components/Reports/PdsGoalCalculator/PdsGoalCalculator.tsx
+++ b/src/components/Reports/PdsGoalCalculator/PdsGoalCalculator.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { SectionList } from 'src/components/Reports/GoalCalculator/SharedComponents/SectionList';
 import { DirectionButtons } from 'src/components/Reports/Shared/CalculationReports/DirectionButtons/DirectionButtons';
+import {
+  AutosaveForm,
+  useAutosaveForm,
+} from 'src/components/Shared/Autosave/AutosaveForm';
 import { PdsGoalCalculatorStepEnum } from './PdsGoalCalculatorHelper';
 import { ReimbursableExpensesStep } from './ReimbursableExpenses/ReimbursableExpensesStep';
 import { SalaryStep } from './Salary/SalaryStep';
@@ -24,27 +28,38 @@ const CurrentStep: React.FC = () => {
   }
 };
 
-export const PdsGoalCalculator: React.FC = () => {
+const StepContent: React.FC = () => {
   const { currentStep, stepIndex, steps, handleContinue, handlePreviousStep } =
     usePdsGoalCalculator();
-  const sections = currentStep.sections;
-
+  const { allValid } = useAutosaveForm();
   const isLastStep = stepIndex === steps.length - 1;
+
+  return (
+    <>
+      <CurrentStep />
+      {!isLastStep && (
+        <DirectionButtons
+          formTitle={currentStep.title}
+          handleNextStep={handleContinue}
+          handlePreviousStep={handlePreviousStep}
+          isValid={allValid}
+        />
+      )}
+    </>
+  );
+};
+
+export const PdsGoalCalculator: React.FC = () => {
+  const { currentStep } = usePdsGoalCalculator();
+  const sections = currentStep.sections;
 
   return (
     <PdsGoalCalculatorLayout
       sectionListPanel={<SectionList sections={sections} />}
       mainContent={
-        <>
-          <CurrentStep />
-          {!isLastStep && (
-            <DirectionButtons
-              formTitle={currentStep.title}
-              handleNextStep={handleContinue}
-              handlePreviousStep={handlePreviousStep}
-            />
-          )}
-        </>
+        <AutosaveForm>
+          <StepContent />
+        </AutosaveForm>
       }
     />
   );

--- a/src/components/Reports/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import CalculateIcon from '@mui/icons-material/Calculate';
 import {
   Autocomplete,
@@ -21,6 +21,7 @@ import {
   CurrencyAdornment,
   PercentageAdornment,
 } from 'src/components/Reports/GoalCalculator/Shared/Adornments';
+import { useOptionalAutosaveForm } from 'src/components/Shared/Autosave/AutosaveForm';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import {
   DesignationSupportSalaryType,
@@ -47,20 +48,27 @@ export const SetupStep: React.FC = () => {
     () =>
       yup.object({
         name: yup.string().required(t('Goal Name is a required field')),
-        status: yup.string().nullable(),
-        salaryOrHourly: yup.string().nullable(),
+        status: yup
+          .string()
+          .required(t('Employment Status is a required field')),
+        salaryOrHourly: yup
+          .string()
+          .required(t('Pay Type is a required field')),
         payRate: yup
           .number()
-          .nullable()
+          .required(t('Pay Rate is a required field'))
           .min(0, t('Pay Rate must be a positive number')),
         hoursWorkedPerWeek: yup
           .number()
-          .nullable()
+          .required(t('Hours Worked is a required field'))
           .min(0, t('Hours Worked must be a positive number')),
         benefits: yup
           .number()
-          .nullable()
+          .required(t('Benefits is a required field'))
           .min(0, t('Benefits must be a positive number')),
+        geographicLocation: yup
+          .string()
+          .required(t('Geographic Multiplier is a required field')),
       }),
     [t],
   );
@@ -71,6 +79,20 @@ export const SetupStep: React.FC = () => {
     () => Array.from(goalGeographicConstantMap.keys()),
     [goalGeographicConstantMap],
   );
+
+  const autosaveForm = useOptionalAutosaveForm();
+  const geographicLocationValue = calculation?.geographicLocation;
+  useEffect(() => {
+    if (!autosaveForm) {
+      return;
+    }
+    if (geographicLocationValue) {
+      autosaveForm.markValid('geographicLocation');
+    } else {
+      autosaveForm.markInvalid('geographicLocation');
+    }
+    return () => autosaveForm.markValid('geographicLocation');
+  }, [autosaveForm, geographicLocationValue]);
 
   const isSalaried =
     calculation?.salaryOrHourly === DesignationSupportSalaryType.Salaried;

--- a/src/components/Reports/Shared/CalculationReports/DirectionButtons/DirectionButtons.test.tsx
+++ b/src/components/Reports/Shared/CalculationReports/DirectionButtons/DirectionButtons.test.tsx
@@ -25,7 +25,7 @@ interface TestComponentProps {
   showBackButton?: boolean;
   buttonTitle?: string;
   isEdit?: boolean;
-  isValid?: boolean;
+  disableNext?: boolean;
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({
@@ -34,7 +34,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
   showBackButton = false,
   buttonTitle,
   isEdit,
-  isValid,
+  disableNext,
 }) => (
   <ThemeProvider theme={theme}>
     <TestRouter
@@ -56,7 +56,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
                 showBackButton={showBackButton}
                 buttonTitle={buttonTitle}
                 isEdit={isEdit}
-                isValid={isValid}
+                disableNext={disableNext}
               />
             </MinisterHousingAllowanceProvider>
           </Formik>
@@ -117,19 +117,19 @@ describe('DirectionButtons', () => {
     expect(await findByRole('button', { name: title })).toBeInTheDocument();
   });
 
-  it('disables Continue when isValid is false', async () => {
-    const { findByRole } = render(<TestComponent isValid={false} />);
+  it('disables Continue when disableNext is true', async () => {
+    const { findByRole } = render(<TestComponent disableNext={true} />);
 
     expect(await findByRole('button', { name: 'Continue' })).toBeDisabled();
   });
 
-  it('enables Continue when isValid is true', async () => {
-    const { findByRole } = render(<TestComponent isValid={true} />);
+  it('enables Continue when disableNext is false', async () => {
+    const { findByRole } = render(<TestComponent disableNext={false} />);
 
     expect(await findByRole('button', { name: 'Continue' })).toBeEnabled();
   });
 
-  it('leaves Continue enabled when isValid is not provided', async () => {
+  it('leaves Continue enabled when disableNext is not provided', async () => {
     const { findByRole } = render(<TestComponent />);
 
     expect(await findByRole('button', { name: 'Continue' })).toBeEnabled();

--- a/src/components/Reports/Shared/CalculationReports/DirectionButtons/DirectionButtons.test.tsx
+++ b/src/components/Reports/Shared/CalculationReports/DirectionButtons/DirectionButtons.test.tsx
@@ -25,6 +25,7 @@ interface TestComponentProps {
   showBackButton?: boolean;
   buttonTitle?: string;
   isEdit?: boolean;
+  isValid?: boolean;
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({
@@ -33,6 +34,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
   showBackButton = false,
   buttonTitle,
   isEdit,
+  isValid,
 }) => (
   <ThemeProvider theme={theme}>
     <TestRouter
@@ -54,6 +56,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
                 showBackButton={showBackButton}
                 buttonTitle={buttonTitle}
                 isEdit={isEdit}
+                isValid={isValid}
               />
             </MinisterHousingAllowanceProvider>
           </Formik>
@@ -112,6 +115,24 @@ describe('DirectionButtons', () => {
     const { findByRole } = render(<TestComponent buttonTitle={title} />);
 
     expect(await findByRole('button', { name: title })).toBeInTheDocument();
+  });
+
+  it('disables Continue when isValid is false', async () => {
+    const { findByRole } = render(<TestComponent isValid={false} />);
+
+    expect(await findByRole('button', { name: 'Continue' })).toBeDisabled();
+  });
+
+  it('enables Continue when isValid is true', async () => {
+    const { findByRole } = render(<TestComponent isValid={true} />);
+
+    expect(await findByRole('button', { name: 'Continue' })).toBeEnabled();
+  });
+
+  it('leaves Continue enabled when isValid is not provided', async () => {
+    const { findByRole } = render(<TestComponent />);
+
+    expect(await findByRole('button', { name: 'Continue' })).toBeEnabled();
   });
 
   it('renders Discard button', async () => {

--- a/src/components/Reports/Shared/CalculationReports/DirectionButtons/DirectionButtons.tsx
+++ b/src/components/Reports/Shared/CalculationReports/DirectionButtons/DirectionButtons.tsx
@@ -141,6 +141,7 @@ export const DirectionButtons: React.FC<DirectionButtonsProps> = ({
             variant="contained"
             color="primary"
             onClick={overrideNext ?? handleNextStep}
+            disabled={isValid === false}
           >
             {buttonTitle ?? t('Continue')}
             <ChevronRight sx={{ ml: 1 }} />

--- a/src/components/Reports/Shared/CalculationReports/DirectionButtons/DirectionButtons.tsx
+++ b/src/components/Reports/Shared/CalculationReports/DirectionButtons/DirectionButtons.tsx
@@ -21,6 +21,7 @@ interface DirectionButtonsProps {
   additionalApproval?: boolean;
   splitAsr?: boolean;
   disableSubmit?: boolean;
+  disableNext?: boolean;
   //Formik validation for submit modal
   isSubmission?: boolean;
   submitForm?: () => Promise<void>;
@@ -51,6 +52,7 @@ export const DirectionButtons: React.FC<DirectionButtonsProps> = ({
   additionalApproval,
   splitAsr,
   disableSubmit,
+  disableNext,
 }) => {
   const { t } = useTranslation();
 
@@ -141,7 +143,7 @@ export const DirectionButtons: React.FC<DirectionButtonsProps> = ({
             variant="contained"
             color="primary"
             onClick={overrideNext ?? handleNextStep}
-            disabled={isValid === false}
+            disabled={disableNext}
           >
             {buttonTitle ?? t('Continue')}
             <ChevronRight sx={{ ml: 1 }} />


### PR DESCRIPTION
## Description

- Since future steps depend on these values in SetupStep, it is important to enforce input from the user before they can continue.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `reports/goalCalculator`
- Ensure all user input fields must be filled before continuing the calculator

## Checklist:

- [ ] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
