### PR TITLE
[no-Jira] Update local-api after every merge

### DIFF
--- a/.github/workflows/update-staging.yml
+++ b/.github/workflows/update-staging.yml
@@ -18,3 +18,16 @@ jobs:
           type: now
           target_branch: 'staging'
           github_token: ${{ github.token }}
+
+  update-branches:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: 🔁 Force-push main to local-api
+        # Keep local-api branch in-sync with main
+        # local-api is set up in Amplify with API_URL=http://localhost:3001/graphql for testing
+        # backend changes locally against the current version of the frontend.
+        run: git push --force-with-lease origin main:local-api


### PR DESCRIPTION
## Description

Keep `local-api` branch in-sync with `main`. `local-api` is set up in Amplify with `API_URL=http://localhost:3001/graphql` for testing backend changes locally against the current version of the frontend.

## Testing

N/A

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
