### PR TITLE
[MPDX-9455] - Display calculated goal amount on PDS Goal Card

### DIFF
--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
@@ -64,4 +64,22 @@ describe('PdsGoalCard', () => {
 
     expect(await findByTestId('date-value')).toHaveTextContent('March 15');
   });
+
+  it('renders the calculated goal amount', async () => {
+    const { findByTestId } = render(
+      <PdsGoalCalculatorTestWrapper
+        withProvider={false}
+        calculationsMock={{
+          nodes: [{ name: 'Test Goal' }],
+        }}
+      >
+        <PdsGoalsList />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    const goalAmount = await findByTestId('goal-amount-value');
+    // The exact value depends on the mock data — just verify it renders
+    // a currency-formatted string (starts with $ sign)
+    expect(goalAmount.textContent).toMatch(/^\$/);
+  });
 });

--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { PdsGoalsList } from '../GoalsList/PdsGoalsList';
 import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
 
@@ -78,8 +78,8 @@ describe('PdsGoalCard', () => {
     );
 
     const goalAmount = await findByTestId('goal-amount-value');
-    // The exact value depends on the mock data — just verify it renders
-    // a currency-formatted string (starts with $ sign)
-    expect(goalAmount.textContent).toMatch(/^\$/);
+    await waitFor(() => {
+      expect(goalAmount).toHaveTextContent('$849.44');
+    });
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
@@ -1,6 +1,14 @@
 import NextLink from 'next/link';
 import React, { useMemo, useState } from 'react';
-import { Box, Button, Card, Divider, Typography, styled } from '@mui/material';
+import {
+  Box,
+  Button,
+  Card,
+  Divider,
+  Skeleton,
+  Typography,
+  styled,
+} from '@mui/material';
 import { DateTime } from 'luxon';
 import { Trans, useTranslation } from 'react-i18next';
 import { Confirmation } from 'src/components/common/Modal/Confirmation/Confirmation';
@@ -66,9 +74,9 @@ export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({
   const accountListId = useAccountListId() ?? '';
   const [deleting, setDeleting] = useState(false);
 
-  const { goalMiscConstants, goalGeographicConstantMap } =
+  const { goalMiscConstants, goalGeographicConstantMap, loading: constantsLoading } =
     useGoalCalculatorConstants();
-  const { data: hcmData } = useHcmUserQuery();
+  const { data: hcmData, loading: hcmLoading } = useHcmUserQuery();
   const hcmUser = hcmData?.hcm[0];
 
   const goalTotal = useMemo(() => {
@@ -133,7 +141,11 @@ export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({
                 {t('Goal Amount')}
               </Typography>
               <Typography data-testid="goal-amount-value" variant="body1">
-                {currencyFormat(goalTotal, 'USD', locale)}
+                {constantsLoading || hcmLoading ? (
+                  <Skeleton width={80} />
+                ) : (
+                  currencyFormat(goalTotal, 'USD', locale)
+                )}
               </Typography>
             </StyledInfoRow>
 

--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
@@ -1,13 +1,17 @@
 import NextLink from 'next/link';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Box, Button, Card, Divider, Typography, styled } from '@mui/material';
 import { DateTime } from 'luxon';
 import { Trans, useTranslation } from 'react-i18next';
 import { Confirmation } from 'src/components/common/Modal/Confirmation/Confirmation';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useLocale } from 'src/hooks/useLocale';
-import { dateFormat } from 'src/lib/intlFormat';
+import { currencyFormat, dateFormat } from 'src/lib/intlFormat';
 import { PdsGoalCalculationFieldsFragment } from '../GoalsList/PdsGoalCalculations.generated';
+import {
+  PdsGoalTotalConstants,
+  calculatePdsGoalTotal,
+} from '../calculations/calculatePdsGoalTotal';
 
 const StyledCard = styled(Card)(({ theme }) => ({
   minWidth: 350,
@@ -49,13 +53,23 @@ const StyledActionBox = styled(Box)(({ theme }) => ({
 export interface PdsGoalCardProps {
   goal: PdsGoalCalculationFieldsFragment;
   onDelete: (id: string) => void;
+  constants: PdsGoalTotalConstants | null;
 }
 
-export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({ goal, onDelete }) => {
+export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({
+  goal,
+  onDelete,
+  constants,
+}) => {
   const { t } = useTranslation();
   const locale = useLocale();
   const accountListId = useAccountListId() ?? '';
   const [deleting, setDeleting] = useState(false);
+
+  const goalTotal = useMemo(
+    () => (constants ? calculatePdsGoalTotal(goal, constants) : 0),
+    [goal, constants],
+  );
 
   const handleDeleteClick = () => {
     setDeleting(true);
@@ -104,6 +118,17 @@ export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({ goal, onDelete }) => {
 
         <StyledContentBox>
           <StyledContentInnerBox>
+            <StyledInfoRow pb={1}>
+              <Typography variant="body1" fontWeight="bold" pl={2}>
+                {t('Goal Amount')}
+              </Typography>
+              <Typography data-testid="goal-amount-value" variant="body1">
+                {currencyFormat(goalTotal, 'USD', locale)}
+              </Typography>
+            </StyledInfoRow>
+
+            <Divider />
+
             <StyledInfoRow pt={1}>
               <Typography variant="body1" fontWeight="bold" pl={2}>
                 {t('Last Updated')}

--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
@@ -5,11 +5,13 @@ import { DateTime } from 'luxon';
 import { Trans, useTranslation } from 'react-i18next';
 import { Confirmation } from 'src/components/common/Modal/Confirmation/Confirmation';
 import { useAccountListId } from 'src/hooks/useAccountListId';
+import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
 import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat, dateFormat } from 'src/lib/intlFormat';
 import { PdsGoalCalculationFieldsFragment } from '../GoalsList/PdsGoalCalculations.generated';
+import { useHcmUserQuery } from '../Shared/HCM.generated';
 import {
-  PdsGoalTotalConstants,
+  buildPdsGoalConstants,
   calculatePdsGoalTotal,
 } from '../calculations/calculatePdsGoalTotal';
 
@@ -52,24 +54,32 @@ const StyledActionBox = styled(Box)(({ theme }) => ({
 
 export interface PdsGoalCardProps {
   goal: PdsGoalCalculationFieldsFragment;
-  onDelete: (id: string) => void;
-  constants: PdsGoalTotalConstants | null;
+  onDelete: (id: string) => Promise<void>;
 }
 
 export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({
   goal,
   onDelete,
-  constants,
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
   const accountListId = useAccountListId() ?? '';
   const [deleting, setDeleting] = useState(false);
 
-  const goalTotal = useMemo(
-    () => (constants ? calculatePdsGoalTotal(goal, constants) : 0),
-    [goal, constants],
-  );
+  const { goalMiscConstants, goalGeographicConstantMap } =
+    useGoalCalculatorConstants();
+  const { data: hcmData } = useHcmUserQuery();
+  const hcmUser = hcmData?.hcm[0];
+
+  const goalTotal = useMemo(() => {
+    const constants = buildPdsGoalConstants(
+      goalMiscConstants,
+      goalGeographicConstantMap,
+      goal.geographicLocation,
+      hcmUser?.fourOThreeB,
+    );
+    return constants ? calculatePdsGoalTotal(goal, constants) : 0;
+  }, [goal, goalMiscConstants, goalGeographicConstantMap, hcmUser]);
 
   const handleDeleteClick = () => {
     setDeleting(true);

--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
@@ -65,17 +65,17 @@ export interface PdsGoalCardProps {
   onDelete: (id: string) => Promise<void>;
 }
 
-export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({
-  goal,
-  onDelete,
-}) => {
+export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({ goal, onDelete }) => {
   const { t } = useTranslation();
   const locale = useLocale();
   const accountListId = useAccountListId() ?? '';
   const [deleting, setDeleting] = useState(false);
 
-  const { goalMiscConstants, goalGeographicConstantMap, loading: constantsLoading } =
-    useGoalCalculatorConstants();
+  const {
+    goalMiscConstants,
+    goalGeographicConstantMap,
+    loading: constantsLoading,
+  } = useGoalCalculatorConstants();
   const { data: hcmData, loading: hcmLoading } = useHcmUserQuery();
   const hcmUser = hcmData?.hcm[0];
 

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
@@ -8,8 +8,6 @@ import { useFetchAllPages } from 'src/hooks/useFetchAllPages';
 import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
 import illustration6graybg from 'src/images/drawkit/grape/drawkit-grape-pack-illustration-6-gray-bg.svg';
 import { PdsGoalCard } from '../GoalCard/PdsGoalCard';
-import { useHcmUserQuery } from '../Shared/HCM.generated';
-import { PdsGoalTotalConstants } from '../calculations/calculatePdsGoalTotal';
 import {
   useCreatePdsGoalCalculationMutation,
   useDeletePdsGoalCalculationMutation,
@@ -43,52 +41,8 @@ export const PdsGoalsList: React.FC = () => {
   });
   const [createPdsGoalCalculation] = useCreatePdsGoalCalculationMutation();
   const [deletePdsGoalCalculation] = useDeletePdsGoalCalculationMutation();
-  const { goalMiscConstants, goalGeographicConstantMap, loading: constantsLoading } =
+  const { goalMiscConstants, loading: constantsLoading } =
     useGoalCalculatorConstants();
-  const { data: hcmData } = useHcmUserQuery();
-  const hcmUser = hcmData?.hcm[0];
-
-  const additionalRates = goalMiscConstants.ADDITIONAL_RATES;
-  const rates = goalMiscConstants.RATES;
-
-  const buildGoalConstants = (
-    geographicLocation: string | null | undefined,
-  ): PdsGoalTotalConstants | null => {
-    const employerFicaRate = additionalRates?.EMPLOYER_FICA_RATE?.fee;
-    const workCompPercentage = additionalRates?.PART_TIME_WORK_COMPENSATION?.fee;
-    const attritionRate = rates?.ATTRITION_RATE?.fee;
-    const creditCardFeeRate = additionalRates?.CREDIT_CARD_FEE_RATE?.fee;
-    const adminRate = rates?.ADMIN_RATE?.fee;
-
-    if (
-      employerFicaRate === undefined ||
-      workCompPercentage === undefined ||
-      attritionRate === undefined ||
-      creditCardFeeRate === undefined ||
-      adminRate === undefined
-    ) {
-      return null;
-    }
-
-    const geographicMultiplier =
-      goalGeographicConstantMap.get(geographicLocation ?? '') ?? 0;
-
-    const taxDeferredPct =
-      (hcmUser?.fourOThreeB?.currentTaxDeferredContributionPercentage ?? 0) /
-      100;
-    const rothPct =
-      (hcmUser?.fourOThreeB?.currentRothContributionPercentage ?? 0) / 100;
-
-    return {
-      employerFicaRate,
-      workCompPercentage,
-      attritionRate,
-      creditCardFeeRate,
-      adminRate,
-      fourOThreeBPercentage: taxDeferredPct + rothPct,
-      geographicMultiplier,
-    };
-  };
 
   const goals = data?.designationSupportCalculations.nodes;
 
@@ -151,7 +105,6 @@ export const PdsGoalsList: React.FC = () => {
               key={goal.id}
               goal={goal}
               onDelete={handleDeleteGoal}
-              constants={buildGoalConstants(goal.geographicLocation)}
             />
           ))}
         </Stack>

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
@@ -8,6 +8,8 @@ import { useFetchAllPages } from 'src/hooks/useFetchAllPages';
 import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
 import illustration6graybg from 'src/images/drawkit/grape/drawkit-grape-pack-illustration-6-gray-bg.svg';
 import { PdsGoalCard } from '../GoalCard/PdsGoalCard';
+import { useHcmUserQuery } from '../Shared/HCM.generated';
+import { PdsGoalTotalConstants } from '../calculations/calculatePdsGoalTotal';
 import {
   useCreatePdsGoalCalculationMutation,
   useDeletePdsGoalCalculationMutation,
@@ -41,8 +43,52 @@ export const PdsGoalsList: React.FC = () => {
   });
   const [createPdsGoalCalculation] = useCreatePdsGoalCalculationMutation();
   const [deletePdsGoalCalculation] = useDeletePdsGoalCalculationMutation();
-  const { goalMiscConstants, loading: constantsLoading } =
+  const { goalMiscConstants, goalGeographicConstantMap, loading: constantsLoading } =
     useGoalCalculatorConstants();
+  const { data: hcmData } = useHcmUserQuery();
+  const hcmUser = hcmData?.hcm[0];
+
+  const additionalRates = goalMiscConstants.ADDITIONAL_RATES;
+  const rates = goalMiscConstants.RATES;
+
+  const buildGoalConstants = (
+    geographicLocation: string | null | undefined,
+  ): PdsGoalTotalConstants | null => {
+    const employerFicaRate = additionalRates?.EMPLOYER_FICA_RATE?.fee;
+    const workCompPercentage = additionalRates?.PART_TIME_WORK_COMPENSATION?.fee;
+    const attritionRate = rates?.ATTRITION_RATE?.fee;
+    const creditCardFeeRate = additionalRates?.CREDIT_CARD_FEE_RATE?.fee;
+    const adminRate = rates?.ADMIN_RATE?.fee;
+
+    if (
+      employerFicaRate === undefined ||
+      workCompPercentage === undefined ||
+      attritionRate === undefined ||
+      creditCardFeeRate === undefined ||
+      adminRate === undefined
+    ) {
+      return null;
+    }
+
+    const geographicMultiplier =
+      goalGeographicConstantMap.get(geographicLocation ?? '') ?? 0;
+
+    const taxDeferredPct =
+      (hcmUser?.fourOThreeB?.currentTaxDeferredContributionPercentage ?? 0) /
+      100;
+    const rothPct =
+      (hcmUser?.fourOThreeB?.currentRothContributionPercentage ?? 0) / 100;
+
+    return {
+      employerFicaRate,
+      workCompPercentage,
+      attritionRate,
+      creditCardFeeRate,
+      adminRate,
+      fourOThreeBPercentage: taxDeferredPct + rothPct,
+      geographicMultiplier,
+    };
+  };
 
   const goals = data?.designationSupportCalculations.nodes;
 
@@ -105,6 +151,7 @@ export const PdsGoalsList: React.FC = () => {
               key={goal.id}
               goal={goal}
               onDelete={handleDeleteGoal}
+              constants={buildGoalConstants(goal.geographicLocation)}
             />
           ))}
         </Stack>

--- a/src/components/HrTools/PdsGoalCalculator/calculations/buildPdsGoalConstants.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/buildPdsGoalConstants.test.ts
@@ -1,0 +1,246 @@
+import {
+  GoalGeographicConstantMap,
+  GoalMiscConstants,
+} from 'src/hooks/useGoalCalculatorConstants';
+import { buildPdsGoalConstants } from './calculatePdsGoalTotal';
+
+const makeConstant = (fee: number) => ({
+  fee,
+  id: '1',
+  category: '' as never,
+  categoryDisplayName: '',
+  label: '' as never,
+  labelDisplayName: '',
+});
+
+const buildMiscConstants = (
+  overrides: Partial<{
+    employerFicaRate: number | undefined;
+    workComp: number | undefined;
+    attritionRate: number | undefined;
+    creditCardFeeRate: number | undefined;
+    adminRate: number | undefined;
+  }> = {},
+): GoalMiscConstants => ({
+  ADDITIONAL_RATES: {
+    ...(overrides.employerFicaRate !== undefined
+      ? { EMPLOYER_FICA_RATE: makeConstant(overrides.employerFicaRate) }
+      : { EMPLOYER_FICA_RATE: makeConstant(0.08) }),
+    ...(overrides.workComp !== undefined
+      ? { PART_TIME_WORK_COMPENSATION: makeConstant(overrides.workComp) }
+      : { PART_TIME_WORK_COMPENSATION: makeConstant(0.17) }),
+    ...(overrides.creditCardFeeRate !== undefined
+      ? { CREDIT_CARD_FEE_RATE: makeConstant(overrides.creditCardFeeRate) }
+      : { CREDIT_CARD_FEE_RATE: makeConstant(0.06) }),
+  },
+  RATES: {
+    ...(overrides.attritionRate !== undefined
+      ? { ATTRITION_RATE: makeConstant(overrides.attritionRate) }
+      : { ATTRITION_RATE: makeConstant(0.06) }),
+    ...(overrides.adminRate !== undefined
+      ? { ADMIN_RATE: makeConstant(overrides.adminRate) }
+      : { ADMIN_RATE: makeConstant(0.12) }),
+  },
+});
+
+const defaultGeoMap: GoalGeographicConstantMap = new Map([
+  ['US-CO', 0.06],
+  ['US-NY', 0.12],
+]);
+
+describe('buildPdsGoalConstants', () => {
+  it('returns constants with correct rate values', () => {
+    const result = buildPdsGoalConstants(
+      buildMiscConstants(),
+      defaultGeoMap,
+      'US-CO',
+      null,
+    );
+
+    expect(result).toEqual({
+      employerFicaRate: 0.08,
+      workCompPercentage: 0.17,
+      attritionRate: 0.06,
+      creditCardFeeRate: 0.06,
+      adminRate: 0.12,
+      fourOThreeBPercentage: 0,
+      geographicMultiplier: 0.06,
+    });
+  });
+
+  it('returns null when EMPLOYER_FICA_RATE is missing', () => {
+    const misc = buildMiscConstants();
+    delete misc.ADDITIONAL_RATES?.EMPLOYER_FICA_RATE;
+
+    const result = buildPdsGoalConstants(misc, defaultGeoMap, 'US-CO', null);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when PART_TIME_WORK_COMPENSATION is missing', () => {
+    const misc = buildMiscConstants();
+    delete misc.ADDITIONAL_RATES?.PART_TIME_WORK_COMPENSATION;
+
+    const result = buildPdsGoalConstants(misc, defaultGeoMap, 'US-CO', null);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when ATTRITION_RATE is missing', () => {
+    const misc = buildMiscConstants();
+    delete misc.RATES?.ATTRITION_RATE;
+
+    const result = buildPdsGoalConstants(misc, defaultGeoMap, 'US-CO', null);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when CREDIT_CARD_FEE_RATE is missing', () => {
+    const misc = buildMiscConstants();
+    delete misc.ADDITIONAL_RATES?.CREDIT_CARD_FEE_RATE;
+
+    const result = buildPdsGoalConstants(misc, defaultGeoMap, 'US-CO', null);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when ADMIN_RATE is missing', () => {
+    const misc = buildMiscConstants();
+    delete misc.RATES?.ADMIN_RATE;
+
+    const result = buildPdsGoalConstants(misc, defaultGeoMap, 'US-CO', null);
+    expect(result).toBeNull();
+  });
+
+  it('returns geographicMultiplier of 0 for unknown location', () => {
+    const result = buildPdsGoalConstants(
+      buildMiscConstants(),
+      defaultGeoMap,
+      'US-XX',
+      null,
+    );
+
+    expect(result?.geographicMultiplier).toBe(0);
+  });
+
+  it('returns geographicMultiplier of 0 when location is null', () => {
+    const result = buildPdsGoalConstants(
+      buildMiscConstants(),
+      defaultGeoMap,
+      null,
+      null,
+    );
+
+    expect(result?.geographicMultiplier).toBe(0);
+  });
+
+  it('returns geographicMultiplier of 0 when location is undefined', () => {
+    const result = buildPdsGoalConstants(
+      buildMiscConstants(),
+      defaultGeoMap,
+      undefined,
+      null,
+    );
+
+    expect(result?.geographicMultiplier).toBe(0);
+  });
+
+  it('looks up correct geographic multiplier', () => {
+    const result = buildPdsGoalConstants(
+      buildMiscConstants(),
+      defaultGeoMap,
+      'US-NY',
+      null,
+    );
+
+    expect(result?.geographicMultiplier).toBe(0.12);
+  });
+
+  it('divides 403b percentages by 100 and sums them', () => {
+    const result = buildPdsGoalConstants(
+      buildMiscConstants(),
+      defaultGeoMap,
+      'US-CO',
+      {
+        currentTaxDeferredContributionPercentage: 5,
+        currentRothContributionPercentage: 3,
+      },
+    );
+
+    expect(result?.fourOThreeBPercentage).toBeCloseTo(0.08);
+  });
+
+  it('treats null 403b percentages as 0', () => {
+    const result = buildPdsGoalConstants(
+      buildMiscConstants(),
+      defaultGeoMap,
+      'US-CO',
+      {
+        currentTaxDeferredContributionPercentage: null,
+        currentRothContributionPercentage: null,
+      },
+    );
+
+    expect(result?.fourOThreeBPercentage).toBe(0);
+  });
+
+  it('treats undefined 403b fields as 0', () => {
+    const result = buildPdsGoalConstants(
+      buildMiscConstants(),
+      defaultGeoMap,
+      'US-CO',
+      {
+        currentTaxDeferredContributionPercentage: undefined,
+        currentRothContributionPercentage: undefined,
+      },
+    );
+
+    expect(result?.fourOThreeBPercentage).toBe(0);
+  });
+
+  it('handles null fourOThreeB object', () => {
+    const result = buildPdsGoalConstants(
+      buildMiscConstants(),
+      defaultGeoMap,
+      'US-CO',
+      null,
+    );
+
+    expect(result?.fourOThreeBPercentage).toBe(0);
+  });
+
+  it('handles undefined fourOThreeB object', () => {
+    const result = buildPdsGoalConstants(
+      buildMiscConstants(),
+      defaultGeoMap,
+      'US-CO',
+      undefined,
+    );
+
+    expect(result?.fourOThreeBPercentage).toBe(0);
+  });
+
+  it('handles only taxDeferred percentage set', () => {
+    const result = buildPdsGoalConstants(
+      buildMiscConstants(),
+      defaultGeoMap,
+      'US-CO',
+      {
+        currentTaxDeferredContributionPercentage: 10,
+        currentRothContributionPercentage: null,
+      },
+    );
+
+    expect(result?.fourOThreeBPercentage).toBeCloseTo(0.1);
+  });
+
+  it('handles only Roth percentage set', () => {
+    const result = buildPdsGoalConstants(
+      buildMiscConstants(),
+      defaultGeoMap,
+      'US-CO',
+      {
+        currentTaxDeferredContributionPercentage: null,
+        currentRothContributionPercentage: 7,
+      },
+    );
+
+    expect(result?.fourOThreeBPercentage).toBeCloseTo(0.07);
+  });
+});

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.test.ts
@@ -64,7 +64,7 @@ describe('calculatePdsGoalTotal', () => {
     expect(result).toBeCloseTo(434.83, 0);
   });
 
-  it('returns 0 when payRate is null', () => {
+  it('returns a positive value when payRate is null', () => {
     const goal = makeGoal({ payRate: null });
     const result = calculatePdsGoalTotal(goal, defaultConstants);
     expect(result).toBeGreaterThan(0);

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.test.ts
@@ -1,0 +1,82 @@
+import {
+  DesignationSupportSalaryType,
+  DesignationSupportStatus,
+} from 'src/graphql/types.generated';
+import { PdsGoalCalculationFieldsFragment } from '../GoalsList/PdsGoalCalculations.generated';
+import {
+  PdsGoalTotalConstants,
+  calculatePdsGoalTotal,
+} from './calculatePdsGoalTotal';
+
+const defaultConstants: PdsGoalTotalConstants = {
+  employerFicaRate: 0.08,
+  workCompPercentage: 0.17,
+  attritionRate: 0.06,
+  creditCardFeeRate: 0.06,
+  adminRate: 0.12,
+  fourOThreeBPercentage: 0.1,
+  geographicMultiplier: 0,
+};
+
+const makeGoal = (
+  overrides: Partial<PdsGoalCalculationFieldsFragment> = {},
+): PdsGoalCalculationFieldsFragment => ({
+  id: 'goal-1',
+  name: 'Test Goal',
+  updatedAt: '2026-01-01T00:00:00Z',
+  averageHoursPerWeek: null,
+  hoursWorkedPerWeek: null,
+  salaryOrHourly: DesignationSupportSalaryType.Salaried,
+  status: DesignationSupportStatus.FullTime,
+  payRate: 60000,
+  benefits: 1500,
+  geographicLocation: null,
+  ministryCellPhone: 50,
+  ministryInternet: 50,
+  mpdNewsletter: 50,
+  mpdMiscellaneous: 50,
+  accountTransfers: 50,
+  otherMonthlyReimbursements: 50,
+  conferenceRetreatCosts: 0,
+  ministryTravelMeals: 0,
+  otherAnnualReimbursements: 0,
+  designationSupportHoursItems: [],
+  ...overrides,
+});
+
+describe('calculatePdsGoalTotal', () => {
+  it('computes the final assessment for a full-time salaried employee', () => {
+    const goal = makeGoal();
+    const result = calculatePdsGoalTotal(goal, defaultConstants);
+    // assessment ≈ 1038.21
+    expect(result).toBeCloseTo(1038.21, 1);
+  });
+
+  it('computes the final assessment for a part-time hourly employee', () => {
+    const goal = makeGoal({
+      status: DesignationSupportStatus.PartTime,
+      salaryOrHourly: DesignationSupportSalaryType.Hourly,
+      payRate: 25,
+      hoursWorkedPerWeek: 20,
+      benefits: null,
+    });
+    const result = calculatePdsGoalTotal(goal, defaultConstants);
+    expect(result).toBeCloseTo(434.83, 0);
+  });
+
+  it('returns 0 when payRate is null', () => {
+    const goal = makeGoal({ payRate: null });
+    const result = calculatePdsGoalTotal(goal, defaultConstants);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('applies geographic multiplier', () => {
+    const goal = makeGoal();
+    const withGeo = calculatePdsGoalTotal(goal, {
+      ...defaultConstants,
+      geographicMultiplier: 0.06,
+    });
+    const withoutGeo = calculatePdsGoalTotal(goal, defaultConstants);
+    expect(withGeo).toBeGreaterThan(withoutGeo);
+  });
+});

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.test.ts
@@ -2,9 +2,9 @@ import {
   DesignationSupportSalaryType,
   DesignationSupportStatus,
 } from 'src/graphql/types.generated';
-import { PdsGoalCalculationFieldsFragment } from '../GoalsList/PdsGoalCalculations.generated';
 import {
   PdsGoalTotalConstants,
+  PdsGoalTotalFields,
   calculatePdsGoalTotal,
 } from './calculatePdsGoalTotal';
 
@@ -19,12 +19,8 @@ const defaultConstants: PdsGoalTotalConstants = {
 };
 
 const makeGoal = (
-  overrides: Partial<PdsGoalCalculationFieldsFragment> = {},
-): PdsGoalCalculationFieldsFragment => ({
-  id: 'goal-1',
-  name: 'Test Goal',
-  updatedAt: '2026-01-01T00:00:00Z',
-  averageHoursPerWeek: null,
+  overrides: Partial<PdsGoalTotalFields> = {},
+): PdsGoalTotalFields => ({
   hoursWorkedPerWeek: null,
   salaryOrHourly: DesignationSupportSalaryType.Salaried,
   status: DesignationSupportStatus.FullTime,
@@ -40,7 +36,6 @@ const makeGoal = (
   conferenceRetreatCosts: 0,
   ministryTravelMeals: 0,
   otherAnnualReimbursements: 0,
-  designationSupportHoursItems: [],
   ...overrides,
 });
 

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
@@ -27,9 +27,7 @@ export interface PdsGoalTotalConstants {
   geographicMultiplier: number;
 }
 
-type FourOThreeB = NonNullable<
-  HcmUserQuery['hcm'][number]['fourOThreeB']
->;
+type FourOThreeB = NonNullable<HcmUserQuery['hcm'][number]['fourOThreeB']>;
 
 export const buildPdsGoalConstants = (
   goalMiscConstants: GoalMiscConstants,
@@ -61,8 +59,7 @@ export const buildPdsGoalConstants = (
 
   const taxDeferredPct =
     (fourOThreeB?.currentTaxDeferredContributionPercentage ?? 0) / 100;
-  const rothPct =
-    (fourOThreeB?.currentRothContributionPercentage ?? 0) / 100;
+  const rothPct = (fourOThreeB?.currentRothContributionPercentage ?? 0) / 100;
 
   return {
     employerFicaRate,

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
@@ -1,7 +1,20 @@
-import { PdsGoalCalculationFieldsFragment } from '../GoalsList/PdsGoalCalculations.generated';
-import { calculateOtherExpenses } from './OtherExpenses';
-import { calculateReimbursableTotals } from './reimbursableExpenses';
-import { calculateSalaryTotals } from './salaryCalculation';
+import {
+  GoalGeographicConstantMap,
+  GoalMiscConstants,
+} from 'src/hooks/useGoalCalculatorConstants';
+import { OtherExpensesFields, calculateOtherExpenses } from './OtherExpenses';
+import {
+  ReimbursableCalculationFields,
+  calculateReimbursableTotals,
+} from './reimbursableExpenses';
+import {
+  SalaryCalculationFields,
+  calculateSalaryTotals,
+} from './salaryCalculation';
+
+export type PdsGoalTotalFields = SalaryCalculationFields &
+  ReimbursableCalculationFields &
+  OtherExpensesFields;
 
 export interface PdsGoalTotalConstants {
   employerFicaRate: number;
@@ -13,8 +26,57 @@ export interface PdsGoalTotalConstants {
   geographicMultiplier: number;
 }
 
+interface FourOThreeB {
+  currentTaxDeferredContributionPercentage?: number | null;
+  currentRothContributionPercentage?: number | null;
+}
+
+export const buildPdsGoalConstants = (
+  goalMiscConstants: GoalMiscConstants,
+  goalGeographicConstantMap: GoalGeographicConstantMap,
+  geographicLocation: string | null | undefined,
+  fourOThreeB: FourOThreeB | null | undefined,
+): PdsGoalTotalConstants | null => {
+  const additionalRates = goalMiscConstants.ADDITIONAL_RATES;
+  const rates = goalMiscConstants.RATES;
+
+  const employerFicaRate = additionalRates?.EMPLOYER_FICA_RATE?.fee;
+  const workCompPercentage = additionalRates?.PART_TIME_WORK_COMPENSATION?.fee;
+  const attritionRate = rates?.ATTRITION_RATE?.fee;
+  const creditCardFeeRate = additionalRates?.CREDIT_CARD_FEE_RATE?.fee;
+  const adminRate = rates?.ADMIN_RATE?.fee;
+
+  if (
+    employerFicaRate === undefined ||
+    workCompPercentage === undefined ||
+    attritionRate === undefined ||
+    creditCardFeeRate === undefined ||
+    adminRate === undefined
+  ) {
+    return null;
+  }
+
+  const geographicMultiplier =
+    goalGeographicConstantMap.get(geographicLocation ?? '') ?? 0;
+
+  const taxDeferredPct =
+    (fourOThreeB?.currentTaxDeferredContributionPercentage ?? 0) / 100;
+  const rothPct =
+    (fourOThreeB?.currentRothContributionPercentage ?? 0) / 100;
+
+  return {
+    employerFicaRate,
+    workCompPercentage,
+    attritionRate,
+    creditCardFeeRate,
+    adminRate,
+    fourOThreeBPercentage: taxDeferredPct + rothPct,
+    geographicMultiplier,
+  };
+};
+
 export const calculatePdsGoalTotal = (
-  calculation: PdsGoalCalculationFieldsFragment,
+  calculation: PdsGoalTotalFields,
   constants: PdsGoalTotalConstants,
 ): number => {
   const salaryTotals = calculateSalaryTotals(calculation, {

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
@@ -1,0 +1,39 @@
+import { PdsGoalCalculationFieldsFragment } from '../GoalsList/PdsGoalCalculations.generated';
+import { calculateOtherExpenses } from './OtherExpenses';
+import { calculateReimbursableTotals } from './reimbursableExpenses';
+import { calculateSalaryTotals } from './salaryCalculation';
+
+export interface PdsGoalTotalConstants {
+  employerFicaRate: number;
+  workCompPercentage: number;
+  attritionRate: number;
+  creditCardFeeRate: number;
+  adminRate: number;
+  fourOThreeBPercentage: number;
+  geographicMultiplier: number;
+}
+
+export const calculatePdsGoalTotal = (
+  calculation: PdsGoalCalculationFieldsFragment,
+  constants: PdsGoalTotalConstants,
+): number => {
+  const salaryTotals = calculateSalaryTotals(calculation, {
+    geographicMultiplier: constants.geographicMultiplier,
+    employerFicaRate: constants.employerFicaRate,
+  });
+
+  const reimbursableTotals = calculateReimbursableTotals(calculation);
+
+  const otherExpenses = calculateOtherExpenses(calculation, {
+    reimbursableTotal: reimbursableTotals.total,
+    salarySubtotal: salaryTotals.subtotal,
+    fourOThreeBPercentage: constants.fourOThreeBPercentage,
+    grossMonthlyPay: salaryTotals.grossMonthlyPay,
+    workCompPercentage: constants.workCompPercentage,
+    attritionRate: constants.attritionRate,
+    creditCardFeeRate: constants.creditCardFeeRate,
+    adminRate: constants.adminRate,
+  });
+
+  return otherExpenses.assessment;
+};

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
@@ -2,6 +2,7 @@ import {
   GoalGeographicConstantMap,
   GoalMiscConstants,
 } from 'src/hooks/useGoalCalculatorConstants';
+import { HcmUserQuery } from '../Shared/HCM.generated';
 import { OtherExpensesFields, calculateOtherExpenses } from './OtherExpenses';
 import {
   ReimbursableCalculationFields,
@@ -26,10 +27,9 @@ export interface PdsGoalTotalConstants {
   geographicMultiplier: number;
 }
 
-interface FourOThreeB {
-  currentTaxDeferredContributionPercentage?: number | null;
-  currentRothContributionPercentage?: number | null;
-}
+type FourOThreeB = NonNullable<
+  HcmUserQuery['hcm'][number]['fourOThreeB']
+>;
 
 export const buildPdsGoalConstants = (
   goalMiscConstants: GoalMiscConstants,


### PR DESCRIPTION
## Description

- Display the calculated total goal amount on each PDS Goal Card in the goals list, so users don't have to open the calculator to see their goal
- Add a `calculatePdsGoalTotal()` helper that composes the three existing calculation functions (salary, reimbursable expenses, other expenses) into a single call returning the final assessment amount
- Wire up goal calculator constants and HCM user data from `PdsGoalsList` to each `PdsGoalCard`
- Matches the layout and behavior of the regular MPD Goal Calculator's GoalCard

Related Jira ticket: [MPDX-9455](https://jira.cru.org/browse/MPDX-9455)

## Testing

- Go to the PDS Goal Calculator goals list page
- Verify each goal card now shows a "Goal Amount" row with a currency-formatted value below the goal name
- Verify the "Last Updated" row still appears below the "Goal Amount" row
- Create a new goal with salary/benefits data, return to the list, and verify the calculated amount updates
- Verify a goal with no pay rate set shows $0.00

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history