### PR TITLE
[MPDX-9369] - Wire up Hours Per Week calculator to back-end with autosave

### DIFF
--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/AddDonation/AddDonation.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/AddDonation/AddDonation.test.tsx
@@ -1,7 +1,7 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
@@ -16,6 +16,15 @@ const accountListId = '111';
 const handleClose = jest.fn();
 
 describe('AddDonation', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
   it('default', async () => {
     const { queryByText } = render(
       <LocalizationProvider dateAdapter={AdapterLuxon}>
@@ -121,6 +130,9 @@ describe('AddDonation', () => {
     expect(getByRole('combobox', { name: 'Currency' })).toBeInTheDocument();
 
     userEvent.type(getByRole('combobox', { name: 'Partner Account' }), 'Cool');
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
     userEvent.click(await findByRole('option', { name: 'Cool Donor Account' }));
 
     userEvent.type(

--- a/src/components/Reports/PdsGoalCalculator/GoalsList/PdsGoalCalculations.graphql
+++ b/src/components/Reports/PdsGoalCalculator/GoalsList/PdsGoalCalculations.graphql
@@ -18,6 +18,15 @@ fragment PdsGoalCalculationFields on DesignationSupportCalculation {
   conferenceRetreatCosts
   ministryTravelMeals
   otherAnnualReimbursements
+  designationSupportHoursItems {
+    id
+    hoursPerWeek
+    numberOfWeeks
+    name
+    label
+    position
+    predefined
+  }
 }
 
 query PdsGoalCalculations($after: String) {
@@ -60,6 +69,38 @@ mutation UpdatePdsGoalCalculation(
   updateDesignationSupportCalculation(input: { attributes: $attributes }) {
     designationSupportCalculation {
       ...PdsGoalCalculationFields
+    }
+  }
+}
+
+mutation CreateDesignationSupportHoursItem(
+  $attributes: DesignationSupportHoursItemCreateInput!
+) {
+  createDesignationSupportHoursItem(input: { attributes: $attributes }) {
+    designationSupportHoursItem {
+      id
+      hoursPerWeek
+      numberOfWeeks
+      name
+      label
+      position
+      predefined
+    }
+  }
+}
+
+mutation UpdateDesignationSupportHoursItem(
+  $attributes: DesignationSupportHoursItemUpdateInput!
+) {
+  updateDesignationSupportHoursItem(input: { attributes: $attributes }) {
+    designationSupportHoursItem {
+      id
+      hoursPerWeek
+      numberOfWeeks
+      name
+      label
+      position
+      predefined
     }
   }
 }

--- a/src/components/Reports/PdsGoalCalculator/GoalsList/PdsGoalCalculations.graphql
+++ b/src/components/Reports/PdsGoalCalculator/GoalsList/PdsGoalCalculations.graphql
@@ -104,3 +104,10 @@ mutation UpdateDesignationSupportHoursItem(
     }
   }
 }
+
+mutation DeleteDesignationSupportHoursItem($id: ID!) {
+  deleteDesignationSupportHoursItem(input: { id: $id }) {
+    id
+  }
+}
+

--- a/src/components/Reports/PdsGoalCalculator/GoalsList/PdsGoalCalculations.graphql
+++ b/src/components/Reports/PdsGoalCalculator/GoalsList/PdsGoalCalculations.graphql
@@ -110,4 +110,3 @@ mutation DeleteDesignationSupportHoursItem($id: ID!) {
     id
   }
 }
-

--- a/src/components/Reports/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
+++ b/src/components/Reports/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
@@ -80,6 +80,7 @@ const calculationDefault = gqlMock<
       geographicLocation: null,
     },
   },
+  variables: { id: 'goal-1' },
 }).designationSupportCalculation;
 
 const hcmUserDefault = gqlMock<HcmUserQuery, HcmUserQueryVariables>(

--- a/src/components/Reports/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
+++ b/src/components/Reports/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
@@ -137,7 +137,8 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
               ...(calculationMock
                 ? {
                     PdsGoalCalculation: {
-                      designationSupportCalculation: calculationMock,
+                      designationSupportCalculation:
+                        calculationMock as PdsGoalCalculationQuery['designationSupportCalculation'],
                     },
                   }
                 : {}),

--- a/src/components/Reports/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
+++ b/src/components/Reports/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
@@ -16,7 +16,9 @@ import {
 import { GoalCalculatorConstantsQuery } from 'src/hooks/goalCalculatorConstants.generated';
 import theme from 'src/theme';
 import {
+  PdsGoalCalculationDocument,
   PdsGoalCalculationQuery,
+  PdsGoalCalculationQueryVariables,
   PdsGoalCalculationsDocument,
   PdsGoalCalculationsQuery,
   PdsGoalCalculationsQueryVariables,
@@ -61,6 +63,24 @@ export type PdsGoalCalculationsMock = DeepPartial<
 export type PdsGoalCalculationMock = DeepPartial<
   PdsGoalCalculationQuery['designationSupportCalculation']
 >;
+
+const calculationDefault = gqlMock<
+  PdsGoalCalculationQuery,
+  PdsGoalCalculationQueryVariables
+>(PdsGoalCalculationDocument, {
+  mocks: {
+    designationSupportCalculation: {
+      id: 'goal-1',
+      name: 'Test Goal',
+      status: DesignationSupportStatus.FullTime,
+      salaryOrHourly: DesignationSupportSalaryType.Salaried,
+      payRate: 50000,
+      hoursWorkedPerWeek: null,
+      benefits: 1500,
+      geographicLocation: null,
+    },
+  },
+}).designationSupportCalculation;
 
 const hcmUserDefault = gqlMock<HcmUserQuery, HcmUserQueryVariables>(
   HcmUserDocument,
@@ -134,14 +154,13 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
                   calculationsMock,
                 ),
               },
-              ...(calculationMock
-                ? {
-                    PdsGoalCalculation: {
-                      designationSupportCalculation:
-                        calculationMock as PdsGoalCalculationQuery['designationSupportCalculation'],
-                    },
-                  }
-                : {}),
+              PdsGoalCalculation: {
+                designationSupportCalculation: merge(
+                  {},
+                  calculationDefault,
+                  calculationMock,
+                ),
+              },
               HcmUser: {
                 hcm:
                   hcmUserMock === null

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
@@ -173,9 +173,7 @@ describe('HoursPerWeekGrid', () => {
     const regularRow = (await findByText('Regular Week')).closest(
       '[role="row"]',
     );
-    const hoursCell = regularRow?.querySelector(
-      '[data-field="hoursPerWeek"]',
-    );
+    const hoursCell = regularRow?.querySelector('[data-field="hoursPerWeek"]');
     userEvent.dblClick(hoursCell!);
 
     await waitFor(() => {
@@ -219,9 +217,7 @@ describe('HoursPerWeekGrid', () => {
     const regularRow = (await findByText('Regular Week')).closest(
       '[role="row"]',
     );
-    const hoursCell = regularRow?.querySelector(
-      '[data-field="hoursPerWeek"]',
-    );
+    const hoursCell = regularRow?.querySelector('[data-field="hoursPerWeek"]');
     userEvent.dblClick(hoursCell!);
 
     await waitFor(() => {
@@ -233,14 +229,11 @@ describe('HoursPerWeekGrid', () => {
 
     // Average = 20 hrs * 48 wks / 48 wks = 20.0
     await waitFor(() =>
-      expect(mutationSpy).toHaveGraphqlOperation(
-        'UpdatePdsGoalCalculation',
-        {
-          attributes: {
-            averageHoursPerWeek: 20,
-          },
+      expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation', {
+        attributes: {
+          averageHoursPerWeek: 20,
         },
-      ),
+      }),
     );
   });
 
@@ -271,9 +264,7 @@ describe('HoursPerWeekGrid', () => {
 
     // Warning should disappear and Apply should be enabled
     await waitFor(() => {
-      expect(
-        queryByRole('alert'),
-      ).not.toBeInTheDocument();
+      expect(queryByRole('alert')).not.toBeInTheDocument();
     });
 
     const applyButton = getByRole('button', { name: 'Apply to Hours Worked' });

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
@@ -65,7 +65,7 @@ describe('HoursPerWeekGrid', () => {
 
     expect(await findByText('Hours Per Week Calculator')).toBeInTheDocument();
     await waitForDataToLoad();
-    expect(getByText('Regular Week')).toBeInTheDocument();
+    expect(await findByText('Regular Week')).toBeInTheDocument();
     expect(getByText('Travel')).toBeInTheDocument();
     expect(getByText('Unpaid Vacation')).toBeInTheDocument();
     expect(getByText('Total')).toBeInTheDocument();
@@ -183,18 +183,16 @@ describe('HoursPerWeekGrid', () => {
     });
     userEvent.tab();
 
-    // Default entries have "default-" IDs since calculation loads after
-    // initial render, so cell edits trigger create (not update)
     await waitFor(() =>
       expect(mutationSpy).toHaveGraphqlOperation(
-        'CreateDesignationSupportHoursItem',
+        'UpdateDesignationSupportHoursItem',
         {
           attributes: {
+            id: 'item-regular',
             designationSupportCalculationId: 'goal-1',
             label: 'Regular Week',
             hoursPerWeek: 20,
             numberOfWeeks: 48,
-            position: 0,
           },
         },
       ),

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
@@ -119,9 +119,32 @@ describe('HoursPerWeekGrid', () => {
     expect(queryByText('Apply to Hours Worked')).not.toBeInTheDocument();
   });
 
-  it('calls onApply with the rounded average when Apply button is clicked', async () => {
+  it('shows warning and disables Apply when weeks do not add up to 52', async () => {
     const onApply = jest.fn();
-    const { findByText, getByText, getByDisplayValue } = render(
+    const { findByText, getByText, getByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={defaultCalculationMock}
+        onCall={mutationSpy}
+      >
+        <HoursPerWeekGrid onApply={onApply} />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await waitForDataToLoad();
+    await findByText('Regular Week');
+
+    // Default entries have 48 weeks total, 4 remaining
+    expect(
+      getByText(/Weeks must add up to 52. 4 week\(s\) remaining./),
+    ).toBeInTheDocument();
+
+    const applyButton = getByRole('button', { name: 'Apply to Hours Worked' });
+    expect(applyButton).toBeDisabled();
+  });
+
+  it('enables Apply when weeks add up to 52', async () => {
+    const onApply = jest.fn();
+    const { findByText, getByDisplayValue, getByRole, queryByRole } = render(
       <PdsGoalCalculatorTestWrapper
         calculationMock={defaultCalculationMock}
         onCall={mutationSpy}
@@ -132,32 +155,30 @@ describe('HoursPerWeekGrid', () => {
 
     await waitForDataToLoad();
 
-    // Edit Regular Week hours from 40 to 20
-    const regularRow = (await findByText('Regular Week')).closest(
-      '[role="row"]',
-    );
-    const hoursCell = regularRow?.querySelector('[data-field="hoursPerWeek"]');
-    userEvent.dblClick(hoursCell!);
+    // Edit Travel weeks from 0 to 4 (48 + 4 = 52)
+    const travelRow = (await findByText('Travel')).closest('[role="row"]');
+    const weeksCell = travelRow?.querySelector('[data-field="weeks"]');
+    userEvent.dblClick(weeksCell!);
 
     await waitFor(() => {
-      const input = getByDisplayValue('40');
+      const input = getByDisplayValue('0');
       userEvent.clear(input);
-      userEvent.type(input, '20');
+      userEvent.type(input, '4');
     });
     userEvent.tab();
 
-    // Average = 20 * 48 / 48 = 20.0
+    // Warning should disappear and Apply should be enabled
     await waitFor(() => {
-      expect(getByText('20.0')).toBeInTheDocument();
+      expect(
+        queryByRole('alert'),
+      ).not.toBeInTheDocument();
     });
 
-    // onApply should not have been called yet
-    expect(onApply).not.toHaveBeenCalled();
+    const applyButton = getByRole('button', { name: 'Apply to Hours Worked' });
+    expect(applyButton).not.toBeDisabled();
 
-    // Click the Apply button
-    userEvent.click(getByText('Apply to Hours Worked'));
-
-    expect(onApply).toHaveBeenCalledWith(20);
+    userEvent.click(applyButton);
+    expect(onApply).toHaveBeenCalled();
   });
 
   it('shows delete button only for custom entries on hover', async () => {

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
@@ -1,23 +1,70 @@
 import React from 'react';
-import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import theme from 'src/theme';
+import {
+  PdsGoalCalculationMock,
+  PdsGoalCalculatorTestWrapper,
+} from '../../PdsGoalCalculatorTestWrapper';
 import { HoursPerWeekGrid } from './HoursPerWeekGrid';
 
-const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <ThemeProvider theme={theme}>{children}</ThemeProvider>
-);
+const defaultCalculationMock: PdsGoalCalculationMock = {
+  id: 'goal-1',
+  designationSupportHoursItems: [
+    {
+      id: 'item-regular',
+      label: 'Regular Week',
+      hoursPerWeek: 40,
+      numberOfWeeks: 48,
+      name: 'regular',
+      position: 0,
+      predefined: true,
+    },
+    {
+      id: 'item-travel',
+      label: 'Travel',
+      hoursPerWeek: 0,
+      numberOfWeeks: 0,
+      name: 'travel',
+      position: 1,
+      predefined: true,
+    },
+    {
+      id: 'item-vacation',
+      label: 'Unpaid Vacation',
+      hoursPerWeek: 0,
+      numberOfWeeks: 0,
+      name: 'vacation',
+      position: 2,
+      predefined: true,
+    },
+  ],
+};
+
+const mutationSpy = jest.fn();
+
+const waitForDataToLoad = async () => {
+  await waitFor(() =>
+    expect(mutationSpy).toHaveGraphqlOperation('PdsGoalCalculation'),
+  );
+};
 
 describe('HoursPerWeekGrid', () => {
-  it('renders the grid correctly', () => {
-    const { getByText } = render(
-      <TestWrapper>
+  beforeEach(() => {
+    mutationSpy.mockClear();
+  });
+
+  it('renders the grid correctly', async () => {
+    const { findByText, getByText } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={defaultCalculationMock}
+        onCall={mutationSpy}
+      >
         <HoursPerWeekGrid />
-      </TestWrapper>,
+      </PdsGoalCalculatorTestWrapper>,
     );
 
-    expect(getByText('Hours Per Week Calculator')).toBeInTheDocument();
+    expect(await findByText('Hours Per Week Calculator')).toBeInTheDocument();
+    await waitForDataToLoad();
     expect(getByText('Regular Week')).toBeInTheDocument();
     expect(getByText('Travel')).toBeInTheDocument();
     expect(getByText('Unpaid Vacation')).toBeInTheDocument();
@@ -25,39 +72,67 @@ describe('HoursPerWeekGrid', () => {
     expect(getByText('Average Hours Worked Per Week')).toBeInTheDocument();
   });
 
-  it('calculates average hours per week from default values', () => {
-    const { getByText } = render(
-      <TestWrapper>
+  it('calculates average hours per week from server values', async () => {
+    const { findByText } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={defaultCalculationMock}
+        onCall={mutationSpy}
+      >
         <HoursPerWeekGrid />
-      </TestWrapper>,
+      </PdsGoalCalculatorTestWrapper>,
     );
 
-    // Default: Regular Week 40hrs * 48wks = 1920 total hours, 48 total weeks
+    await waitForDataToLoad();
+    // Regular Week 40hrs * 48wks = 1920 total hours, 48 total weeks
     // Average = 1920 / 48 = 40.0
-    // The average is rendered in our own footer, outside the DataGrid
-    expect(getByText('40.0')).toBeInTheDocument();
+    expect(await findByText('40.0')).toBeInTheDocument();
   });
 
-  it('adds a new entry when clicking add button', () => {
-    const { getByText } = render(
-      <TestWrapper>
+  it('adds a new entry when clicking add button', async () => {
+    const { findByText, getByText } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={defaultCalculationMock}
+        onCall={mutationSpy}
+      >
         <HoursPerWeekGrid />
-      </TestWrapper>,
+      </PdsGoalCalculatorTestWrapper>,
     );
 
+    await waitForDataToLoad();
+    await findByText('Regular Week');
     userEvent.click(getByText('Add Entry'));
 
-    expect(getByText('New Entry')).toBeInTheDocument();
+    expect(await findByText('New Entry')).toBeInTheDocument();
   });
 
-  it('fires onAverageHoursChange with the new average when a cell is edited', async () => {
-    const onAverageHoursChange = jest.fn();
-    const { findByText, getByDisplayValue } = render(
-      <TestWrapper>
-        <HoursPerWeekGrid onAverageHoursChange={onAverageHoursChange} />
-      </TestWrapper>,
+  it('does not show Apply button when onApply is not provided', async () => {
+    const { queryByText } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={defaultCalculationMock}
+        onCall={mutationSpy}
+      >
+        <HoursPerWeekGrid />
+      </PdsGoalCalculatorTestWrapper>,
     );
 
+    await waitForDataToLoad();
+    expect(queryByText('Apply to Hours Worked')).not.toBeInTheDocument();
+  });
+
+  it('calls onApply with the rounded average when Apply button is clicked', async () => {
+    const onApply = jest.fn();
+    const { findByText, getByText, getByDisplayValue } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={defaultCalculationMock}
+        onCall={mutationSpy}
+      >
+        <HoursPerWeekGrid onApply={onApply} />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await waitForDataToLoad();
+
+    // Edit Regular Week hours from 40 to 20
     const regularRow = (await findByText('Regular Week')).closest(
       '[role="row"]',
     );
@@ -71,32 +146,48 @@ describe('HoursPerWeekGrid', () => {
     });
     userEvent.tab();
 
-    // Regular Week: 20 * 48 = 960 hours / 48 weeks = 20
+    // Average = 20 * 48 / 48 = 20.0
     await waitFor(() => {
-      expect(onAverageHoursChange).toHaveBeenCalledWith(20);
+      expect(getByText('20.0')).toBeInTheDocument();
     });
+
+    // onApply should not have been called yet
+    expect(onApply).not.toHaveBeenCalled();
+
+    // Click the Apply button
+    userEvent.click(getByText('Apply to Hours Worked'));
+
+    expect(onApply).toHaveBeenCalledWith(20);
   });
 
   it('shows delete button only for custom entries on hover', async () => {
-    const { getByText, findByLabelText } = render(
-      <TestWrapper>
+    const { findByText, findByLabelText, getByText } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={defaultCalculationMock}
+        onCall={mutationSpy}
+      >
         <HoursPerWeekGrid />
-      </TestWrapper>,
+      </PdsGoalCalculatorTestWrapper>,
     );
 
-    // Add a custom entry
+    await waitForDataToLoad();
+    await findByText('Regular Week');
     userEvent.click(getByText('Add Entry'));
 
-    // The delete button should exist for the new entry
     expect(await findByLabelText('Delete')).toBeInTheDocument();
   });
 
   it('renders 0.0 (not NaN) when total weeks is zero', async () => {
     const { findByText, getByDisplayValue, queryByText } = render(
-      <TestWrapper>
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={defaultCalculationMock}
+        onCall={mutationSpy}
+      >
         <HoursPerWeekGrid />
-      </TestWrapper>,
+      </PdsGoalCalculatorTestWrapper>,
     );
+
+    await waitForDataToLoad();
 
     const regularRow = (await findByText('Regular Week')).closest(
       '[role="row"]',
@@ -119,10 +210,15 @@ describe('HoursPerWeekGrid', () => {
 
   it('clamps weeks to 52 total across all entries', async () => {
     const { findByText, getByDisplayValue } = render(
-      <TestWrapper>
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={defaultCalculationMock}
+        onCall={mutationSpy}
+      >
         <HoursPerWeekGrid />
-      </TestWrapper>,
+      </PdsGoalCalculatorTestWrapper>,
     );
+
+    await waitForDataToLoad();
 
     // Default: Regular Week has 48 weeks, Travel and Vacation have 0
     // Edit Travel weeks to 10 — should be clamped to 4 (52 - 48 = 4 remaining)
@@ -145,13 +241,17 @@ describe('HoursPerWeekGrid', () => {
   });
 
   it('removes the row and recomputes the average when delete is clicked', async () => {
-    const onAverageHoursChange = jest.fn();
     const { getByText, queryByText, getByLabelText, findByText } = render(
-      <TestWrapper>
-        <HoursPerWeekGrid onAverageHoursChange={onAverageHoursChange} />
-      </TestWrapper>,
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={defaultCalculationMock}
+        onCall={mutationSpy}
+      >
+        <HoursPerWeekGrid />
+      </PdsGoalCalculatorTestWrapper>,
     );
 
+    await waitForDataToLoad();
+    await findByText('Regular Week');
     userEvent.click(getByText('Add Entry'));
     expect(await findByText('New Entry')).toBeInTheDocument();
 

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
@@ -117,6 +117,33 @@ describe('HoursPerWeekGrid', () => {
     expect(await findByText('0.0')).toBeInTheDocument();
   });
 
+  it('clamps weeks to 52 total across all entries', async () => {
+    const { findByText, getByDisplayValue } = render(
+      <TestWrapper>
+        <HoursPerWeekGrid />
+      </TestWrapper>,
+    );
+
+    // Default: Regular Week has 48 weeks, Travel and Vacation have 0
+    // Edit Travel weeks to 10 — should be clamped to 4 (52 - 48 = 4 remaining)
+    const travelRow = (await findByText('Travel')).closest('[role="row"]');
+    const weeksCell = travelRow?.querySelector('[data-field="weeks"]');
+    userEvent.dblClick(weeksCell!);
+
+    await waitFor(() => {
+      const input = getByDisplayValue('0');
+      userEvent.clear(input);
+      userEvent.type(input, '10');
+    });
+    userEvent.tab();
+
+    // The weeks value should be clamped to 4, so total weeks = 48 + 4 = 52
+    await waitFor(() => {
+      const travelWeeksCell = travelRow?.querySelector('[data-field="weeks"]');
+      expect(travelWeeksCell).toHaveTextContent('4');
+    });
+  });
+
   it('removes the row and recomputes the average when delete is clicked', async () => {
     const onAverageHoursChange = jest.fn();
     const { getByText, queryByText, getByLabelText, findByText } = render(

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
@@ -103,6 +103,21 @@ describe('HoursPerWeekGrid', () => {
     userEvent.click(getByText('Add Entry'));
 
     expect(await findByText('New Entry')).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation(
+        'CreateDesignationSupportHoursItem',
+        {
+          attributes: {
+            designationSupportCalculationId: 'goal-1',
+            label: 'New Entry',
+            hoursPerWeek: 0,
+            numberOfWeeks: 0,
+            position: 3,
+          },
+        },
+      ),
+    );
   });
 
   it('does not show Apply button when onApply is not provided', async () => {
@@ -140,6 +155,93 @@ describe('HoursPerWeekGrid', () => {
 
     const applyButton = getByRole('button', { name: 'Apply to Hours Worked' });
     expect(applyButton).toBeDisabled();
+  });
+
+  it('sends correct mutation variables on cell edit', async () => {
+    const { findByText, getByDisplayValue } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={defaultCalculationMock}
+        onCall={mutationSpy}
+      >
+        <HoursPerWeekGrid />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await waitForDataToLoad();
+
+    // Edit Regular Week hours from 40 to 20
+    const regularRow = (await findByText('Regular Week')).closest(
+      '[role="row"]',
+    );
+    const hoursCell = regularRow?.querySelector(
+      '[data-field="hoursPerWeek"]',
+    );
+    userEvent.dblClick(hoursCell!);
+
+    await waitFor(() => {
+      const input = getByDisplayValue('40');
+      userEvent.clear(input);
+      userEvent.type(input, '20');
+    });
+    userEvent.tab();
+
+    // Default entries have "default-" IDs since calculation loads after
+    // initial render, so cell edits trigger create (not update)
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation(
+        'CreateDesignationSupportHoursItem',
+        {
+          attributes: {
+            designationSupportCalculationId: 'goal-1',
+            label: 'Regular Week',
+            hoursPerWeek: 20,
+            numberOfWeeks: 48,
+            position: 0,
+          },
+        },
+      ),
+    );
+  });
+
+  it('autosaves averageHoursPerWeek via UpdatePdsGoalCalculation after cell edit', async () => {
+    const { findByText, getByDisplayValue } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={defaultCalculationMock}
+        onCall={mutationSpy}
+      >
+        <HoursPerWeekGrid />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await waitForDataToLoad();
+
+    // Edit Regular Week hours from 40 to 20
+    const regularRow = (await findByText('Regular Week')).closest(
+      '[role="row"]',
+    );
+    const hoursCell = regularRow?.querySelector(
+      '[data-field="hoursPerWeek"]',
+    );
+    userEvent.dblClick(hoursCell!);
+
+    await waitFor(() => {
+      const input = getByDisplayValue('40');
+      userEvent.clear(input);
+      userEvent.type(input, '20');
+    });
+    userEvent.tab();
+
+    // Average = 20 hrs * 48 wks / 48 wks = 20.0
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation(
+        'UpdatePdsGoalCalculation',
+        {
+          attributes: {
+            averageHoursPerWeek: 20,
+          },
+        },
+      ),
+    );
   });
 
   it('enables Apply when weeks add up to 52', async () => {

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -9,6 +9,11 @@ import {
 } from '@mui/x-data-grid';
 import { useTranslation } from 'react-i18next';
 import { BaseGrid } from 'src/components/Reports/GoalCalculator/SharedComponents/GoalCalculatorGrid/BaseGrid';
+import {
+  useCreateDesignationSupportHoursItemMutation,
+  useUpdateDesignationSupportHoursItemMutation,
+} from '../../GoalsList/PdsGoalCalculations.generated';
+import { usePdsGoalCalculator } from '../../Shared/PdsGoalCalculatorContext';
 
 const StyledCard = styled(Card)(({ theme }) => ({
   borderRadius: theme.shape.borderRadius,
@@ -28,26 +33,46 @@ export interface HoursPerWeekEntry {
   hoursPerWeek: number;
   weeks: number;
   canDelete: boolean;
+  predefined: boolean;
 }
 
 interface HoursPerWeekGridProps {
-  onAverageHoursChange?: (averageHoursPerWeek: number) => void;
+  onApply?: (averageHoursPerWeek: number) => void;
 }
 
 const MAX_TOTAL_WEEKS = 52;
 
 export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
-  onAverageHoursChange,
+  onApply,
 }) => {
   const { t } = useTranslation();
-  const defaultEntries = useMemo<HoursPerWeekEntry[]>(
-    () => [
+  const { calculation, trackMutation } = usePdsGoalCalculator();
+  const [createHoursItem] = useCreateDesignationSupportHoursItemMutation();
+  const [updateHoursItem] = useUpdateDesignationSupportHoursItemMutation();
+
+  const [entries, setEntries] = useState<HoursPerWeekEntry[]>(() => {
+    const items = calculation?.designationSupportHoursItems;
+    if (items && items.length > 0) {
+      return items
+        .slice()
+        .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+        .map((item) => ({
+          id: item.id,
+          label: item.label,
+          hoursPerWeek: item.hoursPerWeek ?? 0,
+          weeks: item.numberOfWeeks ?? 0,
+          canDelete: !item.predefined,
+          predefined: item.predefined,
+        }));
+    }
+    return [
       {
         id: 'default-regular',
         label: t('Regular Week'),
         hoursPerWeek: 40,
         weeks: 48,
         canDelete: false,
+        predefined: true,
       },
       {
         id: 'default-travel',
@@ -55,6 +80,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         hoursPerWeek: 0,
         weeks: 0,
         canDelete: false,
+        predefined: true,
       },
       {
         id: 'default-vacation',
@@ -62,11 +88,10 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         hoursPerWeek: 0,
         weeks: 0,
         canDelete: false,
+        predefined: true,
       },
-    ],
-    [t],
-  );
-  const [entries, setEntries] = useState<HoursPerWeekEntry[]>(defaultEntries);
+    ];
+  });
   const nextEntryIdRef = useRef(0);
 
   const totalWeeks = useMemo(
@@ -85,39 +110,106 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
     [totalHours, totalWeeks],
   );
 
-  const updateEntry = useCallback(
-    (id: string, updates: Partial<HoursPerWeekEntry>) => {
-      setEntries((prev) => {
-        const updated = prev.map((entry) =>
-          entry.id === id ? { ...entry, ...updates } : entry,
-        );
+  const saveHoursItem = useCallback(
+    async (entry: HoursPerWeekEntry, currentEntries: HoursPerWeekEntry[]) => {
+      if (!calculation) {
+        return;
+      }
 
-        // Notify parent of new average
-        const newTotalWeeks = updated.reduce((sum, e) => sum + e.weeks, 0);
-        const newTotalHours = updated.reduce(
-          (sum, e) => sum + e.hoursPerWeek * e.weeks,
-          0,
+      if (entry.id.startsWith('temp-') || entry.id.startsWith('default-')) {
+        const result = await trackMutation(
+          createHoursItem({
+            variables: {
+              attributes: {
+                designationSupportCalculationId: calculation.id,
+                label: entry.label,
+                hoursPerWeek: entry.hoursPerWeek,
+                numberOfWeeks: entry.weeks,
+                position: currentEntries.indexOf(entry),
+              },
+            },
+            refetchQueries: ['PdsGoalCalculation'],
+          }),
         );
-        const newAverage =
-          newTotalWeeks > 0 ? newTotalHours / newTotalWeeks : 0;
-        onAverageHoursChange?.(newAverage);
-
-        return updated;
-      });
+        const created =
+          result.data?.createDesignationSupportHoursItem
+            ?.designationSupportHoursItem;
+        if (created) {
+          setEntries((prev) =>
+            prev.map((e) => (e.id === entry.id ? { ...e, id: created.id } : e)),
+          );
+        }
+      } else {
+        await trackMutation(
+          updateHoursItem({
+            variables: {
+              attributes: {
+                id: entry.id,
+                designationSupportCalculationId: calculation.id,
+                label: entry.label,
+                hoursPerWeek: entry.hoursPerWeek,
+                numberOfWeeks: entry.weeks,
+                position: currentEntries.indexOf(entry),
+              },
+            },
+            refetchQueries: ['PdsGoalCalculation'],
+          }),
+        );
+      }
     },
-    [onAverageHoursChange],
+    [calculation, createHoursItem, updateHoursItem, trackMutation],
   );
 
-  const addEntry = useCallback(() => {
+  const updateEntry = useCallback(
+    (id: string, updates: Partial<HoursPerWeekEntry>) => {
+      setEntries((prev) =>
+        prev.map((entry) =>
+          entry.id === id ? { ...entry, ...updates } : entry,
+        ),
+      );
+    },
+    [],
+  );
+
+  const addEntry = useCallback(async () => {
+    if (!calculation) {
+      return;
+    }
+
+    const tempId = `temp-${nextEntryIdRef.current++}`;
     const newEntry: HoursPerWeekEntry = {
-      id: `custom-${nextEntryIdRef.current++}`,
+      id: tempId,
       label: t('New Entry'),
       hoursPerWeek: 0,
       weeks: 0,
       canDelete: true,
+      predefined: false,
     };
     setEntries((prev) => [...prev, newEntry]);
-  }, [t]);
+
+    const result = await trackMutation(
+      createHoursItem({
+        variables: {
+          attributes: {
+            designationSupportCalculationId: calculation.id,
+            label: t('New Entry'),
+            hoursPerWeek: 0,
+            numberOfWeeks: 0,
+            position: entries.length,
+          },
+        },
+        refetchQueries: ['PdsGoalCalculation'],
+      }),
+    );
+    const created =
+      result.data?.createDesignationSupportHoursItem
+        ?.designationSupportHoursItem;
+    if (created) {
+      setEntries((prev) =>
+        prev.map((e) => (e.id === tempId ? { ...e, id: created.id } : e)),
+      );
+    }
+  }, [t, calculation, createHoursItem, trackMutation, entries.length]);
 
   const deleteEntry = useCallback((id: string | number) => {
     setEntries((prev) => prev.filter((entry) => entry.id !== id.toString()));
@@ -135,15 +227,26 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         .reduce((sum, e) => sum + e.weeks, 0);
       const clampedWeeks = Math.min(newWeeks, MAX_TOTAL_WEEKS - otherWeeks);
 
-      updateEntry(newRow.id as string, {
+      const updatedEntry: HoursPerWeekEntry = {
+        id: newRow.id as string,
         label: newRow.label as string,
         hoursPerWeek: Number(newRow.hoursPerWeek) || 0,
         weeks: Math.max(0, clampedWeeks),
+        canDelete: newRow.canDelete as boolean,
+        predefined: newRow.predefined as boolean,
+      };
+
+      updateEntry(newRow.id as string, {
+        label: updatedEntry.label,
+        hoursPerWeek: updatedEntry.hoursPerWeek,
+        weeks: updatedEntry.weeks,
       });
+
+      saveHoursItem(updatedEntry, entries);
 
       return { ...newRow, weeks: Math.max(0, clampedWeeks) };
     },
-    [updateEntry, entries],
+    [updateEntry, entries, saveHoursItem],
   );
 
   const dataWithTotal = useMemo(
@@ -287,6 +390,19 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
           </Typography>
         </FooterRow>
       </StyledCard>
+
+      {onApply && (
+        <Box sx={{ mt: 2, display: 'flex', justifyContent: 'flex-end' }}>
+          <Button
+            variant="contained"
+            onClick={() =>
+              onApply(Math.round(averageHoursPerWeek * 10) / 10)
+            }
+          >
+            {t('Apply to Hours Worked')}
+          </Button>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -138,7 +138,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
       }
 
       try {
-        if (entry.id.startsWith('temp-') || entry.id.startsWith('default-')) {
+        if (entry.id.startsWith('default-')) {
           const result = await trackMutation(
             createHoursItem({
               variables: {
@@ -481,6 +481,12 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
           }}
           isCellEditable={(params) => {
             if (params.id === 'total') {
+              return false;
+            }
+            if (
+              typeof params.id === 'string' &&
+              params.id.startsWith('temp-')
+            ) {
               return false;
             }
             if (params.field === 'label' && !params.row.canDelete) {

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -13,6 +13,7 @@ import {
   useCreateDesignationSupportHoursItemMutation,
   useUpdateDesignationSupportHoursItemMutation,
 } from '../../GoalsList/PdsGoalCalculations.generated';
+import { useSaveField } from '../../Shared/Autosave/useSaveField';
 import { usePdsGoalCalculator } from '../../Shared/PdsGoalCalculatorContext';
 
 const StyledCard = styled(Card)(({ theme }) => ({
@@ -49,6 +50,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
   const { calculation, trackMutation } = usePdsGoalCalculator();
   const [createHoursItem] = useCreateDesignationSupportHoursItemMutation();
   const [updateHoursItem] = useUpdateDesignationSupportHoursItemMutation();
+  const saveField = useSaveField();
 
   const [entries, setEntries] = useState<HoursPerWeekEntry[]>(() => {
     const items = calculation?.designationSupportHoursItems;
@@ -244,9 +246,27 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
 
       saveHoursItem(updatedEntry, entries);
 
+      // Autosave the recalculated average to the calculation
+      const updatedEntries = entries.map((e) =>
+        e.id === updatedEntry.id ? updatedEntry : e,
+      );
+      const newTotalWeeks = updatedEntries.reduce(
+        (sum, e) => sum + e.weeks,
+        0,
+      );
+      const newTotalHours = updatedEntries.reduce(
+        (sum, e) => sum + e.hoursPerWeek * e.weeks,
+        0,
+      );
+      const newAverage =
+        newTotalWeeks > 0 ? newTotalHours / newTotalWeeks : 0;
+      saveField({
+        averageHoursPerWeek: Math.round(newAverage * 10) / 10,
+      });
+
       return { ...newRow, weeks: Math.max(0, clampedWeeks) };
     },
-    [updateEntry, entries, saveHoursItem],
+    [updateEntry, entries, saveHoursItem, saveField],
   );
 
   const dataWithTotal = useMemo(

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import {
@@ -65,28 +65,33 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
   const [deleteHoursItem] = useDeleteDesignationSupportHoursItemMutation();
   const saveField = useSaveField();
 
-  const [entries, setEntries] = useState<HoursPerWeekEntry[]>(() => {
-    const items = calculation?.designationSupportHoursItems;
-    if (items && items.length > 0) {
-      return items
-        .slice()
-        .sort(
-          (hoursItemA, hoursItemB) =>
-            (hoursItemA.position ?? 0) - (hoursItemB.position ?? 0),
-        )
-        .map((item) => ({
-          id: item.id,
-          label: item.label,
-          hoursPerWeek: item.hoursPerWeek ?? 0,
-          weeks: item.numberOfWeeks ?? 0,
-          canDelete: !item.predefined,
-          predefined: item.predefined,
-          position: item.position ?? 0,
-        }));
-    }
-    return [];
-  });
+  const [entries, setEntries] = useState<HoursPerWeekEntry[]>([]);
+  const initializedRef = useRef(false);
   const nextEntryIdRef = useRef(0);
+
+  useEffect(() => {
+    const items = calculation?.designationSupportHoursItems;
+    if (!initializedRef.current && items && items.length > 0) {
+      initializedRef.current = true;
+      setEntries(
+        items
+          .slice()
+          .sort(
+            (hoursItemA, hoursItemB) =>
+              (hoursItemA.position ?? 0) - (hoursItemB.position ?? 0),
+          )
+          .map((item) => ({
+            id: item.id,
+            label: item.label,
+            hoursPerWeek: item.hoursPerWeek ?? 0,
+            weeks: item.numberOfWeeks ?? 0,
+            canDelete: !item.predefined,
+            predefined: item.predefined,
+            position: item.position ?? 0,
+          })),
+      );
+    }
+  }, [calculation?.designationSupportHoursItems]);
 
   const totalWeeks = useMemo(
     () => entries.reduce((sum, entry) => sum + entry.weeks, 0),

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -15,6 +15,7 @@ import {
   GridColDef,
   GridValidRowModel,
 } from '@mui/x-data-grid';
+import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { BaseGrid } from 'src/components/Reports/GoalCalculator/SharedComponents/GoalCalculatorGrid/BaseGrid';
 import {
@@ -44,6 +45,7 @@ export interface HoursPerWeekEntry {
   weeks: number;
   canDelete: boolean;
   predefined: boolean;
+  position: number;
 }
 
 interface HoursPerWeekGridProps {
@@ -56,6 +58,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
   onApply,
 }) => {
   const { t } = useTranslation();
+  const { enqueueSnackbar } = useSnackbar();
   const { calculation, trackMutation } = usePdsGoalCalculator();
   const [createHoursItem] = useCreateDesignationSupportHoursItemMutation();
   const [updateHoursItem] = useUpdateDesignationSupportHoursItemMutation();
@@ -75,6 +78,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
           weeks: item.numberOfWeeks ?? 0,
           canDelete: !item.predefined,
           predefined: item.predefined,
+          position: item.position ?? 0,
         }));
     }
     return [
@@ -130,48 +134,63 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         return;
       }
 
-      if (entry.id.startsWith('temp-') || entry.id.startsWith('default-')) {
-        const result = await trackMutation(
-          createHoursItem({
-            variables: {
-              attributes: {
-                designationSupportCalculationId: calculation.id,
-                label: entry.label,
-                hoursPerWeek: entry.hoursPerWeek,
-                numberOfWeeks: entry.weeks,
-                position: currentEntries.indexOf(entry),
+      try {
+        if (entry.id.startsWith('temp-') || entry.id.startsWith('default-')) {
+          const result = await trackMutation(
+            createHoursItem({
+              variables: {
+                attributes: {
+                  designationSupportCalculationId: calculation.id,
+                  label: entry.label,
+                  hoursPerWeek: entry.hoursPerWeek,
+                  numberOfWeeks: entry.weeks,
+                  position: currentEntries.findIndex((e) => e.id === entry.id),
+                },
               },
-            },
-            refetchQueries: ['PdsGoalCalculation'],
-          }),
-        );
-        const created =
-          result.data?.createDesignationSupportHoursItem
-            ?.designationSupportHoursItem;
-        if (created) {
-          setEntries((prev) =>
-            prev.map((e) => (e.id === entry.id ? { ...e, id: created.id } : e)),
+              refetchQueries: ['PdsGoalCalculation'],
+            }),
+          );
+          const created =
+            result.data?.createDesignationSupportHoursItem
+              ?.designationSupportHoursItem;
+          if (created) {
+            setEntries((prev) =>
+              prev.map((e) =>
+                e.id === entry.id ? { ...e, id: created.id } : e,
+              ),
+            );
+          }
+        } else {
+          await trackMutation(
+            updateHoursItem({
+              variables: {
+                attributes: {
+                  id: entry.id,
+                  designationSupportCalculationId: calculation.id,
+                  label: entry.label,
+                  hoursPerWeek: entry.hoursPerWeek,
+                  numberOfWeeks: entry.weeks,
+                },
+              },
+              refetchQueries: ['PdsGoalCalculation'],
+            }),
           );
         }
-      } else {
-        await trackMutation(
-          updateHoursItem({
-            variables: {
-              attributes: {
-                id: entry.id,
-                designationSupportCalculationId: calculation.id,
-                label: entry.label,
-                hoursPerWeek: entry.hoursPerWeek,
-                numberOfWeeks: entry.weeks,
-                position: currentEntries.indexOf(entry),
-              },
-            },
-            refetchQueries: ['PdsGoalCalculation'],
-          }),
-        );
+      } catch (error) {
+        enqueueSnackbar(t('Failed to save hours entry. Please try again.'), {
+          variant: 'error',
+        });
+        throw error;
       }
     },
-    [calculation, createHoursItem, updateHoursItem, trackMutation],
+    [
+      calculation,
+      createHoursItem,
+      updateHoursItem,
+      trackMutation,
+      enqueueSnackbar,
+      t,
+    ],
   );
 
   const updateEntry = useCallback(
@@ -201,36 +220,49 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
     };
     setEntries((prev) => [...prev, newEntry]);
 
-    const result = await trackMutation(
-      createHoursItem({
-        variables: {
-          attributes: {
-            designationSupportCalculationId: calculation.id,
-            label: t('New Entry'),
-            hoursPerWeek: 0,
-            numberOfWeeks: 0,
-            position: entries.length,
+    try {
+      const result = await trackMutation(
+        createHoursItem({
+          variables: {
+            attributes: {
+              designationSupportCalculationId: calculation.id,
+              label: t('New Entry'),
+              hoursPerWeek: 0,
+              numberOfWeeks: 0,
+              position: entries.length,
+            },
           },
-        },
-        refetchQueries: ['PdsGoalCalculation'],
-      }),
-    );
-    const created =
-      result.data?.createDesignationSupportHoursItem
-        ?.designationSupportHoursItem;
-    if (created) {
-      setEntries((prev) =>
-        prev.map((e) => (e.id === tempId ? { ...e, id: created.id } : e)),
+          refetchQueries: ['PdsGoalCalculation'],
+        }),
       );
+      const created =
+        result.data?.createDesignationSupportHoursItem
+          ?.designationSupportHoursItem;
+      if (created) {
+        setEntries((prev) =>
+          prev.map((e) => (e.id === tempId ? { ...e, id: created.id } : e)),
+        );
+      }
+    } catch {
+      setEntries((prev) => prev.filter((e) => e.id !== tempId));
+      enqueueSnackbar(t('Failed to add entry. Please try again.'), {
+        variant: 'error',
+      });
     }
-  }, [t, calculation, createHoursItem, trackMutation, entries.length]);
+  }, [
+    t,
+    calculation,
+    createHoursItem,
+    trackMutation,
+    entries.length,
+    enqueueSnackbar,
+  ]);
 
   const deleteEntry = useCallback(
     async (id: string | number) => {
       const entryId = id.toString();
-      const remainingEntries = entries.filter(
-        (entry) => entry.id !== entryId,
-      );
+      const previousEntries = entries;
+      const remainingEntries = entries.filter((entry) => entry.id !== entryId);
       setEntries(remainingEntries);
 
       // Recalculate and autosave the average
@@ -242,26 +274,32 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         (sum, e) => sum + e.hoursPerWeek * e.weeks,
         0,
       );
-      const newAverage =
-        newTotalWeeks > 0 ? newTotalHours / newTotalWeeks : 0;
-      saveField({
-        averageHoursPerWeek: Math.round(newAverage * 10) / 10,
-      });
+      const newAverage = newTotalWeeks > 0 ? newTotalHours / newTotalWeeks : 0;
 
-      if (!entryId.startsWith('temp-') && !entryId.startsWith('default-')) {
-        await trackMutation(
-          deleteHoursItem({
-            variables: { id: entryId },
-            refetchQueries: ['PdsGoalCalculation'],
-          }),
-        );
+      try {
+        if (!entryId.startsWith('temp-') && !entryId.startsWith('default-')) {
+          await trackMutation(
+            deleteHoursItem({
+              variables: { id: entryId },
+              refetchQueries: ['PdsGoalCalculation'],
+            }),
+          );
+        }
+        saveField({
+          averageHoursPerWeek: Math.round(newAverage * 10) / 10,
+        });
+      } catch {
+        setEntries(previousEntries);
+        enqueueSnackbar(t('Failed to delete entry. Please try again.'), {
+          variant: 'error',
+        });
       }
     },
-    [entries, deleteHoursItem, trackMutation, saveField],
+    [entries, deleteHoursItem, trackMutation, saveField, enqueueSnackbar, t],
   );
 
   const processRowUpdate = useCallback(
-    (newRow: GridValidRowModel) => {
+    async (newRow: GridValidRowModel) => {
       if (newRow.id === 'total') {
         return newRow;
       }
@@ -287,22 +325,18 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         weeks: updatedEntry.weeks,
       });
 
-      saveHoursItem(updatedEntry, entries);
+      await saveHoursItem(updatedEntry, entries);
 
       // Autosave the recalculated average to the calculation
       const updatedEntries = entries.map((e) =>
         e.id === updatedEntry.id ? updatedEntry : e,
       );
-      const newTotalWeeks = updatedEntries.reduce(
-        (sum, e) => sum + e.weeks,
-        0,
-      );
+      const newTotalWeeks = updatedEntries.reduce((sum, e) => sum + e.weeks, 0);
       const newTotalHours = updatedEntries.reduce(
         (sum, e) => sum + e.hoursPerWeek * e.weeks,
         0,
       );
-      const newAverage =
-        newTotalWeeks > 0 ? newTotalHours / newTotalWeeks : 0;
+      const newAverage = newTotalWeeks > 0 ? newTotalHours / newTotalWeeks : 0;
       saveField({
         averageHoursPerWeek: Math.round(newAverage * 10) / 10,
       });
@@ -418,7 +452,10 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
           rows={dataWithTotal}
           columns={columns}
           processRowUpdate={processRowUpdate}
-          onCellEditStart={(_, event) => {
+          onCellEditStart={(params, event) => {
+            if (params.field === 'label') {
+              return;
+            }
             requestAnimationFrame(() => {
               const input =
                 event.target instanceof HTMLElement &&
@@ -468,9 +505,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
           <Button
             variant="contained"
             disabled={weeksRemaining > 0}
-            onClick={() =>
-              onApply(Math.round(averageHoursPerWeek * 10) / 10)
-            }
+            onClick={() => onApply(Math.round(averageHoursPerWeek * 10) / 10)}
           >
             {t('Apply to Hours Worked')}
           </Button>

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -34,6 +34,8 @@ interface HoursPerWeekGridProps {
   onAverageHoursChange?: (averageHoursPerWeek: number) => void;
 }
 
+const MAX_TOTAL_WEEKS = 52;
+
 export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
   onAverageHoursChange,
 }) => {
@@ -127,15 +129,21 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         return newRow;
       }
 
+      const newWeeks = Number(newRow.weeks) || 0;
+      const otherWeeks = entries
+        .filter((e) => e.id !== newRow.id)
+        .reduce((sum, e) => sum + e.weeks, 0);
+      const clampedWeeks = Math.min(newWeeks, MAX_TOTAL_WEEKS - otherWeeks);
+
       updateEntry(newRow.id as string, {
         label: newRow.label as string,
         hoursPerWeek: Number(newRow.hoursPerWeek) || 0,
-        weeks: Number(newRow.weeks) || 0,
+        weeks: Math.max(0, clampedWeeks),
       });
 
-      return newRow;
+      return { ...newRow, weeks: Math.max(0, clampedWeeks) };
     },
-    [updateEntry],
+    [updateEntry, entries],
   );
 
   const dataWithTotal = useMemo(
@@ -225,8 +233,9 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
 
   return (
     <Box>
-      <Typography variant="h6" sx={{ mb: 2 }}>
-        {t('Hours Per Week Calculator')}
+      <Typography variant="h6">{t('Hours Per Week Calculator')}</Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        {t('Weeks are limited to 52 total to reflect a full calendar year.')}
       </Typography>
 
       <StyledCard>

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -89,6 +89,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         weeks: 48,
         canDelete: false,
         predefined: true,
+        position: 0,
       },
       {
         id: 'default-travel',
@@ -97,6 +98,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         weeks: 0,
         canDelete: false,
         predefined: true,
+        position: 1,
       },
       {
         id: 'default-vacation',
@@ -105,6 +107,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         weeks: 0,
         canDelete: false,
         predefined: true,
+        position: 2,
       },
     ];
   });
@@ -210,6 +213,10 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
     }
 
     const tempId = `temp-${nextEntryIdRef.current++}`;
+    const newPosition =
+      entries.length > 0
+        ? Math.max(...entries.map((e) => e.position)) + 1
+        : 0;
     const newEntry: HoursPerWeekEntry = {
       id: tempId,
       label: t('New Entry'),
@@ -217,6 +224,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
       weeks: 0,
       canDelete: true,
       predefined: false,
+      position: newPosition,
     };
     setEntries((prev) => [...prev, newEntry]);
 
@@ -229,7 +237,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
               label: t('New Entry'),
               hoursPerWeek: 0,
               numberOfWeeks: 0,
-              position: entries.length,
+              position: newPosition,
             },
           },
           refetchQueries: ['PdsGoalCalculation'],
@@ -317,6 +325,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         weeks: Math.max(0, clampedWeeks),
         canDelete: newRow.canDelete as boolean,
         predefined: newRow.predefined as boolean,
+        position: Number(newRow.position) || 0,
       };
 
       updateEntry(newRow.id as string, {
@@ -348,10 +357,13 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
 
   const dataWithTotal = useMemo(
     () => [
-      ...entries.map((entry) => ({
-        ...entry,
-        totalHours: entry.hoursPerWeek * entry.weeks,
-      })),
+      ...entries
+        .slice()
+        .sort((a, b) => a.position - b.position)
+        .map((entry) => ({
+          ...entry,
+          totalHours: entry.hoursPerWeek * entry.weeks,
+        })),
       {
         id: 'total',
         label: t('Total'),

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -1,7 +1,15 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { Box, Button, Card, Divider, Typography, styled } from '@mui/material';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  Divider,
+  Typography,
+  styled,
+} from '@mui/material';
 import {
   GridActionsCellItem,
   GridColDef,
@@ -111,6 +119,8 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
     () => (totalWeeks > 0 ? totalHours / totalWeeks : 0),
     [totalHours, totalWeeks],
   );
+
+  const weeksRemaining = MAX_TOTAL_WEEKS - totalWeeks;
 
   const saveHoursItem = useCallback(
     async (entry: HoursPerWeekEntry, currentEntries: HoursPerWeekEntry[]) => {
@@ -358,7 +368,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
     <Box>
       <Typography variant="h6">{t('Hours Per Week Calculator')}</Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        {t('Weeks are limited to 52 total to reflect a full calendar year.')}
+        {t('Weeks must add up to 52 to reflect a full calendar year.')}
       </Typography>
 
       <StyledCard>
@@ -411,10 +421,20 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         </FooterRow>
       </StyledCard>
 
+      {weeksRemaining > 0 && (
+        <Alert severity="warning" sx={{ mt: 1 }}>
+          {t('Weeks must add up to {{max}}. {{remaining}} week(s) remaining.', {
+            max: MAX_TOTAL_WEEKS,
+            remaining: weeksRemaining,
+          })}
+        </Alert>
+      )}
+
       {onApply && (
         <Box sx={{ mt: 2, display: 'flex', justifyContent: 'flex-end' }}>
           <Button
             variant="contained"
+            disabled={weeksRemaining > 0}
             onClick={() =>
               onApply(Math.round(averageHoursPerWeek * 10) / 10)
             }

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -214,9 +214,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
 
     const tempId = `temp-${nextEntryIdRef.current++}`;
     const newPosition =
-      entries.length > 0
-        ? Math.max(...entries.map((e) => e.position)) + 1
-        : 0;
+      entries.length > 0 ? Math.max(...entries.map((e) => e.position)) + 1 : 0;
     const newEntry: HoursPerWeekEntry = {
       id: tempId,
       label: t('New Entry'),

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import {

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -70,7 +70,10 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
     if (items && items.length > 0) {
       return items
         .slice()
-        .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+        .sort(
+          (hoursItemA, hoursItemB) =>
+            (hoursItemA.position ?? 0) - (hoursItemB.position ?? 0),
+        )
         .map((item) => ({
           id: item.id,
           label: item.label,
@@ -81,35 +84,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
           position: item.position ?? 0,
         }));
     }
-    return [
-      {
-        id: 'default-regular',
-        label: t('Regular Week'),
-        hoursPerWeek: 40,
-        weeks: 48,
-        canDelete: false,
-        predefined: true,
-        position: 0,
-      },
-      {
-        id: 'default-travel',
-        label: t('Travel'),
-        hoursPerWeek: 0,
-        weeks: 0,
-        canDelete: false,
-        predefined: true,
-        position: 1,
-      },
-      {
-        id: 'default-vacation',
-        label: t('Unpaid Vacation'),
-        hoursPerWeek: 0,
-        weeks: 0,
-        canDelete: false,
-        predefined: true,
-        position: 2,
-      },
-    ];
+    return [];
   });
   const nextEntryIdRef = useRef(0);
 
@@ -292,7 +267,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
           );
         }
         saveField({
-          averageHoursPerWeek: Math.round(newAverage * 10) / 10,
+          averageHoursPerWeek: newAverage,
         });
       } catch {
         setEntries(previousEntries);
@@ -335,8 +310,8 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
       await saveHoursItem(updatedEntry, entries);
 
       // Autosave the recalculated average to the calculation
-      const updatedEntries = entries.map((e) =>
-        e.id === updatedEntry.id ? updatedEntry : e,
+      const updatedEntries = entries.map((entry) =>
+        entry.id === updatedEntry.id ? updatedEntry : entry,
       );
       const newTotalWeeks = updatedEntries.reduce((sum, e) => sum + e.weeks, 0);
       const newTotalHours = updatedEntries.reduce(
@@ -345,7 +320,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
       );
       const newAverage = newTotalWeeks > 0 ? newTotalHours / newTotalWeeks : 0;
       saveField({
-        averageHoursPerWeek: Math.round(newAverage * 10) / 10,
+        averageHoursPerWeek: newAverage,
       });
 
       return { ...newRow, weeks: Math.max(0, clampedWeeks) };
@@ -445,7 +420,9 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
     <Box>
       <Typography variant="h6">{t('Hours Per Week Calculator')}</Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        {t('Weeks must add up to 52 to reflect a full calendar year.')}
+        {t(
+          'This calculator is based on a 52-week year. Weeks are capped at 52 and a warning will appear if the total falls short.',
+        )}
       </Typography>
 
       <StyledCard>
@@ -521,7 +498,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
           <Button
             variant="contained"
             disabled={weeksRemaining > 0}
-            onClick={() => onApply(Math.round(averageHoursPerWeek * 10) / 10)}
+            onClick={() => onApply(averageHoursPerWeek)}
           >
             {t('Apply to Hours Worked')}
           </Button>

--- a/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next';
 import { BaseGrid } from 'src/components/Reports/GoalCalculator/SharedComponents/GoalCalculatorGrid/BaseGrid';
 import {
   useCreateDesignationSupportHoursItemMutation,
+  useDeleteDesignationSupportHoursItemMutation,
   useUpdateDesignationSupportHoursItemMutation,
 } from '../../GoalsList/PdsGoalCalculations.generated';
 import { useSaveField } from '../../Shared/Autosave/useSaveField';
@@ -58,6 +59,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
   const { calculation, trackMutation } = usePdsGoalCalculator();
   const [createHoursItem] = useCreateDesignationSupportHoursItemMutation();
   const [updateHoursItem] = useUpdateDesignationSupportHoursItemMutation();
+  const [deleteHoursItem] = useDeleteDesignationSupportHoursItemMutation();
   const saveField = useSaveField();
 
   const [entries, setEntries] = useState<HoursPerWeekEntry[]>(() => {
@@ -223,9 +225,40 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
     }
   }, [t, calculation, createHoursItem, trackMutation, entries.length]);
 
-  const deleteEntry = useCallback((id: string | number) => {
-    setEntries((prev) => prev.filter((entry) => entry.id !== id.toString()));
-  }, []);
+  const deleteEntry = useCallback(
+    async (id: string | number) => {
+      const entryId = id.toString();
+      const remainingEntries = entries.filter(
+        (entry) => entry.id !== entryId,
+      );
+      setEntries(remainingEntries);
+
+      // Recalculate and autosave the average
+      const newTotalWeeks = remainingEntries.reduce(
+        (sum, e) => sum + e.weeks,
+        0,
+      );
+      const newTotalHours = remainingEntries.reduce(
+        (sum, e) => sum + e.hoursPerWeek * e.weeks,
+        0,
+      );
+      const newAverage =
+        newTotalWeeks > 0 ? newTotalHours / newTotalWeeks : 0;
+      saveField({
+        averageHoursPerWeek: Math.round(newAverage * 10) / 10,
+      });
+
+      if (!entryId.startsWith('temp-') && !entryId.startsWith('default-')) {
+        await trackMutation(
+          deleteHoursItem({
+            variables: { id: entryId },
+            refetchQueries: ['PdsGoalCalculation'],
+          }),
+        );
+      }
+    },
+    [entries, deleteHoursItem, trackMutation, saveField],
+  );
 
   const processRowUpdate = useCallback(
     (newRow: GridValidRowModel) => {

--- a/src/components/Reports/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/Reports/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -83,10 +83,8 @@ export const SetupStep: React.FC = () => {
   const handleOpenHoursCalculator = () => {
     setRightPanelContent(
       <HoursPerWeekGrid
-        onAverageHoursChange={(average) => {
-          saveField({
-            hoursWorkedPerWeek: Math.round(average * 10) / 10,
-          });
+        onApply={(average) => {
+          saveField({ hoursWorkedPerWeek: average });
         }}
       />,
     );

--- a/src/components/Reports/PdsGoalCalculator/Shared/Autosave/useSaveField.ts
+++ b/src/components/Reports/PdsGoalCalculator/Shared/Autosave/useSaveField.ts
@@ -1,4 +1,6 @@
 import { useCallback } from 'react';
+import { useSnackbar } from 'notistack';
+import { useTranslation } from 'react-i18next';
 import { usePdsGoalCalculator } from 'src/components/Reports/PdsGoalCalculator/Shared/PdsGoalCalculatorContext';
 import { DesignationSupportCalculationUpdateInput } from 'src/graphql/types.generated';
 import { useUpdatePdsGoalCalculationMutation } from '../../GoalsList/PdsGoalCalculations.generated';
@@ -6,6 +8,8 @@ import { useUpdatePdsGoalCalculationMutation } from '../../GoalsList/PdsGoalCalc
 export const useSaveField = () => {
   const { calculation, trackMutation } = usePdsGoalCalculator();
   const [updatePdsGoalCalculation] = useUpdatePdsGoalCalculationMutation();
+  const { enqueueSnackbar } = useSnackbar();
+  const { t } = useTranslation();
 
   const saveField = useCallback(
     async (attributes: Partial<DesignationSupportCalculationUpdateInput>) => {
@@ -20,28 +24,35 @@ export const useSaveField = () => {
         return;
       }
 
-      return trackMutation(
-        updatePdsGoalCalculation({
-          variables: {
-            attributes: {
-              id: calculation.id,
-              ...attributes,
-            },
-          },
-          optimisticResponse: {
-            updateDesignationSupportCalculation: {
-              __typename: 'DesignationSupportCalculationUpdateMutationPayload',
-              designationSupportCalculation: {
-                __typename: 'DesignationSupportCalculation',
-                ...calculation,
+      try {
+        return await trackMutation(
+          updatePdsGoalCalculation({
+            variables: {
+              attributes: {
+                id: calculation.id,
                 ...attributes,
               },
             },
-          },
-        }),
-      );
+            optimisticResponse: {
+              updateDesignationSupportCalculation: {
+                __typename:
+                  'DesignationSupportCalculationUpdateMutationPayload',
+                designationSupportCalculation: {
+                  __typename: 'DesignationSupportCalculation',
+                  ...calculation,
+                  ...attributes,
+                },
+              },
+            },
+          }),
+        );
+      } catch {
+        enqueueSnackbar(t('Failed to save changes. Please try again.'), {
+          variant: 'error',
+        });
+      }
     },
-    [calculation, trackMutation, updatePdsGoalCalculation],
+    [calculation, trackMutation, updatePdsGoalCalculation, enqueueSnackbar, t],
   );
 
   return saveField;


### PR DESCRIPTION
## Description

- Wire up the Hours Per Week calculator grid to persist data via `designationSupportHoursItems` GraphQL mutations
- Add `CreateDesignationSupportHoursItem` and `UpdateDesignationSupportHoursItem` mutations to `PdsGoalCalculations.graphql`
- Initialize the grid from server data (`calculation.designationSupportHoursItems`) when available, falling back to hardcoded defaults for new calculations
- Autosave individual hours items on cell edit (create for new/default items, update for existing)
- Autosave the recalculated `averageHoursPerWeek` to the calculation on every edit
- Add an "Apply to Hours Worked" button so users can explicitly push the average into the `hoursWorkedPerWeek` field, decoupling the calculator from the hours worked input
- Update tests to use `PdsGoalCalculatorTestWrapper` with proper GraphQL mocks

Related Jira ticket: [MPDX-9369](https://jira.cru.org/browse/MPDX-9369)

## Testing

- Go to a PDS Goal Calculator
- Open the Hours Per Week calculator from the Setup step (click the calculator icon next to "Hours Worked")
- Edit hours/weeks values in the grid and verify the average updates
- Reload the page and reopen the calculator — verify the edited values persisted
- Add a new entry, edit it, and verify it persists after reload
- Click "Apply to Hours Worked" and verify the Hours Worked field updates
- Verify that editing the Hours Worked field directly still works independently of the calculator

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history