### PR TITLE
MPDX-9433 frontend - MHI Eligibility UI improvements

### DIFF
--- a/src/components/HrTools/MinisterHousingAllowance/MinisterHousingAllowance.test.tsx
+++ b/src/components/HrTools/MinisterHousingAllowance/MinisterHousingAllowance.test.tsx
@@ -15,6 +15,7 @@ import {
   marriedUserEligibleSpouseIneligible,
   marriedUserIneligibleSpouseEligible,
   singleIneligible,
+  singleItalianMhiEligible,
   singleMhaNoException,
   singleNoMhaNoException,
 } from '../Shared/HcmData/mockData';
@@ -142,6 +143,31 @@ describe('MinisterHousingAllowanceReport', () => {
     expect(await findByText('John Doe')).toBeInTheDocument();
 
     expect(getByText('Current Board Approved MHA')).toBeInTheDocument();
+  });
+
+  // Italian staff are intentionally blocked from the online MHA flow: they
+  // apply for MHI via a paper form. The report should show MHA: Ineligible /
+  // MHI: Eligible and hide the "Request New MHA" button.
+  it('renders Italian MHI-eligible user as MHA-ineligible with paper-form note', async () => {
+    const { findByText, findByTestId, queryByRole } = render(
+      <TestComponent hcmMock={singleItalianMhiEligible} mhaRequestsMock={[]} />,
+    );
+
+    expect(
+      await findByText('MHA & MHI Eligibility Status'),
+    ).toBeInTheDocument();
+    expect(await findByTestId('mhi-paper-form-note')).toBeInTheDocument();
+    expect(
+      await findByText('Must complete an MHI form instead'),
+    ).toBeInTheDocument();
+    expect(
+      await findByText('Satisfies the IBS Exception for Italy staff'),
+    ).toBeInTheDocument();
+
+    // Italian users cannot create an online MHA request from this page.
+    expect(
+      queryByRole('button', { name: 'Request New MHA' }),
+    ).not.toBeInTheDocument();
   });
 
   it('renders fully ineligible single user with requests and hides request details', async () => {

--- a/src/components/HrTools/MinisterHousingAllowance/MinisterHousingAllowance.tsx
+++ b/src/components/HrTools/MinisterHousingAllowance/MinisterHousingAllowance.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { EligibilityStatusTable } from 'src/components/HrTools/Shared/EligibilityStatusTable/EligibilityStatusTable';
 import Loading from 'src/components/Loading/Loading';
 import { Notification } from 'src/components/Notification/Notification';
+import { getMhiEligibility } from 'src/components/Reports/Shared/HousingAllowance/housingAllowance';
 import { MhaStatusEnum } from 'src/graphql/types.generated';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import theme from 'src/theme';
@@ -50,10 +51,10 @@ export const MinisterHousingAllowanceReport = () => {
     spouseHcmData,
   } = useMinisterHousingAllowance();
 
-  const personNumber = userHcmData?.staffInfo?.personNumber ?? '';
-  const spousePersonNumber = spouseHcmData?.staffInfo?.personNumber ?? '';
-  const lastName = userHcmData?.staffInfo?.lastName ?? '';
-  const spouseLastName = spouseHcmData?.staffInfo?.lastName ?? '';
+  const personNumber = userHcmData?.staffInfo.personNumber ?? '';
+  const spousePersonNumber = spouseHcmData?.staffInfo.personNumber ?? '';
+  const lastName = userHcmData?.staffInfo.lastName ?? '';
+  const spouseLastName = spouseHcmData?.staffInfo.lastName ?? '';
 
   const names = isMarried
     ? `${preferredName} ${lastName} and ${spousePreferredName} ${spouseLastName}`
@@ -164,7 +165,7 @@ export const MinisterHousingAllowanceReport = () => {
                         userPreferredName={preferredName}
                         userEligible={userEligibleForMHA}
                         userCountry={
-                          userHcmData?.staffInfo?.country ?? undefined
+                          userHcmData?.staffInfo.country ?? undefined
                         }
                         spousePreferredName={
                           isMarried ? spousePreferredName : undefined
@@ -174,7 +175,13 @@ export const MinisterHousingAllowanceReport = () => {
                         }
                         spouseCountry={
                           isMarried
-                            ? (spouseHcmData?.staffInfo?.country ?? undefined)
+                            ? (spouseHcmData?.staffInfo.country ?? undefined)
+                            : undefined
+                        }
+                        userMhiEligibility={getMhiEligibility(userHcmData)}
+                        spouseMhiEligibility={
+                          isMarried
+                            ? getMhiEligibility(spouseHcmData)
                             : undefined
                         }
                       />

--- a/src/components/HrTools/MinisterHousingAllowance/Shared/Context/MinisterHousingAllowanceContext.tsx
+++ b/src/components/HrTools/MinisterHousingAllowance/Shared/Context/MinisterHousingAllowanceContext.tsx
@@ -48,8 +48,8 @@ export type ContextType = {
   setIsDrawerOpen: Dispatch<SetStateAction<boolean>>;
   setIsComplete: Dispatch<SetStateAction<boolean>>;
   isMarried: boolean;
-  userHcmData?: HcmData;
-  spouseHcmData?: HcmData | null;
+  userHcmData: HcmData | null;
+  spouseHcmData: HcmData | null;
   preferredName: string;
   spousePreferredName: string;
   userEligibleForMHA: boolean;
@@ -168,13 +168,13 @@ export const MinisterHousingAllowanceProvider: React.FC<Props> = ({
 
   const { data: hcmData } = useHcmQuery();
 
-  const [userHcmData, setUserHcmData] = useState<HcmData>();
+  const [userHcmData, setUserHcmData] = useState<HcmData | null>(null);
   const [spouseHcmData, setSpouseHcmData] = useState<HcmData | null>(null);
   const [isMarried, setIsMarried] = useState(false);
 
   useEffect(() => {
     if (!hcmData?.hcm?.length) {
-      setUserHcmData(undefined);
+      setUserHcmData(null);
       setSpouseHcmData(null);
       setIsMarried(false);
       return;

--- a/src/components/HrTools/MinisterHousingAllowance/Steps/StepThree/Calculation.test.tsx
+++ b/src/components/HrTools/MinisterHousingAllowance/Steps/StepThree/Calculation.test.tsx
@@ -47,6 +47,8 @@ const defaultContext: ContextType = {
   setIsDrawerOpen: jest.fn(),
   setIsComplete: jest.fn(),
   isMarried: false,
+  userHcmData: null,
+  spouseHcmData: null,
   preferredName: '',
   spousePreferredName: '',
   userEligibleForMHA: false,

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculatorTestWrapper.tsx
@@ -50,6 +50,9 @@ const hcmMock = gqlMock<HcmQuery, HcmQueryVariables>(HcmDocument, {
         mhaEit: {
           mhaEligibility: true,
         },
+        mhiEit: {
+          mhiEligibility: false,
+        },
         exceptionSalaryCap: {
           boardCapException: false,
         },
@@ -74,6 +77,9 @@ const hcmMock = gqlMock<HcmQuery, HcmQueryVariables>(HcmDocument, {
         },
         mhaEit: {
           mhaEligibility: true,
+        },
+        mhiEit: {
+          mhiEligibility: false,
         },
         exceptionSalaryCap: {
           boardCapException: false,

--- a/src/components/HrTools/SalaryCalculator/YourInformation/MhaRequestSection/MhaRequestSection.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/YourInformation/MhaRequestSection/MhaRequestSection.test.tsx
@@ -127,4 +127,59 @@ describe('MhaRequestSection', () => {
       expect(queryByTestId('no-mha-submit-message')).not.toBeInTheDocument();
     });
   });
+
+  describe('MHI labeling for Italian users', () => {
+    const italianUser = {
+      staffInfo: { country: 'IT' },
+      mhaEit: { mhaEligibility: false },
+      mhiEit: { mhiEligibility: true },
+    };
+
+    it('renders MHI field labels when user is from Italy', async () => {
+      const { findByRole } = render(
+        <TestComponent hcmUser={italianUser} hasSpouse={false} />,
+      );
+
+      expect(
+        await findByRole('textbox', { name: 'Current MHI' }),
+      ).toBeInTheDocument();
+      expect(
+        await findByRole('textbox', { name: 'New Requested MHI' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders MHI-labeled submit message when Italian user has no approved amount', async () => {
+      const { findByTestId } = render(
+        <TestComponent
+          hcmUser={{
+            ...italianUser,
+            mhaRequest: { currentApprovedOverallAmount: 0 },
+          }}
+          hasSpouse={false}
+        />,
+      );
+
+      const message = await findByTestId('no-mha-submit-message');
+      expect(message).toHaveTextContent(/have an MHI for the effective date/);
+      expect(message).toHaveTextContent(
+        /To apply for MHI, contact Personnel Records/,
+      );
+      expect(message).toHaveTextContent('MHA@cru.org');
+    });
+
+    // Covers the `showSpouseFields && !showUserFields ? spouseKind : userKind`
+    // fallback at MhaRequestSection.tsx:75-76 — if only the Italian spouse's
+    // field renders, the section copy should follow the spouse's (MHI) kind.
+    it('uses MHI wording when only the Italian spouse field renders (mixed couple)', async () => {
+      const { findByText, queryByText } = render(
+        <TestComponent
+          hcmUser={{ mhaEit: { mhaEligibility: false } }}
+          hcmSpouse={italianUser}
+        />,
+      );
+
+      expect(await findByText('MHI Request')).toBeInTheDocument();
+      expect(queryByText('MHA Request')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/HrTools/SalaryCalculator/YourInformation/MhaRequestSection/MhaRequestSection.tsx
+++ b/src/components/HrTools/SalaryCalculator/YourInformation/MhaRequestSection/MhaRequestSection.tsx
@@ -61,9 +61,45 @@ export const MhaRequestSection: React.FC = () => {
     spouseEligible,
     userCountry,
     spouseCountry,
+    userKind,
+    spouseKind,
+    userMhiEligibility,
+    spouseMhiEligibility,
     anyIneligible,
     hasSpouse,
   } = useMhaRequestData();
+
+  // Section-level copy follows the primary user's kind, except when only the
+  // spouse's fields show — then it follows the spouse's kind so an MHI-only
+  // spouse on a mixed-country couple gets MHI wording.
+  const sectionKind =
+    showSpouseFields && !showUserFields ? spouseKind : userKind;
+
+  const boardApprovedText = () => {
+    if (showUserFields && showSpouseFields) {
+      return t(
+        'You may request up to your Board-approved {{sectionKind}} amount of {{approvedAmount}} combined.',
+        { sectionKind, approvedAmount },
+      );
+    }
+    if (showSpouseFields) {
+      return t(
+        '{{name}} may request up to their Board Approved {{sectionKind}} Amount of {{approvedAmount}}.',
+        { name: spousePreferredName, sectionKind, approvedAmount },
+      );
+    }
+    return t(
+      'You may request up to your Board Approved {{sectionKind}} Amount of {{approvedAmount}}.',
+      { sectionKind, approvedAmount },
+    );
+  };
+
+  const progressHeaderText = () => {
+    if (showUserFields && showSpouseFields) {
+      return t('Combined {{sectionKind}} Requested', { sectionKind });
+    }
+    return t('New {{sectionKind}} Requested', { sectionKind });
+  };
 
   return (
     <StepCard
@@ -73,16 +109,21 @@ export const MhaRequestSection: React.FC = () => {
         },
       }}
     >
-      <CardHeader title={t('MHA Request')} subheader={<EffectiveDateNote />} />
+      <CardHeader
+        title={t('{{sectionKind}} Request', { sectionKind })}
+        subheader={<EffectiveDateNote />}
+      />
       <CardContent>
         {anyIneligible && (
           <EligibilityStatusTable
             userPreferredName={userPreferredName}
             userEligible={userEligible}
             userCountry={userCountry}
+            userMhiEligibility={userMhiEligibility}
             spousePreferredName={hasSpouse ? spousePreferredName : undefined}
             spouseEligible={hasSpouse ? spouseEligible : undefined}
             spouseCountry={hasSpouse ? spouseCountry : undefined}
+            spouseMhiEligibility={hasSpouse ? spouseMhiEligibility : undefined}
             compact
           />
         )}
@@ -93,53 +134,49 @@ export const MhaRequestSection: React.FC = () => {
             sx={{ marginBottom: theme.spacing(2) }}
             data-testid="no-mha-submit-message"
           >
-            <Trans t={t}>
-              Our records show that not all staff have a Minister&apos;s Housing
-              Allowance for the effective date of this salary calculation. If an
-              MHA Request form has not yet been submitted, it may be completed
-              using{' '}
-              <Link
-                href={`/accountLists/${accountListId}/hrTools/mhaCalculator`}
-              >
-                this link
-              </Link>
-              . Pending MHA Requests will not apply to this salary calculation
-              but a new Salary Calculation Form can be submitted after approval.
-            </Trans>
+            {sectionKind === 'MHI' ? (
+              <Trans t={t}>
+                Our records show that not all staff have an MHI for the
+                effective date of this salary calculation. To apply for MHI,
+                contact Personnel Records at{' '}
+                <a href="tel:4078262230">(407) 826-2230</a> or{' '}
+                <a href="mailto:MHA@cru.org">MHA@cru.org</a>. Pending MHI
+                Requests will not apply to this salary calculation but a new
+                Salary Calculation Form can be submitted after approval.
+              </Trans>
+            ) : (
+              <Trans t={t}>
+                Our records show that not all staff have a Minister&apos;s
+                Housing Allowance for the effective date of this salary
+                calculation. If an MHA Request form has not yet been submitted,
+                it may be completed using{' '}
+                <Link
+                  href={`/accountLists/${accountListId}/hrTools/mhaCalculator`}
+                >
+                  this link
+                </Link>
+                . Pending MHA Requests will not apply to this salary calculation
+                but a new Salary Calculation Form can be submitted after
+                approval.
+              </Trans>
+            )}
           </Typography>
         )}
 
         {(showUserFields || showSpouseFields) && (
           <>
             <Typography variant="body1" data-testid="board-approved-amount">
-              <strong>
-                {showUserFields && showSpouseFields
-                  ? t(
-                      'You may request up to your Board-approved MHA amount of {{approvedAmount}} combined.',
-                      { approvedAmount },
-                    )
-                  : showSpouseFields
-                    ? t(
-                        '{{name}} may request up to their Board Approved MHA Amount of {{approvedAmount}}.',
-                        { name: spousePreferredName, approvedAmount },
-                      )
-                    : t(
-                        'You may request up to your Board Approved MHA Amount of {{approvedAmount}}.',
-                        { approvedAmount },
-                      )}
-              </strong>{' '}
+              <strong>{boardApprovedText()}</strong>{' '}
               <Trans t={t}>
                 This is the amount you are approved for as of the effective date
                 of this salary calculation.
               </Trans>
             </Typography>
             <Typography variant="body1">
-              <Trans t={t}>
-                Please enter the amount of your salary you would like to request
-                as MHA below. If you have a pending MHA Request for a new
-                amount, it will not apply to this salary calculation but you can
-                submit a new Salary Calculation Form after it is approved.
-              </Trans>
+              {t(
+                'Please enter the amount of your salary you would like to request as {{sectionKind}} below. If you have a pending {{sectionKind}} Request for a new amount, it will not apply to this salary calculation but you can submit a new Salary Calculation Form after it is approved.',
+                { sectionKind },
+              )}
             </Typography>
           </>
         )}
@@ -166,7 +203,7 @@ export const MhaRequestSection: React.FC = () => {
               <SpouseLayout>
                 {showUserFields && (
                   <TextField
-                    label={t('Current MHA')}
+                    label={t('Current {{kind}}', { kind: userKind })}
                     size="small"
                     fullWidth
                     value={currentTakenAmount}
@@ -176,7 +213,7 @@ export const MhaRequestSection: React.FC = () => {
                 )}
                 {showSpouseFields && (
                   <TextField
-                    label={t('Current MHA')}
+                    label={t('Current {{kind}}', { kind: spouseKind })}
                     size="small"
                     fullWidth
                     value={currentSpouseTakenAmount}
@@ -188,7 +225,7 @@ export const MhaRequestSection: React.FC = () => {
               <SpouseLayout>
                 {showUserFields && (
                   <AutosaveTextField
-                    label={t('New Requested MHA')}
+                    label={t('New Requested {{kind}}', { kind: userKind })}
                     fieldName="mhaAmount"
                     schema={schema}
                     required
@@ -196,7 +233,7 @@ export const MhaRequestSection: React.FC = () => {
                 )}
                 {showSpouseFields && (
                   <AutosaveTextField
-                    label={t('New Requested MHA')}
+                    label={t('New Requested {{kind}}', { kind: spouseKind })}
                     fieldName="spouseMhaAmount"
                     schema={schema}
                     required
@@ -207,11 +244,7 @@ export const MhaRequestSection: React.FC = () => {
 
             <Box>
               <StyledProgressHeaderBox>
-                <Typography variant="body2">
-                  {showUserFields && showSpouseFields
-                    ? t('Combined MHA Requested')
-                    : t('New MHA Requested')}
-                </Typography>
+                <Typography variant="body2">{progressHeaderText()}</Typography>
                 <Typography variant="body2">
                   {totalRequestedMhaValue} / {approvedAmount}
                 </Typography>
@@ -223,7 +256,9 @@ export const MhaRequestSection: React.FC = () => {
               />
               <StyledRemainingBox>
                 <Typography variant="body2" color="textSecondary">
-                  {t('Remaining in approved MHA Amount')}
+                  {t('Remaining in approved {{sectionKind}} Amount', {
+                    sectionKind,
+                  })}
                 </Typography>
                 <Typography variant="body2" color="textSecondary">
                   {difference}

--- a/src/components/HrTools/SalaryCalculator/YourInformation/MhaRequestSection/useMhaRequestData.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/YourInformation/MhaRequestSection/useMhaRequestData.test.tsx
@@ -223,4 +223,79 @@ describe('useMhaRequestData', () => {
     expect(result.current.showUserFields).toBe(false);
     expect(result.current.showSpouseFields).toBe(false);
   });
+
+  it('treats Italian user as MHI-eligible via effective eligibility', async () => {
+    const { result } = renderHook(() => useMhaRequestData(), {
+      wrapper: createWrapper({
+        hcmUser: {
+          staffInfo: { country: 'IT' },
+          mhaEit: { mhaEligibility: false },
+          mhiEit: { mhiEligibility: true },
+        },
+        hasSpouse: false,
+      }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.userKind).toBe('MHI');
+    });
+
+    expect(result.current.userMhiEligibility).toBe(true);
+    expect(result.current.userEligible).toBe(true);
+  });
+
+  it('uses MHI wording in single-max validation for Italian user', async () => {
+    const { result } = renderHook(() => useMhaRequestData(), {
+      wrapper: createWrapper({
+        hcmUser: {
+          staffInfo: { country: 'IT' },
+          mhaEit: { mhaEligibility: false },
+          mhiEit: { mhiEligibility: true },
+        },
+        hasSpouse: false,
+        salaryRequestMock: { mhaAmount: 25000 },
+      }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.approvedAmount).toBe('$20,000');
+    });
+
+    await expect(
+      result.current.schema.validate({
+        mhaAmount: 25000,
+        spouseMhaAmount: 0,
+      }),
+    ).rejects.toThrow(
+      'New Requested MHI cannot exceed Board Approved MHI Amount of $20,000',
+    );
+  });
+
+  it('uses the correct kind in combined-max validation for a mixed US/IT couple', async () => {
+    const { result } = renderHook(() => useMhaRequestData(), {
+      wrapper: createWrapper({
+        hcmUser: {
+          staffInfo: { country: 'US' },
+          mhaEit: { mhaEligibility: true },
+        },
+        hcmSpouse: {
+          staffInfo: { country: 'IT' },
+          mhaEit: { mhaEligibility: false },
+          mhiEit: { mhiEligibility: true },
+        },
+        salaryRequestMock: { mhaAmount: 12000, spouseMhaAmount: 12000 },
+      }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.approvedAmount).toBe('$20,000');
+    });
+
+    await expect(
+      result.current.schema.validate({
+        mhaAmount: 12000,
+        spouseMhaAmount: 12000,
+      }),
+    ).rejects.toThrow(/Combined MHA amounts cannot exceed/);
+  });
 });

--- a/src/components/HrTools/SalaryCalculator/YourInformation/MhaRequestSection/useMhaRequestData.ts
+++ b/src/components/HrTools/SalaryCalculator/YourInformation/MhaRequestSection/useMhaRequestData.ts
@@ -1,6 +1,11 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import {
+  getEffectiveEligibility,
+  getHousingKind,
+  getMhiEligibility,
+} from 'src/components/Reports/Shared/HousingAllowance/housingAllowance';
 import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat } from 'src/lib/intlFormat';
 import { amount } from 'src/lib/yupHelpers';
@@ -11,11 +16,10 @@ export const useMhaRequestData = () => {
   const locale = useLocale();
   const { calculation, hcmUser, hcmSpouse, hasSpouse } = useSalaryCalculator();
 
-  // User MHA eligibility and request status
-  const userEligible = hcmUser?.mhaEit.mhaEligibility ?? false;
+  // Effective eligibility: MHI flag for Italian staff, MHA flag otherwise.
+  const userEligible = getEffectiveEligibility(hcmUser);
   const userHasApprovedMha = !!hcmUser?.mhaRequest.currentApprovedOverallAmount;
-  const spouseEligible =
-    hasSpouse && (hcmSpouse?.mhaEit.mhaEligibility ?? false);
+  const spouseEligible = hasSpouse && getEffectiveEligibility(hcmSpouse);
   const spouseHasApprovedMha =
     !!hcmSpouse?.mhaRequest.currentApprovedOverallAmount;
   // Determine which fields should be shown
@@ -25,9 +29,12 @@ export const useMhaRequestData = () => {
   const userPreferredName = hcmUser?.staffInfo.preferredName ?? '';
   const spousePreferredName = hcmSpouse?.staffInfo.preferredName ?? '';
 
-  // Users from Italy apply for an MHI, and are ineligible
   const userCountry = hcmUser?.staffInfo.country ?? null;
   const spouseCountry = hcmSpouse?.staffInfo.country ?? null;
+  const userKind = getHousingKind(userCountry);
+  const spouseKind = getHousingKind(spouseCountry);
+  const userMhiEligibility = getMhiEligibility(hcmUser);
+  const spouseMhiEligibility = getMhiEligibility(hcmSpouse);
 
   const anyIneligible = !userEligible || (hasSpouse && !spouseEligible);
 
@@ -36,6 +43,10 @@ export const useMhaRequestData = () => {
     (userEligible && !userHasApprovedMha) ||
     (spouseEligible && !spouseHasApprovedMha);
 
+  // For Italian (MHI) staff the backend stores the approved MHI amount in
+  // `mhaRequest.currentApprovedOverallAmount` — there is no separate
+  // `mhiRequest` field. This one value is the approved amount for whichever
+  // kind (MHA or MHI) applies to the person.
   const approvedAmount = userHasApprovedMha
     ? (hcmUser?.mhaRequest.currentApprovedOverallAmount ?? 0)
     : (hcmSpouse?.mhaRequest.currentApprovedOverallAmount ?? 0);
@@ -45,39 +56,53 @@ export const useMhaRequestData = () => {
     [approvedAmount, locale],
   );
 
+  // Validation messages follow the same per-kind labeling as the UI.
+  const sectionKind =
+    showSpouseFields && !showUserFields ? spouseKind : userKind;
+
   const schema = useMemo(() => {
     const combinedMaxMessage = t(
-      'Combined MHA amounts cannot exceed Board Approved MHA Amount of {{amount}}',
-      { amount: approvedAmountFormatted },
+      'Combined {{kind}} amounts cannot exceed Board Approved {{kind}} Amount of {{amount}}',
+      { kind: sectionKind, amount: approvedAmountFormatted },
     );
-    const singleMaxMessage = t(
-      'New Requested MHA cannot exceed Board Approved MHA Amount of {{amount}}',
-      { amount: approvedAmountFormatted },
+    const userSingleMaxMessage = t(
+      'New Requested {{kind}} cannot exceed Board Approved {{kind}} Amount of {{amount}}',
+      { kind: userKind, amount: approvedAmountFormatted },
+    );
+    const spouseSingleMaxMessage = t(
+      'New Requested {{kind}} cannot exceed Board Approved {{kind}} Amount of {{amount}}',
+      { kind: spouseKind, amount: approvedAmountFormatted },
     );
 
-    let mhaAmountField = amount(t('New Requested MHA'), t, {
-      max: approvedAmount,
-      maxMessage: singleMaxMessage,
-    });
-    let spouseMhaAmountField = amount(t('Spouse New Requested MHA'), t, {
-      max: approvedAmount,
-      maxMessage: singleMaxMessage,
-    });
+    const mhaAmountBase = amount(
+      t('New Requested {{kind}}', { kind: userKind }),
+      t,
+      { max: approvedAmount, maxMessage: userSingleMaxMessage },
+    );
+    const spouseMhaAmountBase = amount(
+      t('Spouse New Requested {{kind}}', { kind: spouseKind }),
+      t,
+      { max: approvedAmount, maxMessage: spouseSingleMaxMessage },
+    );
 
-    if (showUserFields && showSpouseFields) {
-      mhaAmountField = mhaAmountField.test(
-        'combined-max',
-        combinedMaxMessage,
-        (value) =>
-          (value ?? 0) + (calculation?.spouseMhaAmount ?? 0) <= approvedAmount,
-      );
-      spouseMhaAmountField = spouseMhaAmountField.test(
-        'combined-max',
-        combinedMaxMessage,
-        (value) =>
-          (value ?? 0) + (calculation?.mhaAmount ?? 0) <= approvedAmount,
-      );
-    }
+    const applyCombinedMax = showUserFields && showSpouseFields;
+    const mhaAmountField = applyCombinedMax
+      ? mhaAmountBase.test(
+          'combined-max',
+          combinedMaxMessage,
+          (value) =>
+            (value ?? 0) + (calculation?.spouseMhaAmount ?? 0) <=
+            approvedAmount,
+        )
+      : mhaAmountBase;
+    const spouseMhaAmountField = applyCombinedMax
+      ? spouseMhaAmountBase.test(
+          'combined-max',
+          combinedMaxMessage,
+          (value) =>
+            (value ?? 0) + (calculation?.mhaAmount ?? 0) <= approvedAmount,
+        )
+      : spouseMhaAmountBase;
 
     return yup.object({
       mhaAmount: mhaAmountField,
@@ -89,6 +114,9 @@ export const useMhaRequestData = () => {
     approvedAmountFormatted,
     showUserFields,
     showSpouseFields,
+    userKind,
+    spouseKind,
+    sectionKind,
     calculation?.mhaAmount,
     calculation?.spouseMhaAmount,
   ]);
@@ -156,6 +184,10 @@ export const useMhaRequestData = () => {
     spouseEligible,
     userCountry,
     spouseCountry,
+    userKind,
+    spouseKind,
+    userMhiEligibility,
+    spouseMhiEligibility,
     anyIneligible,
     hasSpouse,
   };

--- a/src/components/HrTools/Shared/EligibilityStatusTable/EligibilityStatusTable.test.tsx
+++ b/src/components/HrTools/Shared/EligibilityStatusTable/EligibilityStatusTable.test.tsx
@@ -166,4 +166,113 @@ describe('EligibilityStatusTable', () => {
       queryByRole('columnheader', { name: 'Jane' }),
     ).not.toBeInTheDocument();
   });
+
+  it('renders MHI rows and renames MHA rows when country is Italy', () => {
+    const { getByRole } = render(
+      <EligibilityStatusTable
+        userPreferredName="Marco"
+        userEligible={false}
+        userCountry="IT"
+        userMhiEligibility={true}
+      />,
+    );
+
+    expect(getByRole('cell', { name: 'MHA Eligibility' })).toBeInTheDocument();
+    expect(getByRole('cell', { name: 'MHA Reason' })).toBeInTheDocument();
+    expect(getByRole('cell', { name: 'MHI Eligibility' })).toBeInTheDocument();
+    expect(getByRole('cell', { name: 'MHI Reason' })).toBeInTheDocument();
+    expect(
+      getByRole('cell', {
+        name: 'Satisfies the IBS Exception for Italy staff',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows "N/A" in MHI cells for non-Italian spouse in mixed couple', () => {
+    const { getAllByRole } = render(
+      <EligibilityStatusTable
+        userPreferredName="Marco"
+        userEligible={false}
+        userCountry="IT"
+        userMhiEligibility={true}
+        spousePreferredName="Jane"
+        spouseEligible={true}
+        spouseCountry="US"
+      />,
+    );
+
+    expect(getAllByRole('cell', { name: 'Not applicable' })).toHaveLength(2);
+  });
+
+  it('shows "Does not satisfy" MHI reason when Italian user is MHI-ineligible', () => {
+    const { getByRole } = render(
+      <EligibilityStatusTable
+        userPreferredName="Marco"
+        userEligible={false}
+        userCountry="IT"
+        userMhiEligibility={false}
+      />,
+    );
+
+    expect(
+      getByRole('cell', {
+        name: 'Does not satisfy the IBS Exception for Italy staff',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders "MHA & MHI Eligibility Status" card title and paper-form note for Italian user', () => {
+    const { getByText, getByTestId } = render(
+      <EligibilityStatusTable
+        userPreferredName="Marco"
+        userEligible={false}
+        userCountry="IT"
+        userMhiEligibility={true}
+      />,
+    );
+
+    expect(getByText('MHA & MHI Eligibility Status')).toBeInTheDocument();
+    expect(getByTestId('mhi-paper-form-note')).toBeInTheDocument();
+  });
+
+  it('renders MHA-only card title and no paper-form note for non-Italian user', () => {
+    const { getByText, queryByTestId } = render(
+      <EligibilityStatusTable
+        userPreferredName="John"
+        userEligible={true}
+        userCountry="US"
+      />,
+    );
+
+    expect(getByText('MHA Eligibility Status')).toBeInTheDocument();
+    expect(queryByTestId('mhi-paper-form-note')).not.toBeInTheDocument();
+  });
+
+  it('renders MHI cells for both spouses when both are Italian', () => {
+    const { queryAllByRole } = render(
+      <EligibilityStatusTable
+        userPreferredName="Marco"
+        userEligible={false}
+        userCountry="IT"
+        userMhiEligibility={true}
+        spousePreferredName="Giulia"
+        spouseEligible={false}
+        spouseCountry="IT"
+        spouseMhiEligibility={false}
+      />,
+    );
+
+    // No "Not applicable" cells — every MHI cell has a real value because both are Italian.
+    expect(queryAllByRole('cell', { name: 'Not applicable' })).toHaveLength(0);
+    expect(
+      queryAllByRole('cell', {
+        name: 'Satisfies the IBS Exception for Italy staff',
+      }),
+    ).toHaveLength(1);
+    expect(
+      queryAllByRole('cell', {
+        name: 'Does not satisfy the IBS Exception for Italy staff',
+      }),
+    ).toHaveLength(1);
+  });
 });

--- a/src/components/HrTools/Shared/EligibilityStatusTable/EligibilityStatusTable.tsx
+++ b/src/components/HrTools/Shared/EligibilityStatusTable/EligibilityStatusTable.tsx
@@ -10,17 +10,39 @@ import {
   TableHead,
   TableRow,
   Typography,
+  styled,
   useTheme,
 } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
+import { getHousingKind } from 'src/components/Reports/Shared/HousingAllowance/housingAllowance';
+
+const StyledTable = styled(Table)(({ theme }) => ({
+  tableLayout: 'fixed',
+  '.MuiTableCell-head': {
+    fontWeight: 'bold',
+    color: theme.palette.primary.main,
+  },
+  '.MuiTableBody-root .MuiTableCell-root:first-of-type': {
+    fontWeight: 'bold',
+  },
+}));
+
+const MhiSectionRow = styled(TableRow)(({ theme }) => ({
+  td: {
+    borderTop: '2px solid',
+    borderTopColor: theme.palette.divider,
+  },
+}));
 
 interface EligibilityStatusTableProps {
   userPreferredName: string;
   userEligible: boolean;
   userCountry?: string | null;
+  userMhiEligibility?: boolean;
   spousePreferredName?: string;
   spouseEligible?: boolean;
   spouseCountry?: string | null;
+  spouseMhiEligibility?: boolean;
   compact?: boolean;
 }
 
@@ -32,19 +54,34 @@ const getIneligibilityReason = (
   if (eligible) {
     return t('Completed the required IBS courses');
   }
-  if (country === 'IT') {
+  if (getHousingKind(country) === 'MHI') {
     return t('Must complete an MHI form instead');
   }
   return t('Has not completed the required IBS courses');
+};
+
+const getMhiReason = (
+  t: (key: string) => string,
+  eligible: boolean,
+  country: string | null,
+): string => {
+  if (getHousingKind(country) !== 'MHI') {
+    return t('Not applicable');
+  }
+  return eligible
+    ? t('Satisfies the IBS Exception for Italy staff')
+    : t('Does not satisfy the IBS Exception for Italy staff');
 };
 
 export const EligibilityStatusTable: React.FC<EligibilityStatusTableProps> = ({
   userPreferredName,
   userEligible,
   userCountry,
+  userMhiEligibility,
   spousePreferredName,
   spouseEligible,
   spouseCountry,
+  spouseMhiEligibility,
   compact = false,
 }) => {
   const { t } = useTranslation();
@@ -54,10 +91,13 @@ export const EligibilityStatusTable: React.FC<EligibilityStatusTableProps> = ({
   const anyIneligible =
     !userEligible || (hasSpouse && spouseEligible === false);
   const anyEligible = userEligible || (hasSpouse && spouseEligible === true);
+  const showMhiRows =
+    getHousingKind(userCountry ?? null) === 'MHI' ||
+    getHousingKind(spouseCountry ?? null) === 'MHI';
 
   const content = (
     <>
-      <Table sx={{ tableLayout: 'fixed' }}>
+      <StyledTable>
         <TableHead>
           <TableRow>
             <TableCell>{t('Category')}</TableCell>
@@ -67,7 +107,9 @@ export const EligibilityStatusTable: React.FC<EligibilityStatusTableProps> = ({
         </TableHead>
         <TableBody>
           <TableRow>
-            <TableCell>{t('Eligibility')}</TableCell>
+            <TableCell>
+              {showMhiRows ? t('MHA Eligibility') : t('Eligibility')}
+            </TableCell>
             <TableCell>
               {userEligible ? t('Eligible') : t('Ineligible')}
             </TableCell>
@@ -78,7 +120,7 @@ export const EligibilityStatusTable: React.FC<EligibilityStatusTableProps> = ({
             )}
           </TableRow>
           <TableRow>
-            <TableCell>{t('Reason')}</TableCell>
+            <TableCell>{showMhiRows ? t('MHA Reason') : t('Reason')}</TableCell>
             <TableCell>
               {getIneligibilityReason(t, userEligible, userCountry ?? null)}
             </TableCell>
@@ -92,8 +134,50 @@ export const EligibilityStatusTable: React.FC<EligibilityStatusTableProps> = ({
               </TableCell>
             )}
           </TableRow>
+          {showMhiRows && (
+            <>
+              <MhiSectionRow>
+                <TableCell>{t('MHI Eligibility')}</TableCell>
+                <TableCell>
+                  {getHousingKind(userCountry ?? null) === 'MHI'
+                    ? userMhiEligibility
+                      ? t('Eligible')
+                      : t('Ineligible')
+                    : t('Not applicable')}
+                </TableCell>
+                {hasSpouse && (
+                  <TableCell>
+                    {getHousingKind(spouseCountry ?? null) === 'MHI'
+                      ? spouseMhiEligibility
+                        ? t('Eligible')
+                        : t('Ineligible')
+                      : t('Not applicable')}
+                  </TableCell>
+                )}
+              </MhiSectionRow>
+              <TableRow>
+                <TableCell>{t('MHI Reason')}</TableCell>
+                <TableCell>
+                  {getMhiReason(
+                    t,
+                    userMhiEligibility ?? false,
+                    userCountry ?? null,
+                  )}
+                </TableCell>
+                {hasSpouse && (
+                  <TableCell>
+                    {getMhiReason(
+                      t,
+                      spouseMhiEligibility ?? false,
+                      spouseCountry ?? null,
+                    )}
+                  </TableCell>
+                )}
+              </TableRow>
+            </>
+          )}
         </TableBody>
-      </Table>
+      </StyledTable>
       {anyIneligible && (
         <Box
           sx={{ mt: compact ? 0 : theme.spacing(2) }}
@@ -116,6 +200,22 @@ export const EligibilityStatusTable: React.FC<EligibilityStatusTableProps> = ({
           </Typography>
         </Box>
       )}
+      {showMhiRows && (
+        <Box
+          sx={{ mt: compact ? theme.spacing(1) : theme.spacing(2) }}
+          data-testid="mhi-paper-form-note"
+        >
+          <Typography
+            variant="body2"
+            fontStyle="italic"
+            sx={{ lineHeight: 1.5 }}
+          >
+            <Trans t={t}>
+              Note: Italy staff must complete a paper MHI form.
+            </Trans>
+          </Typography>
+        </Box>
+      )}
     </>
   );
 
@@ -125,7 +225,13 @@ export const EligibilityStatusTable: React.FC<EligibilityStatusTableProps> = ({
 
   return (
     <Card data-testid="eligibility-status-table">
-      <CardHeader title={t('MHA Eligibility Status')} />
+      <CardHeader
+        title={
+          showMhiRows
+            ? t('MHA & MHI Eligibility Status')
+            : t('MHA Eligibility Status')
+        }
+      />
       <CardContent>{content}</CardContent>
     </Card>
   );

--- a/src/components/HrTools/Shared/HcmData/Hcm.graphql
+++ b/src/components/HrTools/Shared/HcmData/Hcm.graphql
@@ -42,6 +42,9 @@ query Hcm($effectiveDate: ISO8601Date) {
     mhaEit {
       mhaEligibility
     }
+    mhiEit {
+      mhiEligibility
+    }
     asrEit {
       asrEligibility
       ineligibilityReason

--- a/src/components/HrTools/Shared/HcmData/mockData.ts
+++ b/src/components/HrTools/Shared/HcmData/mockData.ts
@@ -40,6 +40,9 @@ const noMhaAndNoException: HcmQuery['hcm'][number] = {
   mhaEit: {
     mhaEligibility: true,
   },
+  mhiEit: {
+    mhiEligibility: false,
+  },
   asrEit: {
     asrEligibility: true,
   },
@@ -75,8 +78,18 @@ const mhaAndNoException: HcmQuery['hcm'][number] = {
   },
 };
 
+// Italian staff apply for MHI (paper form), so they are intentionally MHA-
+// ineligible on the online flow and expect the MHI row to drive the display.
+const italianMhiEligible: HcmQuery['hcm'][number] = {
+  ...noMhaAndNoException,
+  staffInfo: { ...johnDoe, country: 'IT' },
+  mhaEit: { mhaEligibility: false },
+  mhiEit: { mhiEligibility: true },
+};
+
 export const singleNoMhaNoException: HcmQuery['hcm'] = [noMhaAndNoException];
 export const singleMhaNoException: HcmQuery['hcm'] = [mhaAndNoException];
+export const singleItalianMhiEligible: HcmQuery['hcm'] = [italianMhiEligible];
 export const marriedMhaAndNoException: HcmQuery['hcm'] = [
   mhaAndNoException,
   {

--- a/src/components/Reports/Shared/HousingAllowance/housingAllowance.test.ts
+++ b/src/components/Reports/Shared/HousingAllowance/housingAllowance.test.ts
@@ -1,0 +1,59 @@
+import {
+  getEffectiveEligibility,
+  getHousingKind,
+  getMhiEligibility,
+} from './housingAllowance';
+
+const italianHcm = {
+  staffInfo: { country: 'IT' },
+  mhaEit: { mhaEligibility: false },
+  mhiEit: { mhiEligibility: true },
+};
+const usHcm = {
+  staffInfo: { country: 'US' },
+  mhaEit: { mhaEligibility: true },
+  mhiEit: { mhiEligibility: false },
+};
+
+describe('getHousingKind', () => {
+  it('returns MHI for Italy', () => {
+    expect(getHousingKind('IT')).toBe('MHI');
+  });
+
+  it('returns MHA for everything else', () => {
+    expect(getHousingKind('US')).toBe('MHA');
+    expect(getHousingKind(null)).toBe('MHA');
+  });
+});
+
+describe('getMhiEligibility', () => {
+  it('is true when mhiEit.mhiEligibility is true', () => {
+    expect(getMhiEligibility(italianHcm)).toBe(true);
+  });
+
+  it('is false when mhiEit.mhiEligibility is false or hcm is missing', () => {
+    expect(getMhiEligibility(usHcm)).toBe(false);
+    expect(getMhiEligibility(null)).toBe(false);
+  });
+});
+
+describe('getEffectiveEligibility', () => {
+  it('uses MHI flag for Italian staff', () => {
+    expect(getEffectiveEligibility(italianHcm)).toBe(true);
+  });
+
+  it('uses MHA flag for non-Italian staff', () => {
+    expect(getEffectiveEligibility(usHcm)).toBe(true);
+    expect(
+      getEffectiveEligibility({
+        staffInfo: { country: 'US' },
+        mhaEit: { mhaEligibility: false },
+        mhiEit: { mhiEligibility: false },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when hcm is null', () => {
+    expect(getEffectiveEligibility(null)).toBe(false);
+  });
+});

--- a/src/components/Reports/Shared/HousingAllowance/housingAllowance.ts
+++ b/src/components/Reports/Shared/HousingAllowance/housingAllowance.ts
@@ -1,0 +1,22 @@
+export type HousingKind = 'MHA' | 'MHI';
+
+// Structural shape: both the shared HcmData query and SalaryCalculator's own
+// Hcm query include these fields.
+type HcmForHousing = {
+  staffInfo: { country?: string | null };
+  mhaEit: { mhaEligibility: boolean };
+  mhiEit: { mhiEligibility: boolean };
+};
+
+// Italian staff apply for MHI; everyone else applies for MHA.
+export const getHousingKind = (country: string | null): HousingKind =>
+  country === 'IT' ? 'MHI' : 'MHA';
+
+export const getMhiEligibility = (hcm: HcmForHousing | null): boolean =>
+  hcm?.mhiEit.mhiEligibility ?? false;
+
+// The effective eligibility for whichever kind applies to this person.
+export const getEffectiveEligibility = (hcm: HcmForHousing | null): boolean =>
+  getHousingKind(hcm?.staffInfo.country ?? null) === 'MHI'
+    ? getMhiEligibility(hcm)
+    : (hcm?.mhaEit.mhaEligibility ?? false);


### PR DESCRIPTION
## Description

- MHI Users need to be able to see their MHI amount (which is on MHA)
- MHI Eligibility needs to be explicitly shown on the MHA page

Follow up: Pass MHI or MHA status to SAA, so SAA knows to look up the correct payroll element.

## Testing

- Test with both regular MHA users and MHI users.
- Go to both the Salary Calculator, and the MHA request/calculator
- Check that MHI users can fill out an MHA amount (they are considered MHI)
- Check that MHI eligibility is displayed in MHA request/calculator dashboard, and only when the staff user is from Italy.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
