### PR TITLE
[No-Jira] Fix broken enum after API update

### DIFF
--- a/src/components/Reports/Shared/Helpers/transformStaffExpenseEnums.ts
+++ b/src/components/Reports/Shared/Helpers/transformStaffExpenseEnums.ts
@@ -58,7 +58,7 @@ export const getLocalizedSubCategory = (
     [StaffExpensesSubCategoryEnum.SpecialPay]: t('Special Pay'),
     [StaffExpensesSubCategoryEnum.SalaryAdvance]: t('Salary Advance'),
     [StaffExpensesSubCategoryEnum.EarningsMha]: t('Earnings MHA'),
-    [StaffExpensesSubCategoryEnum.EarningsReb]: t('Earnings REB'),
+    [StaffExpensesSubCategoryEnum.EarningsReg]: t('Earnings REG'),
     [StaffExpensesSubCategoryEnum.EarningsNumeric]: t('Earnings Numeric'),
     [StaffExpensesSubCategoryEnum.DisabilityEarnings]: t('Disability Earnings'),
     [StaffExpensesSubCategoryEnum.OtherStandardEarnings]: t(


### PR DESCRIPTION
## Description

`StaffExpensesSubCategoryEnum` renamed `EarningsReb` to `EarningsReg`. This is used once in the frontend, so naming needs to be updated to match.

API PR: https://github.com/CruGlobal/mpdx_api/pull/3307

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `/reports/staffExpense`
- Check that nothing is broken

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
