### PR TITLE
No-Jira - Adds Goalsetting Resource link received by Keely

### DIFF
--- a/src/components/HrTools/GoalCalculator/GoalsList/GoalsList.test.tsx
+++ b/src/components/HrTools/GoalCalculator/GoalsList/GoalsList.test.tsx
@@ -59,7 +59,9 @@ describe('GoalsList', () => {
       getByRole('button', { name: 'Create a New Goal' }),
     ).toBeInTheDocument();
     expect(
-      getByRole('button', { name: 'Learn About Goalsetting' }),
+      getByRole('link', {
+        name: 'Learn About Goalsetting (opens in a new tab)',
+      }),
     ).toBeInTheDocument();
   });
 

--- a/src/components/HrTools/GoalCalculator/GoalsList/GoalsList.tsx
+++ b/src/components/HrTools/GoalCalculator/GoalsList/GoalsList.tsx
@@ -65,7 +65,7 @@ export const GoalsList: React.FC = () => {
         </Button>
         <Button
           variant="outlined"
-          href="https://docs.google.com/document/d/16eAKM-VZU8D6X1h9H-3bm1_cGyyYEp40bhCayQO6KPY/edit?tab=t.0"
+          href="https://docs.google.com/document/d/1w830y-UUOnhESka9bwA43ozb_2PgFIXp4YZITPbqUx4/edit?tab=t.0"
           target="_blank"
           rel="noopener noreferrer"
           aria-label={t('Learn About Goalsetting (opens in a new tab)')}

--- a/src/components/HrTools/GoalCalculator/GoalsList/GoalsList.tsx
+++ b/src/components/HrTools/GoalCalculator/GoalsList/GoalsList.tsx
@@ -63,7 +63,15 @@ export const GoalsList: React.FC = () => {
         <Button variant="contained" onClick={handleCreateGoal}>
           {t('Create a New Goal')}
         </Button>
-        <Button variant="outlined">{t('Learn About Goalsetting')}</Button>
+        <Button
+          variant="outlined"
+          href="https://docs.google.com/document/d/16eAKM-VZU8D6X1h9H-3bm1_cGyyYEp40bhCayQO6KPY/edit?tab=t.0"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={t('Learn About Goalsetting (opens in a new tab)')}
+        >
+          {t('Learn About Goalsetting')}
+        </Button>
       </Stack>
 
       {loading ? (


### PR DESCRIPTION
## Description

We've been waiting on a resource from the MPD Goals team for the "Learn about Goalsetting" link on the welcome page. This adds the link to that Button.

## Testing

- Go to the MPD Goals Welcome Page
- Click on the Learn About Goalsetting button
- Check that a new tab opens to the [Future Planning by Decade](https://docs.google.com/document/d/16eAKM-VZU8D6X1h9H-3bm1_cGyyYEp40bhCayQO6KPY/edit?tab=t.0) resource

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
