### PR TITLE
MPDX-9416 - Display paycheck process date associated with effective date to provide context for users

### DIFF
--- a/src/components/Reports/AdditionalSalaryRequest/SharedComponents/ValidationAlert.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/SharedComponents/ValidationAlert.tsx
@@ -64,7 +64,6 @@ export const ValidationAlert: React.FC = () => {
           <li>
             {t('The following fields exceed their limits: {{fields}}', {
               fields: exceedingLimitFields.join(', '),
-              interpolation: { escapeValue: false },
             })}
           </li>
         )}

--- a/src/components/Reports/SalaryCalculator/403bSection/403bSection.test.tsx
+++ b/src/components/Reports/SalaryCalculator/403bSection/403bSection.test.tsx
@@ -56,6 +56,21 @@ describe('403bSection', () => {
         ),
       );
     });
+
+    it('should render the effective paycheck note when payroll dates match', async () => {
+      const { findByRole } = render(
+        <TestComponent
+          salaryRequestMock={{ effectiveDate: '2026-06-01' }}
+          payrollDates={[
+            { startDate: '2026-06-01', regularProcessDate: '2026-06-10' },
+          ]}
+        />,
+      );
+
+      expect(await findByRole('note')).toHaveTextContent(
+        'Values shown reflect the paycheck dated 6/10/2026.',
+      );
+    });
   });
 
   describe('single', () => {

--- a/src/components/Reports/SalaryCalculator/403bSection/403bSection.tsx
+++ b/src/components/Reports/SalaryCalculator/403bSection/403bSection.tsx
@@ -12,6 +12,7 @@ import {
 import { Stack } from '@mui/system';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSalaryCalculator } from '../SalaryCalculatorContext/SalaryCalculatorContext';
+import { EffectiveDateNote } from '../Shared/EffectiveDateNote';
 import { StepCard, StepTableHead } from '../Shared/StepCard';
 import { useFormatters } from '../Shared/useFormatters';
 
@@ -26,7 +27,10 @@ export const FourOhThreeBSection: React.FC = () => {
   return (
     <Stack gap={4}>
       <StepCard>
-        <CardHeader title={t('403(b) Retirement Contribution')} />
+        <CardHeader
+          title={t('403(b) Retirement Contribution')}
+          subheader={<EffectiveDateNote />}
+        />
         <CardContent>
           <Typography variant="body1">
             <Trans t={t}>

--- a/src/components/Reports/SalaryCalculator/EffectiveDateStep/useEffectiveDateOptions.test.ts
+++ b/src/components/Reports/SalaryCalculator/EffectiveDateStep/useEffectiveDateOptions.test.ts
@@ -12,14 +12,17 @@ const expectedOptions = [
   {
     value: '2025-01-01',
     label: 'Jan 25, 2025',
+    shortLabel: '1/25/2025',
   },
   {
     value: '2025-01-16',
     label: 'Feb 10, 2025',
+    shortLabel: '2/10/2025',
   },
   {
     value: '2025-02-01',
     label: 'Feb 25, 2025',
+    shortLabel: '2/25/2025',
   },
 ];
 

--- a/src/components/Reports/SalaryCalculator/EffectiveDateStep/useEffectiveDateOptions.ts
+++ b/src/components/Reports/SalaryCalculator/EffectiveDateStep/useEffectiveDateOptions.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { DateTime } from 'luxon';
 import { useLocale } from 'src/hooks/useLocale';
-import { dateFormat } from 'src/lib/intlFormat';
+import { dateFormat, dateFormatShort } from 'src/lib/intlFormat';
 import {
   PayrollDatesQuery,
   usePayrollDatesQuery,
@@ -10,6 +10,7 @@ import {
 export interface DateOption {
   value: string;
   label: string;
+  shortLabel: string;
 }
 
 export const formatEffectiveDates = (
@@ -19,12 +20,12 @@ export const formatEffectiveDates = (
   return (
     effectiveDates?.map(({ startDate, regularProcessDate }) => {
       const date = DateTime.fromISO(regularProcessDate);
-      const formattedDate = dateFormat(date, locale);
 
       // The user sees the regularProcessDate, but we store the startDate
       return {
         value: startDate,
-        label: formattedDate,
+        label: dateFormat(date, locale),
+        shortLabel: dateFormatShort(date, locale),
       };
     }) ?? []
   );

--- a/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.test.tsx
+++ b/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.test.tsx
@@ -93,6 +93,24 @@ As you set your salary level, the amount you receive should reflect the amount o
         ).toEqual(expectedCells),
       );
     });
+
+    it('should render the effective paycheck note when payroll dates match', async () => {
+      const { findByRole } = render(
+        <TestComponent
+          salaryRequestMock={{
+            ...defaultSalaryMock,
+            effectiveDate: '2026-06-01',
+          }}
+          payrollDates={[
+            { startDate: '2026-06-01', regularProcessDate: '2026-06-10' },
+          ]}
+        />,
+      );
+
+      expect(await findByRole('note')).toHaveTextContent(
+        'Values shown reflect the paycheck dated 6/10/2026.',
+      );
+    });
   });
 
   describe('single', () => {

--- a/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.tsx
+++ b/src/components/Reports/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.tsx
@@ -14,6 +14,7 @@ import { amount } from 'src/lib/yupHelpers';
 import { AutosaveTextField } from '../../Autosave/AutosaveTextField';
 import { CalculationFieldsFragment } from '../../SalaryCalculatorContext/SalaryCalculation.generated';
 import { useSalaryCalculator } from '../../SalaryCalculatorContext/SalaryCalculatorContext';
+import { EffectiveDateNote } from '../../Shared/EffectiveDateNote';
 import { StepCard, StepTableHead } from '../../Shared/StepCard';
 import { useFormatters } from '../../Shared/useFormatters';
 
@@ -72,7 +73,10 @@ export const RequestedSalaryCard: React.FC = () => {
 
   return (
     <StepCard>
-      <CardHeader title={t('Requested Salary')} />
+      <CardHeader
+        title={t('Requested Salary')}
+        subheader={<EffectiveDateNote />}
+      />
       <CardContent>
         <Typography variant="body1" data-testid="RequestedSalaryCard-message">
           <Trans t={t}>

--- a/src/components/Reports/SalaryCalculator/Shared/EffectiveDateNote.test.tsx
+++ b/src/components/Reports/SalaryCalculator/Shared/EffectiveDateNote.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { SalaryRequestStatusEnum } from 'src/graphql/types.generated';
+import { SalaryCalculatorTestWrapper } from '../SalaryCalculatorTestWrapper';
+import { EffectiveDateNote } from './EffectiveDateNote';
+
+describe('EffectiveDateNote', () => {
+  it('renders the note with the formatted paycheck date when available', async () => {
+    const { findByRole } = render(
+      <SalaryCalculatorTestWrapper
+        salaryRequestMock={{
+          status: SalaryRequestStatusEnum.InProgress,
+          effectiveDate: '2026-06-01',
+        }}
+        payrollDates={[
+          { startDate: '2026-06-01', regularProcessDate: '2026-06-10' },
+        ]}
+      >
+        <EffectiveDateNote />
+      </SalaryCalculatorTestWrapper>,
+    );
+
+    expect(await findByRole('note')).toHaveTextContent(
+      'Values shown reflect the paycheck dated 6/10/2026.',
+    );
+  });
+
+  it('renders nothing when the paycheck date cannot be resolved', async () => {
+    const { queryByRole } = render(
+      <SalaryCalculatorTestWrapper
+        salaryRequestMock={{
+          status: SalaryRequestStatusEnum.InProgress,
+          effectiveDate: '2026-06-01',
+        }}
+        payrollDates={[]}
+      >
+        <EffectiveDateNote />
+      </SalaryCalculatorTestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(queryByRole('note')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Reports/SalaryCalculator/Shared/EffectiveDateNote.tsx
+++ b/src/components/Reports/SalaryCalculator/Shared/EffectiveDateNote.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useEffectivePaycheckDate } from './useEffectivePaycheckDate';
+
+export const EffectiveDateNote: React.FC = () => {
+  const { t } = useTranslation();
+  const paycheckDate = useEffectivePaycheckDate();
+
+  if (!paycheckDate) {
+    return null;
+  }
+
+  return (
+    <Typography
+      variant="body2"
+      color="textSecondary"
+      role="note"
+      component="span"
+    >
+      {t('Values shown reflect the paycheck dated {{date}}.', {
+        date: paycheckDate,
+        interpolation: { escapeValue: false },
+      })}
+    </Typography>
+  );
+};

--- a/src/components/Reports/SalaryCalculator/Shared/EffectiveDateNote.tsx
+++ b/src/components/Reports/SalaryCalculator/Shared/EffectiveDateNote.tsx
@@ -20,7 +20,6 @@ export const EffectiveDateNote: React.FC = () => {
     >
       {t('Values shown reflect the paycheck dated {{date}}.', {
         date: paycheckDate,
-        interpolation: { escapeValue: false },
       })}
     </Typography>
   );

--- a/src/components/Reports/SalaryCalculator/Shared/useEffectivePaycheckDate.test.tsx
+++ b/src/components/Reports/SalaryCalculator/Shared/useEffectivePaycheckDate.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { SalaryRequestStatusEnum } from 'src/graphql/types.generated';
+import {
+  SalaryCalculatorTestWrapper,
+  SalaryCalculatorTestWrapperProps,
+} from '../SalaryCalculatorTestWrapper';
+import { useEffectivePaycheckDate } from './useEffectivePaycheckDate';
+
+const wrapperWith = (
+  props: Partial<SalaryCalculatorTestWrapperProps> = {},
+): React.FC<{ children: React.ReactNode }> => {
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <SalaryCalculatorTestWrapper {...props}>
+      {children}
+    </SalaryCalculatorTestWrapper>
+  );
+  return Wrapper;
+};
+
+const mutationSpy = jest.fn();
+
+describe('useEffectivePaycheckDate', () => {
+  it('returns the formatted regularProcessDate when the effective date matches a payroll date', async () => {
+    const { result } = renderHook(() => useEffectivePaycheckDate(), {
+      wrapper: wrapperWith({
+        salaryRequestMock: {
+          status: SalaryRequestStatusEnum.InProgress,
+          effectiveDate: '2026-06-01',
+        },
+        payrollDates: [
+          { startDate: '2026-06-01', regularProcessDate: '2026-06-10' },
+          { startDate: '2026-12-01', regularProcessDate: '2026-12-10' },
+        ],
+      }),
+    });
+
+    await waitFor(() => expect(result.current).toBe('6/10/2026'));
+  });
+
+  it('returns null when the effective date is not in the payroll dates list', async () => {
+    const { result } = renderHook(() => useEffectivePaycheckDate(), {
+      wrapper: wrapperWith({
+        salaryRequestMock: {
+          status: SalaryRequestStatusEnum.InProgress,
+          effectiveDate: '2026-06-01',
+        },
+        payrollDates: [
+          { startDate: '2026-12-01', regularProcessDate: '2026-12-10' },
+        ],
+        onCall: mutationSpy,
+      }),
+    });
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('PayrollDates'),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when payrollDates is empty', async () => {
+    const { result } = renderHook(() => useEffectivePaycheckDate(), {
+      wrapper: wrapperWith({
+        salaryRequestMock: {
+          status: SalaryRequestStatusEnum.InProgress,
+          effectiveDate: '2026-06-01',
+        },
+        payrollDates: [],
+        onCall: mutationSpy,
+      }),
+    });
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('PayrollDates'),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when the calculation has no effective date', async () => {
+    const { result } = renderHook(() => useEffectivePaycheckDate(), {
+      wrapper: wrapperWith({
+        salaryRequestMock: {
+          status: SalaryRequestStatusEnum.InProgress,
+          effectiveDate: null,
+        },
+        payrollDates: [
+          { startDate: '2026-06-01', regularProcessDate: '2026-06-10' },
+        ],
+        onCall: mutationSpy,
+      }),
+    });
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('PayrollDates'),
+    );
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/components/Reports/SalaryCalculator/Shared/useEffectivePaycheckDate.ts
+++ b/src/components/Reports/SalaryCalculator/Shared/useEffectivePaycheckDate.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+import { DateTime } from 'luxon';
+import { useLocale } from 'src/hooks/useLocale';
+import { dateFormatShort } from 'src/lib/intlFormat';
+import { usePayrollDatesQuery } from '../EffectiveDateStep/PayrollDates.generated';
+import { useSalaryCalculator } from '../SalaryCalculatorContext/SalaryCalculatorContext';
+
+export const useEffectivePaycheckDate = (): string | null => {
+  const { calculation } = useSalaryCalculator();
+  const { data } = usePayrollDatesQuery();
+  const locale = useLocale();
+
+  return useMemo(() => {
+    if (!calculation?.effectiveDate || !data?.payrollDates) {
+      return null;
+    }
+
+    const payrollDate = data.payrollDates.find(
+      (entry) => entry.startDate === calculation.effectiveDate,
+    );
+
+    return payrollDate
+      ? dateFormatShort(
+          DateTime.fromISO(payrollDate.regularProcessDate),
+          locale,
+        )
+      : null;
+  }, [calculation?.effectiveDate, data?.payrollDates, locale]);
+};

--- a/src/components/Reports/SalaryCalculator/Shared/useEffectivePaycheckDate.ts
+++ b/src/components/Reports/SalaryCalculator/Shared/useEffectivePaycheckDate.ts
@@ -1,29 +1,12 @@
-import { useMemo } from 'react';
-import { DateTime } from 'luxon';
-import { useLocale } from 'src/hooks/useLocale';
-import { dateFormatShort } from 'src/lib/intlFormat';
-import { usePayrollDatesQuery } from '../EffectiveDateStep/PayrollDates.generated';
+import { useEffectiveDateOptions } from '../EffectiveDateStep/useEffectiveDateOptions';
 import { useSalaryCalculator } from '../SalaryCalculatorContext/SalaryCalculatorContext';
 
 export const useEffectivePaycheckDate = (): string | null => {
   const { calculation } = useSalaryCalculator();
-  const { data } = usePayrollDatesQuery();
-  const locale = useLocale();
+  const dateOptions = useEffectiveDateOptions();
 
-  return useMemo(() => {
-    if (!calculation?.effectiveDate || !data?.payrollDates) {
-      return null;
-    }
-
-    const payrollDate = data.payrollDates.find(
-      (entry) => entry.startDate === calculation.effectiveDate,
-    );
-
-    return payrollDate
-      ? dateFormatShort(
-          DateTime.fromISO(payrollDate.regularProcessDate),
-          locale,
-        )
-      : null;
-  }, [calculation?.effectiveDate, data?.payrollDates, locale]);
+  return (
+    dateOptions.find((option) => option.value === calculation?.effectiveDate)
+      ?.shortLabel ?? null
+  );
 };

--- a/src/components/Reports/SalaryCalculator/Summary/StaffInfoSummaryCard.tsx
+++ b/src/components/Reports/SalaryCalculator/Summary/StaffInfoSummaryCard.tsx
@@ -12,15 +12,14 @@ import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import { SalaryRequestStatusEnum } from 'src/graphql/types.generated';
 import { useLocale } from 'src/hooks/useLocale';
 import { dateFormatShort } from 'src/lib/intlFormat';
-import { usePayrollDatesQuery } from '../EffectiveDateStep/PayrollDates.generated';
 import { useSalaryCalculator } from '../SalaryCalculatorContext/SalaryCalculatorContext';
 import { StepCard } from '../Shared/StepCard';
+import { useEffectivePaycheckDate } from '../Shared/useEffectivePaycheckDate';
 
 export const StaffInfoSummaryCard: React.FC = () => {
   const { t } = useTranslation();
   const locale = useLocale();
   const { hcmUser, hcmSpouse, calculation } = useSalaryCalculator();
-  const { data: payrollDatesData } = usePayrollDatesQuery();
   const { data: userData } = useGetUserQuery();
 
   const name =
@@ -33,12 +32,7 @@ export const StaffInfoSummaryCard: React.FC = () => {
     ? t('{{ name }} and {{ spouseName }}', { name, spouseName })
     : name;
 
-  const payrollDate = payrollDatesData?.payrollDates.find(
-    (date) => date.startDate === calculation?.effectiveDate,
-  );
-  const effectiveDate = payrollDate
-    ? dateFormatShort(DateTime.fromISO(payrollDate.regularProcessDate), locale)
-    : null;
+  const effectiveDate = useEffectivePaycheckDate();
   const submittedDate = calculation?.submittedAt
     ? dateFormatShort(DateTime.fromISO(calculation.submittedAt), locale)
     : null;

--- a/src/components/Reports/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.test.tsx
+++ b/src/components/Reports/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.test.tsx
@@ -25,18 +25,35 @@ const defaultSalaryRequestMock: DeepPartial<
   splitCapRequired: true,
 };
 
-const TestComponent: React.FC<
-  Pick<SalaryCalculatorTestWrapperProps, 'salaryRequestMock'>
-> = ({ salaryRequestMock }) => (
+const TestComponent: React.FC<SalaryCalculatorTestWrapperProps> = ({
+  salaryRequestMock,
+  ...props
+}) => (
   <SalaryCalculatorTestWrapper
-    salaryRequestMock={merge({}, defaultSalaryRequestMock, salaryRequestMock)}
+    {...props}
     onCall={mutationSpy}
+    salaryRequestMock={merge({}, defaultSalaryRequestMock, salaryRequestMock)}
   >
     <MaxAllowableStep />
   </SalaryCalculatorTestWrapper>
 );
 
 describe('MaxAllowableSection', () => {
+  it('should render the effective paycheck note when payroll dates match', async () => {
+    const { findByRole } = render(
+      <TestComponent
+        salaryRequestMock={{ effectiveDate: '2026-06-01' }}
+        payrollDates={[
+          { startDate: '2026-06-01', regularProcessDate: '2026-06-10' },
+        ]}
+      />,
+    );
+
+    expect(await findByRole('note')).toHaveTextContent(
+      'Values shown reflect the paycheck dated 6/10/2026.',
+    );
+  });
+
   it('shows hard caps', async () => {
     const { findByText } = render(<TestComponent />);
 

--- a/src/components/Reports/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.tsx
+++ b/src/components/Reports/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.tsx
@@ -21,6 +21,7 @@ import { amount } from 'src/lib/yupHelpers';
 import { AutosaveCheckbox } from '../../Autosave/AutosaveCheckbox';
 import { AutosaveTextField } from '../../Autosave/AutosaveTextField';
 import { useSalaryCalculator } from '../../SalaryCalculatorContext/SalaryCalculatorContext';
+import { EffectiveDateNote } from '../../Shared/EffectiveDateNote';
 import { StepCard, StepTableHead } from '../../Shared/StepCard';
 import { useFormatters } from '../../Shared/useFormatters';
 
@@ -84,7 +85,10 @@ export const MaxAllowableStep: React.FC = () => {
 
   return (
     <StepCard>
-      <CardHeader title={t('Maximum Allowable Salary (CAP)')} />
+      <CardHeader
+        title={t('Maximum Allowable Salary (CAP)')}
+        subheader={<EffectiveDateNote />}
+      />
       <CardContent>
         <Typography variant="body1">
           <Trans t={t}>

--- a/src/components/Reports/SalaryCalculator/YourInformation/MhaRequestSection/MhaRequestSection.test.tsx
+++ b/src/components/Reports/SalaryCalculator/YourInformation/MhaRequestSection/MhaRequestSection.test.tsx
@@ -16,6 +16,21 @@ const TestComponent: React.FC<
 );
 
 describe('MhaRequestSection', () => {
+  it('should render the effective paycheck note when payroll dates match', async () => {
+    const { findByRole } = render(
+      <TestComponent
+        salaryRequestMock={{ effectiveDate: '2026-06-01' }}
+        payrollDates={[
+          { startDate: '2026-06-01', regularProcessDate: '2026-06-10' },
+        ]}
+      />,
+    );
+
+    expect(await findByRole('note')).toHaveTextContent(
+      'Values shown reflect the paycheck dated 6/10/2026.',
+    );
+  });
+
   it('should display both spouse names as headers', async () => {
     const { findByRole } = render(<TestComponent />);
 

--- a/src/components/Reports/SalaryCalculator/YourInformation/MhaRequestSection/MhaRequestSection.tsx
+++ b/src/components/Reports/SalaryCalculator/YourInformation/MhaRequestSection/MhaRequestSection.tsx
@@ -16,6 +16,7 @@ import { EligibilityStatusTable } from 'src/components/Reports/Shared/Eligibilit
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { AutosaveTextField } from '../../Autosave/AutosaveTextField';
 import { useSalaryCalculator } from '../../SalaryCalculatorContext/SalaryCalculatorContext';
+import { EffectiveDateNote } from '../../Shared/EffectiveDateNote';
 import { StepCard } from '../../Shared/StepCard';
 import { useMhaRequestData } from './useMhaRequestData';
 
@@ -72,7 +73,7 @@ export const MhaRequestSection: React.FC = () => {
         },
       }}
     >
-      <CardHeader title={t('MHA Request')} />
+      <CardHeader title={t('MHA Request')} subheader={<EffectiveDateNote />} />
       <CardContent>
         {anyIneligible && (
           <EligibilityStatusTable

--- a/src/components/Reports/SalaryCalculator/YourInformation/PersonalInformationSection/PersonalInformationSection.test.tsx
+++ b/src/components/Reports/SalaryCalculator/YourInformation/PersonalInformationSection/PersonalInformationSection.test.tsx
@@ -3,6 +3,7 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   SalaryCalculatorTestWrapper,
+  SalaryCalculatorTestWrapperProps,
   SalaryRequestMock,
 } from '../../SalaryCalculatorTestWrapper';
 import { PersonalInformationSection } from './PersonalInformationSection';
@@ -10,10 +11,12 @@ import { PersonalInformationSection } from './PersonalInformationSection';
 const TestComponent: React.FC<{
   hasSpouse?: boolean;
   requestMock?: SalaryRequestMock;
-}> = ({ hasSpouse, requestMock }) => (
+  payrollDates?: SalaryCalculatorTestWrapperProps['payrollDates'];
+}> = ({ hasSpouse, requestMock, payrollDates }) => (
   <SalaryCalculatorTestWrapper
     hasSpouse={hasSpouse}
     salaryRequestMock={requestMock}
+    payrollDates={payrollDates}
   >
     <PersonalInformationSection />
   </SalaryCalculatorTestWrapper>
@@ -49,7 +52,7 @@ describe('PersonalInformationSection', () => {
     expect(
       await findByRole('columnheader', { name: 'John' }),
     ).toBeInTheDocument();
-    waitFor(() => {
+    await waitFor(() => {
       expect(
         queryByRole('columnheader', { name: 'Jane' }),
       ).not.toBeInTheDocument();
@@ -104,6 +107,21 @@ describe('PersonalInformationSection', () => {
     userEvent.click(await findByRole('button', { name: 'Open' }));
 
     expect(await findAllByRole('option')).toHaveLength(2);
+  });
+
+  it('should render the effective paycheck note when payroll dates match', async () => {
+    const { findByRole } = render(
+      <TestComponent
+        requestMock={{ effectiveDate: '2026-06-01' }}
+        payrollDates={[
+          { startDate: '2026-06-01', regularProcessDate: '2026-06-10' },
+        ]}
+      />,
+    );
+
+    expect(await findByRole('note')).toHaveTextContent(
+      'Values shown reflect the paycheck dated 6/10/2026.',
+    );
   });
 
   it('should not display spouse information when no spouse exists', async () => {

--- a/src/components/Reports/SalaryCalculator/YourInformation/PersonalInformationSection/PersonalInformationSection.tsx
+++ b/src/components/Reports/SalaryCalculator/YourInformation/PersonalInformationSection/PersonalInformationSection.tsx
@@ -14,6 +14,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
 import { AutosaveAutocomplete } from '../../Autosave/AutosaveAutocomplete';
 import { useSalaryCalculator } from '../../SalaryCalculatorContext/SalaryCalculatorContext';
+import { EffectiveDateNote } from '../../Shared/EffectiveDateNote';
 import { StepCard, StepTableHead } from '../../Shared/StepCard';
 import { usePersonalInformation } from './usePersonalInformation';
 
@@ -40,6 +41,7 @@ export const PersonalInformationSection: React.FC = () => {
     <StepCard>
       <CardHeader
         title={t('Personal Information')}
+        subheader={<EffectiveDateNote />}
         data-testid="personal-information-header"
       />
       <CardContent>

--- a/src/components/Reports/Shared/CalculationReports/ReceiptStep/Receipt.tsx
+++ b/src/components/Reports/Shared/CalculationReports/ReceiptStep/Receipt.tsx
@@ -84,7 +84,7 @@ export const Receipt: React.FC<ReceiptProps> = ({
               ? alertText
               : t(
                   'We will review your information and you will receive notice for your {{approval}}.',
-                  { approval, interpolation: { escapeValue: false } },
+                  { approval },
                 )}
           </Typography>
         </Box>

--- a/src/components/Reports/Shared/CalculationReports/SubmitModal/getModalText.ts
+++ b/src/components/Reports/Shared/CalculationReports/SubmitModal/getModalText.ts
@@ -73,7 +73,6 @@ export const getModalText = ({
           'This updated request will take the place of your previous request. Once submitted, you can return and make edits until {{date}}. After this date, your request will be processed as is.',
           {
             date: formattedDeadlineDate,
-            interpolation: { escapeValue: false },
           },
         ),
         cancelButtonText: t('Yes, Continue'),
@@ -90,7 +89,6 @@ export const getModalText = ({
           'Once submitted, you can return and make edits until {{date}}. After this date, your request will be processed as is.',
           {
             date: formattedDeadlineDate,
-            interpolation: { escapeValue: false },
           },
         ),
         cancelButtonText: t('Yes, Continue'),

--- a/src/components/Settings/Organization/AccountLists/AccountListRow/DeleteAccountConfirmModal.tsx
+++ b/src/components/Settings/Organization/AccountLists/AccountListRow/DeleteAccountConfirmModal.tsx
@@ -96,7 +96,6 @@ export const DeleteAccountConfirmModal: React.FC<
               `Are you sure you want to permanently delete the account list: {{accountListName}}?`,
               {
                 accountListName: name,
-                interpolation: { escapeValue: false },
               },
             )}
           </Typography>

--- a/src/components/Settings/Organization/AccountLists/AccountListRow/DeleteUserConfirmModal.tsx
+++ b/src/components/Settings/Organization/AccountLists/AccountListRow/DeleteUserConfirmModal.tsx
@@ -87,7 +87,6 @@ export const DeleteUserConfirmModal: React.FC<DeleteUserConfirmModalProps> = ({
               {
                 first: deleteUser?.userFirstName,
                 last: deleteUser?.userLastName,
-                interpolation: { escapeValue: false },
               },
             )}
           </Typography>

--- a/src/components/Tool/FixCommitmentInfo/FixCommitmentInfo.tsx
+++ b/src/components/Tool/FixCommitmentInfo/FixCommitmentInfo.tsx
@@ -289,7 +289,6 @@ const FixCommitmentInfo: React.FC<Props> = ({ accountListId }: Props) => {
           message={
             <Trans
               defaults="{{message}}"
-              tOptions={{ interpolation: { escapeValue: false } }}
               shouldUnescape
               values={{ message: modalState.message }}
               components={{ bold: <strong /> }}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -20,6 +20,12 @@ i18next
     react: {
       useSuspense: false,
     },
+    // React escapes interpolated values for us, so disable i18next's default
+    // escaping to avoid double-escaping characters like / and <. Safe as long
+    // as we never render translated strings via dangerouslySetInnerHTML.
+    interpolation: {
+      escapeValue: false,
+    },
     detection: {
       order: ['localStorage', 'navigator', 'htmlTag'],
     },


### PR DESCRIPTION
## Description

- Implements a hook for displaying the paycheck process date associated with the given effective date. This is to provide users context. It might be overkill. 

[Jira ticket](https://jira.cru.org/browse/MPDX-9370)

## Testing

- Go to the SalaryCalculator
- Continue or create a salary request.
- Determine if the change of displaying the process date is appropriate or not.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
