### PR TITLE
No-Jira - PDS Goal refactors: Fix long title name stretching goal cards

### DIFF
--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { PdsGoalsList } from '../GoalsList/PdsGoalsList';
 import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
 
@@ -63,6 +64,42 @@ describe('PdsGoalCard', () => {
     );
 
     expect(await findByTestId('date-value')).toHaveTextContent('March 15');
+  });
+
+  it('shows the full goal name in a tooltip on hover', async () => {
+    const longName =
+      'A very long goal name that would otherwise stretch the card';
+    const { findByTestId, findByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        withProvider={false}
+        calculationsMock={{
+          nodes: [{ name: longName }],
+        }}
+      >
+        <PdsGoalsList />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    userEvent.hover(await findByTestId('goal-name'));
+
+    expect(await findByRole('tooltip')).toHaveTextContent(longName);
+  });
+
+  it('shows the unnamed goal fallback in a tooltip on hover', async () => {
+    const { findByTestId, findByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        withProvider={false}
+        calculationsMock={{
+          nodes: [{ name: null }],
+        }}
+      >
+        <PdsGoalsList />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    userEvent.hover(await findByTestId('goal-name'));
+
+    expect(await findByRole('tooltip')).toHaveTextContent('Unnamed Goal');
   });
 
   it('renders the calculated goal amount', async () => {

--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
@@ -6,6 +6,7 @@ import {
   Card,
   Divider,
   Skeleton,
+  Tooltip,
   Typography,
   styled,
 } from '@mui/material';
@@ -24,7 +25,7 @@ import {
 } from '../calculations/calculatePdsGoalTotal';
 
 const StyledCard = styled(Card)(({ theme }) => ({
-  minWidth: 350,
+  width: 350,
   borderRadius: theme.shape.borderRadius,
 }));
 
@@ -34,6 +35,7 @@ const StyledHeaderBox = styled(Box)(({ theme }) => ({
   justifyContent: 'center',
   marginBottom: theme.spacing(2),
   marginTop: theme.spacing(2),
+  paddingInline: theme.spacing(2),
 }));
 
 const StyledContentBox = styled(Box)(({ theme }) => ({
@@ -127,9 +129,16 @@ export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({ goal, onDelete }) => {
 
       <StyledCard>
         <StyledHeaderBox>
-          <Typography data-testid="goal-name" variant="h6">
-            {goal.name ?? t('Unnamed Goal')}
-          </Typography>
+          <Tooltip title={goal.name ?? t('Unnamed Goal')}>
+            <Typography
+              data-testid="goal-name"
+              variant="h6"
+              noWrap
+              sx={{ width: '100%', textAlign: 'center' }}
+            >
+              {goal.name ?? t('Unnamed Goal')}
+            </Typography>
+          </Tooltip>
         </StyledHeaderBox>
 
         <Divider />


### PR DESCRIPTION
## Description

- Fixes styling for Goal Cards so long titles no longer stretch cards
- Long titles are given ellipses and a tooltip to show the rest of the title

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to hrTools/pdsGoalCalculator
- Make a goal with a long title
- Check that the styling of the card is maintained and looks good.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
