### PR TITLE
MPDX-9488 Update "Reports" tab menu item names

### DIFF
--- a/pages/accountLists/[accountListId]/hrTools/additionalSalaryRequest/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/additionalSalaryRequest/index.page.tsx
@@ -158,7 +158,7 @@ const AdditionalSalaryRequestPage: React.FC = () => {
   return (
     <>
       <Head>
-        <title>{`${appName} | ${t('Additional Salary Request')}`}</title>
+        <title>{`${appName} | ${t('HR Tools | Additional Salary Request')}`}</title>
       </Head>
       <UserTypeAccess
         requireStaffAccount

--- a/pages/accountLists/[accountListId]/hrTools/goalCalculator/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/goalCalculator/index.page.tsx
@@ -33,7 +33,7 @@ export const GoalCalculatorPage: React.FC = () => {
   return (
     <>
       <Head>
-        <title>{`${appName} | ${t('Reports - Goal Calculation')}`}</title>
+        <title>{`${appName} | ${t('HR Tools | MPD Goal Calculator')}`}</title>
       </Head>
       {accountListId ? (
         <UserTypeAccess>

--- a/pages/accountLists/[accountListId]/hrTools/mhaCalculator/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/mhaCalculator/index.page.tsx
@@ -33,7 +33,7 @@ const MinisterHousingAllowancePage: React.FC = () => {
   return (
     <>
       <Head>
-        <title>{`${appName} | ${t("Reports - Minister's Housing Allowance")}`}</title>
+        <title>{`${appName} | ${t('HR Tools | MHA Calculation Form')}`}</title>
       </Head>
       <UserTypeAccess
         requireStaffAccount

--- a/pages/accountLists/[accountListId]/hrTools/partnerReminders/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/partnerReminders/index.page.tsx
@@ -30,7 +30,7 @@ const PartnerRemindersReportPage: React.FC = () => {
   return (
     <>
       <Head>
-        <title>{`${appName} | ${t('Reports')} - ${t('Ministry Partner Reminders')}`}</title>
+        <title>{`${appName} | ${t('HR Tools | Ministry Partner Reminders')}`}</title>
       </Head>
       <UserTypeAccess requireStaffAccount>
         <PartnerRemindersReportPageWrapper>

--- a/pages/accountLists/[accountListId]/hrTools/pdsGoalCalculator/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/pdsGoalCalculator/index.page.tsx
@@ -31,7 +31,7 @@ const PdsGoalCalculatorPage: React.FC = () => {
   return (
     <>
       <Head>
-        <title>{`${appName} | ${t('HR Tools - Paid with Designation Support Goal Calculator')}`}</title>
+        <title>{`${appName} | ${t('HR Tools | Paid with Designation Support Goal Calculator')}`}</title>
       </Head>
       {accountListId ? (
         <ReportPageWrapper>

--- a/pages/accountLists/[accountListId]/hrTools/salaryCalculator/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/salaryCalculator/index.page.tsx
@@ -33,7 +33,7 @@ const SalaryCalculatorPage: React.FC = () => {
   return (
     <>
       <Head>
-        <title>{`${appName} | ${t('Salary Calculator')}`}</title>
+        <title>{`${appName} | ${t('HR Tools | Salary Calculation Form')}`}</title>
       </Head>
       <UserTypeAccess
         requireStaffAccount

--- a/pages/accountLists/[accountListId]/hrTools/staffSavingFund/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/staffSavingFund/index.page.tsx
@@ -8,7 +8,7 @@ import { StaffSavingFundLayout } from 'src/components/HrTools/StaffSavingFund/St
 export const StaffSavingFundPage: React.FC = () => {
   const { t } = useTranslation();
 
-  const title = t('Savings Fund Transfer');
+  const title = t('HR Tools | Savings Fund Transfer');
 
   return (
     <StaffSavingFundProvider>

--- a/pages/accountLists/[accountListId]/reports/designationAccounts.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/designationAccounts.page.tsx
@@ -27,7 +27,7 @@ const DesignationAccountsReportPage: React.FC = () => {
   return (
     <>
       <Head>
-        <title>{`${appName} | ${t('Reports - Designation Accounts')}`}</title>
+        <title>{`${appName} | ${t('Reports | Designation Accounts')}`}</title>
       </Head>
       {accountListId ? (
         <ReportPageWrapper>

--- a/pages/accountLists/[accountListId]/reports/mpgaIncomeExpenses/index.page.tsx
+++ b/pages/accountLists/[accountListId]/reports/mpgaIncomeExpenses/index.page.tsx
@@ -30,8 +30,8 @@ const MPGAReportPage: React.FC = () => {
   return (
     <>
       <Head>
-        <title>{`${appName} | ${t('Reports')} - ${t(
-          'MPGA Monthly Report',
+        <title>{`${appName} | ${t('Reports')} | ${t(
+          'Income/Expense Analysis',
         )}`}</title>
       </Head>
       <UserTypeAccess requireStaffAccount>

--- a/pages/accountLists/[accountListId]/reports/partnerCurrency/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/partnerCurrency/[[...contactId]].page.tsx
@@ -75,7 +75,7 @@ const PartnerCurrencyReportPage: React.FC = () => {
   return (
     <>
       <Head>
-        <title>{`${appName} | ${t('Reports - Partner')}`}</title>
+        <title>{`${appName} | ${t('Reports | Partner')}`}</title>
       </Head>
       <ContactPanelProvider>
         <PageContent />

--- a/pages/accountLists/[accountListId]/reports/salaryCurrency/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/salaryCurrency/[[...contactId]].page.tsx
@@ -75,7 +75,7 @@ const SalaryCurrencyReportPage: React.FC = () => {
   return (
     <>
       <Head>
-        <title>{`${appName} | ${t('Reports - Salary')}`}</title>
+        <title>{`${appName} | ${t('Reports | Salary')}`}</title>
       </Head>
       <ContactPanelProvider>
         <PageContent />

--- a/src/components/HrTools/StaffSavingFund/StaffSavingFundLayout.tsx
+++ b/src/components/HrTools/StaffSavingFund/StaffSavingFundLayout.tsx
@@ -8,6 +8,7 @@ import {
   NavTypeEnum,
 } from 'src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu';
 import { UserTypeAccess } from 'src/components/Shared/UserTypeAccess/UserTypeAccess';
+import { getAppName } from 'src/lib/getAppName';
 import {
   StaffSavingFundContext,
   StaffSavingFundType,
@@ -28,6 +29,7 @@ export const StaffSavingFundLayout: React.FC<StaffSavingFundLayoutProps> = ({
   selectedMenuId,
   children,
 }) => {
+  const appName = getAppName();
   const { isNavListOpen, onNavListToggle } = useContext(
     StaffSavingFundContext,
   ) as StaffSavingFundType;
@@ -35,7 +37,7 @@ export const StaffSavingFundLayout: React.FC<StaffSavingFundLayoutProps> = ({
   return (
     <>
       <Head>
-        <title>{`${pageTitle}`}</title>
+        <title>{`${appName} | ${pageTitle}`}</title>
       </Head>
       <UserTypeAccess requireStaffAccount>
         <StaffSavingFundPageWrapper>

--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
@@ -111,7 +111,7 @@ describe('NavMenu', () => {
       getByRole('menuitem', { name: 'Staff Expense Report' }),
     ).toBeInTheDocument();
     expect(
-      getByRole('menuitem', { name: 'MPGA Monthly Report' }),
+      getByRole('menuitem', { name: 'Income/Expense Analysis' }),
     ).toBeInTheDocument();
     expect(
       getByRole('menuitem', { name: 'Designation Accounts' }),
@@ -164,7 +164,7 @@ describe('NavMenu', () => {
       getByRole('menuitem', { name: 'MPD Goal Calculator' }),
     ).toBeInTheDocument();
     expect(
-      getByRole('menuitem', { name: 'MHA Calculation Tool' }),
+      getByRole('menuitem', { name: 'MHA Calculation Form' }),
     ).toBeInTheDocument();
     expect(
       getByRole('menuitem', { name: 'Additional Salary Request' }),

--- a/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
@@ -79,7 +79,7 @@ describe('MultiPageMenu', () => {
     expect(getByText('14 Month Partner Report')).toBeInTheDocument();
     expect(getByText('14 Month Salary Report')).toBeInTheDocument();
     expect(await findByText('Staff Expense Report')).toBeInTheDocument();
-    expect(getByText('MPGA Monthly Report')).toBeInTheDocument();
+    expect(getByText('Income/Expense Analysis')).toBeInTheDocument();
     expect(getByText('Designation Accounts')).toBeInTheDocument();
     expect(getByText('Expected Monthly Total')).toBeInTheDocument();
     expect(getByText('Partner Giving Analysis')).toBeInTheDocument();
@@ -130,7 +130,7 @@ describe('MultiPageMenu', () => {
     expect(getByText('Coaching')).toBeInTheDocument();
 
     expect(queryByText('Staff Expense Report')).not.toBeInTheDocument();
-    expect(queryByText('MPGA Monthly Report')).not.toBeInTheDocument();
+    expect(queryByText('Income/Expense Analysis')).not.toBeInTheDocument();
   });
 
   it('non Cru default', async () => {
@@ -174,7 +174,7 @@ describe('MultiPageMenu', () => {
     expect(getByText('Coaching')).toBeInTheDocument();
 
     expect(queryByText('Staff Expense Report')).not.toBeInTheDocument();
-    expect(queryByText('MPGA Monthly Report')).not.toBeInTheDocument();
+    expect(queryByText('Income/Expense Analysis')).not.toBeInTheDocument();
     await waitFor(() => {
       expect(queryByText('Responsibility Centers')).not.toBeInTheDocument();
     });
@@ -515,7 +515,7 @@ describe('MultiPageMenu', () => {
       expect(getByText('Salary Calculation Form')).toBeInTheDocument();
       expect(getByText('Savings Fund Transfer')).toBeInTheDocument();
       expect(getByText('MPD Goal Calculator')).toBeInTheDocument();
-      expect(getByText('MHA Calculation Tool')).toBeInTheDocument();
+      expect(getByText('MHA Calculation Form')).toBeInTheDocument();
       expect(getByText('Additional Salary Request')).toBeInTheDocument();
       expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
     });

--- a/src/hooks/useHrToolsNavItems.ts
+++ b/src/hooks/useHrToolsNavItems.ts
@@ -30,7 +30,7 @@ export function useHrToolsNavItems(): NavItems[] {
     },
     {
       id: 'mhaCalculator',
-      title: t('MHA Calculation Tool'),
+      title: t('MHA Calculation Form'),
       hideItem: inMhaIneligibleGroup,
     },
     {

--- a/src/hooks/useReportNavItems.ts
+++ b/src/hooks/useReportNavItems.ts
@@ -48,8 +48,7 @@ export function useReportNavItems(): NavItems[] {
           },
           {
             id: 'mpgaIncomeExpenses',
-            title: t('MPGA Monthly Report'),
-            subTitle: t('Income & Expenses'),
+            title: t('Income/Expense Analysis'),
             hideItem: !usStaff || hasNoStaffAccount,
           },
         ]),


### PR DESCRIPTION
## Description

Stakeholders want to rename "MPGA Monthly Expenses" to "Income/Expense Analysis" in Reports tab. They also want to change "MHA Calculation Tool" to "MHA Calculation Form".

I checked with Scott that we want browser tabs formatted as "MPDX | Reports | Donations" 

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

MPGA:
- Go to dashboard
- Click "Reports" tab
- Check that MPGA is now "Income/Expense Analysis"

MHA:
- Go to dashboard
- Click "HR Tools" tab
- Check that MHA is now "MHA Calculation Form"

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
