### PR TITLE
HS-1592048 - Fix CrowdIn action to use yarn command for downloading translations

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -28,14 +28,7 @@ jobs:
       - name: 🌐 Extract Translations
         run: yarn extract
       - name: 🔤🔽 CrowdIn Translations Download
-        uses: crowdin/github-action@v2
-        with:
-          upload_sources: false
-          upload_translations: false
-          download_sources: false
-          download_translations: true
-          push_translations: false
-          create_pull_request: false
+        run: yarn crowdin download translations
         env:
           CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}
       - name: 🔤 Sort Translations


### PR DESCRIPTION
## Description

[HS ticket](https://secure.helpscout.net/conversation/3294022916/1592048/)
[Jira ticket](https://jira.cru.org/browse/MPDX-9477)
Related PR: https://github.com/CruGlobal/mpdx-react/pull/1723
Translation PR produced by `Crowdin Translation PR` action: https://github.com/CruGlobal/mpdx-react/pull/1726

### Issue:

The scheduled CrowdIn translation workflow fails at the `Sort Translations` step with `EACCES: permission denied` writing to `public/locales/<locale>/translation.json`.

###  Why:

`crowdin/github-action@v2` is a Docker action whose container runs as root. On GitHub's Linux runners the workspace is bind-mounted into the container and UIDs are shared with the host, so the files the action writes land on the host. The subsequent `Sort Translations` step runs on the host as the unprivileged `runner` user and can't overwrite root-owned files.

### Current solution: 
- Try to replace the Docker action with a direct invocation of the Crowdin CLI
- At this point, we have purposely removed all default behaviors from `crowdin/github-action@v2` apart from downloading, it no longer serves any purpose that the direct Crowdin CLI invocation can't solve.

### Alternative solution:

The alternative was keeping the Docker action and inserting a chown step between download and sort to fix ownership:
- name: 🔓 Fix ownership of downloaded files
  run: sudo chown -R runner:runner public/locales/

**Successful Action run against this branch**: https://github.com/CruGlobal/mpdx-react/actions/runs/24574287028

List any PRs that this PR is dependent on and any Jira tickets that this PR is related to.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

https://github.com/CruGlobal/mpdx-react/pull/1726 needs to be carefully reviewed.
Ideally, the logs for the Action need to be carefully reviewed as well, to ensure no leak of data: https://github.com/CruGlobal/mpdx-react/actions/runs/24574287028 

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
