### PR TITLE
MPDX-9488 Change tab names under HR Tools

### DIFF
--- a/src/components/HrTools/StaffSavingFund/StaffSavingFundLayout.test.tsx
+++ b/src/components/HrTools/StaffSavingFund/StaffSavingFundLayout.test.tsx
@@ -95,7 +95,7 @@ describe('StaffSavingFundLayout', () => {
 
   it('should open nav list', async () => {
     const { findByText } = render(<Components />);
-    expect(await findByText(/salary calculator/i)).toBeInTheDocument();
+    expect(await findByText(/salary calculation form/i)).toBeInTheDocument();
     expect(await findByText(/hr tools/i)).toBeInTheDocument();
   });
 

--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
@@ -155,7 +155,7 @@ describe('NavMenu', () => {
     await findByRole('menuitem', { name: 'HR Tools' });
     userEvent.click(getByTestId('HrToolsMenuToggle'));
     expect(
-      getByRole('menuitem', { name: 'Salary Calculator' }),
+      getByRole('menuitem', { name: 'Salary Calculation Form' }),
     ).toBeInTheDocument();
     expect(
       getByRole('menuitem', { name: 'Savings Fund Transfer' }),
@@ -164,7 +164,7 @@ describe('NavMenu', () => {
       getByRole('menuitem', { name: 'MPD Goal Calculator' }),
     ).toBeInTheDocument();
     expect(
-      getByRole('menuitem', { name: 'MHA Calculator' }),
+      getByRole('menuitem', { name: 'MHA Calculation Tool' }),
     ).toBeInTheDocument();
     expect(
       getByRole('menuitem', { name: 'Additional Salary Request' }),

--- a/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
@@ -512,10 +512,10 @@ describe('MultiPageMenu', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Salary Calculator')).toBeInTheDocument();
+      expect(getByText('Salary Calculation Form')).toBeInTheDocument();
       expect(getByText('Savings Fund Transfer')).toBeInTheDocument();
       expect(getByText('MPD Goal Calculator')).toBeInTheDocument();
-      expect(getByText('MHA Calculator')).toBeInTheDocument();
+      expect(getByText('MHA Calculation Tool')).toBeInTheDocument();
       expect(getByText('Additional Salary Request')).toBeInTheDocument();
       expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
     });

--- a/src/hooks/useHrToolsNavItems.ts
+++ b/src/hooks/useHrToolsNavItems.ts
@@ -16,7 +16,7 @@ export function useHrToolsNavItems(): NavItems[] {
   const hrToolsNavItems: NavItems[] = [
     {
       id: 'salaryCalculator',
-      title: t('Salary Calculator'),
+      title: t('Salary Calculation Form'),
       hideItem: inSalaryCalcIneligibleGroup,
     },
     {
@@ -30,7 +30,7 @@ export function useHrToolsNavItems(): NavItems[] {
     },
     {
       id: 'mhaCalculator',
-      title: t('MHA Calculator'),
+      title: t('MHA Calculation Tool'),
       hideItem: inMhaIneligibleGroup,
     },
     {


### PR DESCRIPTION
## Description

Stakeholders requested different naming for forms under the HR Tools tab:

- Salary Calculator --> Salary Calculation Form
- MHA Calculator --> MHA Calculation Tool

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to dashboard
- Click on "HR Tools"
- Check that salary calculator and mha calculator were updated

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
