### PR TITLE
[No Jira] - MPDX Update PDS nav item to use full name instead of acronym

### DIFF
--- a/src/hooks/useHrToolsNavItems.ts
+++ b/src/hooks/useHrToolsNavItems.ts
@@ -40,7 +40,7 @@ export function useHrToolsNavItems(): NavItems[] {
     },
     {
       id: 'pdsGoalCalculator',
-      title: t('PDS Goal Calculator'),
+      title: t('Paid With Designation Goal Calculator'),
     },
     {
       id: 'partnerReminders',

--- a/src/hooks/useHrToolsNavItems.ts
+++ b/src/hooks/useHrToolsNavItems.ts
@@ -40,7 +40,7 @@ export function useHrToolsNavItems(): NavItems[] {
     },
     {
       id: 'pdsGoalCalculator',
-      title: t('Paid With Designation Goal Calculator'),
+      title: t('Paid with Designation Support Goal Calculator'),
     },
     {
       id: 'partnerReminders',


### PR DESCRIPTION
## Description

- Renamed "PDS Goal Calculator" to "Paid With Designation Goal Calculator" in the HR Tools nav items to avoid using the PDS acronym
- Related Slack thread: https://cru-main.slack.com/archives/C09GYN5KQ9E/p1777315830761649

## Testing

- Go to any account list page
- Open the HR Tools navigation menu
- Check that the nav item reads "Paid With Designation Goal Calculator" instead of "PDS Goal Calculator"

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history