### PR TITLE
No-Jira [HS high priority level] - Explicitly disable pushing translations and creating pull requests in crowdin workflow

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -34,6 +34,8 @@ jobs:
           upload_translations: false
           download_sources: false
           download_translations: true
+          push_translations: false
+          create_pull_request: false
         env:
           CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}
       - name: 🔤 Sort Translations


### PR DESCRIPTION
## Description

The daily CrowdIn translation workflow has been failing with ERROR: Either 'GITHUB_TOKEN' or 'GH_TOKEN' must be set in the environment variables!. 

The error *likely* originates from the crowdin/github-action@v2 step where it defaults push_translations: true and create_pull_request: true (reflected in the failing logs). These attempted pushes and pull request creations are likely requiring a GitHub token during this step hence the error and failure.

We don't want either of those defaults: the workflow already runs yarn crowdin:sort-translations after the download and lets peter-evans/create-pull-request@v7 handle the push and PR creation.

Refer to the Crowdin Translation PR GH Action for reference and logs to verify.

We will only really know if this fixes the workflow after merging this PR

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

After merge:
1. Manually trigger the workflow via the Actions tab → "CrowdIn Translation PR" → "Run workflow" after merge
2. Verify the Crowdin step completes without the token error
3. Verify a single bot-update-translations PR is opened/updated with sorted translation files

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
