### PR TITLE
[No-Jira] Revert organization page changes

### DIFF
--- a/pages/accountLists/[accountListId]/settings/organizations.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/organizations.page.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import React, { ReactElement, useEffect, useState } from 'react';
 import { Box, Skeleton } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { enforceAdmin } from 'pages/api/utils/pagePropsHelpers';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { ImpersonateUserAccordion } from 'src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion';
 import { ManageOrganizationAccessAccordion } from 'src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion';
 import { OrganizationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
@@ -111,6 +111,6 @@ const Organizations = (): ReactElement => {
   );
 };
 
-export const getServerSideProps = enforceAdmin;
+export const getServerSideProps = ensureSessionAndAccountList;
 
 export default Organizations;


### PR DESCRIPTION
## Description

There are some HelpScout tickets where users cannot impersonate anymore. It is likely due to the recent changes with the customized login for different user groups on the organizations page. There was some confusion with who should have certain permissions, but I think my change was incorrect. This PR is reverting that change.

> Settings:
Preferences - ALL
Notifications - ALL
Connect services - ALL
Manage accounts - ALL
Manage coaches - ALL
Manage organization (admin)
Admin console (developer)
Backend admin (developer)
sidekiq (developer)

Old PR: https://github.com/CruGlobal/mpdx-react/pull/1714 

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to ...
- Do ...
- Check that ...

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
