### PR TITLE
[MPDX-9531] Swap spouse salary request fields

### DIFF
--- a/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/LandingSalaryCalculations.graphql
+++ b/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/LandingSalaryCalculations.graphql
@@ -17,6 +17,7 @@ query LandingSalaryCalculations {
   }
   effectiveCalculation: effectiveSalaryRequest {
     id
+    personNumber
     salary
     spouseSalary
     calculations {

--- a/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/LandingTestWrapper.tsx
+++ b/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/LandingTestWrapper.tsx
@@ -51,6 +51,7 @@ export const LandingTestWrapper: React.FC<LandingTestWrapperProps> = ({
                 staffInfo: {
                   preferredName: 'John',
                   lastName: 'Doe',
+                  personNumber: '000123456',
                   secaStatus: SecaStatusEnum.Seca,
                   peopleGroupSupportType:
                     PeopleGroupSupportTypeEnum.SupportedRmo,
@@ -75,6 +76,7 @@ export const LandingTestWrapper: React.FC<LandingTestWrapperProps> = ({
                 staffInfo: {
                   preferredName: 'Jane',
                   lastName: 'Doe',
+                  personNumber: '000123457',
                   secaStatus: SecaStatusEnum.Seca,
                 },
                 currentSalary: {
@@ -98,6 +100,7 @@ export const LandingTestWrapper: React.FC<LandingTestWrapperProps> = ({
               : null,
             effectiveCalculation: hasApprovedCalculation
               ? {
+                  personNumber: '000123456',
                   salary: 50000,
                   spouseSalary: 60000,
                   calculations: { effectiveCap: 60000 },

--- a/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/LandingTestWrapper.tsx
+++ b/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/LandingTestWrapper.tsx
@@ -18,11 +18,12 @@ import { AccountBalanceQuery } from '../AccountBalance.generated';
 import { StaffAccountIdQuery } from '../StaffAccountId.generated';
 import { LandingSalaryCalculationsQuery } from './LandingSalaryCalculations.generated';
 
-interface LandingTestWrapperProps {
+export interface LandingTestWrapperProps {
   onCall?: MockLinkCallHandler;
   children?: React.ReactNode;
   hasInProgressCalculation?: boolean;
   hasApprovedCalculation?: boolean;
+  hasSpouseApprovedCalculation?: boolean;
   hasLatestCalculation?: boolean;
   salaryRequestEligible?: boolean;
 }
@@ -32,6 +33,7 @@ export const LandingTestWrapper: React.FC<LandingTestWrapperProps> = ({
   children,
   hasInProgressCalculation = false,
   hasApprovedCalculation = false,
+  hasSpouseApprovedCalculation = false,
   hasLatestCalculation = false,
   salaryRequestEligible = true,
 }) => (
@@ -100,7 +102,9 @@ export const LandingTestWrapper: React.FC<LandingTestWrapperProps> = ({
               : null,
             effectiveCalculation: hasApprovedCalculation
               ? {
-                  personNumber: '000123456',
+                  personNumber: hasSpouseApprovedCalculation
+                    ? '000123457'
+                    : '000123456',
                   salary: 50000,
                   spouseSalary: 60000,
                   calculations: { effectiveCap: 60000 },

--- a/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/NewSalaryCalculatorLanding.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/NewSalaryCalculatorLanding.test.tsx
@@ -1,27 +1,15 @@
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { LandingTestWrapper } from './LandingTestWrapper';
+import {
+  LandingTestWrapper,
+  LandingTestWrapperProps,
+} from './LandingTestWrapper';
 import { NewSalaryCalculatorLanding } from './NewSalaryCalculatorLanding';
 
 const mutationSpy = jest.fn();
 
-interface TestComponentProps {
-  hasInProgressCalculation?: boolean;
-  hasApprovedCalculation?: boolean;
-  salaryRequestEligible?: boolean;
-}
-
-const TestComponent: React.FC<TestComponentProps> = ({
-  hasInProgressCalculation = false,
-  hasApprovedCalculation = false,
-  salaryRequestEligible,
-}) => (
-  <LandingTestWrapper
-    hasInProgressCalculation={hasInProgressCalculation}
-    hasApprovedCalculation={hasApprovedCalculation}
-    salaryRequestEligible={salaryRequestEligible}
-    onCall={mutationSpy}
-  >
+const TestComponent: React.FC<LandingTestWrapperProps> = (props) => (
+  <LandingTestWrapper {...props} onCall={mutationSpy}>
     <NewSalaryCalculatorLanding />
   </LandingTestWrapper>
 );
@@ -45,18 +33,54 @@ describe('NewSalaryCalculatorLanding', () => {
     expect(await findByTestId('amount-two')).toHaveTextContent('$10,000.00');
   });
 
-  it('renders SalaryInformationCard with correct cell data', async () => {
-    const { findByRole } = render(<TestComponent />);
+  it('renders table with correct cell data', async () => {
+    const { getAllByRole } = render(<TestComponent hasApprovedCalculation />);
 
-    // Self
-    expect(
-      await findByRole('heading', { name: '$55,000.00' }),
-    ).toBeInTheDocument();
+    const expectedCells = [
+      ['Maximum Allowable Salary', '$60,000.00', '$70,000.00'],
+      ['Requested Salary', '$50,000.00', '$60,000.00'],
+      ['Tax-deferred 403(b) Contribution', '5%', '6%'],
+      ['Roth 403(b) Contribution', '12%', '10%'],
+      ['Security (SECA/FICA) Status', 'Subject to SECA', 'Subject to SECA'],
+      ['Current Gross Salary', '$55,000.00', '$10,000.00'],
+      [
+        'Current MHA (Included in Current Gross Salary)',
+        '$10,000.00View MHA Form',
+        '$12,000.00',
+      ],
+    ].flat();
 
-    // Spouse
-    expect(
-      await findByRole('heading', { name: '$10,000.00' }),
-    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
+        expectedCells,
+      ),
+    );
+  });
+
+  it('swaps effective request fields when the spouse created the request', async () => {
+    const { getAllByRole } = render(
+      <TestComponent hasApprovedCalculation hasSpouseApprovedCalculation />,
+    );
+
+    const expectedCells = [
+      ['Maximum Allowable Salary', '$70,000.00', '$60,000.00'],
+      ['Requested Salary', '$60,000.00', '$50,000.00'],
+      ['Tax-deferred 403(b) Contribution', '5%', '6%'],
+      ['Roth 403(b) Contribution', '12%', '10%'],
+      ['Security (SECA/FICA) Status', 'Subject to SECA', 'Subject to SECA'],
+      ['Current Gross Salary', '$55,000.00', '$10,000.00'],
+      [
+        'Current MHA (Included in Current Gross Salary)',
+        '$10,000.00View MHA Form',
+        '$12,000.00',
+      ],
+    ].flat();
+
+    await waitFor(() =>
+      expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
+        expectedCells,
+      ),
+    );
   });
 
   it('renders action button', async () => {

--- a/src/components/HrTools/SalaryCalculator/Landing/useLandingData.ts
+++ b/src/components/HrTools/SalaryCalculator/Landing/useLandingData.ts
@@ -153,36 +153,45 @@ export const useLandingData = (): LandingData => {
     [accountBalanceData],
   );
 
-  const salaryCategories = useMemo<SalaryCategory[]>(
-    () => [
+  const salaryCategories = useMemo<SalaryCategory[]>(() => {
+    const ownRequest =
+      effectiveCalculation?.personNumber === self?.staffInfo.personNumber;
+    const effectiveCap = ownRequest
+      ? effectiveCalculation?.calculations.effectiveCap
+      : effectiveCalculation?.spouseCalculations?.effectiveCap;
+    const spouseEffectiveCap = ownRequest
+      ? effectiveCalculation?.spouseCalculations?.effectiveCap
+      : effectiveCalculation?.calculations.effectiveCap;
+    const salary = ownRequest
+      ? effectiveCalculation?.salary
+      : effectiveCalculation?.spouseSalary;
+    const spouseSalary = ownRequest
+      ? effectiveCalculation?.spouseSalary
+      : effectiveCalculation?.salary;
+
+    return [
       {
         category: t('Maximum Allowable Salary'),
-        user: effectiveCalculation?.calculations.effectiveCap
-          ? currencyFormat(
-              effectiveCalculation.calculations.effectiveCap,
-              'USD',
-              locale,
-              { showTrailingZeros: true },
-            )
+        user: effectiveCap
+          ? currencyFormat(effectiveCap, 'USD', locale, {
+              showTrailingZeros: true,
+            })
           : 'TBD',
-        spouse: effectiveCalculation?.spouseCalculations?.effectiveCap
-          ? currencyFormat(
-              effectiveCalculation.spouseCalculations?.effectiveCap,
-              'USD',
-              locale,
-              { showTrailingZeros: true },
-            )
+        spouse: spouseEffectiveCap
+          ? currencyFormat(spouseEffectiveCap, 'USD', locale, {
+              showTrailingZeros: true,
+            })
           : 'TBD',
       },
       {
         category: t('Requested Salary'),
-        user: effectiveCalculation?.salary
-          ? currencyFormat(effectiveCalculation.salary, 'USD', locale, {
+        user: salary
+          ? currencyFormat(salary, 'USD', locale, {
               showTrailingZeros: true,
             })
           : 'TBD',
-        spouse: effectiveCalculation?.spouseSalary
-          ? currencyFormat(effectiveCalculation.spouseSalary, 'USD', locale, {
+        spouse: spouseSalary
+          ? currencyFormat(spouseSalary, 'USD', locale, {
               showTrailingZeros: true,
             })
           : 'TBD',
@@ -242,9 +251,8 @@ export const useLandingData = (): LandingData => {
         }),
         link: '/hrTools/mhaCalculator',
       },
-    ],
-    [t, salaryData, self, spouse, effectiveCalculation, locale],
-  );
+    ];
+  }, [t, salaryData, self, spouse, effectiveCalculation, locale]);
 
   return {
     staffAccountId,

--- a/src/components/HrTools/SalaryCalculator/Landing/useLandingData.ts
+++ b/src/components/HrTools/SalaryCalculator/Landing/useLandingData.ts
@@ -5,6 +5,7 @@ import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat, percentageFormat } from 'src/lib/intlFormat';
 import { type HcmQuery, useHcmQuery } from '../../Shared/HcmData/Hcm.generated';
 import { getLocalizedTaxStatus } from '../Shared/getLocalizedTaxStatus';
+import { orientSalaryRequest } from '../Shared/orientSalaryRequest';
 import { useAccountBalanceQuery } from './AccountBalance.generated';
 import {
   type LandingSalaryCalculationsQuery,
@@ -64,7 +65,6 @@ export const useLandingData = (): LandingData => {
   const { data: staffAccountIdData, loading: staffAccountIdLoading } =
     useStaffAccountIdQuery();
 
-  const effectiveCalculation = calculationData?.effectiveCalculation;
   const inProgressCalculationId =
     calculationData?.inProgressCalculation?.id ?? null;
   const latestCalculation = calculationData?.latestCalculation;
@@ -154,44 +154,40 @@ export const useLandingData = (): LandingData => {
   );
 
   const salaryCategories = useMemo<SalaryCategory[]>(() => {
-    const ownRequest =
-      effectiveCalculation?.personNumber === self?.staffInfo.personNumber;
-    const effectiveCap = ownRequest
-      ? effectiveCalculation?.calculations.effectiveCap
-      : effectiveCalculation?.spouseCalculations?.effectiveCap;
-    const spouseEffectiveCap = ownRequest
-      ? effectiveCalculation?.spouseCalculations?.effectiveCap
-      : effectiveCalculation?.calculations.effectiveCap;
-    const salary = ownRequest
-      ? effectiveCalculation?.salary
-      : effectiveCalculation?.spouseSalary;
-    const spouseSalary = ownRequest
-      ? effectiveCalculation?.spouseSalary
-      : effectiveCalculation?.salary;
+    const effectiveCalculation = orientSalaryRequest(
+      calculationData?.effectiveCalculation,
+      self?.staffInfo.personNumber,
+    );
 
     return [
       {
         category: t('Maximum Allowable Salary'),
-        user: effectiveCap
-          ? currencyFormat(effectiveCap, 'USD', locale, {
-              showTrailingZeros: true,
-            })
+        user: effectiveCalculation?.calculations.effectiveCap
+          ? currencyFormat(
+              effectiveCalculation.calculations.effectiveCap,
+              'USD',
+              locale,
+              { showTrailingZeros: true },
+            )
           : 'TBD',
-        spouse: spouseEffectiveCap
-          ? currencyFormat(spouseEffectiveCap, 'USD', locale, {
-              showTrailingZeros: true,
-            })
+        spouse: effectiveCalculation?.spouseCalculations?.effectiveCap
+          ? currencyFormat(
+              effectiveCalculation.spouseCalculations?.effectiveCap,
+              'USD',
+              locale,
+              { showTrailingZeros: true },
+            )
           : 'TBD',
       },
       {
         category: t('Requested Salary'),
-        user: salary
-          ? currencyFormat(salary, 'USD', locale, {
+        user: effectiveCalculation?.salary
+          ? currencyFormat(effectiveCalculation.salary, 'USD', locale, {
               showTrailingZeros: true,
             })
           : 'TBD',
-        spouse: spouseSalary
-          ? currencyFormat(spouseSalary, 'USD', locale, {
+        spouse: effectiveCalculation?.spouseSalary
+          ? currencyFormat(effectiveCalculation.spouseSalary, 'USD', locale, {
               showTrailingZeros: true,
             })
           : 'TBD',
@@ -252,7 +248,7 @@ export const useLandingData = (): LandingData => {
         link: '/hrTools/mhaCalculator',
       },
     ];
-  }, [t, salaryData, self, spouse, effectiveCalculation, locale]);
+  }, [t, salaryData, self, spouse, calculationData, locale]);
 
   return {
     staffAccountId,

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculatorContext/SalaryCalculation.graphql
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculatorContext/SalaryCalculation.graphql
@@ -75,6 +75,7 @@ query SalaryCalculation($id: ID!) {
 query EffectiveSalaryCalculation {
   salaryRequest: effectiveSalaryRequest {
     id
+    personNumber
     mhaAmount
     spouseMhaAmount
     salary

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculatorTestWrapper.tsx
@@ -29,6 +29,7 @@ const hcmMock = gqlMock<HcmQuery, HcmQueryVariables>(HcmDocument, {
         staffInfo: {
           preferredName: 'John',
           lastName: 'Doe',
+          personNumber: '000123456',
           city: 'Miami',
           country: 'US',
           state: 'FL',
@@ -62,6 +63,7 @@ const hcmMock = gqlMock<HcmQuery, HcmQueryVariables>(HcmDocument, {
         staffInfo: {
           preferredName: 'Jane',
           lastName: 'Doe',
+          personNumber: '000789123',
           tenure: 1000,
           primaryPhoneNumber: '555-0124',
           emailAddress: 'jane.doe@example.com',

--- a/src/components/HrTools/SalaryCalculator/Shared/orientSalaryRequest.test.ts
+++ b/src/components/HrTools/SalaryCalculator/Shared/orientSalaryRequest.test.ts
@@ -1,0 +1,51 @@
+import { orientSalaryRequest } from './orientSalaryRequest';
+
+const baseRequest = {
+  personNumber: 'user-1',
+  salary: 10001,
+  spouseSalary: 20001,
+  mhaAmount: 10002,
+  spouseMhaAmount: 20003,
+  salaryCap: 10003,
+  spouseSalaryCap: 20003,
+  calculations: { effectiveCap: 10004, contributing403bFraction: 0.15 },
+  spouseCalculations: { effectiveCap: 20005, contributing403bFraction: 0.25 },
+};
+
+describe('orientSalaryRequest', () => {
+  it('returns the request unchanged when person numbers match', () => {
+    expect(orientSalaryRequest(baseRequest, 'user-1')).toEqual(baseRequest);
+  });
+
+  it('swaps user and spouse fields when the spouse created the request', () => {
+    const oriented = orientSalaryRequest(baseRequest, 'user-2');
+
+    expect(oriented).toEqual({
+      personNumber: 'user-2',
+      salary: 20001,
+      spouseSalary: 10001,
+      mhaAmount: 20003,
+      spouseMhaAmount: 10002,
+      salaryCap: 20003,
+      spouseSalaryCap: 10003,
+      calculations: {
+        effectiveCap: 20005,
+        contributing403bFraction: 0.25,
+      },
+      spouseCalculations: {
+        effectiveCap: 10004,
+        contributing403bFraction: 0.15,
+      },
+    });
+  });
+
+  it('passes through nullish requests', () => {
+    expect(orientSalaryRequest(null, 'user-1')).toBeNull();
+    expect(orientSalaryRequest(undefined, 'user-1')).toBeUndefined();
+  });
+
+  it('returns the request unchanged when the user person number is missing', () => {
+    expect(orientSalaryRequest(baseRequest, null)).toEqual(baseRequest);
+    expect(orientSalaryRequest(baseRequest, undefined)).toEqual(baseRequest);
+  });
+});

--- a/src/components/HrTools/SalaryCalculator/Shared/orientSalaryRequest.ts
+++ b/src/components/HrTools/SalaryCalculator/Shared/orientSalaryRequest.ts
@@ -1,0 +1,52 @@
+import type {
+  SalaryRequest,
+  SalaryRequestCalculations,
+} from 'src/graphql/types.generated';
+
+type SwappableSalaryRequest = Partial<
+  Pick<
+    SalaryRequest,
+    | 'personNumber'
+    | 'salary'
+    | 'spouseSalary'
+    | 'mhaAmount'
+    | 'spouseMhaAmount'
+    | 'salaryCap'
+    | 'spouseSalaryCap'
+  >
+> & {
+  calculations?: Partial<SalaryRequestCalculations> | null;
+  spouseCalculations?: Partial<SalaryRequestCalculations> | null;
+};
+
+/**
+ * The database stores salary requests from the perspective of the person who created it. This
+ * helper detects when the request was created by the spouse and swaps the fields to be from the
+ * user's perspective.
+ */
+export const orientSalaryRequest = <Request extends SwappableSalaryRequest>(
+  request: Request | null | undefined,
+  userPersonNumber: string | null | undefined,
+): Request | null | undefined => {
+  if (
+    !request?.personNumber ||
+    !userPersonNumber ||
+    request.personNumber === userPersonNumber
+  ) {
+    return request;
+  }
+
+  // The person number of the request doesn't match the user's person number, so swap the fields
+  return {
+    ...request,
+    personNumber: userPersonNumber,
+    salary: request.spouseSalary,
+    spouseSalary: request.salary,
+    mhaAmount: request.spouseMhaAmount,
+    spouseMhaAmount: request.mhaAmount,
+    salaryCap: request.spouseSalaryCap,
+    spouseSalaryCap: request.salaryCap,
+    calculations: request.spouseCalculations,
+    spouseCalculations: request.calculations,
+  };
+};

--- a/src/components/HrTools/SalaryCalculator/Summary/SalarySummaryCard.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/Summary/SalarySummaryCard.test.tsx
@@ -4,26 +4,31 @@ import { DeepPartial } from 'ts-essentials';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { HcmQuery } from '../../Shared/HcmData/Hcm.generated';
-import { SalaryCalculationQuery } from '../SalaryCalculatorContext/SalaryCalculation.generated';
+import {
+  EffectiveSalaryCalculationQuery,
+  SalaryCalculationQuery,
+} from '../SalaryCalculatorContext/SalaryCalculation.generated';
 import { SalaryCalculatorProvider } from '../SalaryCalculatorContext/SalaryCalculatorContext';
 import { hcmSpouseMock, hcmUserMock } from '../SalaryCalculatorTestWrapper';
 import { SalarySummaryCard } from './SalarySummaryCard';
 
-const approvedSalaryMock: DeepPartial<SalaryCalculationQuery['salaryRequest']> =
-  {
-    salary: 10001,
-    mhaAmount: 10002,
-    spouseSalary: 20001,
-    spouseMhaAmount: 20002,
-    calculations: {
-      contributing403bFraction: 0.1,
-      effectiveCap: 10003,
-    },
-    spouseCalculations: {
-      contributing403bFraction: 0.2,
-      effectiveCap: 20003,
-    },
-  };
+const approvedSalaryMock: DeepPartial<
+  EffectiveSalaryCalculationQuery['salaryRequest']
+> = {
+  personNumber: hcmUserMock.staffInfo.personNumber,
+  salary: 10001,
+  mhaAmount: 10002,
+  spouseSalary: 20001,
+  spouseMhaAmount: 20002,
+  calculations: {
+    contributing403bFraction: 0.1,
+    effectiveCap: 10003,
+  },
+  spouseCalculations: {
+    contributing403bFraction: 0.2,
+    effectiveCap: 20003,
+  },
+};
 
 const defaultSalaryMock: DeepPartial<SalaryCalculationQuery['salaryRequest']> =
   {
@@ -45,11 +50,13 @@ const defaultSalaryMock: DeepPartial<SalaryCalculationQuery['salaryRequest']> =
 interface TestComponentProps {
   hasSpouse?: boolean;
   hasApprovedCalculation?: boolean;
+  hasSpouseApprovedCalculation?: boolean;
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({
   hasSpouse = true,
   hasApprovedCalculation = true,
+  hasSpouseApprovedCalculation = false,
 }) => (
   <TestRouter
     router={{
@@ -59,6 +66,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
     <GqlMockedProvider<{
       Hcm: HcmQuery;
       SalaryCalculation: SalaryCalculationQuery;
+      EffectiveSalaryCalculation: EffectiveSalaryCalculationQuery;
     }>
       mocks={{
         Hcm: {
@@ -68,7 +76,14 @@ const TestComponent: React.FC<TestComponentProps> = ({
           salaryRequest: defaultSalaryMock,
         },
         EffectiveSalaryCalculation: {
-          salaryRequest: hasApprovedCalculation ? approvedSalaryMock : null,
+          salaryRequest: hasApprovedCalculation
+            ? {
+                ...approvedSalaryMock,
+                personNumber: hasSpouseApprovedCalculation
+                  ? hcmSpouseMock.staffInfo.personNumber
+                  : hcmUserMock.staffInfo.personNumber,
+              }
+            : null,
         },
       }}
     >
@@ -107,6 +122,29 @@ describe('SalarySummaryCard', () => {
       ['MHA', '$20,002.00', '$40,002.00'],
       ['403(b) Contribution', '20.00%', '40.00%'],
       ['Max Allowable Salary', '$20,003.00', '$40,003.00'],
+    ].flat();
+
+    await waitFor(() =>
+      expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
+        expectedCells,
+      ),
+    );
+  });
+
+  it('swaps fields when the spouse created the request', async () => {
+    const { getAllByRole } = render(
+      <TestComponent hasSpouseApprovedCalculation />,
+    );
+
+    const expectedCells = [
+      ['Requested Salary', '$20,001.00', '$30,001.00'],
+      ['MHA', '$20,002.00', '$30,002.00'],
+      ['403(b) Contribution', '20.00%', '30.00%'],
+      ['Max Allowable Salary', '$20,003.00', '$30,003.00'],
+      ['Requested Salary', '$10,001.00', '$40,001.00'],
+      ['MHA', '$10,002.00', '$40,002.00'],
+      ['403(b) Contribution', '10.00%', '40.00%'],
+      ['Max Allowable Salary', '$10,003.00', '$40,003.00'],
     ].flat();
 
     await waitFor(() =>

--- a/src/components/HrTools/SalaryCalculator/Summary/SalarySummaryCard.tsx
+++ b/src/components/HrTools/SalaryCalculator/Summary/SalarySummaryCard.tsx
@@ -16,8 +16,16 @@ import { useFormatters } from '../Shared/useFormatters';
 export const SalarySummaryCard: React.FC = () => {
   const { t } = useTranslation();
   const { hcmUser, hcmSpouse, calculation } = useSalaryCalculator();
-  const { data: approvedData } = useEffectiveSalaryCalculationQuery();
-  const effectiveCalculation = approvedData?.salaryRequest;
+  const { data: effectiveData } = useEffectiveSalaryCalculationQuery();
+  const oldCalculation = effectiveData?.salaryRequest;
+  const ownRequest =
+    oldCalculation?.personNumber === hcmUser?.staffInfo.personNumber;
+  const oldCalculations = ownRequest
+    ? oldCalculation?.calculations
+    : oldCalculation?.spouseCalculations;
+  const oldSpouseCalculations = ownRequest
+    ? oldCalculation?.spouseCalculations
+    : oldCalculation?.calculations;
   const { formatCurrency, formatFraction } = useFormatters();
 
   return (
@@ -37,38 +45,42 @@ export const SalarySummaryCard: React.FC = () => {
               <TableCell scope="col">
                 {hcmUser?.staffInfo.preferredName}
               </TableCell>
-              {effectiveCalculation && (
-                <TableCell scope="col">{t('Old')}</TableCell>
-              )}
+              {oldCalculation && <TableCell scope="col">{t('Old')}</TableCell>}
               <TableCell scope="col">{t('New')}</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             <TableRow>
               <TableCell scope="row">{t('Requested Salary')}</TableCell>
-              {effectiveCalculation && (
+              {oldCalculation && (
                 <TableCell>
-                  {formatCurrency(effectiveCalculation.salary)}
+                  {formatCurrency(
+                    ownRequest
+                      ? oldCalculation.salary
+                      : oldCalculation.spouseSalary,
+                  )}
                 </TableCell>
               )}
               <TableCell>{formatCurrency(calculation?.salary)}</TableCell>
             </TableRow>
             <TableRow>
               <TableCell scope="row">{t('MHA')}</TableCell>
-              {effectiveCalculation && (
+              {oldCalculation && (
                 <TableCell>
-                  {formatCurrency(effectiveCalculation.mhaAmount)}
+                  {formatCurrency(
+                    ownRequest
+                      ? oldCalculation.mhaAmount
+                      : oldCalculation.spouseMhaAmount,
+                  )}
                 </TableCell>
               )}
               <TableCell>{formatCurrency(calculation?.mhaAmount)}</TableCell>
             </TableRow>
             <TableRow>
               <TableCell scope="row">{t('403(b) Contribution')}</TableCell>
-              {effectiveCalculation && (
+              {oldCalculation && (
                 <TableCell>
-                  {formatFraction(
-                    effectiveCalculation.calculations.contributing403bFraction,
-                  )}
+                  {formatFraction(oldCalculations?.contributing403bFraction)}
                 </TableCell>
               )}
               <TableCell>
@@ -79,11 +91,9 @@ export const SalarySummaryCard: React.FC = () => {
             </TableRow>
             <TableRow>
               <TableCell scope="row">{t('Max Allowable Salary')}</TableCell>
-              {effectiveCalculation && (
+              {oldCalculation && (
                 <TableCell>
-                  {formatCurrency(
-                    effectiveCalculation.calculations.effectiveCap,
-                  )}
+                  {formatCurrency(oldCalculations?.effectiveCap)}
                 </TableCell>
               )}
               <TableCell>
@@ -100,7 +110,7 @@ export const SalarySummaryCard: React.FC = () => {
                 <TableCell scope="col">
                   {hcmSpouse?.staffInfo.preferredName}
                 </TableCell>
-                {effectiveCalculation && (
+                {oldCalculation && (
                   <TableCell scope="col">{t('Old')}</TableCell>
                 )}
                 <TableCell scope="col">{t('New')}</TableCell>
@@ -109,9 +119,13 @@ export const SalarySummaryCard: React.FC = () => {
             <TableBody>
               <TableRow>
                 <TableCell scope="row">{t('Requested Salary')}</TableCell>
-                {effectiveCalculation && (
+                {oldCalculation && (
                   <TableCell>
-                    {formatCurrency(effectiveCalculation.spouseSalary)}
+                    {formatCurrency(
+                      ownRequest
+                        ? oldCalculation.spouseSalary
+                        : oldCalculation.salary,
+                    )}
                   </TableCell>
                 )}
                 <TableCell>
@@ -120,9 +134,13 @@ export const SalarySummaryCard: React.FC = () => {
               </TableRow>
               <TableRow>
                 <TableCell scope="row">{t('MHA')}</TableCell>
-                {effectiveCalculation && (
+                {oldCalculation && (
                   <TableCell>
-                    {formatCurrency(effectiveCalculation.spouseMhaAmount)}
+                    {formatCurrency(
+                      ownRequest
+                        ? oldCalculation.spouseMhaAmount
+                        : oldCalculation.mhaAmount,
+                    )}
                   </TableCell>
                 )}
                 <TableCell>
@@ -131,11 +149,10 @@ export const SalarySummaryCard: React.FC = () => {
               </TableRow>
               <TableRow>
                 <TableCell scope="row">{t('403(b) Contribution')}</TableCell>
-                {effectiveCalculation && (
+                {oldCalculation && (
                   <TableCell>
                     {formatFraction(
-                      effectiveCalculation.spouseCalculations
-                        ?.contributing403bFraction,
+                      oldSpouseCalculations?.contributing403bFraction,
                     )}
                   </TableCell>
                 )}
@@ -147,11 +164,9 @@ export const SalarySummaryCard: React.FC = () => {
               </TableRow>
               <TableRow>
                 <TableCell scope="row">{t('Max Allowable Salary')}</TableCell>
-                {effectiveCalculation && (
+                {oldCalculation && (
                   <TableCell>
-                    {formatCurrency(
-                      effectiveCalculation.spouseCalculations?.effectiveCap,
-                    )}
+                    {formatCurrency(oldSpouseCalculations?.effectiveCap)}
                   </TableCell>
                 )}
                 <TableCell>

--- a/src/components/HrTools/SalaryCalculator/Summary/SalarySummaryCard.tsx
+++ b/src/components/HrTools/SalaryCalculator/Summary/SalarySummaryCard.tsx
@@ -11,21 +11,17 @@ import { useTranslation } from 'react-i18next';
 import { useEffectiveSalaryCalculationQuery } from '../SalaryCalculatorContext/SalaryCalculation.generated';
 import { useSalaryCalculator } from '../SalaryCalculatorContext/SalaryCalculatorContext';
 import { StepCard } from '../Shared/StepCard';
+import { orientSalaryRequest } from '../Shared/orientSalaryRequest';
 import { useFormatters } from '../Shared/useFormatters';
 
 export const SalarySummaryCard: React.FC = () => {
   const { t } = useTranslation();
   const { hcmUser, hcmSpouse, calculation } = useSalaryCalculator();
   const { data: effectiveData } = useEffectiveSalaryCalculationQuery();
-  const oldCalculation = effectiveData?.salaryRequest;
-  const ownRequest =
-    oldCalculation?.personNumber === hcmUser?.staffInfo.personNumber;
-  const oldCalculations = ownRequest
-    ? oldCalculation?.calculations
-    : oldCalculation?.spouseCalculations;
-  const oldSpouseCalculations = ownRequest
-    ? oldCalculation?.spouseCalculations
-    : oldCalculation?.calculations;
+  const effectiveCalculation = orientSalaryRequest(
+    effectiveData?.salaryRequest,
+    hcmUser?.staffInfo.personNumber,
+  );
   const { formatCurrency, formatFraction } = useFormatters();
 
   return (
@@ -45,42 +41,38 @@ export const SalarySummaryCard: React.FC = () => {
               <TableCell scope="col">
                 {hcmUser?.staffInfo.preferredName}
               </TableCell>
-              {oldCalculation && <TableCell scope="col">{t('Old')}</TableCell>}
+              {effectiveCalculation && (
+                <TableCell scope="col">{t('Old')}</TableCell>
+              )}
               <TableCell scope="col">{t('New')}</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             <TableRow>
               <TableCell scope="row">{t('Requested Salary')}</TableCell>
-              {oldCalculation && (
+              {effectiveCalculation && (
                 <TableCell>
-                  {formatCurrency(
-                    ownRequest
-                      ? oldCalculation.salary
-                      : oldCalculation.spouseSalary,
-                  )}
+                  {formatCurrency(effectiveCalculation.salary)}
                 </TableCell>
               )}
               <TableCell>{formatCurrency(calculation?.salary)}</TableCell>
             </TableRow>
             <TableRow>
               <TableCell scope="row">{t('MHA')}</TableCell>
-              {oldCalculation && (
+              {effectiveCalculation && (
                 <TableCell>
-                  {formatCurrency(
-                    ownRequest
-                      ? oldCalculation.mhaAmount
-                      : oldCalculation.spouseMhaAmount,
-                  )}
+                  {formatCurrency(effectiveCalculation.mhaAmount)}
                 </TableCell>
               )}
               <TableCell>{formatCurrency(calculation?.mhaAmount)}</TableCell>
             </TableRow>
             <TableRow>
               <TableCell scope="row">{t('403(b) Contribution')}</TableCell>
-              {oldCalculation && (
+              {effectiveCalculation && (
                 <TableCell>
-                  {formatFraction(oldCalculations?.contributing403bFraction)}
+                  {formatFraction(
+                    effectiveCalculation.calculations.contributing403bFraction,
+                  )}
                 </TableCell>
               )}
               <TableCell>
@@ -91,9 +83,11 @@ export const SalarySummaryCard: React.FC = () => {
             </TableRow>
             <TableRow>
               <TableCell scope="row">{t('Max Allowable Salary')}</TableCell>
-              {oldCalculation && (
+              {effectiveCalculation && (
                 <TableCell>
-                  {formatCurrency(oldCalculations?.effectiveCap)}
+                  {formatCurrency(
+                    effectiveCalculation.calculations.effectiveCap,
+                  )}
                 </TableCell>
               )}
               <TableCell>
@@ -110,7 +104,7 @@ export const SalarySummaryCard: React.FC = () => {
                 <TableCell scope="col">
                   {hcmSpouse?.staffInfo.preferredName}
                 </TableCell>
-                {oldCalculation && (
+                {effectiveCalculation && (
                   <TableCell scope="col">{t('Old')}</TableCell>
                 )}
                 <TableCell scope="col">{t('New')}</TableCell>
@@ -119,13 +113,9 @@ export const SalarySummaryCard: React.FC = () => {
             <TableBody>
               <TableRow>
                 <TableCell scope="row">{t('Requested Salary')}</TableCell>
-                {oldCalculation && (
+                {effectiveCalculation && (
                   <TableCell>
-                    {formatCurrency(
-                      ownRequest
-                        ? oldCalculation.spouseSalary
-                        : oldCalculation.salary,
-                    )}
+                    {formatCurrency(effectiveCalculation.spouseSalary)}
                   </TableCell>
                 )}
                 <TableCell>
@@ -134,13 +124,9 @@ export const SalarySummaryCard: React.FC = () => {
               </TableRow>
               <TableRow>
                 <TableCell scope="row">{t('MHA')}</TableCell>
-                {oldCalculation && (
+                {effectiveCalculation && (
                   <TableCell>
-                    {formatCurrency(
-                      ownRequest
-                        ? oldCalculation.spouseMhaAmount
-                        : oldCalculation.mhaAmount,
-                    )}
+                    {formatCurrency(effectiveCalculation.spouseMhaAmount)}
                   </TableCell>
                 )}
                 <TableCell>
@@ -149,10 +135,11 @@ export const SalarySummaryCard: React.FC = () => {
               </TableRow>
               <TableRow>
                 <TableCell scope="row">{t('403(b) Contribution')}</TableCell>
-                {oldCalculation && (
+                {effectiveCalculation && (
                   <TableCell>
                     {formatFraction(
-                      oldSpouseCalculations?.contributing403bFraction,
+                      effectiveCalculation.spouseCalculations
+                        ?.contributing403bFraction,
                     )}
                   </TableCell>
                 )}
@@ -164,9 +151,11 @@ export const SalarySummaryCard: React.FC = () => {
               </TableRow>
               <TableRow>
                 <TableCell scope="row">{t('Max Allowable Salary')}</TableCell>
-                {oldCalculation && (
+                {effectiveCalculation && (
                   <TableCell>
-                    {formatCurrency(oldSpouseCalculations?.effectiveCap)}
+                    {formatCurrency(
+                      effectiveCalculation.spouseCalculations?.effectiveCap,
+                    )}
                   </TableCell>
                 )}
                 <TableCell>


### PR DESCRIPTION
## Description

When the spouse created the effective salary request, the fields will be swapped from the perspective of the current user. This PR swaps them back.

MPDX-9531

Related backend PR: https://github.com/CruGlobal/mpdx_api/pull/3309

## Testing

- Login with the test account (this account is linked to Mickie)
- Check that the dashboard shows Minnie as having $40K Requested Salary and Mickie as having $30K
- Impersonate caleb.cox@cru.org (my account is linked to Minnie)
- Check that the dashboard shows Minnie as having $40K Requested Salary and Mickie as having $30K

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
