### PR TITLE
[no-Jira] Always configure i18n in tests

### DIFF
--- a/__tests__/util/setup.ts
+++ b/__tests__/util/setup.ts
@@ -9,6 +9,8 @@ import { loadConstantsMockData } from 'src/components/Constants/LoadConstantsMoc
 import { useApiConstants } from 'src/components/Constants/UseApiConstants';
 import { toHaveGraphqlOperation } from '../extensions/toHaveGraphqlOperation';
 import matchMediaMock from './matchMediaMock';
+// Configure i18next in tests
+import 'src/lib/i18n';
 
 jest.mock('src/components/Constants/UseApiConstants');
 jest.mock('next-auth/react', () => {

--- a/pages/acceptInvite.test.tsx
+++ b/pages/acceptInvite.test.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
-import i18n from 'src/lib/i18n';
 import AcceptInvitePage from './acceptInvite.page';
 import 'node-fetch';
 
@@ -51,11 +49,9 @@ describe('AcceptInvitePage', () => {
 
     const { getByText } = render(
       <TestRouter router={router}>
-        <I18nextProvider i18n={i18n}>
-          <SnackbarProvider>
-            <AcceptInvitePage />
-          </SnackbarProvider>
-        </I18nextProvider>
+        <SnackbarProvider>
+          <AcceptInvitePage />
+        </SnackbarProvider>
       </TestRouter>,
     );
 
@@ -89,11 +85,9 @@ describe('AcceptInvitePage', () => {
 
     const { getByText } = render(
       <TestRouter router={router}>
-        <I18nextProvider i18n={i18n}>
-          <SnackbarProvider>
-            <AcceptInvitePage />
-          </SnackbarProvider>
-        </I18nextProvider>
+        <SnackbarProvider>
+          <AcceptInvitePage />
+        </SnackbarProvider>
       </TestRouter>,
     );
 
@@ -127,11 +121,9 @@ describe('AcceptInvitePage', () => {
 
     render(
       <TestRouter router={router}>
-        <I18nextProvider i18n={i18n}>
-          <SnackbarProvider>
-            <AcceptInvitePage />
-          </SnackbarProvider>
-        </I18nextProvider>
+        <SnackbarProvider>
+          <AcceptInvitePage />
+        </SnackbarProvider>
       </TestRouter>,
     );
 
@@ -156,11 +148,9 @@ describe('AcceptInvitePage', () => {
 
     render(
       <TestRouter router={router}>
-        <I18nextProvider i18n={i18n}>
-          <SnackbarProvider>
-            <AcceptInvitePage />
-          </SnackbarProvider>
-        </I18nextProvider>
+        <SnackbarProvider>
+          <AcceptInvitePage />
+        </SnackbarProvider>
       </TestRouter>,
     );
 

--- a/pages/accountLists/[accountListId].page.test.tsx
+++ b/pages/accountLists/[accountListId].page.test.tsx
@@ -5,11 +5,9 @@ import { render } from '@testing-library/react';
 import { GraphQLError } from 'graphql';
 import { getSession } from 'next-auth/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import makeSsrClient from 'src/lib/apollo/ssrClient';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import AccountListIdPage, {
   AccountListIdPageProps,
@@ -96,9 +94,7 @@ describe('AccountListsId page', () => {
           <TestRouter>
             <SnackbarProvider>
               <GqlMockedProvider>
-                <I18nextProvider i18n={i18n}>
-                  <AccountListIdPage {...props} />
-                </I18nextProvider>
+                <AccountListIdPage {...props} />
               </GqlMockedProvider>
             </SnackbarProvider>
           </TestRouter>

--- a/pages/accountLists/[accountListId]/reports/financialAccounts/[financialAccountId].page.test.tsx
+++ b/pages/accountLists/[accountListId]/reports/financialAccounts/[financialAccountId].page.test.tsx
@@ -5,7 +5,6 @@ import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { defaultFinancialAccountSummary } from 'src/components/Reports/FinancialAccountsReport/AccountSummary/AccountSummaryMock';
@@ -14,7 +13,6 @@ import { FinancialAccountQuery } from 'src/components/Reports/FinancialAccountsR
 import { defaultFinancialAccount } from 'src/components/Reports/FinancialAccountsReport/Header/HeaderMocks';
 import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import { UserTypeEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import FinancialAccountSummaryPage from './[financialAccountId].page';
 
@@ -32,31 +30,29 @@ interface ComponentProps {
 const Components: React.FC<ComponentProps> = ({
   userType = UserTypeEnum.GlobalStaff,
 }) => (
-  <I18nextProvider i18n={i18n}>
-    <LocalizationProvider dateAdapter={AdapterLuxon}>
-      <SnackbarProvider>
-        <ThemeProvider theme={theme}>
-          <TestRouter router={router}>
-            <GqlMockedProvider<{
-              FinancialAccountSummary: FinancialAccountSummaryQuery;
-              FinancialAccount: FinancialAccountQuery;
-              GetUser: GetUserQuery;
-            }>
-              mocks={{
-                FinancialAccountSummary: defaultFinancialAccountSummary,
-                FinancialAccount: defaultFinancialAccount,
-                GetUser: {
-                  user: { userType },
-                },
-              }}
-            >
-              <FinancialAccountSummaryPage />
-            </GqlMockedProvider>
-          </TestRouter>
-        </ThemeProvider>
-      </SnackbarProvider>
-    </LocalizationProvider>
-  </I18nextProvider>
+  <LocalizationProvider dateAdapter={AdapterLuxon}>
+    <SnackbarProvider>
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<{
+            FinancialAccountSummary: FinancialAccountSummaryQuery;
+            FinancialAccount: FinancialAccountQuery;
+            GetUser: GetUserQuery;
+          }>
+            mocks={{
+              FinancialAccountSummary: defaultFinancialAccountSummary,
+              FinancialAccount: defaultFinancialAccount,
+              GetUser: {
+                user: { userType },
+              },
+            }}
+          >
+            <FinancialAccountSummaryPage />
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>
+    </SnackbarProvider>
+  </LocalizationProvider>
 );
 
 describe('Financial Accounts Page', () => {

--- a/pages/accountLists/[accountListId]/reports/financialAccounts/[financialAccountId]/entries.page.test.tsx
+++ b/pages/accountLists/[accountListId]/reports/financialAccounts/[financialAccountId]/entries.page.test.tsx
@@ -5,14 +5,12 @@ import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { FinancialAccountQuery } from 'src/components/Reports/FinancialAccountsReport/Context/FinancialAccount.generated';
 import { defaultFinancialAccount } from 'src/components/Reports/FinancialAccountsReport/Header/HeaderMocks';
 import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import { UserTypeEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import FinancialAccountsPage from './entries.page';
 
@@ -32,27 +30,25 @@ interface ComponentProps {
 const Components: React.FC<ComponentProps> = ({
   userType = UserTypeEnum.GlobalStaff,
 }) => (
-  <I18nextProvider i18n={i18n}>
-    <LocalizationProvider dateAdapter={AdapterLuxon}>
-      <SnackbarProvider>
-        <ThemeProvider theme={theme}>
-          <TestRouter router={router}>
-            <GqlMockedProvider<{
-              FinancialAccount: FinancialAccountQuery;
-              GetUser: GetUserQuery;
-            }>
-              mocks={{
-                FinancialAccount: defaultFinancialAccount,
-                GetUser: { user: { userType } },
-              }}
-            >
-              <FinancialAccountsPage />
-            </GqlMockedProvider>
-          </TestRouter>
-        </ThemeProvider>
-      </SnackbarProvider>
-    </LocalizationProvider>
-  </I18nextProvider>
+  <LocalizationProvider dateAdapter={AdapterLuxon}>
+    <SnackbarProvider>
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<{
+            FinancialAccount: FinancialAccountQuery;
+            GetUser: GetUserQuery;
+          }>
+            mocks={{
+              FinancialAccount: defaultFinancialAccount,
+              GetUser: { user: { userType } },
+            }}
+          >
+            <FinancialAccountsPage />
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>
+    </SnackbarProvider>
+  </LocalizationProvider>
 );
 
 describe('Financial Accounts Page', () => {

--- a/pages/accountLists/[accountListId]/reports/financialAccounts/index.page.test.tsx
+++ b/pages/accountLists/[accountListId]/reports/financialAccounts/index.page.test.tsx
@@ -5,14 +5,12 @@ import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { FinancialAccountsQuery } from 'src/components/Reports/FinancialAccountsReport/FinancialAccounts/FinancialAccounts.generated';
 import { FinancialAccountsMock } from 'src/components/Reports/FinancialAccountsReport/FinancialAccounts/FinancialAccountsMocks';
 import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import { UserTypeEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import FinancialAccountsPage from './index.page';
 
@@ -28,29 +26,27 @@ interface ComponentProps {
 const Components: React.FC<ComponentProps> = ({
   userType = UserTypeEnum.GlobalStaff,
 }) => (
-  <I18nextProvider i18n={i18n}>
-    <LocalizationProvider dateAdapter={AdapterLuxon}>
-      <SnackbarProvider>
-        <ThemeProvider theme={theme}>
-          <TestRouter router={router}>
-            <GqlMockedProvider<{
-              FinancialAccounts: FinancialAccountsQuery;
-              GetUser: GetUserQuery;
-            }>
-              mocks={{
-                ...FinancialAccountsMock,
-                GetUser: {
-                  user: { userType },
-                },
-              }}
-            >
-              <FinancialAccountsPage />
-            </GqlMockedProvider>
-          </TestRouter>
-        </ThemeProvider>
-      </SnackbarProvider>
-    </LocalizationProvider>
-  </I18nextProvider>
+  <LocalizationProvider dateAdapter={AdapterLuxon}>
+    <SnackbarProvider>
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<{
+            FinancialAccounts: FinancialAccountsQuery;
+            GetUser: GetUserQuery;
+          }>
+            mocks={{
+              ...FinancialAccountsMock,
+              GetUser: {
+                user: { userType },
+              },
+            }}
+          >
+            <FinancialAccountsPage />
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>
+    </SnackbarProvider>
+  </LocalizationProvider>
 );
 
 describe('Financial Accounts Page', () => {

--- a/pages/accountLists/[accountListId]/settings/admin.page.test.tsx
+++ b/pages/accountLists/[accountListId]/settings/admin.page.test.tsx
@@ -1,11 +1,9 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { AdminAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import Admin from './admin.page';
 
@@ -28,11 +26,9 @@ const Components: React.FC<ComponentsProps> = ({ selectedTab }) => (
   <ThemeProvider theme={theme}>
     <TestRouter router={{ query: { selectedTab } }}>
       <GqlMockedProvider>
-        <I18nextProvider i18n={i18n}>
-          <SnackbarProvider>
-            <Admin />
-          </SnackbarProvider>
-        </I18nextProvider>
+        <SnackbarProvider>
+          <Admin />
+        </SnackbarProvider>
       </GqlMockedProvider>
     </TestRouter>
   </ThemeProvider>

--- a/pages/accountLists/[accountListId]/settings/manageAccounts.page.test.tsx
+++ b/pages/accountLists/[accountListId]/settings/manageAccounts.page.test.tsx
@@ -1,11 +1,9 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { AccountAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import ManageAccounts from './manageAccounts.page';
 
@@ -28,11 +26,9 @@ const Components: React.FC<ComponentsProps> = ({ selectedTab }) => (
   <ThemeProvider theme={theme}>
     <TestRouter router={{ query: { selectedTab } }}>
       <GqlMockedProvider>
-        <I18nextProvider i18n={i18n}>
-          <SnackbarProvider>
-            <ManageAccounts />
-          </SnackbarProvider>
-        </I18nextProvider>
+        <SnackbarProvider>
+          <ManageAccounts />
+        </SnackbarProvider>
       </GqlMockedProvider>
     </TestRouter>
   </ThemeProvider>

--- a/pages/accountLists/[accountListId]/settings/manageCoaches.page.test.tsx
+++ b/pages/accountLists/[accountListId]/settings/manageCoaches.page.test.tsx
@@ -2,10 +2,8 @@ import { useRouter } from 'next/router';
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import ManageCoaching from './manageCoaches.page';
 
@@ -27,11 +25,9 @@ const Components = () => (
   <ThemeProvider theme={theme}>
     <TestRouter>
       <GqlMockedProvider>
-        <I18nextProvider i18n={i18n}>
-          <SnackbarProvider>
-            <ManageCoaching />
-          </SnackbarProvider>
-        </I18nextProvider>
+        <SnackbarProvider>
+          <ManageCoaching />
+        </SnackbarProvider>
       </GqlMockedProvider>
     </TestRouter>
   </ThemeProvider>

--- a/pages/accountLists/[accountListId]/settings/organizations/accountLists.page.test.tsx
+++ b/pages/accountLists/[accountListId]/settings/organizations/accountLists.page.test.tsx
@@ -1,10 +1,8 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { OrganizationsQuery } from '../organizations.generated';
 import AccountListsOrganizations from './accountLists.page';
@@ -33,9 +31,7 @@ const Components = ({ mutationSpy }: { mutationSpy?: () => void }) => (
         }}
         onCall={mutationSpy}
       >
-        <I18nextProvider i18n={i18n}>
-          <AccountListsOrganizations />
-        </I18nextProvider>
+        <AccountListsOrganizations />
       </GqlMockedProvider>
     </TestRouter>
   </ThemeProvider>

--- a/pages/accountLists/[accountListId]/settings/organizations/contacts.page.test.tsx
+++ b/pages/accountLists/[accountListId]/settings/organizations/contacts.page.test.tsx
@@ -1,10 +1,8 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { OrganizationsQuery } from '../organizations.generated';
 import OrganizationsContacts from './contacts.page';
@@ -33,9 +31,7 @@ const Components = ({ mutationSpy }: { mutationSpy?: () => void }) => (
         }}
         onCall={mutationSpy}
       >
-        <I18nextProvider i18n={i18n}>
-          <OrganizationsContacts />
-        </I18nextProvider>
+        <OrganizationsContacts />
       </GqlMockedProvider>
     </TestRouter>
   </ThemeProvider>

--- a/pages/accountLists/[accountListId]/tools/fix/commitmentInfo/[[...contactId]].page.test.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/commitmentInfo/[[...contactId]].page.test.tsx
@@ -2,13 +2,11 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { ErgonoMockShape } from 'graphql-ergonomock';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import { VirtuosoMockContext } from 'react-virtuoso';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { mockInvalidStatusesResponse } from 'src/components/Tool/FixCommitmentInfo/FixCommitmentInfoMocks';
 import { InvalidStatusesQuery } from 'src/components/Tool/FixCommitmentInfo/GetInvalidStatuses.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import FixCommitmentInfoPage from './[[...contactId]].page';
 
@@ -38,15 +36,13 @@ const Components = ({
           },
         }}
       >
-        <I18nextProvider i18n={i18n}>
-          <SnackbarProvider>
-            <VirtuosoMockContext.Provider
-              value={{ viewportHeight: 1000, itemHeight: 100 }}
-            >
-              <FixCommitmentInfoPage />
-            </VirtuosoMockContext.Provider>
-          </SnackbarProvider>
-        </I18nextProvider>
+        <SnackbarProvider>
+          <VirtuosoMockContext.Provider
+            value={{ viewportHeight: 1000, itemHeight: 100 }}
+          >
+            <FixCommitmentInfoPage />
+          </VirtuosoMockContext.Provider>
+        </SnackbarProvider>
       </GqlMockedProvider>
     </TestRouter>
   </ThemeProvider>

--- a/pages/accountLists/[accountListId]/tools/fix/emailAddresses/[[...contactId]].page.test.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/emailAddresses/[[...contactId]].page.test.tsx
@@ -2,13 +2,11 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { ErgonoMockShape } from 'graphql-ergonomock';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import { VirtuosoMockContext } from 'react-virtuoso';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { mockInvalidEmailAddressesResponse } from 'src/components/Tool/FixEmailAddresses/FixEmailAddressesMocks';
 import { InvalidAddressesQuery } from 'src/components/Tool/FixMailingAddresses/GetInvalidAddresses.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import FixEmailAddressesPage from './[[...contactId]].page';
 
@@ -52,11 +50,9 @@ const Components = ({
             },
           }}
         >
-          <I18nextProvider i18n={i18n}>
-            <SnackbarProvider>
-              <FixEmailAddressesPage />
-            </SnackbarProvider>
-          </I18nextProvider>
+          <SnackbarProvider>
+            <FixEmailAddressesPage />
+          </SnackbarProvider>
         </GqlMockedProvider>
       </VirtuosoMockContext.Provider>
     </TestRouter>

--- a/pages/accountLists/[accountListId]/tools/fix/mailingAddresses/[[...contactId]].page.test.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/mailingAddresses/[[...contactId]].page.test.tsx
@@ -2,12 +2,10 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { ApolloErgonoMockMap } from 'graphql-ergonomock';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { mockInvalidAddressesResponse } from 'src/components/Tool/FixMailingAddresses/FixMailingAddressesMock';
 import { InvalidAddressesQuery } from 'src/components/Tool/FixMailingAddresses/GetInvalidAddresses.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import FixMailingAddressesPage from './[[...contactId]].page';
 
@@ -38,11 +36,9 @@ const Components = ({ mocks }: { mocks: ApolloErgonoMockMap }) => (
       }>
         mocks={mocks}
       >
-        <I18nextProvider i18n={i18n}>
-          <SnackbarProvider>
-            <FixMailingAddressesPage />
-          </SnackbarProvider>
-        </I18nextProvider>
+        <SnackbarProvider>
+          <FixMailingAddressesPage />
+        </SnackbarProvider>
       </GqlMockedProvider>
     </TestRouter>
   </ThemeProvider>

--- a/pages/accountLists/[accountListId]/tools/fix/phoneNumbers/[[...contactId]].page.test.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/phoneNumbers/[[...contactId]].page.test.tsx
@@ -1,12 +1,10 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { GetInvalidPhoneNumbersMocks } from 'src/components/Tool/FixPhoneNumbers/FixPhoneNumbersMocks';
 import { GetInvalidPhoneNumbersQuery } from 'src/components/Tool/FixPhoneNumbers/GetInvalidPhoneNumbers.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import FixPhoneNumbersPage from './[[...contactId]].page';
 
@@ -30,17 +28,15 @@ const router = {
 const Components = () => (
   <ThemeProvider theme={theme}>
     <TestRouter router={router}>
-      <I18nextProvider i18n={i18n}>
-        <SnackbarProvider>
-          <GqlMockedProvider<{
-            GetInvalidPhoneNumbers: GetInvalidPhoneNumbersQuery;
-          }>
-            mocks={GetInvalidPhoneNumbersMocks}
-          >
-            <FixPhoneNumbersPage />
-          </GqlMockedProvider>
-        </SnackbarProvider>
-      </I18nextProvider>
+      <SnackbarProvider>
+        <GqlMockedProvider<{
+          GetInvalidPhoneNumbers: GetInvalidPhoneNumbersQuery;
+        }>
+          mocks={GetInvalidPhoneNumbersMocks}
+        >
+          <FixPhoneNumbersPage />
+        </GqlMockedProvider>
+      </SnackbarProvider>
     </TestRouter>
   </ThemeProvider>
 );

--- a/pages/accountLists/[accountListId]/tools/fix/sendNewsletter/[[...contactId]].page.test.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/sendNewsletter/[[...contactId]].page.test.tsx
@@ -2,12 +2,10 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { ApolloErgonoMockMap } from 'graphql-ergonomock';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { mockInvalidNewslettersResponse } from 'src/components/Tool/FixSendNewsletter/FixSendNewsletterMock';
 import { InvalidNewsletterQuery } from 'src/components/Tool/FixSendNewsletter/InvalidNewsletter.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import FixSendNewsletterPage from './[[...contactId]].page';
 
@@ -32,17 +30,15 @@ const router = {
 const Components = () => (
   <ThemeProvider theme={theme}>
     <TestRouter router={router}>
-      <I18nextProvider i18n={i18n}>
-        <SnackbarProvider>
-          <GqlMockedProvider<{
-            InvalidNewsletter: InvalidNewsletterQuery;
-          }>
-            mocks={mockInvalidNewslettersResponse as ApolloErgonoMockMap}
-          >
-            <FixSendNewsletterPage />
-          </GqlMockedProvider>
-        </SnackbarProvider>
-      </I18nextProvider>
+      <SnackbarProvider>
+        <GqlMockedProvider<{
+          InvalidNewsletter: InvalidNewsletterQuery;
+        }>
+          mocks={mockInvalidNewslettersResponse as ApolloErgonoMockMap}
+        >
+          <FixSendNewsletterPage />
+        </GqlMockedProvider>
+      </SnackbarProvider>
     </TestRouter>
   </ThemeProvider>
 );

--- a/pages/accountLists/[accountListId]/tools/merge/contacts/[[...contactId]].page.test.tsx
+++ b/pages/accountLists/[accountListId]/tools/merge/contacts/[[...contactId]].page.test.tsx
@@ -1,12 +1,10 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { GetContactDuplicatesQuery } from 'src/components/Tool/MergeContacts/GetContactDuplicates.generated';
 import { getContactDuplicatesMocks } from 'src/components/Tool/MergeContacts/MergeContactsMock';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import MergeContactsPage from './[[...contactId]].page';
 
@@ -39,11 +37,9 @@ const Components = () => (
           ...getContactDuplicatesMocks,
         }}
       >
-        <I18nextProvider i18n={i18n}>
-          <SnackbarProvider>
-            <MergeContactsPage />
-          </SnackbarProvider>
-        </I18nextProvider>
+        <SnackbarProvider>
+          <MergeContactsPage />
+        </SnackbarProvider>
       </GqlMockedProvider>
     </TestRouter>
   </ThemeProvider>

--- a/pages/accountLists/[accountListId]/tools/merge/people/[[...contactId]].page.test.tsx
+++ b/pages/accountLists/[accountListId]/tools/merge/people/[[...contactId]].page.test.tsx
@@ -1,12 +1,10 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { GetPersonDuplicatesQuery } from 'src/components/Tool/MergePeople/GetPersonDuplicates.generated';
 import { getPersonDuplicatesMocks } from 'src/components/Tool/MergePeople/PersonDuplicatesMock';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import MergePeoplePage from './[[...contactId]].page';
 
@@ -35,11 +33,9 @@ const Components = () => (
       }>
         mocks={getPersonDuplicatesMocks}
       >
-        <I18nextProvider i18n={i18n}>
-          <SnackbarProvider>
-            <MergePeoplePage />
-          </SnackbarProvider>
-        </I18nextProvider>
+        <SnackbarProvider>
+          <MergePeoplePage />
+        </SnackbarProvider>
       </GqlMockedProvider>
     </TestRouter>
   </ThemeProvider>

--- a/pages/login-apioauth.page.test.tsx
+++ b/pages/login-apioauth.page.test.tsx
@@ -3,10 +3,8 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getSession, signIn } from 'next-auth/react';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import Login, { LoginProps, getServerSideProps } from './login.page';
 
@@ -29,9 +27,7 @@ const Components = ({ props, mutationSpy }: ComponentsProps) => (
   <ThemeProvider theme={theme}>
     <TestRouter>
       <GqlMockedProvider onCall={mutationSpy}>
-        <I18nextProvider i18n={i18n}>
-          <Login {...props} />
-        </I18nextProvider>
+        <Login {...props} />
       </GqlMockedProvider>
     </TestRouter>
   </ThemeProvider>

--- a/pages/login.page.test.tsx
+++ b/pages/login.page.test.tsx
@@ -3,10 +3,8 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getSession, signIn } from 'next-auth/react';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import Login, { LoginProps, getServerSideProps } from './login.page';
 
@@ -30,9 +28,7 @@ const Components = ({ props, mutationSpy }: ComponentsProps) => (
   <ThemeProvider theme={theme}>
     <TestRouter>
       <GqlMockedProvider onCall={mutationSpy}>
-        <I18nextProvider i18n={i18n}>
-          <Login {...props} />
-        </I18nextProvider>
+        <Login {...props} />
       </GqlMockedProvider>
     </TestRouter>
   </ThemeProvider>

--- a/src/components/Announcements/AnnouncementBanner/AnnouncementBanner.test.tsx
+++ b/src/components/Announcements/AnnouncementBanner/AnnouncementBanner.test.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { announcement } from '../Announcements.mock';
 import { AnnouncementBanner } from './AnnouncementBanner';
@@ -18,16 +16,14 @@ const router = {
 
 const TestComponent: React.FC = () => {
   return (
-    <I18nextProvider i18n={i18n}>
-      <TestRouter router={router}>
-        <ThemeProvider theme={theme}>
-          <AnnouncementBanner
-            announcement={announcement}
-            handlePerformAction={handlePerformAction}
-          />
-        </ThemeProvider>
-      </TestRouter>
-    </I18nextProvider>
+    <TestRouter router={router}>
+      <ThemeProvider theme={theme}>
+        <AnnouncementBanner
+          announcement={announcement}
+          handlePerformAction={handlePerformAction}
+        />
+      </ThemeProvider>
+    </TestRouter>
   );
 };
 

--- a/src/components/Announcements/AnnouncementModal/AnnouncementModal.test.tsx
+++ b/src/components/Announcements/AnnouncementModal/AnnouncementModal.test.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { DisplayMethodEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { announcement } from '../Announcements.mock';
 import { AnnouncementModal } from './AnnouncementModal';
@@ -19,19 +17,17 @@ const router = {
 
 const TestComponent: React.FC = () => {
   return (
-    <I18nextProvider i18n={i18n}>
-      <TestRouter router={router}>
-        <ThemeProvider theme={theme}>
-          <AnnouncementModal
-            announcement={{
-              ...announcement,
-              displayMethod: DisplayMethodEnum.Modal,
-            }}
-            handlePerformAction={handlePerformAction}
-          />
-        </ThemeProvider>
-      </TestRouter>
-    </I18nextProvider>
+    <TestRouter router={router}>
+      <ThemeProvider theme={theme}>
+        <AnnouncementModal
+          announcement={{
+            ...announcement,
+            displayMethod: DisplayMethodEnum.Modal,
+          }}
+          handlePerformAction={handlePerformAction}
+        />
+      </ThemeProvider>
+    </TestRouter>
   );
 };
 

--- a/src/components/Announcements/Announcements.test.tsx
+++ b/src/components/Announcements/Announcements.test.tsx
@@ -5,12 +5,10 @@ import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { DisplayMethodEnum } from 'src/graphql/types.generated';
 import { dispatch } from 'src/lib/analytics';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { ContactTagsQuery } from '../Tool/Appeal/InitialPage/AddAppealForm/AddAppealForm.generated';
 import { contactTagsMock } from '../Tool/Appeal/InitialPage/AddAppealForm/AddAppealFormMocks';
@@ -43,32 +41,30 @@ const TestComponent: React.FC<AnnouncementModalProps> = ({
   announcement = defaultAnnouncement,
 }) => {
   return (
-    <I18nextProvider i18n={i18n}>
-      <LocalizationProvider dateAdapter={AdapterLuxon}>
-        <SnackbarProvider>
-          <TestRouter router={router}>
-            <ThemeProvider theme={theme}>
-              <GqlMockedProvider<{
-                Announcements: AnnouncementsQuery;
-                ContactTags: ContactTagsQuery;
-              }>
-                mocks={{
-                  Announcements: {
-                    announcements: {
-                      nodes: [announcement],
-                    },
+    <LocalizationProvider dateAdapter={AdapterLuxon}>
+      <SnackbarProvider>
+        <TestRouter router={router}>
+          <ThemeProvider theme={theme}>
+            <GqlMockedProvider<{
+              Announcements: AnnouncementsQuery;
+              ContactTags: ContactTagsQuery;
+            }>
+              mocks={{
+                Announcements: {
+                  announcements: {
+                    nodes: [announcement],
                   },
-                  ContactTags: contactTagsMock,
-                }}
-                onCall={mutationSpy}
-              >
-                <Announcements />
-              </GqlMockedProvider>
-            </ThemeProvider>
-          </TestRouter>
-        </SnackbarProvider>
-      </LocalizationProvider>
-    </I18nextProvider>
+                },
+                ContactTags: contactTagsMock,
+              }}
+              onCall={mutationSpy}
+            >
+              <Announcements />
+            </GqlMockedProvider>
+          </ThemeProvider>
+        </TestRouter>
+      </SnackbarProvider>
+    </LocalizationProvider>
   );
 };
 

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactHeaderSection/ContactHeaderStatusSection.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactHeaderSection/ContactHeaderStatusSection.test.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
-import { I18nextProvider } from 'react-i18next';
 import { gqlMock } from '__tests__/util/graphqlMocking';
 import { loadConstantsMockData } from 'src/components/Constants/LoadConstantsMock';
 import { PledgeFrequencyEnum, StatusEnum } from 'src/graphql/types.generated';
-import i18n from '../../../../../lib/i18n';
 import theme from '../../../../../theme';
 import {
   ContactDetailsHeaderFragment,
@@ -53,9 +51,7 @@ interface ComponentsProps {
 
 const Components = ({ loading, contact }: ComponentsProps) => (
   <ThemeProvider theme={theme}>
-    <I18nextProvider i18n={i18n}>
-      <ContactHeaderStatusSection loading={loading} contact={contact} />
-    </I18nextProvider>
+    <ContactHeaderStatusSection loading={loading} contact={contact} />
   </ThemeProvider>
 );
 

--- a/src/components/Contacts/ContactPartnershipStatus/ContactPartnershipStatus.test.tsx
+++ b/src/components/Contacts/ContactPartnershipStatus/ContactPartnershipStatus.test.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { loadConstantsMockData } from 'src/components/Constants/LoadConstantsMock';
 import { ContactPanelProvider } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { StatusEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from '../../../theme';
 import { ContactPartnershipStatus } from './ContactPartnershipStatus';
 
@@ -30,19 +28,17 @@ const TestComponent: React.FC<TestComponentProps> = ({
     <TestRouter>
       <GqlMockedProvider>
         <ThemeProvider theme={theme}>
-          <I18nextProvider i18n={i18n}>
-            <ContactPanelProvider>
-              <ContactPartnershipStatus
-                lateAt={null}
-                pledgeStartDate={null}
-                pledgeAmount={pledgeAmount}
-                pledgeCurrency={pledgeCurrency}
-                pledgeFrequency={null}
-                pledgeReceived={pledgeReceived}
-                status={status}
-              />
-            </ContactPanelProvider>
-          </I18nextProvider>
+          <ContactPanelProvider>
+            <ContactPartnershipStatus
+              lateAt={null}
+              pledgeStartDate={null}
+              pledgeAmount={pledgeAmount}
+              pledgeCurrency={pledgeCurrency}
+              pledgeFrequency={null}
+              pledgeReceived={pledgeReceived}
+              status={status}
+            />
+          </ContactPanelProvider>
         </ThemeProvider>
       </GqlMockedProvider>
     </TestRouter>

--- a/src/components/Contacts/ContactPartnershipStatus/ContactPartnershipStatusLabel/ContactPartnershipStatusLabel.test.tsx
+++ b/src/components/Contacts/ContactPartnershipStatus/ContactPartnershipStatusLabel/ContactPartnershipStatusLabel.test.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
-import { I18nextProvider } from 'react-i18next';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { loadConstantsMockData } from 'src/components/Constants/LoadConstantsMock';
 import { StatusEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from '../../../../theme';
 import { ContactPartnershipStatusLabel } from './ContactPartnershipStatusLabel';
 
@@ -16,9 +14,7 @@ describe('ContactPartnershipStatusLabel', () => {
     const { findByText } = render(
       <GqlMockedProvider>
         <ThemeProvider theme={theme}>
-          <I18nextProvider i18n={i18n}>
-            <ContactPartnershipStatusLabel status={status} />
-          </I18nextProvider>
+          <ContactPartnershipStatusLabel status={status} />
         </ThemeProvider>
       </GqlMockedProvider>,
     );

--- a/src/components/Layouts/Primary/TopBar/Items/SearchMenu/SearchMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/SearchMenu/SearchMenu.test.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { StatusEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import SearchMenu from './SearchMenu';
 import { GetSearchMenuContactsQuery } from './SearchMenu.generated';
@@ -52,52 +50,50 @@ describe('SearchMenu', () => {
 
   it('handles searching', async () => {
     const { getByRole, getByPlaceholderText, getByText } = render(
-      <I18nextProvider i18n={i18n}>
-        <GqlMockedProvider<{
-          GetSearchMenuContacts: GetSearchMenuContactsQuery;
-        }>
-          mocks={{
-            GetSearchMenuContacts: {
-              contacts: {
-                nodes: [
-                  {
-                    name: 'Cool, Guy',
-                    status: StatusEnum.AskInFuture,
-                    id: '123',
-                  },
-                  {
-                    name: 'Cool, Dude',
-                    status: StatusEnum.CallForDecision,
-                    id: '1234',
-                  },
-                  {
-                    name: 'Cool, One',
-                    status: StatusEnum.CallForDecision,
-                    id: '12341',
-                  },
-                  {
-                    name: 'Cool, Two',
-                    status: StatusEnum.CallForDecision,
-                    id: '12342',
-                  },
-                  {
-                    name: 'Cool, Three',
-                    status: StatusEnum.CallForDecision,
-                    id: '12343',
-                  },
-                ],
-                totalCount: 8,
-              },
+      <GqlMockedProvider<{
+        GetSearchMenuContacts: GetSearchMenuContactsQuery;
+      }>
+        mocks={{
+          GetSearchMenuContacts: {
+            contacts: {
+              nodes: [
+                {
+                  name: 'Cool, Guy',
+                  status: StatusEnum.AskInFuture,
+                  id: '123',
+                },
+                {
+                  name: 'Cool, Dude',
+                  status: StatusEnum.CallForDecision,
+                  id: '1234',
+                },
+                {
+                  name: 'Cool, One',
+                  status: StatusEnum.CallForDecision,
+                  id: '12341',
+                },
+                {
+                  name: 'Cool, Two',
+                  status: StatusEnum.CallForDecision,
+                  id: '12342',
+                },
+                {
+                  name: 'Cool, Three',
+                  status: StatusEnum.CallForDecision,
+                  id: '12343',
+                },
+              ],
+              totalCount: 8,
             },
-          }}
-        >
-          <ThemeProvider theme={theme}>
-            <TestRouter router={router}>
-              <SearchMenu />
-            </TestRouter>
-          </ThemeProvider>
-        </GqlMockedProvider>
-      </I18nextProvider>,
+          },
+        }}
+      >
+        <ThemeProvider theme={theme}>
+          <TestRouter router={router}>
+            <SearchMenu />
+          </TestRouter>
+        </ThemeProvider>
+      </GqlMockedProvider>,
     );
 
     userEvent.click(getByRole('button'));
@@ -119,36 +115,34 @@ describe('SearchMenu', () => {
 
   it('handles clicking search result', async () => {
     const { getByRole, getByPlaceholderText, getByText } = render(
-      <I18nextProvider i18n={i18n}>
-        <GqlMockedProvider<{
-          GetSearchMenuContacts: GetSearchMenuContactsQuery;
-        }>
-          mocks={{
-            GetSearchMenuContacts: {
-              contacts: {
-                nodes: [
-                  {
-                    name: 'Cool, Guy',
-                    status: StatusEnum.AskInFuture,
-                    id: '123',
-                  },
-                  {
-                    name: 'Cool, Dude',
-                    status: StatusEnum.CallForDecision,
-                    id: '1234',
-                  },
-                ],
-              },
+      <GqlMockedProvider<{
+        GetSearchMenuContacts: GetSearchMenuContactsQuery;
+      }>
+        mocks={{
+          GetSearchMenuContacts: {
+            contacts: {
+              nodes: [
+                {
+                  name: 'Cool, Guy',
+                  status: StatusEnum.AskInFuture,
+                  id: '123',
+                },
+                {
+                  name: 'Cool, Dude',
+                  status: StatusEnum.CallForDecision,
+                  id: '1234',
+                },
+              ],
             },
-          }}
-        >
-          <ThemeProvider theme={theme}>
-            <TestRouter router={router}>
-              <SearchMenu />
-            </TestRouter>
-          </ThemeProvider>
-        </GqlMockedProvider>
-      </I18nextProvider>,
+          },
+        }}
+      >
+        <ThemeProvider theme={theme}>
+          <TestRouter router={router}>
+            <SearchMenu />
+          </TestRouter>
+        </ThemeProvider>
+      </GqlMockedProvider>,
     );
 
     userEvent.click(getByRole('button'));
@@ -172,41 +166,39 @@ describe('SearchMenu', () => {
 
 it('handles creating a new contact', async () => {
   const { getByRole, getByPlaceholderText, getByText } = render(
-    <I18nextProvider i18n={i18n}>
-      <GqlMockedProvider<{ GetSearchMenuContacts: GetSearchMenuContactsQuery }>
-        mocks={{
-          GetSearchMenuContacts: {
-            contacts: {
-              nodes: [
-                {
-                  name: 'Cool, Guy',
-                  status: StatusEnum.AskInFuture,
-                  id: '123',
-                },
-                {
-                  name: 'Cool, Dude',
-                  status: StatusEnum.CallForDecision,
-                  id: '1234',
-                },
-              ],
-            },
-          },
-          CreateContact: {
-            createContact: {
-              contact: {
-                id: 'abc123',
+    <GqlMockedProvider<{ GetSearchMenuContacts: GetSearchMenuContactsQuery }>
+      mocks={{
+        GetSearchMenuContacts: {
+          contacts: {
+            nodes: [
+              {
+                name: 'Cool, Guy',
+                status: StatusEnum.AskInFuture,
+                id: '123',
               },
+              {
+                name: 'Cool, Dude',
+                status: StatusEnum.CallForDecision,
+                id: '1234',
+              },
+            ],
+          },
+        },
+        CreateContact: {
+          createContact: {
+            contact: {
+              id: 'abc123',
             },
           },
-        }}
-      >
-        <ThemeProvider theme={theme}>
-          <TestRouter router={router}>
-            <SearchMenu />
-          </TestRouter>
-        </ThemeProvider>
-      </GqlMockedProvider>
-    </I18nextProvider>,
+        },
+      }}
+    >
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <SearchMenu />
+        </TestRouter>
+      </ThemeProvider>
+    </GqlMockedProvider>,
   );
 
   userEvent.click(getByRole('button'));

--- a/src/components/Reports/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { HcmDataQuery } from '../../Shared/HcmData/HCMData.generated';
 import { AdditionalSalaryRequestProvider } from '../Shared/AdditionalSalaryRequestContext';
@@ -61,15 +59,13 @@ const mocks = {
 const TestWrapper: React.FC = () => (
   <ThemeProvider theme={theme}>
     <TestRouter router={router}>
-      <I18nextProvider i18n={i18n}>
-        <SnackbarProvider>
-          <GqlMockedProvider<{ HcmData: HcmDataQuery }> mocks={mocks}>
-            <AdditionalSalaryRequestProvider>
-              <AboutForm />
-            </AdditionalSalaryRequestProvider>
-          </GqlMockedProvider>
-        </SnackbarProvider>
-      </I18nextProvider>
+      <SnackbarProvider>
+        <GqlMockedProvider<{ HcmData: HcmDataQuery }> mocks={mocks}>
+          <AdditionalSalaryRequestProvider>
+            <AboutForm />
+          </AdditionalSalaryRequestProvider>
+        </GqlMockedProvider>
+      </SnackbarProvider>
     </TestRouter>
   </ThemeProvider>
 );

--- a/src/components/Reports/AdditionalSalaryRequest/AdditionalSalaryRequest.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/AdditionalSalaryRequest.test.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { AsrStatusEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { AdditionalSalaryRequest } from './AdditionalSalaryRequest';
 import { AdditionalSalaryRequestQuery } from './AdditionalSalaryRequest.generated';
@@ -97,21 +95,19 @@ const TestWrapper: React.FC<TestWrapperProps> = ({
   return (
     <ThemeProvider theme={theme}>
       <SnackbarProvider>
-        <I18nextProvider i18n={i18n}>
-          <TestRouter
-            router={{
-              query: {
-                accountListId,
-              },
-            }}
-          >
-            <GqlMockedProvider mocks={defaultMocks} onCall={onCall}>
-              <AdditionalSalaryRequestProvider>
-                <AdditionalSalaryRequest />
-              </AdditionalSalaryRequestProvider>
-            </GqlMockedProvider>
-          </TestRouter>
-        </I18nextProvider>
+        <TestRouter
+          router={{
+            query: {
+              accountListId,
+            },
+          }}
+        >
+          <GqlMockedProvider mocks={defaultMocks} onCall={onCall}>
+            <AdditionalSalaryRequestProvider>
+              <AdditionalSalaryRequest />
+            </AdditionalSalaryRequestProvider>
+          </GqlMockedProvider>
+        </TestRouter>
       </SnackbarProvider>
     </ThemeProvider>
   );

--- a/src/components/Reports/AdditionalSalaryRequest/FormVersions/testUtils.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/FormVersions/testUtils.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { FormikProvider, useFormik } from 'formik';
-import { I18nextProvider } from 'react-i18next';
 import * as yup from 'yup';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
@@ -122,15 +121,13 @@ export const createRenderFormComponent =
 
     return render(
       <ThemeProvider theme={theme}>
-        <I18nextProvider i18n={i18n}>
-          <TestRouter router={router}>
-            <GqlMockedProvider>
-              <TestFormikWrapper initialValues={initialValues}>
-                <FormComponent />
-              </TestFormikWrapper>
-            </GqlMockedProvider>
-          </TestRouter>
-        </I18nextProvider>
+        <TestRouter router={router}>
+          <GqlMockedProvider>
+            <TestFormikWrapper initialValues={initialValues}>
+              <FormComponent />
+            </TestFormikWrapper>
+          </GqlMockedProvider>
+        </TestRouter>
       </ThemeProvider>,
     );
   };

--- a/src/components/Reports/AdditionalSalaryRequest/MainPages/EligibleDisplay.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/MainPages/EligibleDisplay.test.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { AsrStatusEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { AdditionalSalaryRequestProvider } from '../Shared/AdditionalSalaryRequestContext';
 import { EligibleDisplay } from './EligibleDisplay';
@@ -35,40 +33,38 @@ const TestWrapper: React.FC<TestWrapperProps> = ({
 
   return (
     <ThemeProvider theme={theme}>
-      <I18nextProvider i18n={i18n}>
-        <TestRouter
-          router={{
-            query: {
-              accountListId,
-            },
-          }}
-        >
-          <SnackbarProvider>
-            <GqlMockedProvider
-              mocks={{
-                HcmData: hcmData,
-                AdditionalSalaryRequest: {
-                  latestAdditionalSalaryRequest: status
-                    ? {
-                        id: 'asr-1',
-                        status,
-                      }
-                    : null,
+      <TestRouter
+        router={{
+          query: {
+            accountListId,
+          },
+        }}
+      >
+        <SnackbarProvider>
+          <GqlMockedProvider
+            mocks={{
+              HcmData: hcmData,
+              AdditionalSalaryRequest: {
+                latestAdditionalSalaryRequest: status
+                  ? {
+                      id: 'asr-1',
+                      status,
+                    }
+                  : null,
+              },
+              StaffAccountId: {
+                user: {
+                  staffAccountId: 'staff-account-1',
                 },
-                StaffAccountId: {
-                  user: {
-                    staffAccountId: 'staff-account-1',
-                  },
-                },
-              }}
-            >
-              <AdditionalSalaryRequestProvider>
-                <EligibleDisplay />
-              </AdditionalSalaryRequestProvider>
-            </GqlMockedProvider>
-          </SnackbarProvider>
-        </TestRouter>
-      </I18nextProvider>
+              },
+            }}
+          >
+            <AdditionalSalaryRequestProvider>
+              <EligibleDisplay />
+            </AdditionalSalaryRequestProvider>
+          </GqlMockedProvider>
+        </SnackbarProvider>
+      </TestRouter>
     </ThemeProvider>
   );
 };

--- a/src/components/Reports/AdditionalSalaryRequest/MainPages/IneligiblePage.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/MainPages/IneligiblePage.test.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { AdditionalSalaryRequestProvider } from '../Shared/AdditionalSalaryRequestContext';
 import { IneligiblePage } from './IneligiblePage';
@@ -33,35 +31,33 @@ const TestWrapper: React.FC<TestWrapperProps> = ({
 
   return (
     <ThemeProvider theme={theme}>
-      <I18nextProvider i18n={i18n}>
-        <TestRouter
-          router={{
-            query: {
-              accountListId,
-            },
-          }}
-        >
-          <SnackbarProvider>
-            <GqlMockedProvider
-              mocks={{
-                HcmData: hcmData,
-                AdditionalSalaryRequest: {
-                  latestAdditionalSalaryRequest: null,
+      <TestRouter
+        router={{
+          query: {
+            accountListId,
+          },
+        }}
+      >
+        <SnackbarProvider>
+          <GqlMockedProvider
+            mocks={{
+              HcmData: hcmData,
+              AdditionalSalaryRequest: {
+                latestAdditionalSalaryRequest: null,
+              },
+              StaffAccountId: {
+                user: {
+                  staffAccountId: 'staff-account-1',
                 },
-                StaffAccountId: {
-                  user: {
-                    staffAccountId: 'staff-account-1',
-                  },
-                },
-              }}
-            >
-              <AdditionalSalaryRequestProvider>
-                <IneligiblePage />
-              </AdditionalSalaryRequestProvider>
-            </GqlMockedProvider>
-          </SnackbarProvider>
-        </TestRouter>
-      </I18nextProvider>
+              },
+            }}
+          >
+            <AdditionalSalaryRequestProvider>
+              <IneligiblePage />
+            </AdditionalSalaryRequestProvider>
+          </GqlMockedProvider>
+        </SnackbarProvider>
+      </TestRouter>
     </ThemeProvider>
   );
 };

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.test.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { FormikProvider, useFormik } from 'formik';
-import { I18nextProvider } from 'react-i18next';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { CompleteFormValues } from '../../AdditionalSalaryRequest';
 import { useAdditionalSalaryRequest } from '../../Shared/AdditionalSalaryRequestContext';
@@ -35,11 +33,9 @@ const FormikWrapper: React.FC<{ children: React.ReactNode }> = ({
 const renderCapSubContent = () =>
   render(
     <ThemeProvider theme={theme}>
-      <I18nextProvider i18n={i18n}>
-        <FormikWrapper>
-          <CapSubContent />
-        </FormikWrapper>
-      </I18nextProvider>
+      <FormikWrapper>
+        <CapSubContent />
+      </FormikWrapper>
     </ThemeProvider>,
   );
 

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.test.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { FormikProvider, useFormik } from 'formik';
-import { I18nextProvider } from 'react-i18next';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { CompleteFormValues } from '../../AdditionalSalaryRequest';
 import { useAdditionalSalaryRequest } from '../../Shared/AdditionalSalaryRequestContext';
@@ -61,11 +59,9 @@ const setupContext = (opts: {
 const renderSplitCapSubContent = (spouseName = 'Jane') =>
   render(
     <ThemeProvider theme={theme}>
-      <I18nextProvider i18n={i18n}>
-        <FormikWrapper>
-          <SplitCapSubContent spouseName={spouseName} />
-        </FormikWrapper>
-      </I18nextProvider>
+      <FormikWrapper>
+        <SplitCapSubContent spouseName={spouseName} />
+      </FormikWrapper>
     </ThemeProvider>,
   );
 

--- a/src/components/Reports/AdditionalSalaryRequest/RequestPage/RequestPage.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/RequestPage/RequestPage.test.tsx
@@ -4,7 +4,6 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FormikProvider, useFormik } from 'formik';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import * as yup from 'yup';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
@@ -164,15 +163,13 @@ interface TestWrapperProps {
 const TestWrapper: React.FC<TestWrapperProps> = ({ initialValues }) => (
   <ThemeProvider theme={theme}>
     <SnackbarProvider>
-      <I18nextProvider i18n={i18n}>
-        <TestRouter router={router}>
-          <GqlMockedProvider>
-            <TestFormikWrapper initialValues={initialValues}>
-              <RequestPage />
-            </TestFormikWrapper>
-          </GqlMockedProvider>
-        </TestRouter>
-      </I18nextProvider>
+      <TestRouter router={router}>
+        <GqlMockedProvider>
+          <TestFormikWrapper initialValues={initialValues}>
+            <RequestPage />
+          </TestFormikWrapper>
+        </GqlMockedProvider>
+      </TestRouter>
     </SnackbarProvider>
   </ThemeProvider>
 );
@@ -573,24 +570,22 @@ describe('RequestPage', () => {
     const { getByRole } = render(
       <ThemeProvider theme={theme}>
         <SnackbarProvider>
-          <I18nextProvider i18n={i18n}>
-            <TestRouter router={router}>
-              <GqlMockedProvider
-                mocks={{
-                  CreateAdditionalSalaryRequest: {
-                    createAdditionalSalaryRequest: {
-                      additionalSalaryRequest: { id: 'new-request-id' },
-                    },
+          <TestRouter router={router}>
+            <GqlMockedProvider
+              mocks={{
+                CreateAdditionalSalaryRequest: {
+                  createAdditionalSalaryRequest: {
+                    additionalSalaryRequest: { id: 'new-request-id' },
                   },
-                }}
-                onCall={mutationSpy}
-              >
-                <TestFormikWrapper>
-                  <RequestPage />
-                </TestFormikWrapper>
-              </GqlMockedProvider>
-            </TestRouter>
-          </I18nextProvider>
+                },
+              }}
+              onCall={mutationSpy}
+            >
+              <TestFormikWrapper>
+                <RequestPage />
+              </TestFormikWrapper>
+            </GqlMockedProvider>
+          </TestRouter>
         </SnackbarProvider>
       </ThemeProvider>,
     );
@@ -617,21 +612,19 @@ describe('RequestPage', () => {
     const { getByRole } = render(
       <ThemeProvider theme={theme}>
         <SnackbarProvider>
-          <I18nextProvider i18n={i18n}>
-            <TestRouter router={router}>
-              <GqlMockedProvider
-                mocks={{
-                  CreateAdditionalSalaryRequest: {
-                    createAdditionalSalaryRequest: null,
-                  },
-                }}
-              >
-                <TestFormikWrapper>
-                  <RequestPage />
-                </TestFormikWrapper>
-              </GqlMockedProvider>
-            </TestRouter>
-          </I18nextProvider>
+          <TestRouter router={router}>
+            <GqlMockedProvider
+              mocks={{
+                CreateAdditionalSalaryRequest: {
+                  createAdditionalSalaryRequest: null,
+                },
+              }}
+            >
+              <TestFormikWrapper>
+                <RequestPage />
+              </TestFormikWrapper>
+            </GqlMockedProvider>
+          </TestRouter>
         </SnackbarProvider>
       </ThemeProvider>,
     );
@@ -656,15 +649,13 @@ describe('RequestPage', () => {
     const { getByRole } = render(
       <ThemeProvider theme={theme}>
         <SnackbarProvider>
-          <I18nextProvider i18n={i18n}>
-            <TestRouter router={router}>
-              <GqlMockedProvider onCall={mutationSpy}>
-                <TestFormikWrapper>
-                  <RequestPage />
-                </TestFormikWrapper>
-              </GqlMockedProvider>
-            </TestRouter>
-          </I18nextProvider>
+          <TestRouter router={router}>
+            <GqlMockedProvider onCall={mutationSpy}>
+              <TestFormikWrapper>
+                <RequestPage />
+              </TestFormikWrapper>
+            </GqlMockedProvider>
+          </TestRouter>
         </SnackbarProvider>
       </ThemeProvider>,
     );

--- a/src/components/Reports/AdditionalSalaryRequest/SharedComponents/ContactInformationSummaryCard.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/SharedComponents/ContactInformationSummaryCard.test.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
-import { I18nextProvider } from 'react-i18next';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { useAdditionalSalaryRequest } from '../Shared/AdditionalSalaryRequestContext';
 import { ContactInformationSummaryCard } from './ContactInformationSummaryCard';
@@ -46,9 +44,7 @@ const renderComponent = ({
 
   return render(
     <ThemeProvider theme={theme}>
-      <I18nextProvider i18n={i18n}>
-        <ContactInformationSummaryCard />
-      </I18nextProvider>
+      <ContactInformationSummaryCard />
     </ThemeProvider>,
   );
 };

--- a/src/components/Reports/AdditionalSalaryRequest/SharedComponents/ValidationAlert.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/SharedComponents/ValidationAlert.test.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { FormikProvider, useFormik } from 'formik';
-import { I18nextProvider } from 'react-i18next';
 import * as yup from 'yup';
 import i18n from 'src/lib/i18n';
 import { amount, phoneNumber } from 'src/lib/yupHelpers';
@@ -127,14 +126,12 @@ const renderComponent = ({
 
   return render(
     <ThemeProvider theme={theme}>
-      <I18nextProvider i18n={i18n}>
-        <TestFormikWrapper
-          initialValues={initialValues}
-          submitOnMount={submitOnMount}
-        >
-          <ValidationAlert />
-        </TestFormikWrapper>
-      </I18nextProvider>
+      <TestFormikWrapper
+        initialValues={initialValues}
+        submitOnMount={submitOnMount}
+      >
+        <ValidationAlert />
+      </TestFormikWrapper>
     </ThemeProvider>,
   );
 };

--- a/src/components/Reports/AdditionalSalaryRequest/SubmitModalAccordions/ApprovalProcess/ApprovalProcess.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/SubmitModalAccordions/ApprovalProcess/ApprovalProcess.test.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { FormikProvider, useFormik } from 'formik';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import * as yup from 'yup';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { render } from '__tests__/util/testingLibraryReactMock';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { useAdditionalSalaryRequest } from '../../Shared/AdditionalSalaryRequestContext';
 import { ApprovalProcess } from './ApprovalProcess';
@@ -61,17 +59,15 @@ const TestComponent: React.FC<{
 }> = ({ onForm }) => {
   return (
     <ThemeProvider theme={theme}>
-      <I18nextProvider i18n={i18n}>
-        <TestRouter>
-          <SnackbarProvider>
-            <GqlMockedProvider>
-              <TestFormikWrapper>
-                <ApprovalProcess onForm={onForm} />
-              </TestFormikWrapper>
-            </GqlMockedProvider>
-          </SnackbarProvider>
-        </TestRouter>
-      </I18nextProvider>
+      <TestRouter>
+        <SnackbarProvider>
+          <GqlMockedProvider>
+            <TestFormikWrapper>
+              <ApprovalProcess onForm={onForm} />
+            </TestFormikWrapper>
+          </GqlMockedProvider>
+        </SnackbarProvider>
+      </TestRouter>
     </ThemeProvider>
   );
 };

--- a/src/components/Reports/AdditionalSalaryRequest/SubmitModalAccordions/TotalSalaryRequested/TotalSalaryRequested.test.tsx
+++ b/src/components/Reports/AdditionalSalaryRequest/SubmitModalAccordions/TotalSalaryRequested/TotalSalaryRequested.test.tsx
@@ -3,8 +3,6 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FormikProvider, useFormik } from 'formik';
-import { I18nextProvider } from 'react-i18next';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { CompleteFormValues } from '../../AdditionalSalaryRequest';
 import { useAdditionalSalaryRequest } from '../../Shared/AdditionalSalaryRequestContext';
@@ -85,11 +83,9 @@ const renderComponent = ({
 
   return render(
     <ThemeProvider theme={theme}>
-      <I18nextProvider i18n={i18n}>
-        <TestFormikWrapper initialValues={initialValues}>
-          <TotalSalaryRequested onForm={onForm} />
-        </TestFormikWrapper>
-      </I18nextProvider>
+      <TestFormikWrapper initialValues={initialValues}>
+        <TotalSalaryRequested onForm={onForm} />
+      </TestFormikWrapper>
     </ThemeProvider>,
   );
 };

--- a/src/components/Reports/FinancialAccountsReport/AccountSummary/AccountSummary.test.tsx
+++ b/src/components/Reports/FinancialAccountsReport/AccountSummary/AccountSummary.test.tsx
@@ -4,10 +4,8 @@ import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import {
   AccountSummary,
@@ -32,26 +30,24 @@ const mutationSpy = jest.fn();
 const handleNavListToggle = jest.fn();
 
 const Component = () => (
-  <I18nextProvider i18n={i18n}>
-    <LocalizationProvider dateAdapter={AdapterLuxon}>
-      <SnackbarProvider>
-        <ThemeProvider theme={theme}>
-          <TestRouter router={router}>
-            <GqlMockedProvider<{
-              FinancialAccountSummary: FinancialAccountSummaryQuery;
-            }>
-              mocks={{
-                FinancialAccountSummary: defaultFinancialAccountSummary,
-              }}
-              onCall={mutationSpy}
-            >
-              <AccountSummary handleNavListToggle={handleNavListToggle} />
-            </GqlMockedProvider>
-          </TestRouter>
-        </ThemeProvider>
-      </SnackbarProvider>
-    </LocalizationProvider>
-  </I18nextProvider>
+  <LocalizationProvider dateAdapter={AdapterLuxon}>
+    <SnackbarProvider>
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<{
+            FinancialAccountSummary: FinancialAccountSummaryQuery;
+          }>
+            mocks={{
+              FinancialAccountSummary: defaultFinancialAccountSummary,
+            }}
+            onCall={mutationSpy}
+          >
+            <AccountSummary handleNavListToggle={handleNavListToggle} />
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>
+    </SnackbarProvider>
+  </LocalizationProvider>
 );
 
 describe('AccountSummary', () => {

--- a/src/components/Reports/FinancialAccountsReport/AccountTransactions/AccountTransactions.test.tsx
+++ b/src/components/Reports/FinancialAccountsReport/AccountTransactions/AccountTransactions.test.tsx
@@ -7,12 +7,10 @@ import { fireEvent, render, waitFor } from '@testing-library/react';
 import { Settings } from 'luxon';
 import { SnackbarProvider } from 'notistack';
 import { buildURI } from 'react-csv/lib/core';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { Panel } from 'pages/accountLists/[accountListId]/reports/helpers';
 import { UrlFiltersProvider } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import {
   FinancialAccountQuery,
@@ -42,60 +40,58 @@ interface ComponentsProps {
 
 const Components = ({ filters, searchTerm }: ComponentsProps) => {
   return (
-    <I18nextProvider i18n={i18n}>
-      <LocalizationProvider dateAdapter={AdapterLuxon}>
-        <SnackbarProvider>
-          <ThemeProvider theme={theme}>
-            <TestRouter
-              router={{
-                ...defaultRouter,
-                query: {
-                  ...defaultRouter.query,
-                  filters,
-                  searchTerm,
-                },
-              }}
-            >
-              <UrlFiltersProvider>
-                <GqlMockedProvider<{
-                  FinancialAccount: FinancialAccountQuery;
-                  FinancialAccountEntries: FinancialAccountEntriesQuery;
-                }>
-                  mocks={{
-                    FinancialAccount: defaultFinancialAccount,
-                    FinancialAccountEntries: financialAccountEntriesMock,
+    <LocalizationProvider dateAdapter={AdapterLuxon}>
+      <SnackbarProvider>
+        <ThemeProvider theme={theme}>
+          <TestRouter
+            router={{
+              ...defaultRouter,
+              query: {
+                ...defaultRouter.query,
+                filters,
+                searchTerm,
+              },
+            }}
+          >
+            <UrlFiltersProvider>
+              <GqlMockedProvider<{
+                FinancialAccount: FinancialAccountQuery;
+                FinancialAccountEntries: FinancialAccountEntriesQuery;
+              }>
+                mocks={{
+                  FinancialAccount: defaultFinancialAccount,
+                  FinancialAccountEntries: financialAccountEntriesMock,
+                }}
+                onCall={mutationSpy}
+              >
+                <FinancialAccountContext.Provider
+                  value={{
+                    accountListId,
+                    financialAccountId,
+                    financialAccountQuery: {
+                      data: defaultFinancialAccount,
+                      loading: false,
+                    } as unknown as QueryResult<
+                      FinancialAccountQuery,
+                      FinancialAccountQueryVariables
+                    >,
+                    isNavListOpen: false,
+                    designationAccounts: [],
+                    setDesignationAccounts: jest.fn(),
+                    panelOpen: null,
+                    setPanelOpen,
+                    handleNavListToggle: jest.fn(),
+                    handleFilterListToggle: jest.fn(),
                   }}
-                  onCall={mutationSpy}
                 >
-                  <FinancialAccountContext.Provider
-                    value={{
-                      accountListId,
-                      financialAccountId,
-                      financialAccountQuery: {
-                        data: defaultFinancialAccount,
-                        loading: false,
-                      } as unknown as QueryResult<
-                        FinancialAccountQuery,
-                        FinancialAccountQueryVariables
-                      >,
-                      isNavListOpen: false,
-                      designationAccounts: [],
-                      setDesignationAccounts: jest.fn(),
-                      panelOpen: null,
-                      setPanelOpen,
-                      handleNavListToggle: jest.fn(),
-                      handleFilterListToggle: jest.fn(),
-                    }}
-                  >
-                    <AccountTransactions />
-                  </FinancialAccountContext.Provider>
-                </GqlMockedProvider>
-              </UrlFiltersProvider>
-            </TestRouter>
-          </ThemeProvider>
-        </SnackbarProvider>
-      </LocalizationProvider>
-    </I18nextProvider>
+                  <AccountTransactions />
+                </FinancialAccountContext.Provider>
+              </GqlMockedProvider>
+            </UrlFiltersProvider>
+          </TestRouter>
+        </ThemeProvider>
+      </SnackbarProvider>
+    </LocalizationProvider>
   );
 };
 

--- a/src/components/Reports/FinancialAccountsReport/Header/SummaryHeader.test.tsx
+++ b/src/components/Reports/FinancialAccountsReport/Header/SummaryHeader.test.tsx
@@ -4,10 +4,8 @@ import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { FinancialAccountQuery } from '../Context/FinancialAccount.generated';
 import { defaultFinancialAccount } from './HeaderMocks';
@@ -22,29 +20,27 @@ const router = {
 };
 
 const Components = () => (
-  <I18nextProvider i18n={i18n}>
-    <LocalizationProvider dateAdapter={AdapterLuxon}>
-      <SnackbarProvider>
-        <ThemeProvider theme={theme}>
-          <TestRouter router={router}>
-            <GqlMockedProvider<{
-              FinancialAccount: FinancialAccountQuery;
-            }>
-              mocks={{
-                FinancialAccount: defaultFinancialAccount,
-              }}
-            >
-              <SummaryHeader
-                accountListId={accountListId}
-                financialAccountId={financialAccountId}
-                handleNavListToggle={handleNavListToggle}
-              />
-            </GqlMockedProvider>
-          </TestRouter>
-        </ThemeProvider>
-      </SnackbarProvider>
-    </LocalizationProvider>
-  </I18nextProvider>
+  <LocalizationProvider dateAdapter={AdapterLuxon}>
+    <SnackbarProvider>
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<{
+            FinancialAccount: FinancialAccountQuery;
+          }>
+            mocks={{
+              FinancialAccount: defaultFinancialAccount,
+            }}
+          >
+            <SummaryHeader
+              accountListId={accountListId}
+              financialAccountId={financialAccountId}
+              handleNavListToggle={handleNavListToggle}
+            />
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>
+    </SnackbarProvider>
+  </LocalizationProvider>
 );
 
 describe('Financial Account Summary Header', () => {

--- a/src/components/Reports/FinancialAccountsReport/Header/TransactionsHeader.test.tsx
+++ b/src/components/Reports/FinancialAccountsReport/Header/TransactionsHeader.test.tsx
@@ -6,11 +6,9 @@ import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { UrlFiltersProvider } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import {
   FinancialAccountQuery,
@@ -32,56 +30,54 @@ interface ComponentsProps {
 
 const Components = ({ disableExportCSV = false }: ComponentsProps) => {
   return (
-    <I18nextProvider i18n={i18n}>
-      <LocalizationProvider dateAdapter={AdapterLuxon}>
-        <SnackbarProvider>
-          <ThemeProvider theme={theme}>
-            <TestRouter
-              router={{
-                query: { accountListId },
-                isReady: true,
-              }}
-            >
-              <UrlFiltersProvider>
-                <GqlMockedProvider<{
-                  FinancialAccount: FinancialAccountQuery;
-                }>
-                  mocks={{
-                    FinancialAccount: defaultFinancialAccount,
+    <LocalizationProvider dateAdapter={AdapterLuxon}>
+      <SnackbarProvider>
+        <ThemeProvider theme={theme}>
+          <TestRouter
+            router={{
+              query: { accountListId },
+              isReady: true,
+            }}
+          >
+            <UrlFiltersProvider>
+              <GqlMockedProvider<{
+                FinancialAccount: FinancialAccountQuery;
+              }>
+                mocks={{
+                  FinancialAccount: defaultFinancialAccount,
+                }}
+              >
+                <FinancialAccountContext.Provider
+                  value={{
+                    accountListId,
+                    financialAccountId,
+                    financialAccountQuery: {
+                      data: defaultFinancialAccount,
+                      loading: false,
+                    } as unknown as QueryResult<
+                      FinancialAccountQuery,
+                      FinancialAccountQueryVariables
+                    >,
+                    isNavListOpen: false,
+                    designationAccounts: [],
+                    setDesignationAccounts: jest.fn(),
+                    panelOpen: null,
+                    setPanelOpen: jest.fn(),
+                    handleNavListToggle,
+                    handleFilterListToggle,
                   }}
                 >
-                  <FinancialAccountContext.Provider
-                    value={{
-                      accountListId,
-                      financialAccountId,
-                      financialAccountQuery: {
-                        data: defaultFinancialAccount,
-                        loading: false,
-                      } as unknown as QueryResult<
-                        FinancialAccountQuery,
-                        FinancialAccountQueryVariables
-                      >,
-                      isNavListOpen: false,
-                      designationAccounts: [],
-                      setDesignationAccounts: jest.fn(),
-                      panelOpen: null,
-                      setPanelOpen: jest.fn(),
-                      handleNavListToggle,
-                      handleFilterListToggle,
-                    }}
-                  >
-                    <TransactionsHeader
-                      disableExportCSV={disableExportCSV}
-                      handleExportCSV={handleExportCSV}
-                    />
-                  </FinancialAccountContext.Provider>
-                </GqlMockedProvider>
-              </UrlFiltersProvider>
-            </TestRouter>
-          </ThemeProvider>
-        </SnackbarProvider>
-      </LocalizationProvider>
-    </I18nextProvider>
+                  <TransactionsHeader
+                    disableExportCSV={disableExportCSV}
+                    handleExportCSV={handleExportCSV}
+                  />
+                </FinancialAccountContext.Provider>
+              </GqlMockedProvider>
+            </UrlFiltersProvider>
+          </TestRouter>
+        </ThemeProvider>
+      </SnackbarProvider>
+    </LocalizationProvider>
   );
 };
 

--- a/src/components/Reports/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategory.test.tsx
+++ b/src/components/Reports/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategory.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { I18nextProvider } from 'react-i18next';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import {
@@ -9,7 +8,6 @@ import {
   MpdGoalBenefitsConstantSizeEnum,
 } from 'src/graphql/types.generated';
 import { GoalCalculatorConstantsQuery } from 'src/hooks/goalCalculatorConstants.generated';
-import i18n from 'src/lib/i18n';
 import {
   GoalCalculatorTestWrapper,
   constantsMock,
@@ -50,11 +48,9 @@ const TestComponent: React.FC<TestComponentProps> = ({ single = false }) => (
     }}
     onCall={mutationSpy}
   >
-    <I18nextProvider i18n={i18n}>
-      <GoalCalculatorTestWrapper noMocks>
-        <InformationCategory />
-      </GoalCalculatorTestWrapper>
-    </I18nextProvider>
+    <GoalCalculatorTestWrapper noMocks>
+      <InformationCategory />
+    </GoalCalculatorTestWrapper>
   </GqlMockedProvider>
 );
 

--- a/src/components/Reports/MinisterHousingAllowance/Steps/StepThree/CalcComponents/PersonInfo.test.tsx
+++ b/src/components/Reports/MinisterHousingAllowance/Steps/StepThree/CalcComponents/PersonInfo.test.tsx
@@ -2,37 +2,33 @@ import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { HcmDataQuery } from 'src/components/Reports/Shared/HcmData/HCMData.generated';
 import { singleNoMhaNoException } from 'src/components/Reports/Shared/HcmData/mockData';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { MinisterHousingAllowanceProvider } from '../../../Shared/Context/MinisterHousingAllowanceContext';
 import { PersonInfo } from './PersonInfo';
 
 const TestComponent: React.FC = () => (
   <ThemeProvider theme={theme}>
-    <I18nextProvider i18n={i18n}>
-      <TestRouter>
-        <SnackbarProvider>
-          <GqlMockedProvider<{
-            HcmData: HcmDataQuery;
-          }>
-            mocks={{
-              HcmData: {
-                hcm: singleNoMhaNoException,
-              },
-            }}
-          >
-            <MinisterHousingAllowanceProvider>
-              <PersonInfo />
-            </MinisterHousingAllowanceProvider>
-          </GqlMockedProvider>
-        </SnackbarProvider>
-      </TestRouter>
-    </I18nextProvider>
+    <TestRouter>
+      <SnackbarProvider>
+        <GqlMockedProvider<{
+          HcmData: HcmDataQuery;
+        }>
+          mocks={{
+            HcmData: {
+              hcm: singleNoMhaNoException,
+            },
+          }}
+        >
+          <MinisterHousingAllowanceProvider>
+            <PersonInfo />
+          </MinisterHousingAllowanceProvider>
+        </GqlMockedProvider>
+      </SnackbarProvider>
+    </TestRouter>
   </ThemeProvider>
 );
 

--- a/src/components/Reports/PdsGoalCalculator/SupportItem/otherBreakdown.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/SupportItem/otherBreakdown.test.tsx
@@ -1,7 +1,7 @@
 import { DataGrid } from '@mui/x-data-grid';
 import { render } from '@testing-library/react';
-import { t } from 'i18next';
 import { DesignationSupportStatus } from 'src/graphql/types.generated';
+import i18n from 'src/lib/i18n';
 import {
   OtherExpensesConstants,
   OtherExpensesFields,
@@ -43,7 +43,7 @@ const renderBreakdown = (rows: OtherBreakdownRow[]) =>
     <div style={{ height: 500 }}>
       <DataGrid
         rows={rows}
-        columns={buildOtherBreakdownColumns('en-US', t)}
+        columns={buildOtherBreakdownColumns('en-US', i18n.t)}
         hideFooter
         disableVirtualization
       />
@@ -56,7 +56,7 @@ describe('buildOtherBreakdownRows', () => {
       fullTimeCalculation,
       constants,
       'en-US',
-      t,
+      i18n.t,
     );
     expect(rows.map((row) => row.id)).toEqual([
       'reimbursable-expenses',
@@ -74,7 +74,7 @@ describe('buildOtherBreakdownRows', () => {
       partTimeCalculation,
       constants,
       'en-US',
-      t,
+      i18n.t,
     );
     expect(rows.map((row) => row.id)).toEqual([
       'reimbursable-expenses',
@@ -92,7 +92,7 @@ describe('buildOtherBreakdownRows', () => {
       nullStatusCalculation,
       constants,
       'en-US',
-      t,
+      i18n.t,
     );
     expect(rows.map((row) => row.id)).toEqual([
       'reimbursable-expenses',
@@ -109,7 +109,7 @@ describe('buildOtherBreakdownRows', () => {
       fullTimeCalculation,
       constants,
       'en-US',
-      t,
+      i18n.t,
     );
     const boldIds = rows.filter((row) => row.bold).map((row) => row.id);
     expect(boldIds).toEqual([
@@ -125,7 +125,7 @@ describe('buildOtherBreakdownRows', () => {
       fullTimeCalculation,
       constants,
       'en-US',
-      t,
+      i18n.t,
     );
     rows.forEach((row) => {
       expect(row.testId).toBeDefined();

--- a/src/components/Reports/PdsGoalCalculator/SupportItem/salaryBreakdown.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/SupportItem/salaryBreakdown.test.tsx
@@ -1,7 +1,7 @@
 import { DataGrid } from '@mui/x-data-grid';
 import { render } from '@testing-library/react';
-import { t } from 'i18next';
 import { DesignationSupportSalaryType } from 'src/graphql/types.generated';
+import i18n from 'src/lib/i18n';
 import { SalaryCalculationFields } from '../calculations/salaryCalculation';
 import {
   SalaryBreakdownRow,
@@ -31,7 +31,7 @@ const renderBreakdown = (rows: SalaryBreakdownRow[]) =>
     <div style={{ height: 500 }}>
       <DataGrid
         rows={rows}
-        columns={buildSalaryBreakdownColumns('en-US', t)}
+        columns={buildSalaryBreakdownColumns('en-US', i18n.t)}
         hideFooter
         disableVirtualization
       />
@@ -44,7 +44,7 @@ describe('buildSalaryBreakdownRows', () => {
       salariedCalculation,
       constants,
       'en-US',
-      t,
+      i18n.t,
     );
     expect(rows.map((row) => row.id)).toEqual([
       'pay-rate',
@@ -61,7 +61,7 @@ describe('buildSalaryBreakdownRows', () => {
       salariedCalculation,
       constants,
       'en-US',
-      t,
+      i18n.t,
     );
     const byId = Object.fromEntries(rows.map((r) => [r.id, r.amount]));
 
@@ -84,7 +84,7 @@ describe('buildSalaryBreakdownRows', () => {
       hourlyCalculation,
       constants,
       'en-US',
-      t,
+      i18n.t,
     );
     const byId = Object.fromEntries(rows.map((r) => [r.id, r.amount]));
 
@@ -107,7 +107,7 @@ describe('buildSalaryBreakdownRows', () => {
       hourlyCalculation,
       constants,
       'en-US',
-      t,
+      i18n.t,
     );
     expect(rows.map((row) => row.id)).toEqual([
       'pay-rate',

--- a/src/components/Reports/SalaryCalculator/SalaryCalculatorTestWrapper.tsx
+++ b/src/components/Reports/SalaryCalculator/SalaryCalculatorTestWrapper.tsx
@@ -1,7 +1,6 @@
 import { ThemeProvider } from '@emotion/react';
 import { MockLinkCallHandler } from 'graphql-ergonomock/dist/apollo/MockLink';
 import { merge } from 'lodash';
-import { I18nextProvider } from 'react-i18next';
 import { DeepPartial } from 'ts-essentials';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider, gqlMock } from '__tests__/util/graphqlMocking';
@@ -12,7 +11,6 @@ import {
   UserTypeEnum,
 } from 'src/graphql/types.generated';
 import { GoalCalculatorConstantsQuery } from 'src/hooks/goalCalculatorConstants.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { PayrollDatesQuery } from './EffectiveDateStep/PayrollDates.generated';
 import {
@@ -120,76 +118,74 @@ export const SalaryCalculatorTestWrapper: React.FC<
   const hcmSpouseMerged = merge({}, hcmSpouseMock, hcmSpouse);
   return (
     <ThemeProvider theme={theme}>
-      <I18nextProvider i18n={i18n}>
-        <TestRouter
-          router={{
-            query: {
-              accountListId: 'account-list-1',
-              calculationId: 'salary-request-1',
-              ...(editing ? {} : { mode: 'view' }),
+      <TestRouter
+        router={{
+          query: {
+            accountListId: 'account-list-1',
+            calculationId: 'salary-request-1',
+            ...(editing ? {} : { mode: 'view' }),
+          },
+        }}
+      >
+        <GqlMockedProvider<{
+          Hcm: HcmQuery;
+          PayrollDates: PayrollDatesQuery;
+          SalaryCalculation: SalaryCalculationQuery;
+          GoalCalculatorConstants: GoalCalculatorConstantsQuery;
+          StaffAccount: StaffAccountQuery;
+          GetUser: GetUserQuery;
+        }>
+          mocks={{
+            StaffAccount: {
+              staffAccount: {
+                id: '12345',
+                name: 'Test Account',
+              },
+            },
+            GetUser: {
+              user: {
+                userType,
+              },
+            },
+            PayrollDates: {
+              payrollDates,
+            },
+            GoalCalculatorConstants: {
+              constant: {
+                mpdGoalGeographicConstants: [
+                  { location: 'Atlanta, GA' },
+                  { location: 'Miami, FL' },
+                ],
+              },
+            },
+            Hcm: {
+              hcm: hasSpouse
+                ? [hcmUserMerged, hcmSpouseMerged]
+                : [hcmUserMerged],
+            },
+            SalaryCalculation: {
+              salaryRequest: merge(
+                {
+                  id: 'salary-request-1',
+                  status: SalaryRequestStatusEnum.InProgress,
+                  effectiveDate: '2025-01-01',
+                  calculations: {
+                    hardCap: 80000,
+                    exceptionCap: null,
+                    combinedCap: 125000,
+                  },
+                  progressiveApprovalTier: null,
+                } satisfies SalaryRequestMock,
+                salaryRequestMock,
+                hasSpouse ? undefined : { spouseCalculations: null },
+              ),
             },
           }}
+          onCall={onCall}
         >
-          <GqlMockedProvider<{
-            Hcm: HcmQuery;
-            PayrollDates: PayrollDatesQuery;
-            SalaryCalculation: SalaryCalculationQuery;
-            GoalCalculatorConstants: GoalCalculatorConstantsQuery;
-            StaffAccount: StaffAccountQuery;
-            GetUser: GetUserQuery;
-          }>
-            mocks={{
-              StaffAccount: {
-                staffAccount: {
-                  id: '12345',
-                  name: 'Test Account',
-                },
-              },
-              GetUser: {
-                user: {
-                  userType,
-                },
-              },
-              PayrollDates: {
-                payrollDates,
-              },
-              GoalCalculatorConstants: {
-                constant: {
-                  mpdGoalGeographicConstants: [
-                    { location: 'Atlanta, GA' },
-                    { location: 'Miami, FL' },
-                  ],
-                },
-              },
-              Hcm: {
-                hcm: hasSpouse
-                  ? [hcmUserMerged, hcmSpouseMerged]
-                  : [hcmUserMerged],
-              },
-              SalaryCalculation: {
-                salaryRequest: merge(
-                  {
-                    id: 'salary-request-1',
-                    status: SalaryRequestStatusEnum.InProgress,
-                    effectiveDate: '2025-01-01',
-                    calculations: {
-                      hardCap: 80000,
-                      exceptionCap: null,
-                      combinedCap: 125000,
-                    },
-                    progressiveApprovalTier: null,
-                  } satisfies SalaryRequestMock,
-                  salaryRequestMock,
-                  hasSpouse ? undefined : { spouseCalculations: null },
-                ),
-              },
-            }}
-            onCall={onCall}
-          >
-            <SalaryCalculatorProvider>{children}</SalaryCalculatorProvider>
-          </GqlMockedProvider>
-        </TestRouter>
-      </I18nextProvider>
+          <SalaryCalculatorProvider>{children}</SalaryCalculatorProvider>
+        </GqlMockedProvider>
+      </TestRouter>
     </ThemeProvider>
   );
 };

--- a/src/components/Reports/SavingsFundTransfer/BalanceCard/BalanceCard.test.tsx
+++ b/src/components/Reports/SavingsFundTransfer/BalanceCard/BalanceCard.test.tsx
@@ -3,10 +3,8 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { FundFieldsFragment } from '../ReportsSavingsFund.generated';
 import { FundTypeEnum } from '../mockData';
@@ -40,15 +38,13 @@ const Components = ({
   <SnackbarProvider>
     <ThemeProvider theme={theme}>
       <TestRouter router={router}>
-        <I18nextProvider i18n={i18n}>
-          <GqlMockedProvider onCall={mutationSpy}>
-            <BalanceCard
-              fund={fund}
-              handleOpenTransferModal={mockHandleOpenTransferModal}
-              isSelected={isSelected}
-            />
-          </GqlMockedProvider>
-        </I18nextProvider>
+        <GqlMockedProvider onCall={mutationSpy}>
+          <BalanceCard
+            fund={fund}
+            handleOpenTransferModal={mockHandleOpenTransferModal}
+            isSelected={isSelected}
+          />
+        </GqlMockedProvider>
       </TestRouter>
     </ThemeProvider>
   </SnackbarProvider>

--- a/src/components/Reports/SavingsFundTransfer/DeleteTransferModal/DeleteTransferModal.test.tsx
+++ b/src/components/Reports/SavingsFundTransfer/DeleteTransferModal/DeleteTransferModal.test.tsx
@@ -54,9 +54,7 @@ describe('DeleteTransferModal', () => {
 
     expect(getByText('Stop Transfer')).toBeInTheDocument();
     expect(
-      getByText(
-        /are you sure you want to {{action}} this recurring transfer?/i,
-      ),
+      getByText(/are you sure you want to stop this recurring transfer?/i),
     ).toBeInTheDocument();
   });
 

--- a/src/components/Reports/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
+++ b/src/components/Reports/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
@@ -6,10 +6,8 @@ import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Settings } from 'luxon';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { StaffAccountQuery } from '../../StaffAccount.generated';
 import { StaffSavingFundContext } from '../../StaffSavingFund/StaffSavingFundContext';
@@ -174,20 +172,18 @@ const Components = ({
     <ThemeProvider theme={theme}>
       <LocalizationProvider dateAdapter={AdapterLuxon}>
         <TestRouter>
-          <I18nextProvider i18n={i18n}>
-            <GqlMockedProvider<{
-              StaffAccount: StaffAccountQuery;
-              ReportsSavingsFundTransfer: ReportsSavingsFundTransferQuery;
-              FundBalances: FundBalancesQuery;
-            }>
-              mocks={mock}
-              onCall={mutationSpy}
-            >
-              <MockStaffSavingFundProvider>
-                <TransfersPage title={title} />
-              </MockStaffSavingFundProvider>
-            </GqlMockedProvider>
-          </I18nextProvider>
+          <GqlMockedProvider<{
+            StaffAccount: StaffAccountQuery;
+            ReportsSavingsFundTransfer: ReportsSavingsFundTransferQuery;
+            FundBalances: FundBalancesQuery;
+          }>
+            mocks={mock}
+            onCall={mutationSpy}
+          >
+            <MockStaffSavingFundProvider>
+              <TransfersPage title={title} />
+            </MockStaffSavingFundProvider>
+          </GqlMockedProvider>
         </TestRouter>
       </LocalizationProvider>
     </ThemeProvider>
@@ -267,19 +263,17 @@ describe('TransfersPage', () => {
         <ThemeProvider theme={theme}>
           <LocalizationProvider dateAdapter={AdapterLuxon}>
             <TestRouter>
-              <I18nextProvider i18n={i18n}>
-                <GqlMockedProvider<{
-                  ReportsSavingsFundTransfer: ReportsSavingsFundTransferQuery;
-                  FundBalances: FundBalancesQuery;
-                }>
-                  mocks={emptyMock}
-                  onCall={mutationSpy}
-                >
-                  <MockStaffSavingFundProvider>
-                    <TransfersPage title={'Empty Transfer History'} />
-                  </MockStaffSavingFundProvider>
-                </GqlMockedProvider>
-              </I18nextProvider>
+              <GqlMockedProvider<{
+                ReportsSavingsFundTransfer: ReportsSavingsFundTransferQuery;
+                FundBalances: FundBalancesQuery;
+              }>
+                mocks={emptyMock}
+                onCall={mutationSpy}
+              >
+                <MockStaffSavingFundProvider>
+                  <TransfersPage title={'Empty Transfer History'} />
+                </MockStaffSavingFundProvider>
+              </GqlMockedProvider>
             </TestRouter>
           </LocalizationProvider>
         </ThemeProvider>

--- a/src/components/Settings/Accounts/InviteForm/InviteForm.test.tsx
+++ b/src/components/Settings/Accounts/InviteForm/InviteForm.test.tsx
@@ -91,10 +91,8 @@ describe('InviteForm', () => {
     });
 
     expect(mockEnqueue).toHaveBeenCalledWith(
-      '{{appName}} sent an invite to {{email}}',
-      {
-        variant: 'success',
-      },
+      'MPDX sent an invite to test@test.org',
+      { variant: 'success' },
     );
     expect(await findByRole('textbox')).toHaveValue('');
   });
@@ -139,10 +137,8 @@ describe('InviteForm', () => {
     });
 
     expect(mockEnqueue).toHaveBeenCalledWith(
-      '{{appName}} sent an invite to {{email}}',
-      {
-        variant: 'success',
-      },
+      'MPDX sent an invite to test@test.org',
+      { variant: 'success' },
     );
     expect(await findByRole('textbox')).toHaveValue('');
   });

--- a/src/components/Settings/Accounts/ManageAccountAccess/ManageAccountAccessAccordion.test.tsx
+++ b/src/components/Settings/Accounts/ManageAccountAccess/ManageAccountAccessAccordion.test.tsx
@@ -126,7 +126,7 @@ describe('ManageAccountAccessAccordion', () => {
 
     await waitFor(() => {
       expect(mockEnqueue).toHaveBeenCalledWith(
-        '{{appName}} removed the user successfully',
+        'MPDX removed the user successfully',
         { variant: 'success' },
       );
       expect(queryByText('firstName1 lastName1')).not.toBeInTheDocument();

--- a/src/components/Settings/Accounts/ManageAccounts/ManageAccounts.test.tsx
+++ b/src/components/Settings/Accounts/ManageAccounts/ManageAccounts.test.tsx
@@ -4,11 +4,9 @@ import { Box } from '@mui/system';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { InviteTypeEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from '../../../../theme';
 import { ManageAccounts } from './ManageAccounts';
 import {
@@ -99,9 +97,7 @@ const CoachIntro = (): React.ReactElement => (
 const Components = ({ children }: PropsWithChildren) => (
   <SnackbarProvider>
     <TestRouter router={router}>
-      <ThemeProvider theme={theme}>
-        <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
-      </ThemeProvider>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
     </TestRouter>
   </SnackbarProvider>
 );

--- a/src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion.test.tsx
+++ b/src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion.test.tsx
@@ -109,7 +109,7 @@ describe('ManageCoachesAccessAccordion', () => {
     userEvent.click(getAllByLabelText('Delete access')[0]);
     await waitFor(() => {
       expect(mockEnqueue).toHaveBeenCalledWith(
-        '{{appName}} removed the coach successfully',
+        'MPDX removed the coach successfully',
         {
           variant: 'success',
         },

--- a/src/components/Settings/integrations/Google/Modals/DeleteGoogleAccountModal.test.tsx
+++ b/src/components/Settings/integrations/Google/Modals/DeleteGoogleAccountModal.test.tsx
@@ -96,7 +96,7 @@ describe('DeleteGoogleAccountModal', () => {
 
     await waitFor(() => {
       expect(mockEnqueue).toHaveBeenCalledWith(
-        '{{appName}} removed your integration with Google.',
+        'MPDX removed your integration with Google.',
         {
           variant: 'success',
         },

--- a/src/components/Settings/integrations/Organization/ConnectOrganization.test.tsx
+++ b/src/components/Settings/integrations/Organization/ConnectOrganization.test.tsx
@@ -157,7 +157,7 @@ describe('Connect Organization', () => {
     });
     await waitFor(() => {
       expect(mockEnqueue).toHaveBeenCalledWith(
-        '{{appName}} added your organization account',
+        'MPDX added your organization account',
         { variant: 'success' },
       );
       expect(mutationSpy.mock.calls[1][0].operation.operationName).toEqual(
@@ -202,7 +202,7 @@ describe('Connect Organization', () => {
     });
     await waitFor(() => {
       expect(mockEnqueue).toHaveBeenCalledWith(
-        '{{appName}} added your organization account',
+        'MPDX added your organization account',
         { variant: 'success' },
       );
     });
@@ -231,9 +231,7 @@ describe('Connect Organization', () => {
     userEvent.click(await findByRole('option', { name: 'ministryName' }));
 
     expect(
-      await findByText(
-        'You must log into {{appName}} with your ministry email',
-      ),
+      await findByText('You must log into MPDX with your ministry email'),
     ).toBeInTheDocument();
     expect(getByText('Add Account')).toBeDisabled();
     expect(
@@ -284,7 +282,7 @@ describe('Connect Organization', () => {
 
     await waitFor(() => {
       expect(mockEnqueue).toHaveBeenCalledWith(
-        '{{appName}} added your organization account',
+        'MPDX added your organization account',
         { variant: 'success' },
       );
       expect(mutationSpy.mock.calls[1][0].operation.operationName).toEqual(
@@ -324,7 +322,7 @@ describe('Connect Organization', () => {
 
     expect(
       await findByText(
-        "You will be taken to your organization's donation services system to grant {{appName}} permission to access your donation data.",
+        "You will be taken to your organization's donation services system to grant MPDX permission to access your donation data.",
       ),
     ).toBeInTheDocument();
     expect(getByText('Connect')).toBeInTheDocument();

--- a/src/components/Settings/integrations/Organization/Modals/OrganizationEditAccountModal.test.tsx
+++ b/src/components/Settings/integrations/Organization/Modals/OrganizationEditAccountModal.test.tsx
@@ -98,7 +98,7 @@ describe('OrganizationEditAccountModal', () => {
 
     await waitFor(() => {
       expect(mockEnqueue).toHaveBeenCalledWith(
-        '{{appName}} updated your organization account',
+        'MPDX updated your organization account',
         { variant: 'success' },
       );
       expect(mutationSpy.mock.calls[0][0].operation.operationName).toEqual(

--- a/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
+++ b/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
@@ -4,12 +4,10 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { cloneDeep } from 'lodash';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import * as Types from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from '../../../../theme';
 import { OrganizationAccordion } from './OrganizationAccordion';
 import {
@@ -42,11 +40,9 @@ const handleAccordionChange = jest.fn();
 
 const Components = ({ children }: PropsWithChildren) => (
   <SnackbarProvider>
-    <I18nextProvider i18n={i18n}>
-      <TestRouter router={router}>
-        <ThemeProvider theme={theme}>{children}</ThemeProvider>
-      </TestRouter>
-    </I18nextProvider>
+    <TestRouter router={router}>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </TestRouter>
   </SnackbarProvider>
 );
 

--- a/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.test.tsx
+++ b/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.test.tsx
@@ -178,7 +178,7 @@ describe('PrayerlettersAccount', () => {
 
       await waitFor(() => {
         expect(mockEnqueue).toHaveBeenCalledWith(
-          '{{appName}} removed your integration with Prayer Letters',
+          'MPDX removed your integration with Prayer Letters',
           {
             variant: 'success',
           },
@@ -216,9 +216,7 @@ describe('PrayerlettersAccount', () => {
 
       await waitFor(() => {
         expect(
-          queryByText(
-            'We strongly recommend only making changes in {{appName}}.',
-          ),
+          queryByText('We strongly recommend only making changes in MPDX.'),
         ).toBeInTheDocument();
       });
 
@@ -243,7 +241,7 @@ describe('PrayerlettersAccount', () => {
 
       await waitFor(() => {
         expect(mockEnqueue).toHaveBeenCalledWith(
-          '{{appName}} removed your integration with Prayer Letters',
+          'MPDX removed your integration with Prayer Letters',
           {
             variant: 'success',
           },
@@ -281,9 +279,7 @@ describe('PrayerlettersAccount', () => {
 
       await waitFor(() => {
         expect(
-          queryByText(
-            'We strongly recommend only making changes in {{appName}}.',
-          ),
+          queryByText('We strongly recommend only making changes in MPDX.'),
         ).toBeInTheDocument();
       });
 
@@ -295,7 +291,7 @@ describe('PrayerlettersAccount', () => {
 
       await waitFor(() => {
         expect(mockEnqueue).toHaveBeenCalledWith(
-          '{{appName}} is now syncing your newsletter recipients with Prayer Letters',
+          'MPDX is now syncing your newsletter recipients with Prayer Letters',
           {
             variant: 'success',
           },

--- a/src/components/Setup/Connect.test.tsx
+++ b/src/components/Setup/Connect.test.tsx
@@ -78,7 +78,7 @@ describe('Connect', () => {
 
       expect(
         await findByText(
-          'First, connect your organization to your {{appName}} account.',
+          'First, connect your organization to your MPDX account.',
         ),
       ).toBeInTheDocument();
       expect(

--- a/src/components/Shared/Autosave/AutosaveForm.test.tsx
+++ b/src/components/Shared/Autosave/AutosaveForm.test.tsx
@@ -3,14 +3,14 @@ import { TextField } from '@mui/material';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as yup from 'yup';
-import i18next from 'src/lib/i18n';
+import i18n from 'src/lib/i18n';
 import { amount } from 'src/lib/yupHelpers';
 import { AutosaveForm, useAutosaveForm } from './AutosaveForm';
 import { useAutoSave } from './useAutosave';
 
 const schema = yup.object({
-  field1: amount('field', i18next.t, { max: 100 }),
-  field2: amount('field', i18next.t, { max: 200 }),
+  field1: amount('field', i18n.t, { max: 100 }),
+  field2: amount('field', i18n.t, { max: 200 }),
 });
 
 const saveValue = jest.fn().mockResolvedValue(undefined);

--- a/src/components/Shared/Autosave/useAutosave.test.tsx
+++ b/src/components/Shared/Autosave/useAutosave.test.tsx
@@ -3,7 +3,7 @@ import { MenuItem, TextField } from '@mui/material';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as yup from 'yup';
-import i18next from 'src/lib/i18n';
+import i18n from 'src/lib/i18n';
 import { amount } from 'src/lib/yupHelpers';
 import { useAutoSave } from './useAutosave';
 
@@ -19,7 +19,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
   required = false,
 }) => {
   const schema = yup.object({
-    field: amount('Field', i18next.t, { required }),
+    field: amount('Field', i18n.t, { required }),
   });
 
   const props = useAutoSave({
@@ -35,7 +35,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
 
 const SelectTestComponent: React.FC = () => {
   const schema = yup.object({
-    field: amount('Field', i18next.t),
+    field: amount('Field', i18n.t),
   });
 
   const props = useAutoSave({

--- a/src/components/Shared/Filters/TagsSection/FilterTagDeleteModal.test.tsx
+++ b/src/components/Shared/Filters/TagsSection/FilterTagDeleteModal.test.tsx
@@ -52,7 +52,7 @@ describe('FilterTagDeleteModal', () => {
     );
     expect(
       getByText(
-        'Are you sure you want to completely delete this tag ({{tagName}}) and remove it from all tasks?',
+        'Are you sure you want to completely delete this tag (test) and remove it from all tasks?',
       ),
     ).toBeInTheDocument();
   });

--- a/src/components/Shared/Header/ListHeader.test.tsx
+++ b/src/components/Shared/Header/ListHeader.test.tsx
@@ -4,12 +4,10 @@ import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { ContactPanelProvider } from 'src/components/common/ContactPanelProvider/ContactPanelProvider';
 import { UrlFiltersProvider } from 'src/components/common/UrlFiltersProvider/UrlFiltersProvider';
-import i18n from 'src/lib/i18n';
 import theme from '../../../theme';
 import { TasksMassActionsDropdown } from '../MassActions/TasksMassActionsDropdown';
 import {
@@ -100,27 +98,25 @@ const Components = ({
     }}
   >
     <ThemeProvider theme={theme}>
-      <I18nextProvider i18n={i18n}>
-        <GqlMockedProvider>
-          <SnackbarProvider>
-            <ContactPanelProvider>
-              <UrlFiltersProvider>
-                <ListHeader
-                  selectedIds={selectedIds}
-                  page={page}
-                  contactsView={contactsView}
-                  headerCheckboxState={headerCheckboxState}
-                  filterPanelOpen={filterPanelOpen}
-                  buttonGroup={buttonGroup}
-                  totalItems={totalItems}
-                  showShowingCount={showShowingCount}
-                  {...mockedProps}
-                />
-              </UrlFiltersProvider>
-            </ContactPanelProvider>
-          </SnackbarProvider>
-        </GqlMockedProvider>
-      </I18nextProvider>
+      <GqlMockedProvider>
+        <SnackbarProvider>
+          <ContactPanelProvider>
+            <UrlFiltersProvider>
+              <ListHeader
+                selectedIds={selectedIds}
+                page={page}
+                contactsView={contactsView}
+                headerCheckboxState={headerCheckboxState}
+                filterPanelOpen={filterPanelOpen}
+                buttonGroup={buttonGroup}
+                totalItems={totalItems}
+                showShowingCount={showShowingCount}
+                {...mockedProps}
+              />
+            </UrlFiltersProvider>
+          </ContactPanelProvider>
+        </SnackbarProvider>
+      </GqlMockedProvider>
     </ThemeProvider>
   </TestRouter>
 );

--- a/src/components/Shared/MassActions/TasksMassActionsDropdown.test.tsx
+++ b/src/components/Shared/MassActions/TasksMassActionsDropdown.test.tsx
@@ -5,11 +5,9 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { GetTasksForAddingTagsQuery } from 'src/components/Task/MassActions/AddTags/TasksAddTags.generated';
-import i18n from 'src/lib/i18n';
 import theme from '../../../theme';
 import { TasksMassActionsDropdown } from './TasksMassActionsDropdown';
 
@@ -57,21 +55,19 @@ interface TaskComponentsProps {
 const TaskComponents = ({ ids = selectedIds }: TaskComponentsProps) => {
   return (
     <TestRouter>
-      <I18nextProvider i18n={i18n}>
-        <ThemeProvider theme={theme}>
-          <GqlMockedProvider>
-            <LocalizationProvider dateAdapter={AdapterLuxon}>
-              <SnackbarProvider>
-                <TasksMassActionsDropdown
-                  selectedIdCount={ids?.length ?? 0}
-                  selectedIds={ids}
-                  massDeselectAll={massDeselectAll}
-                />
-              </SnackbarProvider>
-            </LocalizationProvider>
-          </GqlMockedProvider>
-        </ThemeProvider>
-      </I18nextProvider>
+      <ThemeProvider theme={theme}>
+        <GqlMockedProvider>
+          <LocalizationProvider dateAdapter={AdapterLuxon}>
+            <SnackbarProvider>
+              <TasksMassActionsDropdown
+                selectedIdCount={ids?.length ?? 0}
+                selectedIds={ids}
+                massDeselectAll={massDeselectAll}
+              />
+            </SnackbarProvider>
+          </LocalizationProvider>
+        </GqlMockedProvider>
+      </ThemeProvider>
     </TestRouter>
   );
 };

--- a/src/components/Task/Modal/Form/Inputs/SuggestedContactStatus/SuggestedContactStatus.test.tsx
+++ b/src/components/Task/Modal/Form/Inputs/SuggestedContactStatus/SuggestedContactStatus.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { render, waitFor } from '@testing-library/react';
-import { I18nextProvider } from 'react-i18next';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { StatusEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import {
   FormikHandleChange,
@@ -30,29 +28,27 @@ const Components = ({
   contactStatusQueryMock,
 }: ComponentsProps) => (
   <ThemeProvider theme={theme}>
-    <I18nextProvider i18n={i18n}>
-      <GqlMockedProvider<{
-        ContactStatus: ContactStatusQuery;
-      }>
-        mocks={{
-          ContactStatus: {
-            contact: {
-              status: contactStatusQueryMock || null,
-            },
+    <GqlMockedProvider<{
+      ContactStatus: ContactStatusQuery;
+    }>
+      mocks={{
+        ContactStatus: {
+          contact: {
+            status: contactStatusQueryMock || null,
           },
-        }}
-        onCall={mutationSpy}
-      >
-        <SuggestedContactStatus
-          suggestedContactStatus={suggestedContactStatus}
-          changeContactStatus={false}
-          handleChange={handleChange}
-          accountListId={accountListId}
-          contactIds={contactIds}
-          contactStatus={contactStatus}
-        />
-      </GqlMockedProvider>
-    </I18nextProvider>
+        },
+      }}
+      onCall={mutationSpy}
+    >
+      <SuggestedContactStatus
+        suggestedContactStatus={suggestedContactStatus}
+        changeContactStatus={false}
+        handleChange={handleChange}
+        accountListId={accountListId}
+        contactIds={contactIds}
+        contactStatus={contactStatus}
+      />
+    </GqlMockedProvider>
   </ThemeProvider>
 );
 

--- a/src/components/Tool/Appeal/Flow/ContactFlow.test.tsx
+++ b/src/components/Tool/Appeal/Flow/ContactFlow.test.tsx
@@ -6,13 +6,11 @@ import { fireEvent, render, waitFor, within } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import { I18nextProvider } from 'react-i18next';
 import { VirtuosoMockContext } from 'react-virtuoso';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { AppealsWrapper } from 'pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper';
 import { PledgeStatusEnum, StatusEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import { AppealsContext, AppealsType } from '../AppealsContext/AppealsContext';
 import { AppealsContactsQuery } from '../AppealsContext/contacts.generated';
@@ -86,62 +84,60 @@ const Components = ({
   updatedPledgeStatus = PledgeStatusEnum.NotReceived,
   contactFlowProps = defaultContactFlowProps,
 }: ComponentsProps) => (
-  <I18nextProvider i18n={i18n}>
-    <LocalizationProvider dateAdapter={AdapterLuxon}>
-      <SnackbarProvider>
-        <DndProvider backend={HTML5Backend}>
-          <ThemeProvider theme={theme}>
-            <TestRouter router={router}>
-              <GqlMockedProvider<{
-                AppealsContacts: AppealsContactsQuery;
-                UpdateAccountListPledge: UpdateAccountListPledgeMutation;
-              }>
-                mocks={{
-                  AppealsContacts: {
-                    contacts: {
-                      nodes: [contact],
-                      pageInfo: { endCursor: 'Mg', hasNextPage: false },
-                      totalCount: 1,
+  <LocalizationProvider dateAdapter={AdapterLuxon}>
+    <SnackbarProvider>
+      <DndProvider backend={HTML5Backend}>
+        <ThemeProvider theme={theme}>
+          <TestRouter router={router}>
+            <GqlMockedProvider<{
+              AppealsContacts: AppealsContactsQuery;
+              UpdateAccountListPledge: UpdateAccountListPledgeMutation;
+            }>
+              mocks={{
+                AppealsContacts: {
+                  contacts: {
+                    nodes: [contact],
+                    pageInfo: { endCursor: 'Mg', hasNextPage: false },
+                    totalCount: 1,
+                  },
+                },
+                UpdateAccountListPledge: {
+                  updateAccountListPledge: {
+                    pledge: {
+                      id: 'pledgeId',
+                      status: updatedPledgeStatus,
                     },
                   },
-                  UpdateAccountListPledge: {
-                    updateAccountListPledge: {
-                      pledge: {
-                        id: 'pledgeId',
-                        status: updatedPledgeStatus,
-                      },
-                    },
-                  },
-                }}
-                onCall={mutationSpy}
-              >
-                <AppealsWrapper>
-                  <AppealsContext.Provider
-                    value={
-                      {
-                        accountListId,
-                        appealId: appealId,
-                        sanitizedFilters: {},
-                        isRowChecked: jest.fn(),
-                        toggleSelectionById: jest.fn(),
-                        getContactUrl,
-                      } as unknown as AppealsType
-                    }
+                },
+              }}
+              onCall={mutationSpy}
+            >
+              <AppealsWrapper>
+                <AppealsContext.Provider
+                  value={
+                    {
+                      accountListId,
+                      appealId: appealId,
+                      sanitizedFilters: {},
+                      isRowChecked: jest.fn(),
+                      toggleSelectionById: jest.fn(),
+                      getContactUrl,
+                    } as unknown as AppealsType
+                  }
+                >
+                  <VirtuosoMockContext.Provider
+                    value={{ viewportHeight: 300, itemHeight: 100 }}
                   >
-                    <VirtuosoMockContext.Provider
-                      value={{ viewportHeight: 300, itemHeight: 100 }}
-                    >
-                      <ContactFlow {...contactFlowProps} />
-                    </VirtuosoMockContext.Provider>
-                  </AppealsContext.Provider>
-                </AppealsWrapper>
-              </GqlMockedProvider>
-            </TestRouter>
-          </ThemeProvider>
-        </DndProvider>
-      </SnackbarProvider>
-    </LocalizationProvider>
-  </I18nextProvider>
+                    <ContactFlow {...contactFlowProps} />
+                  </VirtuosoMockContext.Provider>
+                </AppealsContext.Provider>
+              </AppealsWrapper>
+            </GqlMockedProvider>
+          </TestRouter>
+        </ThemeProvider>
+      </DndProvider>
+    </SnackbarProvider>
+  </LocalizationProvider>
 );
 
 describe('ContactFlow', () => {

--- a/src/components/Tool/Appeal/Flow/ContactFlowRow/ContactFlowRow.test.tsx
+++ b/src/components/Tool/Appeal/Flow/ContactFlowRow/ContactFlowRow.test.tsx
@@ -7,11 +7,9 @@ import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { AppealsWrapper } from 'pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import {
   AppealStatusEnum,
@@ -50,38 +48,36 @@ const Components = ({
   contact = defaultContact,
   excludedContacts = [],
 }: ComponentsProps) => (
-  <I18nextProvider i18n={i18n}>
-    <LocalizationProvider dateAdapter={AdapterLuxon}>
-      <DndProvider backend={HTML5Backend}>
-        <ThemeProvider theme={theme}>
-          <TestRouter router={router}>
-            <GqlMockedProvider>
-              <SnackbarProvider>
-                <AppealsWrapper>
-                  <AppealsContext.Provider
-                    value={
-                      {
-                        appealId,
-                        isRowChecked: isChecked,
-                        toggleSelectionById,
-                      } as unknown as AppealsType
-                    }
-                  >
-                    <ContactFlowRow
-                      accountListId={accountListId}
-                      contact={contact}
-                      appealStatus={appealStatus}
-                      excludedContacts={excludedContacts}
-                    />
-                  </AppealsContext.Provider>
-                </AppealsWrapper>
-              </SnackbarProvider>
-            </GqlMockedProvider>
-          </TestRouter>
-        </ThemeProvider>
-      </DndProvider>
-    </LocalizationProvider>
-  </I18nextProvider>
+  <LocalizationProvider dateAdapter={AdapterLuxon}>
+    <DndProvider backend={HTML5Backend}>
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider>
+            <SnackbarProvider>
+              <AppealsWrapper>
+                <AppealsContext.Provider
+                  value={
+                    {
+                      appealId,
+                      isRowChecked: isChecked,
+                      toggleSelectionById,
+                    } as unknown as AppealsType
+                  }
+                >
+                  <ContactFlowRow
+                    accountListId={accountListId}
+                    contact={contact}
+                    appealStatus={appealStatus}
+                    excludedContacts={excludedContacts}
+                  />
+                </AppealsContext.Provider>
+              </AppealsWrapper>
+            </SnackbarProvider>
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>
+    </DndProvider>
+  </LocalizationProvider>
 );
 
 describe('ContactFlowRow', () => {

--- a/src/components/Tool/Appeal/InitialPage/AddAppealForm/AddAppealForm.test.tsx
+++ b/src/components/Tool/Appeal/InitialPage/AddAppealForm/AddAppealForm.test.tsx
@@ -5,11 +5,9 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { AppealsWrapper } from 'pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import AddAppealForm, {
   AddAppealFormProps,
@@ -48,36 +46,34 @@ const Components = ({
   appealIncludes,
   formRef,
 }: Omit<AddAppealFormProps, 'accountListId'>) => (
-  <I18nextProvider i18n={i18n}>
-    <LocalizationProvider dateAdapter={AdapterLuxon}>
-      <SnackbarProvider>
-        <ThemeProvider theme={theme}>
-          <TestRouter router={router}>
-            <GqlMockedProvider<{
-              ContactTags: ContactTagsQuery;
-            }>
-              mocks={{
-                ContactTags: contactTagsMock,
-              }}
-              onCall={mutationSpy}
-            >
-              <AppealsWrapper>
-                <AddAppealForm
-                  accountListId={accountListId}
-                  appealName={appealName}
-                  appealGoal={appealGoal}
-                  appealStatuses={appealStatuses}
-                  appealExcludes={appealExcludes}
-                  appealIncludes={appealIncludes}
-                  formRef={formRef}
-                />
-              </AppealsWrapper>
-            </GqlMockedProvider>
-          </TestRouter>
-        </ThemeProvider>
-      </SnackbarProvider>
-    </LocalizationProvider>
-  </I18nextProvider>
+  <LocalizationProvider dateAdapter={AdapterLuxon}>
+    <SnackbarProvider>
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<{
+            ContactTags: ContactTagsQuery;
+          }>
+            mocks={{
+              ContactTags: contactTagsMock,
+            }}
+            onCall={mutationSpy}
+          >
+            <AppealsWrapper>
+              <AddAppealForm
+                accountListId={accountListId}
+                appealName={appealName}
+                appealGoal={appealGoal}
+                appealStatuses={appealStatuses}
+                appealExcludes={appealExcludes}
+                appealIncludes={appealIncludes}
+                formRef={formRef}
+              />
+            </AppealsWrapper>
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>
+    </SnackbarProvider>
+  </LocalizationProvider>
 );
 
 describe('AddAppealForm', () => {

--- a/src/components/Tool/Appeal/Modals/AddExcludedContactModal/AddExcludedContactModal.test.tsx
+++ b/src/components/Tool/Appeal/Modals/AddExcludedContactModal/AddExcludedContactModal.test.tsx
@@ -5,11 +5,9 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { AppealsWrapper } from 'pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import {
   AppealsContext,
@@ -53,40 +51,38 @@ const Components = ({
 }: {
   contactIds?: string[];
 }) => (
-  <I18nextProvider i18n={i18n}>
-    <LocalizationProvider dateAdapter={AdapterLuxon}>
-      <SnackbarProvider>
-        <ThemeProvider theme={theme}>
-          <TestRouter router={router}>
-            <GqlMockedProvider<{
-              AppealContacts: AppealContactsQuery;
-            }>
-              mocks={{
-                AppealContacts: appealMock,
-              }}
-              onCall={mutationSpy}
-            >
-              <AppealsWrapper>
-                <AppealsContext.Provider
-                  value={
-                    {
-                      accountListId,
-                      appealId: appealId,
-                    } as unknown as AppealsType
-                  }
-                >
-                  <AddExcludedContactModal
-                    handleClose={handleClose}
-                    contactIds={contactIds}
-                  />
-                </AppealsContext.Provider>
-              </AppealsWrapper>
-            </GqlMockedProvider>
-          </TestRouter>
-        </ThemeProvider>
-      </SnackbarProvider>
-    </LocalizationProvider>
-  </I18nextProvider>
+  <LocalizationProvider dateAdapter={AdapterLuxon}>
+    <SnackbarProvider>
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<{
+            AppealContacts: AppealContactsQuery;
+          }>
+            mocks={{
+              AppealContacts: appealMock,
+            }}
+            onCall={mutationSpy}
+          >
+            <AppealsWrapper>
+              <AppealsContext.Provider
+                value={
+                  {
+                    accountListId,
+                    appealId: appealId,
+                  } as unknown as AppealsType
+                }
+              >
+                <AddExcludedContactModal
+                  handleClose={handleClose}
+                  contactIds={contactIds}
+                />
+              </AppealsContext.Provider>
+            </AppealsWrapper>
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>
+    </SnackbarProvider>
+  </LocalizationProvider>
 );
 
 describe('AddExcludedContactModal', () => {

--- a/src/components/Tool/Appeal/Modals/DeleteAppealContact/DeleteAppealContactModal.test.tsx
+++ b/src/components/Tool/Appeal/Modals/DeleteAppealContact/DeleteAppealContactModal.test.tsx
@@ -5,11 +5,9 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { AppealsWrapper } from 'pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import {
   AppealsContext,
@@ -48,117 +46,115 @@ interface ComponentsProps {
 const Components = ({ viewMode = TableViewModeEnum.List }: ComponentsProps) => {
   let requestCount = 0;
   return (
-    <I18nextProvider i18n={i18n}>
-      <SnackbarProvider>
-        <LocalizationProvider dateAdapter={AdapterLuxon}>
-          <SnackbarProvider>
-            <ThemeProvider theme={theme}>
-              <TestRouter router={router}>
-                <GqlMockedProvider
-                  mocks={{
-                    AppealContacts: () => {
-                      let mutationResponse;
-                      if (requestCount < 3) {
-                        mutationResponse = {
-                          appealContacts: {
-                            nodes: [
-                              {
-                                id: `id1${requestCount}`,
-                                contact: {
-                                  id: `contactId1${requestCount}`,
-                                },
+    <SnackbarProvider>
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <SnackbarProvider>
+          <ThemeProvider theme={theme}>
+            <TestRouter router={router}>
+              <GqlMockedProvider
+                mocks={{
+                  AppealContacts: () => {
+                    let mutationResponse;
+                    if (requestCount < 3) {
+                      mutationResponse = {
+                        appealContacts: {
+                          nodes: [
+                            {
+                              id: `id1${requestCount}`,
+                              contact: {
+                                id: `contactId1${requestCount}`,
                               },
-                              {
-                                id: `id2${requestCount}`,
-                                contact: {
-                                  id: `contactId2${requestCount}`,
-                                },
-                              },
-                              {
-                                id: `id3${requestCount}`,
-                                contact: {
-                                  id: `contactId3${requestCount}`,
-                                },
-                              },
-                            ],
-                            pageInfo: {
-                              hasNextPage: true,
-                              endCursor: `endCursor${requestCount}`,
                             },
-                          },
-                        };
-                      } else {
-                        mutationResponse = {
-                          appealContacts: {
-                            nodes: [
-                              {
-                                id: appealContactId,
-                                contact: {
-                                  id: contactId,
-                                },
+                            {
+                              id: `id2${requestCount}`,
+                              contact: {
+                                id: `contactId2${requestCount}`,
                               },
-                              {
-                                id: `id5${requestCount}`,
-                                contact: {
-                                  id: `contactId5${requestCount}`,
-                                },
-                              },
-                              {
-                                id: `id6${requestCount}`,
-                                contact: {
-                                  id: `contactId6${requestCount}`,
-                                },
-                              },
-                            ],
-                            pageInfo: {
-                              hasNextPage: false,
-                              endCursor: 'endCursor3',
                             },
+                            {
+                              id: `id3${requestCount}`,
+                              contact: {
+                                id: `contactId3${requestCount}`,
+                              },
+                            },
+                          ],
+                          pageInfo: {
+                            hasNextPage: true,
+                            endCursor: `endCursor${requestCount}`,
                           },
-                        };
-                      }
-                      requestCount++;
-                      return mutationResponse;
+                        },
+                      };
+                    } else {
+                      mutationResponse = {
+                        appealContacts: {
+                          nodes: [
+                            {
+                              id: appealContactId,
+                              contact: {
+                                id: contactId,
+                              },
+                            },
+                            {
+                              id: `id5${requestCount}`,
+                              contact: {
+                                id: `contactId5${requestCount}`,
+                              },
+                            },
+                            {
+                              id: `id6${requestCount}`,
+                              contact: {
+                                id: `contactId6${requestCount}`,
+                              },
+                            },
+                          ],
+                          pageInfo: {
+                            hasNextPage: false,
+                            endCursor: 'endCursor3',
+                          },
+                        },
+                      };
+                    }
+                    requestCount++;
+                    return mutationResponse;
+                  },
+                  GetContactIdsForMassSelection: {
+                    contacts: {
+                      nodes: [
+                        { id: '01' },
+                        { id: '02' },
+                        { id: '03' },
+                        { id: '04' },
+                        { id: '05' },
+                        { id: '06' },
+                      ],
                     },
-                    GetContactIdsForMassSelection: {
-                      contacts: {
-                        nodes: [
-                          { id: '01' },
-                          { id: '02' },
-                          { id: '03' },
-                          { id: '04' },
-                          { id: '05' },
-                          { id: '06' },
-                        ],
-                      },
-                    },
-                  }}
-                  onCall={mutationSpy}
-                >
-                  <AppealsWrapper>
-                    <AppealsContext.Provider
-                      value={
-                        {
-                          accountListId,
-                          appealId: appealId,
-                          filterPanelOpen: false,
-                          viewMode,
-                        } as unknown as AppealsType
-                      }
-                    >
-                      <DeleteAppealContactModal
-                        handleClose={handleClose}
-                        contactId={contactId}
-                      />
-                    </AppealsContext.Provider>
-                  </AppealsWrapper>
-                </GqlMockedProvider>
-              </TestRouter>
-            </ThemeProvider>
-          </SnackbarProvider>
-        </LocalizationProvider>
-      </SnackbarProvider>
-    </I18nextProvider>
+                  },
+                }}
+                onCall={mutationSpy}
+              >
+                <AppealsWrapper>
+                  <AppealsContext.Provider
+                    value={
+                      {
+                        accountListId,
+                        appealId: appealId,
+                        filterPanelOpen: false,
+                        viewMode,
+                      } as unknown as AppealsType
+                    }
+                  >
+                    <DeleteAppealContactModal
+                      handleClose={handleClose}
+                      contactId={contactId}
+                    />
+                  </AppealsContext.Provider>
+                </AppealsWrapper>
+              </GqlMockedProvider>
+            </TestRouter>
+          </ThemeProvider>
+        </SnackbarProvider>
+      </LocalizationProvider>
+    </SnackbarProvider>
   );
 };
 

--- a/src/components/Tool/Appeal/Modals/DeletePledgeModal/DeletePledgeModal.test.tsx
+++ b/src/components/Tool/Appeal/Modals/DeletePledgeModal/DeletePledgeModal.test.tsx
@@ -5,12 +5,10 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { AppealsWrapper } from 'pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper';
 import { PledgeStatusEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import {
   AppealsContext,
@@ -53,34 +51,29 @@ interface ComponentsProps {
   viewMode?: TableViewModeEnum;
 }
 const Components = ({ viewMode = TableViewModeEnum.List }: ComponentsProps) => (
-  <I18nextProvider i18n={i18n}>
-    <LocalizationProvider dateAdapter={AdapterLuxon}>
-      <SnackbarProvider>
-        <ThemeProvider theme={theme}>
-          <TestRouter router={router}>
-            <GqlMockedProvider onCall={mutationSpy}>
-              <AppealsWrapper>
-                <AppealsContext.Provider
-                  value={
-                    {
-                      accountListId,
-                      appealId: appealId,
-                      viewMode,
-                    } as unknown as AppealsType
-                  }
-                >
-                  <DeletePledgeModal
-                    pledge={pledge}
-                    handleClose={handleClose}
-                  />
-                </AppealsContext.Provider>
-              </AppealsWrapper>
-            </GqlMockedProvider>
-          </TestRouter>
-        </ThemeProvider>
-      </SnackbarProvider>
-    </LocalizationProvider>
-  </I18nextProvider>
+  <LocalizationProvider dateAdapter={AdapterLuxon}>
+    <SnackbarProvider>
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider onCall={mutationSpy}>
+            <AppealsWrapper>
+              <AppealsContext.Provider
+                value={
+                  {
+                    accountListId,
+                    appealId: appealId,
+                    viewMode,
+                  } as unknown as AppealsType
+                }
+              >
+                <DeletePledgeModal pledge={pledge} handleClose={handleClose} />
+              </AppealsContext.Provider>
+            </AppealsWrapper>
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>
+    </SnackbarProvider>
+  </LocalizationProvider>
 );
 
 describe('DeletePledgeModal', () => {

--- a/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.test.tsx
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.test.tsx
@@ -5,12 +5,10 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { AppealsWrapper } from 'pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper';
 import { PledgeStatusEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import {
   AppealStatusEnum,
@@ -83,44 +81,42 @@ const Components = ({
   updateAccountListPledge = defaultUpdateAccountListPledge,
   createAccountListPledge = defaultCreateAccountListPledge,
 }: ComponentsProps) => (
-  <I18nextProvider i18n={i18n}>
-    <LocalizationProvider dateAdapter={AdapterLuxon}>
-      <SnackbarProvider>
-        <ThemeProvider theme={theme}>
-          <TestRouter router={router}>
-            <GqlMockedProvider<{
-              UpdateAccountListPledge: UpdateAccountListPledgeMutation;
-              CreateAccountListPledge: CreateAccountListPledgeMutation;
-            }>
-              onCall={mutationSpy}
-              mocks={{
-                UpdateAccountListPledge: { updateAccountListPledge },
-                CreateAccountListPledge: { createAccountListPledge },
-              }}
-            >
-              <AppealsWrapper>
-                <AppealsContext.Provider
-                  value={
-                    {
-                      accountListId,
-                      appealId: appealId,
-                    } as unknown as AppealsType
-                  }
-                >
-                  <PledgeModal
-                    handleClose={handleClose}
-                    contact={defaultContact}
-                    pledge={pledge}
-                    selectedAppealStatus={selectedAppealStatus}
-                  />
-                </AppealsContext.Provider>
-              </AppealsWrapper>
-            </GqlMockedProvider>
-          </TestRouter>
-        </ThemeProvider>
-      </SnackbarProvider>
-    </LocalizationProvider>
-  </I18nextProvider>
+  <LocalizationProvider dateAdapter={AdapterLuxon}>
+    <SnackbarProvider>
+      <ThemeProvider theme={theme}>
+        <TestRouter router={router}>
+          <GqlMockedProvider<{
+            UpdateAccountListPledge: UpdateAccountListPledgeMutation;
+            CreateAccountListPledge: CreateAccountListPledgeMutation;
+          }>
+            onCall={mutationSpy}
+            mocks={{
+              UpdateAccountListPledge: { updateAccountListPledge },
+              CreateAccountListPledge: { createAccountListPledge },
+            }}
+          >
+            <AppealsWrapper>
+              <AppealsContext.Provider
+                value={
+                  {
+                    accountListId,
+                    appealId: appealId,
+                  } as unknown as AppealsType
+                }
+              >
+                <PledgeModal
+                  handleClose={handleClose}
+                  contact={defaultContact}
+                  pledge={pledge}
+                  selectedAppealStatus={selectedAppealStatus}
+                />
+              </AppealsContext.Provider>
+            </AppealsWrapper>
+          </GqlMockedProvider>
+        </TestRouter>
+      </ThemeProvider>
+    </SnackbarProvider>
+  </LocalizationProvider>
 );
 
 describe('PledgeModal', () => {

--- a/src/components/Tool/Appeal/Modals/UpdateDonationsModal/UpdateDonationsModal.test.tsx
+++ b/src/components/Tool/Appeal/Modals/UpdateDonationsModal/UpdateDonationsModal.test.tsx
@@ -5,7 +5,6 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { AppealsWrapper } from 'pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper';
@@ -15,7 +14,6 @@ import {
   DonationTableQuery,
 } from 'src/components/DonationTable/DonationTable.generated';
 import { PledgeStatusEnum } from 'src/graphql/types.generated';
-import i18n from 'src/lib/i18n';
 import theme from 'src/theme';
 import {
   AppealsContext,
@@ -81,158 +79,154 @@ const Components = ({
   mutationsThrowErrors = false,
 }: ComponentsProps) => {
   return (
-    <I18nextProvider i18n={i18n}>
-      <SnackbarProvider>
-        <LocalizationProvider dateAdapter={AdapterLuxon}>
-          <SnackbarProvider>
-            <ThemeProvider theme={theme}>
-              <TestRouter router={router}>
-                <GqlMockedProvider<{
-                  AccountListCurrency: AccountListCurrencyQuery;
-                  GetContactDonations: GetContactDonationsQuery;
-                  DonationTable: DonationTableQuery;
-                }>
-                  mocks={{
-                    UpdateDonations: mutationsThrowErrors
-                      ? () => {
-                          throw new Error('Server Error');
-                        }
-                      : {},
-                    UpdateAccountListPledge: mutationsThrowErrors
-                      ? () => {
-                          throw new Error('Server Error');
-                        }
-                      : {},
-                    CreateAccountListPledge: mutationsThrowErrors
-                      ? () => {
-                          throw new Error('Server Error');
-                        }
-                      : {},
-                    AccountListCurrency: {
-                      accountList: {
-                        currency: 'CAD',
-                      },
-                    },
-                    GetContactDonations: isEmpty
-                      ? contactNoDonationsMock
-                      : contactWithDonationsMock,
-                    DonationTable: {
-                      donations: {
-                        nodes: isEmpty
-                          ? []
-                          : [
-                              {
-                                id: 'donation-1',
-                                amount: {
-                                  amount: zeroAmount ? 0 : 10,
-                                  convertedAmount: zeroAmount ? 0 : 10,
-                                  convertedCurrency: 'CAD',
-                                  currency: 'CAD',
-                                },
-                                appeal: {
-                                  id: noDonationsMatchAppeal
-                                    ? 'appeal-99'
-                                    : appealId,
-                                  name: 'Appeal 1',
-                                },
-                                designationAccount: {
-                                  id: 'designation-account-1',
-                                  name: 'Designation Account 1',
-                                },
-                                donationDate: '2023-03-01',
-                                donorAccount: {
-                                  contacts: {
-                                    nodes: [
-                                      {
-                                        id: defaultContact.id,
-                                      },
-                                    ],
-                                  },
-                                  id: defaultContact.id,
-                                  displayName: defaultContact.name,
-                                },
-                                paymentMethod: 'Check',
-                              },
-                              {
-                                id: 'donation-2',
-                                amount: {
-                                  amount: hasForeignCurrency ? 200 : 100,
-                                  convertedAmount: 100,
-                                  convertedCurrency: 'CAD',
-                                  currency: hasForeignCurrency ? 'USD' : 'CAD',
-                                },
-                                appeal: null,
-                                donationDate: '2023-03-02',
-                                donorAccount: {
-                                  contacts: {
-                                    nodes: [],
-                                  },
-                                  displayName: 'Donor 2',
-                                },
-                                paymentMethod: 'Credit Card',
-                              },
-                              {
-                                id: 'donation-3',
-                                amount: {
-                                  amount: 0,
-                                  convertedAmount: 0,
-                                  convertedCurrency: 'CAD',
-                                  currency: 'CAD',
-                                },
-                                appeal: null,
-                                designationAccount: {
-                                  id: 'designation-account-2',
-                                  name: 'Designation Account 2',
-                                },
-                                donationDate: '2023-03-01',
-                                donorAccount: {
-                                  contacts: {
-                                    nodes: [
-                                      {
-                                        id: defaultContact.id,
-                                      },
-                                    ],
-                                  },
-                                  id: defaultContact.id,
-                                  displayName: defaultContact.name,
-                                },
-                                paymentMethod: 'Credit Card',
-                              },
-                            ],
-                        pageInfo: {
-                          endCursor: 'cursor',
-                          hasNextPage: hasMultiplePages,
-                        },
-                      },
-                    },
-                  }}
-                  onCall={mutationSpy}
-                >
-                  <AppealsWrapper>
-                    <AppealsContext.Provider
-                      value={
-                        {
-                          accountListId,
-                          appealId: appealId,
-                        } as unknown as AppealsType
+    <SnackbarProvider>
+      <LocalizationProvider dateAdapter={AdapterLuxon}>
+        <SnackbarProvider>
+          <ThemeProvider theme={theme}>
+            <TestRouter router={router}>
+              <GqlMockedProvider<{
+                AccountListCurrency: AccountListCurrencyQuery;
+                GetContactDonations: GetContactDonationsQuery;
+                DonationTable: DonationTableQuery;
+              }>
+                mocks={{
+                  UpdateDonations: mutationsThrowErrors
+                    ? () => {
+                        throw new Error('Server Error');
                       }
-                    >
-                      <UpdateDonationsModal
-                        handleClose={handleClose}
-                        contact={defaultContact}
-                        pledge={
-                          pledge as AppealContactInfoFragment['pledges'][0]
-                        }
-                      />
-                    </AppealsContext.Provider>
-                  </AppealsWrapper>
-                </GqlMockedProvider>
-              </TestRouter>
-            </ThemeProvider>
-          </SnackbarProvider>
-        </LocalizationProvider>
-      </SnackbarProvider>
-    </I18nextProvider>
+                    : {},
+                  UpdateAccountListPledge: mutationsThrowErrors
+                    ? () => {
+                        throw new Error('Server Error');
+                      }
+                    : {},
+                  CreateAccountListPledge: mutationsThrowErrors
+                    ? () => {
+                        throw new Error('Server Error');
+                      }
+                    : {},
+                  AccountListCurrency: {
+                    accountList: {
+                      currency: 'CAD',
+                    },
+                  },
+                  GetContactDonations: isEmpty
+                    ? contactNoDonationsMock
+                    : contactWithDonationsMock,
+                  DonationTable: {
+                    donations: {
+                      nodes: isEmpty
+                        ? []
+                        : [
+                            {
+                              id: 'donation-1',
+                              amount: {
+                                amount: zeroAmount ? 0 : 10,
+                                convertedAmount: zeroAmount ? 0 : 10,
+                                convertedCurrency: 'CAD',
+                                currency: 'CAD',
+                              },
+                              appeal: {
+                                id: noDonationsMatchAppeal
+                                  ? 'appeal-99'
+                                  : appealId,
+                                name: 'Appeal 1',
+                              },
+                              designationAccount: {
+                                id: 'designation-account-1',
+                                name: 'Designation Account 1',
+                              },
+                              donationDate: '2023-03-01',
+                              donorAccount: {
+                                contacts: {
+                                  nodes: [
+                                    {
+                                      id: defaultContact.id,
+                                    },
+                                  ],
+                                },
+                                id: defaultContact.id,
+                                displayName: defaultContact.name,
+                              },
+                              paymentMethod: 'Check',
+                            },
+                            {
+                              id: 'donation-2',
+                              amount: {
+                                amount: hasForeignCurrency ? 200 : 100,
+                                convertedAmount: 100,
+                                convertedCurrency: 'CAD',
+                                currency: hasForeignCurrency ? 'USD' : 'CAD',
+                              },
+                              appeal: null,
+                              donationDate: '2023-03-02',
+                              donorAccount: {
+                                contacts: {
+                                  nodes: [],
+                                },
+                                displayName: 'Donor 2',
+                              },
+                              paymentMethod: 'Credit Card',
+                            },
+                            {
+                              id: 'donation-3',
+                              amount: {
+                                amount: 0,
+                                convertedAmount: 0,
+                                convertedCurrency: 'CAD',
+                                currency: 'CAD',
+                              },
+                              appeal: null,
+                              designationAccount: {
+                                id: 'designation-account-2',
+                                name: 'Designation Account 2',
+                              },
+                              donationDate: '2023-03-01',
+                              donorAccount: {
+                                contacts: {
+                                  nodes: [
+                                    {
+                                      id: defaultContact.id,
+                                    },
+                                  ],
+                                },
+                                id: defaultContact.id,
+                                displayName: defaultContact.name,
+                              },
+                              paymentMethod: 'Credit Card',
+                            },
+                          ],
+                      pageInfo: {
+                        endCursor: 'cursor',
+                        hasNextPage: hasMultiplePages,
+                      },
+                    },
+                  },
+                }}
+                onCall={mutationSpy}
+              >
+                <AppealsWrapper>
+                  <AppealsContext.Provider
+                    value={
+                      {
+                        accountListId,
+                        appealId: appealId,
+                      } as unknown as AppealsType
+                    }
+                  >
+                    <UpdateDonationsModal
+                      handleClose={handleClose}
+                      contact={defaultContact}
+                      pledge={pledge as AppealContactInfoFragment['pledges'][0]}
+                    />
+                  </AppealsContext.Provider>
+                </AppealsWrapper>
+              </GqlMockedProvider>
+            </TestRouter>
+          </ThemeProvider>
+        </SnackbarProvider>
+      </LocalizationProvider>
+    </SnackbarProvider>
   );
 };
 

--- a/src/components/Tool/Import/Csv/CsvUpload.test.tsx
+++ b/src/components/Tool/Import/Csv/CsvUpload.test.tsx
@@ -11,7 +11,6 @@ import {
 } from './CsvImportContext';
 import CsvUpload from './CsvUpload';
 import { getMaxFileSize, uploadFile } from './uploadCsvFile';
-import 'src/lib/i18n';
 
 jest.mock('./uploadCsvFile');
 

--- a/src/components/common/EmptyDonationsTable/EmptyDonationsTable.test.tsx
+++ b/src/components/common/EmptyDonationsTable/EmptyDonationsTable.test.tsx
@@ -5,10 +5,8 @@ import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
-import { I18nextProvider } from 'react-i18next';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import i18n from 'src/lib/i18n';
 import theme from '../../../theme';
 import { EmptyDonationsTable } from './EmptyDonationsTable';
 
@@ -21,19 +19,17 @@ describe('EmptyDonationsTable', () => {
   it('renders', async () => {
     const { findByRole, getByRole, getByText, queryByRole } = render(
       <ThemeProvider theme={theme}>
-        <I18nextProvider i18n={i18n}>
-          <TestRouter router={router}>
-            <LocalizationProvider dateAdapter={AdapterLuxon}>
-              <GqlMockedProvider>
-                <SnackbarProvider>
-                  <EmptyDonationsTable
-                    title={'You have no expected donations this month'}
-                  />
-                </SnackbarProvider>
-              </GqlMockedProvider>
-            </LocalizationProvider>
-          </TestRouter>
-        </I18nextProvider>
+        <TestRouter router={router}>
+          <LocalizationProvider dateAdapter={AdapterLuxon}>
+            <GqlMockedProvider>
+              <SnackbarProvider>
+                <EmptyDonationsTable
+                  title={'You have no expected donations this month'}
+                />
+              </SnackbarProvider>
+            </GqlMockedProvider>
+          </LocalizationProvider>
+        </TestRouter>
       </ThemeProvider>,
     );
 


### PR DESCRIPTION
## Description

There is a tricky bug where tests that import `import 'src/lib/i18n';` will interpolate a label like `Hi, {{name}}!` as `Hi, Caleb` and ones that don't will interpolate it as `Hi, {{name}}!`. When running multiple test files at a time, the behavior can change based on whether or not one of those tests imports `src/lib/i18n` and configures the global i18next instance. This PR resolves those inconsistencies by always importing `src/lib/i18n` in test files to ensure consistent behavior. This also removes the need for `<I18nextProvider i18n={i18n}>` in tests.

## Testing

- Check that all tests still pass

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
