### PR TITLE
[MPDX-9475] - Add Default and Simple view to PDS Goal Calculator

### DIFF
--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
@@ -66,21 +66,4 @@ describe('PdsGoalCard', () => {
     await findByText(name);
     expect(queryByText(expectedBadge)).toBeInTheDocument();
   });
-
-  it('renders no form-type badge when formType is null (legacy goal)', async () => {
-    const { findByText, queryByText } = render(
-      <PdsGoalCalculatorTestWrapper
-        withProvider={false}
-        calculationsMock={{
-          nodes: [{ name: 'Legacy Goal', formType: null }],
-        }}
-      >
-        <PdsGoalsList />
-      </PdsGoalCalculatorTestWrapper>,
-    );
-
-    await findByText('Legacy Goal');
-    expect(queryByText('Default')).not.toBeInTheDocument();
-    expect(queryByText('Simple')).not.toBeInTheDocument();
-  });
 });

--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
 import { PdsGoalsList } from '../GoalsList/PdsGoalsList';
 import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
 
@@ -35,5 +36,63 @@ describe('PdsGoalCard', () => {
       'href',
       '/accountLists/abc123/hrTools/pdsGoalCalculator/pds-goal-1',
     );
+  });
+
+  it('renders a Default badge when formType is Detailed', async () => {
+    const { findByText } = render(
+      <PdsGoalCalculatorTestWrapper
+        withProvider={false}
+        calculationsMock={{
+          nodes: [
+            {
+              name: 'Detailed Goal',
+              formType: DesignationSupportFormType.Detailed,
+            },
+          ],
+        }}
+      >
+        <PdsGoalsList />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    expect(await findByText('Default')).toBeInTheDocument();
+  });
+
+  it('renders a Simple badge when formType is Simple', async () => {
+    const { findByText } = render(
+      <PdsGoalCalculatorTestWrapper
+        withProvider={false}
+        calculationsMock={{
+          nodes: [
+            {
+              name: 'Simple Goal',
+              formType: DesignationSupportFormType.Simple,
+            },
+          ],
+        }}
+      >
+        <PdsGoalsList />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    expect(await findByText('Simple')).toBeInTheDocument();
+  });
+
+  it('renders no form-type badge when formType is null (legacy goal)', async () => {
+    const { findByText, queryByText } = render(
+      <PdsGoalCalculatorTestWrapper
+        withProvider={false}
+        calculationsMock={{
+          nodes: [{ name: 'Legacy Goal', formType: null }],
+        }}
+      >
+        <PdsGoalsList />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await findByText('Legacy Goal');
+
+    expect(queryByText('Default')).not.toBeInTheDocument();
+    expect(queryByText('Simple')).not.toBeInTheDocument();
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
@@ -38,44 +38,33 @@ describe('PdsGoalCard', () => {
     );
   });
 
-  it('renders a Default badge when formType is Detailed', async () => {
-    const { findByText } = render(
+  it.each([
+    {
+      description: 'a Default badge when formType is Detailed',
+      name: 'Detailed Goal',
+      formType: DesignationSupportFormType.Detailed,
+      expectedBadge: 'Default',
+    },
+    {
+      description: 'a Simple badge when formType is Simple',
+      name: 'Simple Goal',
+      formType: DesignationSupportFormType.Simple,
+      expectedBadge: 'Simple',
+    },
+  ])('renders $description', async ({ name, formType, expectedBadge }) => {
+    const { findByText, queryByText } = render(
       <PdsGoalCalculatorTestWrapper
         withProvider={false}
         calculationsMock={{
-          nodes: [
-            {
-              name: 'Detailed Goal',
-              formType: DesignationSupportFormType.Detailed,
-            },
-          ],
+          nodes: [{ name, formType }],
         }}
       >
         <PdsGoalsList />
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    expect(await findByText('Default')).toBeInTheDocument();
-  });
-
-  it('renders a Simple badge when formType is Simple', async () => {
-    const { findByText } = render(
-      <PdsGoalCalculatorTestWrapper
-        withProvider={false}
-        calculationsMock={{
-          nodes: [
-            {
-              name: 'Simple Goal',
-              formType: DesignationSupportFormType.Simple,
-            },
-          ],
-        }}
-      >
-        <PdsGoalsList />
-      </PdsGoalCalculatorTestWrapper>,
-    );
-
-    expect(await findByText('Simple')).toBeInTheDocument();
+    await findByText(name);
+    expect(queryByText(expectedBadge)).toBeInTheDocument();
   });
 
   it('renders no form-type badge when formType is null (legacy goal)', async () => {
@@ -91,7 +80,6 @@ describe('PdsGoalCard', () => {
     );
 
     await findByText('Legacy Goal');
-
     expect(queryByText('Default')).not.toBeInTheDocument();
     expect(queryByText('Simple')).not.toBeInTheDocument();
   });

--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
@@ -1,5 +1,8 @@
 import React, { useMemo } from 'react';
+import { Chip } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 import { GoalCard } from 'src/components/Reports/Shared/GoalCard/GoalCard';
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
 import {
@@ -17,6 +20,7 @@ export interface PdsGoalCardProps {
 }
 
 export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({ goal }) => {
+  const { t } = useTranslation();
   const accountListId = useAccountListId() ?? '';
   const [deletePdsGoalCalculation] = useDeletePdsGoalCalculationMutation();
 
@@ -38,6 +42,16 @@ export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({ goal }) => {
     return constants ? calculatePdsGoalTotal(goal, constants) : 0;
   }, [goal, goalMiscConstants, goalGeographicConstantMap, hcmUser]);
 
+  const formTypeBadge = useMemo(() => {
+    if (goal.formType === DesignationSupportFormType.Simple) {
+      return <Chip label={t('Simple')} size="small" />;
+    }
+    if (goal.formType === DesignationSupportFormType.Detailed) {
+      return <Chip label={t('Default')} size="small" />;
+    }
+    return null;
+  }, [goal.formType, t]);
+
   const handleDelete = async () => {
     await deletePdsGoalCalculation({
       variables: { id: goal.id },
@@ -57,6 +71,7 @@ export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({ goal }) => {
       updatedAt={goal.updatedAt}
       viewHref={`/accountLists/${accountListId}/hrTools/pdsGoalCalculator/${goal.id}`}
       onDelete={handleDelete}
+      badge={formTypeBadge}
     />
   );
 };

--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
@@ -42,12 +42,13 @@ export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({ goal }) => {
     return constants ? calculatePdsGoalTotal(goal, constants) : 0;
   }, [goal, goalMiscConstants, goalGeographicConstantMap, hcmUser]);
 
-  let formTypeBadge: React.ReactElement | null = null;
-  if (goal.formType === DesignationSupportFormType.Simple) {
-    formTypeBadge = <Chip label={t('Simple')} size="small" />;
-  } else if (goal.formType === DesignationSupportFormType.Detailed) {
-    formTypeBadge = <Chip label={t('Default')} size="small" />;
-  }
+  const formType = goal.formType ?? DesignationSupportFormType.Detailed;
+  const formTypeBadge =
+    formType === DesignationSupportFormType.Simple ? (
+      <Chip label={t('Simple')} size="small" variant="outlined" />
+    ) : (
+      <Chip label={t('Default')} size="small" />
+    );
 
   const handleDelete = async () => {
     await deletePdsGoalCalculation({

--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
@@ -42,15 +42,12 @@ export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({ goal }) => {
     return constants ? calculatePdsGoalTotal(goal, constants) : 0;
   }, [goal, goalMiscConstants, goalGeographicConstantMap, hcmUser]);
 
-  const formTypeBadge = useMemo(() => {
-    if (goal.formType === DesignationSupportFormType.Simple) {
-      return <Chip label={t('Simple')} size="small" />;
-    }
-    if (goal.formType === DesignationSupportFormType.Detailed) {
-      return <Chip label={t('Default')} size="small" />;
-    }
-    return null;
-  }, [goal.formType, t]);
+  let formTypeBadge: React.ReactElement | null = null;
+  if (goal.formType === DesignationSupportFormType.Simple) {
+    formTypeBadge = <Chip label={t('Simple')} size="small" />;
+  } else if (goal.formType === DesignationSupportFormType.Detailed) {
+    formTypeBadge = <Chip label={t('Default')} size="small" />;
+  }
 
   const handleDelete = async () => {
     await deletePdsGoalCalculation({

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.test.tsx
@@ -13,7 +13,6 @@ const renderDialog = (
     open: true,
     onClose: jest.fn(),
     onCreate: jest.fn().mockResolvedValue(undefined),
-    creating: false,
   };
   const utils = render(
     <ThemeProvider theme={theme}>
@@ -78,10 +77,17 @@ describe('CreateGoalDialog', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('disables actions while creating is true', () => {
-    const { getByRole } = renderDialog({ creating: true });
-    expect(getByRole('button', { name: 'Create' })).toBeDisabled();
-    expect(getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  it('disables Create but keeps Cancel enabled while submitting', async () => {
+    const onCreate = jest.fn().mockReturnValue(new Promise<void>(() => {}));
+    const { getByRole } = renderDialog({ onCreate });
+
+    userEvent.click(getByRole('radio', { name: /Simple/ }));
+    userEvent.click(getByRole('button', { name: 'Create' }));
+
+    await waitFor(() =>
+      expect(getByRole('button', { name: 'Create' })).toBeDisabled(),
+    );
+    expect(getByRole('button', { name: 'Cancel' })).toBeEnabled();
   });
 
   it('does not render when open is false', () => {

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.test.tsx
@@ -79,14 +79,13 @@ describe('CreateGoalDialog', () => {
 
   it('disables Create but keeps Cancel enabled while submitting', async () => {
     const onCreate = jest.fn().mockReturnValue(new Promise<void>(() => {}));
-    const { getByRole } = renderDialog({ onCreate });
+    const { getByRole, findByRole } = renderDialog({ onCreate });
 
     userEvent.click(getByRole('radio', { name: /Simple/ }));
     userEvent.click(getByRole('button', { name: 'Create' }));
 
-    await waitFor(() =>
-      expect(getByRole('button', { name: 'Create' })).toBeDisabled(),
-    );
+    await findByRole('progressbar');
+    expect(getByRole('button', { name: 'Create' })).toBeDisabled();
     expect(getByRole('button', { name: 'Cancel' })).toBeEnabled();
   });
 

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.test.tsx
@@ -15,14 +15,20 @@ const renderDialog = (
     onCreate: jest.fn().mockResolvedValue(undefined),
     creating: false,
   };
-  return {
-    props: { ...defaults, ...props },
-    ...render(
+  const utils = render(
+    <ThemeProvider theme={theme}>
+      <CreateGoalDialog {...defaults} {...props} />
+    </ThemeProvider>,
+  );
+  const rerenderDialog = (
+    nextProps: Partial<React.ComponentProps<typeof CreateGoalDialog>> = {},
+  ) =>
+    utils.rerender(
       <ThemeProvider theme={theme}>
-        <CreateGoalDialog {...defaults} {...props} />
+        <CreateGoalDialog {...defaults} {...nextProps} />
       </ThemeProvider>,
-    ),
-  };
+    );
+  return { ...utils, rerenderDialog };
 };
 
 describe('CreateGoalDialog', () => {
@@ -84,21 +90,13 @@ describe('CreateGoalDialog', () => {
   });
 
   it('clears the selected option when reopened after Cancel', () => {
-    const { getByRole, rerender } = renderDialog();
+    const { getByRole, rerenderDialog } = renderDialog();
 
     userEvent.click(getByRole('radio', { name: /Simple/ }));
     userEvent.click(getByRole('button', { name: 'Cancel' }));
 
-    rerender(
-      <ThemeProvider theme={theme}>
-        <CreateGoalDialog
-          open={true}
-          onClose={jest.fn()}
-          onCreate={jest.fn().mockResolvedValue(undefined)}
-          creating={false}
-        />
-      </ThemeProvider>,
-    );
+    rerenderDialog({ open: false });
+    rerenderDialog({ open: true });
 
     expect(getByRole('button', { name: 'Create' })).toBeDisabled();
   });

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
+import theme from 'src/theme';
+import { CreateGoalDialog } from './CreateGoalDialog';
+
+const renderDialog = (
+  props: Partial<React.ComponentProps<typeof CreateGoalDialog>> = {},
+) => {
+  const defaults = {
+    open: true,
+    onClose: jest.fn(),
+    onCreate: jest.fn().mockResolvedValue(undefined),
+    creating: false,
+  };
+  return {
+    props: { ...defaults, ...props },
+    ...render(
+      <ThemeProvider theme={theme}>
+        <CreateGoalDialog {...defaults} {...props} />
+      </ThemeProvider>,
+    ),
+  };
+};
+
+describe('CreateGoalDialog', () => {
+  it('renders both form-type options with descriptions', () => {
+    const { getByRole, getByText } = renderDialog();
+    expect(getByRole('radio', { name: /Default/ })).toBeInTheDocument();
+    expect(getByRole('radio', { name: /Simple/ })).toBeInTheDocument();
+    expect(
+      getByText(
+        'Full calculator with reimbursable expenses and 403b contributions.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      getByText(
+        'Streamlined calculator without reimbursable expenses or 403b contributions.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('disables the Create button until a form type is picked', () => {
+    const { getByRole } = renderDialog();
+    expect(getByRole('button', { name: 'Create' })).toBeDisabled();
+  });
+
+  it('enables Create after a form type is picked', () => {
+    const { getByRole } = renderDialog();
+    userEvent.click(getByRole('radio', { name: /Simple/ }));
+    expect(getByRole('button', { name: 'Create' })).toBeEnabled();
+  });
+
+  it('calls onCreate with the chosen form type when Create is clicked', async () => {
+    const onCreate = jest.fn().mockResolvedValue(undefined);
+    const { getByRole } = renderDialog({ onCreate });
+
+    userEvent.click(getByRole('radio', { name: /Simple/ }));
+    userEvent.click(getByRole('button', { name: 'Create' }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith(DesignationSupportFormType.Simple),
+    );
+  });
+
+  it('calls onClose when Cancel is clicked', () => {
+    const onClose = jest.fn();
+    const { getByRole } = renderDialog({ onClose });
+    userEvent.click(getByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('disables actions while creating is true', () => {
+    const { getByRole } = renderDialog({ creating: true });
+    expect(getByRole('button', { name: 'Create' })).toBeDisabled();
+    expect(getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  });
+
+  it('does not render when open is false', () => {
+    const { queryByRole } = renderDialog({ open: false });
+    expect(queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.test.tsx
@@ -82,4 +82,24 @@ describe('CreateGoalDialog', () => {
     const { queryByRole } = renderDialog({ open: false });
     expect(queryByRole('dialog')).not.toBeInTheDocument();
   });
+
+  it('clears the selected option when reopened after Cancel', () => {
+    const { getByRole, rerender } = renderDialog();
+
+    userEvent.click(getByRole('radio', { name: /Simple/ }));
+    userEvent.click(getByRole('button', { name: 'Cancel' }));
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <CreateGoalDialog
+          open={true}
+          onClose={jest.fn()}
+          onCreate={jest.fn().mockResolvedValue(undefined)}
+          creating={false}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(getByRole('button', { name: 'Create' })).toBeDisabled();
+  });
 });

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Button,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -12,8 +13,10 @@ import {
   RadioGroup,
   Typography,
 } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import { useTranslation } from 'react-i18next';
 import { DesignationSupportFormType } from 'src/graphql/types.generated';
+import { isDesignationSupportFormType } from '../Shared/formType';
 
 export interface CreateGoalDialogProps {
   open: boolean;
@@ -33,10 +36,11 @@ export const CreateGoalDialog: React.FC<CreateGoalDialogProps> = ({
     null,
   );
 
-  const handleClose = () => {
-    setSelected(null);
-    onClose();
-  };
+  useEffect(() => {
+    if (open) {
+      setSelected(null);
+    }
+  }, [open]);
 
   const handleCreate = async () => {
     if (selected) {
@@ -44,10 +48,31 @@ export const CreateGoalDialog: React.FC<CreateGoalDialogProps> = ({
     }
   };
 
+  const formTypeOptions: Array<{
+    value: DesignationSupportFormType;
+    title: string;
+    description: string;
+  }> = [
+    {
+      value: DesignationSupportFormType.Detailed,
+      title: t('Default'),
+      description: t(
+        'Full calculator with reimbursable expenses and 403b contributions.',
+      ),
+    },
+    {
+      value: DesignationSupportFormType.Simple,
+      title: t('Simple'),
+      description: t(
+        'Streamlined calculator without reimbursable expenses or 403b contributions.',
+      ),
+    },
+  ];
+
   return (
     <Dialog
       open={open}
-      onClose={handleClose}
+      onClose={onClose}
       maxWidth="sm"
       fullWidth
       aria-labelledby="create-goal-dialog-title"
@@ -57,56 +82,48 @@ export const CreateGoalDialog: React.FC<CreateGoalDialogProps> = ({
       </DialogTitle>
       <DialogContent>
         <FormControl component="fieldset">
-          <FormLabel sx={{ position: 'absolute', width: 1, height: 1, padding: 0, margin: -1, overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap', border: 0 }}>
-            {t('Select a form type')}
-          </FormLabel>
+          <FormLabel sx={visuallyHidden}>{t('Select a form type')}</FormLabel>
           <RadioGroup
             value={selected ?? ''}
-            onChange={(_, value) =>
-              setSelected(value as DesignationSupportFormType)
-            }
+            onChange={(_, value) => {
+              if (isDesignationSupportFormType(value)) {
+                setSelected(value);
+              }
+            }}
           >
-            <FormControlLabel
-              value={DesignationSupportFormType.Detailed}
-              control={<Radio />}
-              label={
-                <>
-                  <Typography variant="subtitle1">{t('Default')}</Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    {t(
-                      'Full calculator with reimbursable expenses and 403b contributions.',
-                    )}
-                  </Typography>
-                </>
-              }
-              sx={{ alignItems: 'flex-start', mb: 2 }}
-            />
-            <FormControlLabel
-              value={DesignationSupportFormType.Simple}
-              control={<Radio />}
-              label={
-                <>
-                  <Typography variant="subtitle1">{t('Simple')}</Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    {t(
-                      'Streamlined calculator without reimbursable expenses or 403b contributions.',
-                    )}
-                  </Typography>
-                </>
-              }
-              sx={{ alignItems: 'flex-start' }}
-            />
+            {formTypeOptions.map(({ value, title, description }, index) => (
+              <FormControlLabel
+                key={value}
+                value={value}
+                control={<Radio />}
+                label={
+                  <>
+                    <Typography variant="subtitle1">{title}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {description}
+                    </Typography>
+                  </>
+                }
+                sx={{
+                  alignItems: 'flex-start',
+                  mb: index < formTypeOptions.length - 1 ? 2 : 0,
+                }}
+              />
+            ))}
           </RadioGroup>
         </FormControl>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose} disabled={creating}>
+        <Button onClick={onClose} disabled={creating}>
           {t('Cancel')}
         </Button>
         <Button
           onClick={handleCreate}
           variant="contained"
           disabled={!selected || creating}
+          startIcon={
+            creating ? <CircularProgress size={16} color="inherit" /> : null
+          }
         >
           {t('Create')}
         </Button>

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
+
+export interface CreateGoalDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (formType: DesignationSupportFormType) => Promise<void>;
+  creating: boolean;
+}
+
+export const CreateGoalDialog: React.FC<CreateGoalDialogProps> = ({
+  open,
+  onClose,
+  onCreate,
+  creating,
+}) => {
+  const { t } = useTranslation();
+  const [selected, setSelected] = useState<DesignationSupportFormType | null>(
+    null,
+  );
+
+  const handleCreate = async () => {
+    if (selected) {
+      await onCreate(selected);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{t('Create a New Goal')}</DialogTitle>
+      <DialogContent>
+        <FormControl component="fieldset">
+          <RadioGroup
+            value={selected ?? ''}
+            onChange={(_, value) =>
+              setSelected(value as DesignationSupportFormType)
+            }
+          >
+            <FormControlLabel
+              value={DesignationSupportFormType.Detailed}
+              control={<Radio />}
+              label={
+                <>
+                  <Typography variant="subtitle1">{t('Default')}</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {t(
+                      'Full calculator with reimbursable expenses and 403b contributions.',
+                    )}
+                  </Typography>
+                </>
+              }
+              sx={{ alignItems: 'flex-start', mb: 2 }}
+            />
+            <FormControlLabel
+              value={DesignationSupportFormType.Simple}
+              control={<Radio />}
+              label={
+                <>
+                  <Typography variant="subtitle1">{t('Simple')}</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {t(
+                      'Streamlined calculator without reimbursable expenses or 403b contributions.',
+                    )}
+                  </Typography>
+                </>
+              }
+              sx={{ alignItems: 'flex-start' }}
+            />
+          </RadioGroup>
+        </FormControl>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={creating}>
+          {t('Cancel')}
+        </Button>
+        <Button
+          onClick={handleCreate}
+          variant="contained"
+          disabled={!selected || creating}
+        >
+          {t('Create')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.tsx
@@ -33,6 +33,11 @@ export const CreateGoalDialog: React.FC<CreateGoalDialogProps> = ({
     null,
   );
 
+  const handleClose = () => {
+    setSelected(null);
+    onClose();
+  };
+
   const handleCreate = async () => {
     if (selected) {
       await onCreate(selected);
@@ -40,8 +45,16 @@ export const CreateGoalDialog: React.FC<CreateGoalDialogProps> = ({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>{t('Create a New Goal')}</DialogTitle>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="create-goal-dialog-title"
+    >
+      <DialogTitle id="create-goal-dialog-title">
+        {t('Create a New Goal')}
+      </DialogTitle>
       <DialogContent>
         <FormControl component="fieldset">
           <FormLabel sx={{ position: 'absolute', width: 1, height: 1, padding: 0, margin: -1, overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap', border: 0 }}>
@@ -87,7 +100,7 @@ export const CreateGoalDialog: React.FC<CreateGoalDialogProps> = ({
         </FormControl>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={creating}>
+        <Button onClick={handleClose} disabled={creating}>
           {t('Cancel')}
         </Button>
         <Button

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   Button,
   CircularProgress,
@@ -14,7 +14,7 @@ import {
   Typography,
 } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
-import { Formik } from 'formik';
+import { Formik, FormikProps } from 'formik';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 import { DesignationSupportFormType } from 'src/graphql/types.generated';
@@ -42,6 +42,13 @@ export const CreateGoalDialog: React.FC<CreateGoalDialogProps> = ({
   onCreate,
 }) => {
   const { t } = useTranslation();
+  const formikRef = useRef<FormikProps<FormValues>>(null);
+
+  useEffect(() => {
+    if (open) {
+      formikRef.current?.resetForm();
+    }
+  }, [open]);
 
   const formTypeOptions: Array<{
     value: DesignationSupportFormType;
@@ -76,7 +83,7 @@ export const CreateGoalDialog: React.FC<CreateGoalDialogProps> = ({
         {t('Create a New Goal')}
       </DialogTitle>
       <Formik<FormValues>
-        key={String(open)}
+        innerRef={formikRef}
         initialValues={{ formType: '' }}
         validationSchema={schema}
         onSubmit={async ({ formType }) => {
@@ -99,35 +106,43 @@ export const CreateGoalDialog: React.FC<CreateGoalDialogProps> = ({
                 >
                   {formTypeOptions.map(
                     ({ value, title, description }, index) => (
-                      <React.Fragment key={value}>
-                        <FormControlLabel
-                          value={value}
-                          control={
-                            <Radio
-                              inputProps={{
-                                'aria-describedby': `${value}-desc`,
-                              }}
-                            />
-                          }
-                          label={
-                            <Typography variant="subtitle1" component="span">
+                      <FormControlLabel
+                        key={value}
+                        value={value}
+                        control={
+                          <Radio
+                            inputProps={{
+                              'aria-labelledby': `${value}-title`,
+                              'aria-describedby': `${value}-desc`,
+                            }}
+                          />
+                        }
+                        label={
+                          <>
+                            <Typography
+                              id={`${value}-title`}
+                              variant="subtitle1"
+                              component="span"
+                              display="block"
+                            >
                               {title}
                             </Typography>
-                          }
-                          sx={{ alignItems: 'flex-start' }}
-                        />
-                        <Typography
-                          id={`${value}-desc`}
-                          variant="body2"
-                          color="text.secondary"
-                          sx={{
-                            pl: 4,
-                            mb: index < formTypeOptions.length - 1 ? 2 : 0,
-                          }}
-                        >
-                          {description}
-                        </Typography>
-                      </React.Fragment>
+                            <Typography
+                              id={`${value}-desc`}
+                              variant="body2"
+                              color="text.secondary"
+                              component="span"
+                              display="block"
+                            >
+                              {description}
+                            </Typography>
+                          </>
+                        }
+                        sx={{
+                          alignItems: 'flex-start',
+                          mb: index < formTypeOptions.length - 1 ? 2 : 0,
+                        }}
+                      />
                     ),
                   )}
                 </RadioGroup>

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import {
   Button,
   CircularProgress,
@@ -14,39 +14,34 @@ import {
   Typography,
 } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
+import { Formik } from 'formik';
 import { useTranslation } from 'react-i18next';
+import * as yup from 'yup';
 import { DesignationSupportFormType } from 'src/graphql/types.generated';
-import { isDesignationSupportFormType } from '../Shared/formType';
 
 export interface CreateGoalDialogProps {
   open: boolean;
   onClose: () => void;
   onCreate: (formType: DesignationSupportFormType) => Promise<void>;
-  creating: boolean;
 }
+
+interface FormValues {
+  formType: DesignationSupportFormType | '';
+}
+
+const schema = yup.object({
+  formType: yup
+    .string()
+    .oneOf(Object.values(DesignationSupportFormType))
+    .required(),
+});
 
 export const CreateGoalDialog: React.FC<CreateGoalDialogProps> = ({
   open,
   onClose,
   onCreate,
-  creating,
 }) => {
   const { t } = useTranslation();
-  const [selected, setSelected] = useState<DesignationSupportFormType | null>(
-    null,
-  );
-
-  useEffect(() => {
-    if (open) {
-      setSelected(null);
-    }
-  }, [open]);
-
-  const handleCreate = async () => {
-    if (selected) {
-      await onCreate(selected);
-    }
-  };
 
   const formTypeOptions: Array<{
     value: DesignationSupportFormType;
@@ -80,54 +75,82 @@ export const CreateGoalDialog: React.FC<CreateGoalDialogProps> = ({
       <DialogTitle id="create-goal-dialog-title">
         {t('Create a New Goal')}
       </DialogTitle>
-      <DialogContent>
-        <FormControl component="fieldset">
-          <FormLabel sx={visuallyHidden}>{t('Select a form type')}</FormLabel>
-          <RadioGroup
-            value={selected ?? ''}
-            onChange={(_, value) => {
-              if (isDesignationSupportFormType(value)) {
-                setSelected(value);
-              }
-            }}
-          >
-            {formTypeOptions.map(({ value, title, description }, index) => (
-              <FormControlLabel
-                key={value}
-                value={value}
-                control={<Radio />}
-                label={
-                  <>
-                    <Typography variant="subtitle1">{title}</Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      {description}
-                    </Typography>
-                  </>
-                }
-                sx={{
-                  alignItems: 'flex-start',
-                  mb: index < formTypeOptions.length - 1 ? 2 : 0,
-                }}
-              />
-            ))}
-          </RadioGroup>
-        </FormControl>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} disabled={creating}>
-          {t('Cancel')}
-        </Button>
-        <Button
-          onClick={handleCreate}
-          variant="contained"
-          disabled={!selected || creating}
-          startIcon={
-            creating ? <CircularProgress size={16} color="inherit" /> : null
+      <Formik<FormValues>
+        key={String(open)}
+        initialValues={{ formType: '' }}
+        validationSchema={schema}
+        onSubmit={async ({ formType }) => {
+          if (formType) {
+            await onCreate(formType);
           }
-        >
-          {t('Create')}
-        </Button>
-      </DialogActions>
+        }}
+      >
+        {({ values, isSubmitting, handleChange, handleSubmit }) => (
+          <form onSubmit={handleSubmit}>
+            <DialogContent>
+              <FormControl component="fieldset">
+                <FormLabel sx={visuallyHidden}>
+                  {t('Select a form type')}
+                </FormLabel>
+                <RadioGroup
+                  name="formType"
+                  value={values.formType}
+                  onChange={handleChange}
+                >
+                  {formTypeOptions.map(
+                    ({ value, title, description }, index) => (
+                      <React.Fragment key={value}>
+                        <FormControlLabel
+                          value={value}
+                          control={
+                            <Radio
+                              inputProps={{
+                                'aria-describedby': `${value}-desc`,
+                              }}
+                            />
+                          }
+                          label={
+                            <Typography variant="subtitle1" component="span">
+                              {title}
+                            </Typography>
+                          }
+                          sx={{ alignItems: 'flex-start' }}
+                        />
+                        <Typography
+                          id={`${value}-desc`}
+                          variant="body2"
+                          color="text.secondary"
+                          sx={{
+                            pl: 4,
+                            mb: index < formTypeOptions.length - 1 ? 2 : 0,
+                          }}
+                        >
+                          {description}
+                        </Typography>
+                      </React.Fragment>
+                    ),
+                  )}
+                </RadioGroup>
+              </FormControl>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={onClose}>{t('Cancel')}</Button>
+              <Button
+                type="submit"
+                variant="contained"
+                disabled={!values.formType || isSubmitting}
+                startIcon={
+                  isSubmitting ? (
+                    <CircularProgress size={16} color="inherit" />
+                  ) : null
+                }
+              >
+                {t('Create')}
+              </Button>
+            </DialogActions>
+          </form>
+        )}
+      </Formik>
     </Dialog>
   );
 };

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/CreateGoalDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
   FormControl,
   FormControlLabel,
+  FormLabel,
   Radio,
   RadioGroup,
   Typography,
@@ -43,6 +44,9 @@ export const CreateGoalDialog: React.FC<CreateGoalDialogProps> = ({
       <DialogTitle>{t('Create a New Goal')}</DialogTitle>
       <DialogContent>
         <FormControl component="fieldset">
+          <FormLabel sx={{ position: 'absolute', width: 1, height: 1, padding: 0, margin: -1, overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap', border: 0 }}>
+            {t('Select a form type')}
+          </FormLabel>
           <RadioGroup
             value={selected ?? ''}
             onChange={(_, value) =>

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalCalculations.graphql
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalCalculations.graphql
@@ -1,5 +1,6 @@
 fragment PdsGoalCalculationFields on DesignationSupportCalculation {
   id
+  formType
   name
   updatedAt
   averageHoursPerWeek

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.test.tsx
@@ -197,4 +197,11 @@ describe('PdsGoalsList', () => {
       expect(mutationSpy).toHaveGraphqlOperation('DeletePdsGoalCalculation');
     });
   });
+
+  // Skipped: testing the error-snackbar path requires overriding useCreatePdsGoalCalculationMutation,
+  // but the hook's exports are non-configurable in the generated file (jest.spyOn fails) and a
+  // module-level jest.mock would break the existing GqlMockedProvider-based mutation tests that
+  // verify calls via onCall/mutationSpy. The production fix (try/catch + enqueueSnackbar) is in
+  // PdsGoalsList.tsx; integration coverage can be added once a test-helper pattern for mocking
+  // individual generated hooks alongside GqlMockedProvider is established.
 });

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.test.tsx
@@ -9,6 +9,12 @@ import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
 import { PdsGoalsList } from './PdsGoalsList';
 
 const mutationSpy = jest.fn();
+const mockEnqueue = jest.fn();
+
+jest.mock('notistack', () => ({
+  ...jest.requireActual('notistack'),
+  useSnackbar: () => ({ enqueueSnackbar: mockEnqueue }),
+}));
 
 type FindByRole = ReturnType<typeof render>['findByRole'];
 
@@ -203,7 +209,7 @@ describe('PdsGoalsList', () => {
     });
   });
 
-  it('skips mutation when reimbursement constants are missing for a Default goal', async () => {
+  it('shows an error and skips mutation when reimbursement constants are missing for a Default goal', async () => {
     const { findByRole } = render(
       <PdsGoalCalculatorTestWrapper
         withProvider={false}
@@ -217,10 +223,15 @@ describe('PdsGoalsList', () => {
     await openCreateGoalDialog(findByRole);
     await submitFormType(findByRole, 'Default');
 
-    await waitFor(() => {
-      expect(mutationSpy).not.toHaveGraphqlOperation(
-        'CreatePdsGoalCalculation',
-      );
-    });
+    await waitFor(() =>
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        'Could not load required defaults. Please try again or pick Simple.',
+        { variant: 'error' },
+      ),
+    );
+    expect(mutationSpy).not.toHaveGraphqlOperation('CreatePdsGoalCalculation');
+    await waitFor(() =>
+      expect(findByRole('button', { name: 'Create' })).resolves.toBeEnabled(),
+    );
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.test.tsx
@@ -203,8 +203,8 @@ describe('PdsGoalsList', () => {
     });
   });
 
-  it('shows error snackbar and skips mutation when reimbursement constants are missing for a Default goal', async () => {
-    const { findByRole, findByText } = render(
+  it('skips mutation when reimbursement constants are missing for a Default goal', async () => {
+    const { findByRole } = render(
       <PdsGoalCalculatorTestWrapper
         withProvider={false}
         onCall={mutationSpy}
@@ -217,31 +217,10 @@ describe('PdsGoalsList', () => {
     await openCreateGoalDialog(findByRole);
     await submitFormType(findByRole, 'Default');
 
-    expect(
-      await findByText('Failed to create goal. Please try again.'),
-    ).toBeInTheDocument();
-    expect(mutationSpy).not.toHaveGraphqlOperation('CreatePdsGoalCalculation');
-  });
-
-  it('shows error snackbar when create mutation fails', async () => {
-    const { findByRole, findByText } = render(
-      <PdsGoalCalculatorTestWrapper
-        withProvider={false}
-        mocksOverride={{
-          CreatePdsGoalCalculation: () => {
-            throw new Error('Server Error');
-          },
-        }}
-      >
-        <PdsGoalsList />
-      </PdsGoalCalculatorTestWrapper>,
-    );
-
-    await openCreateGoalDialog(findByRole);
-    await submitFormType(findByRole, 'Simple');
-
-    expect(
-      await findByText('Failed to create goal. Please try again.'),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mutationSpy).not.toHaveGraphqlOperation(
+        'CreatePdsGoalCalculation',
+      );
+    });
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.test.tsx
@@ -49,7 +49,21 @@ describe('PdsGoalsList', () => {
     expect(queryByTestId('goal-name')).not.toBeInTheDocument();
   });
 
-  it('seeds reimbursable defaults from MPD constants on create', async () => {
+  it('opens the create dialog when Create a New Goal is clicked', async () => {
+    const { findByRole } = render(
+      <PdsGoalCalculatorTestWrapper withProvider={false}>
+        <PdsGoalsList />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    const button = await findByRole('button', { name: 'Create a New Goal' });
+    await waitFor(() => expect(button).toBeEnabled());
+    userEvent.click(button);
+
+    expect(await findByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('creates a Default goal with seeded reimbursable defaults via the dialog', async () => {
     const { findByRole } = render(
       <PdsGoalCalculatorTestWrapper
         withProvider={false}
@@ -75,17 +89,46 @@ describe('PdsGoalsList', () => {
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    const button = await findByRole('button', { name: 'Create a New Goal' });
-    await waitFor(() => {
-      expect(button).toBeEnabled();
+    const openButton = await findByRole('button', {
+      name: 'Create a New Goal',
     });
-    userEvent.click(button);
+    await waitFor(() => expect(openButton).toBeEnabled());
+    userEvent.click(openButton);
+
+    userEvent.click(await findByRole('radio', { name: /Default/ }));
+    userEvent.click(await findByRole('button', { name: 'Create' }));
 
     await waitFor(() => {
       expect(mutationSpy).toHaveGraphqlOperation('CreatePdsGoalCalculation', {
         attributes: {
+          formType: 'DETAILED',
           ministryCellPhone: 75,
           ministryInternet: 50,
+        },
+      });
+    });
+  });
+
+  it('creates a Simple goal via the dialog', async () => {
+    const { findByRole } = render(
+      <PdsGoalCalculatorTestWrapper withProvider={false} onCall={mutationSpy}>
+        <PdsGoalsList />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    const openButton = await findByRole('button', {
+      name: 'Create a New Goal',
+    });
+    await waitFor(() => expect(openButton).toBeEnabled());
+    userEvent.click(openButton);
+
+    userEvent.click(await findByRole('radio', { name: /Simple/ }));
+    userEvent.click(await findByRole('button', { name: 'Create' }));
+
+    await waitFor(() => {
+      expect(mutationSpy).toHaveGraphqlOperation('CreatePdsGoalCalculation', {
+        attributes: {
+          formType: 'SIMPLE',
         },
       });
     });

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.test.tsx
@@ -10,6 +10,25 @@ import { PdsGoalsList } from './PdsGoalsList';
 
 const mutationSpy = jest.fn();
 
+type FindByRole = ReturnType<typeof render>['findByRole'];
+
+// The "Create a New Goal" button is disabled while the GoalCalculatorConstants
+// query is in flight (constantsLoading drives `disabled`), so we wait for it
+// to become enabled before clicking.
+const openCreateGoalDialog = async (findByRole: FindByRole) => {
+  const button = await findByRole('button', { name: 'Create a New Goal' });
+  await waitFor(() => expect(button).toBeEnabled());
+  userEvent.click(button);
+};
+
+const submitFormType = async (
+  findByRole: FindByRole,
+  formType: 'Default' | 'Simple',
+) => {
+  userEvent.click(await findByRole('radio', { name: new RegExp(formType) }));
+  userEvent.click(await findByRole('button', { name: 'Create' }));
+};
+
 describe('PdsGoalsList', () => {
   it('renders the create button', () => {
     const { getByRole } = render(
@@ -56,9 +75,7 @@ describe('PdsGoalsList', () => {
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    const button = await findByRole('button', { name: 'Create a New Goal' });
-    await waitFor(() => expect(button).toBeEnabled());
-    userEvent.click(button);
+    await openCreateGoalDialog(findByRole);
 
     expect(await findByRole('dialog')).toBeInTheDocument();
   });
@@ -89,14 +106,8 @@ describe('PdsGoalsList', () => {
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    const openButton = await findByRole('button', {
-      name: 'Create a New Goal',
-    });
-    await waitFor(() => expect(openButton).toBeEnabled());
-    userEvent.click(openButton);
-
-    userEvent.click(await findByRole('radio', { name: /Default/ }));
-    userEvent.click(await findByRole('button', { name: 'Create' }));
+    await openCreateGoalDialog(findByRole);
+    await submitFormType(findByRole, 'Default');
 
     await waitFor(() => {
       expect(mutationSpy).toHaveGraphqlOperation('CreatePdsGoalCalculation', {
@@ -116,14 +127,8 @@ describe('PdsGoalsList', () => {
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    const openButton = await findByRole('button', {
-      name: 'Create a New Goal',
-    });
-    await waitFor(() => expect(openButton).toBeEnabled());
-    userEvent.click(openButton);
-
-    userEvent.click(await findByRole('radio', { name: /Simple/ }));
-    userEvent.click(await findByRole('button', { name: 'Create' }));
+    await openCreateGoalDialog(findByRole);
+    await submitFormType(findByRole, 'Simple');
 
     await waitFor(() => {
       expect(mutationSpy).toHaveGraphqlOperation('CreatePdsGoalCalculation', {
@@ -198,10 +203,45 @@ describe('PdsGoalsList', () => {
     });
   });
 
-  // Skipped: testing the error-snackbar path requires overriding useCreatePdsGoalCalculationMutation,
-  // but the hook's exports are non-configurable in the generated file (jest.spyOn fails) and a
-  // module-level jest.mock would break the existing GqlMockedProvider-based mutation tests that
-  // verify calls via onCall/mutationSpy. The production fix (try/catch + enqueueSnackbar) is in
-  // PdsGoalsList.tsx; integration coverage can be added once a test-helper pattern for mocking
-  // individual generated hooks alongside GqlMockedProvider is established.
+  it('shows error snackbar and skips mutation when reimbursement constants are missing for a Default goal', async () => {
+    const { findByRole, findByText } = render(
+      <PdsGoalCalculatorTestWrapper
+        withProvider={false}
+        onCall={mutationSpy}
+        constantsMock={{ mpdGoalMiscConstants: [] }}
+      >
+        <PdsGoalsList />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await openCreateGoalDialog(findByRole);
+    await submitFormType(findByRole, 'Default');
+
+    expect(
+      await findByText('Failed to create goal. Please try again.'),
+    ).toBeInTheDocument();
+    expect(mutationSpy).not.toHaveGraphqlOperation('CreatePdsGoalCalculation');
+  });
+
+  it('shows error snackbar when create mutation fails', async () => {
+    const { findByRole, findByText } = render(
+      <PdsGoalCalculatorTestWrapper
+        withProvider={false}
+        mocksOverride={{
+          CreatePdsGoalCalculation: () => {
+            throw new Error('Server Error');
+          },
+        }}
+      >
+        <PdsGoalsList />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await openCreateGoalDialog(findByRole);
+    await submitFormType(findByRole, 'Simple');
+
+    expect(
+      await findByText('Failed to create goal. Please try again.'),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
@@ -40,8 +40,7 @@ export const PdsGoalsList: React.FC = () => {
     error,
     pageInfo: data?.designationSupportCalculations.pageInfo,
   });
-  const [createPdsGoalCalculation, { loading: creating }] =
-    useCreatePdsGoalCalculationMutation();
+  const [createPdsGoalCalculation] = useCreatePdsGoalCalculationMutation();
   const { goalMiscConstants, loading: constantsLoading } =
     useGoalCalculatorConstants();
 
@@ -103,7 +102,6 @@ export const PdsGoalsList: React.FC = () => {
         open={dialogOpen}
         onClose={() => setDialogOpen(false)}
         onCreate={handleCreateGoal}
-        creating={creating}
       />
 
       {loading ? (

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import { Box, Button, CircularProgress, Stack, styled } from '@mui/material';
-import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import { DesignationSupportFormType } from 'src/graphql/types.generated';
@@ -28,7 +27,6 @@ const PlaceholderImage = styled('img')(({ theme }) => ({
 
 export const PdsGoalsList: React.FC = () => {
   const { t } = useTranslation();
-  const { enqueueSnackbar } = useSnackbar();
   const router = useRouter();
   const accountListId = useAccountListId() ?? '';
 
@@ -62,9 +60,6 @@ export const PdsGoalsList: React.FC = () => {
       const phoneFee = reimbursements?.PHONE?.fee;
       const internetFee = reimbursements?.INTERNET?.fee;
       if (phoneFee === undefined || internetFee === undefined) {
-        enqueueSnackbar(t('Failed to create goal. Please try again.'), {
-          variant: 'error',
-        });
         return;
       }
       detailedDefaults = {
@@ -72,28 +67,22 @@ export const PdsGoalsList: React.FC = () => {
         ministryInternet: internetFee,
       };
     }
-    try {
-      const { data } = await createPdsGoalCalculation({
-        variables: {
-          attributes: {
-            formType,
-            ...(detailedDefaults ?? {}),
-          },
+    const { data } = await createPdsGoalCalculation({
+      variables: {
+        attributes: {
+          formType,
+          ...(detailedDefaults ?? {}),
         },
-      });
-      const calculation =
-        data?.createDesignationSupportCalculation?.designationSupportCalculation;
+      },
+    });
+    const calculation =
+      data?.createDesignationSupportCalculation?.designationSupportCalculation;
 
-      if (calculation) {
-        setDialogOpen(false);
-        router.push(
-          `/accountLists/${accountListId}/hrTools/pdsGoalCalculator/${calculation.id}`,
-        );
-      }
-    } catch (error) {
-      enqueueSnackbar(t('Failed to create goal. Please try again.'), {
-        variant: 'error',
-      });
+    if (calculation) {
+      setDialogOpen(false);
+      router.push(
+        `/accountLists/${accountListId}/hrTools/pdsGoalCalculator/${calculation.id}`,
+      );
     }
   };
 

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import { Box, Button, CircularProgress, Stack, styled } from '@mui/material';
+import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import { DesignationSupportFormType } from 'src/graphql/types.generated';
@@ -27,6 +28,7 @@ const PlaceholderImage = styled('img')(({ theme }) => ({
 
 export const PdsGoalsList: React.FC = () => {
   const { t } = useTranslation();
+  const { enqueueSnackbar } = useSnackbar();
   const router = useRouter();
   const accountListId = useAccountListId() ?? '';
 
@@ -51,29 +53,35 @@ export const PdsGoalsList: React.FC = () => {
 
   const handleCreateGoal = async (formType: DesignationSupportFormType) => {
     const isDetailed = formType === DesignationSupportFormType.Detailed;
-    const { data } = await createPdsGoalCalculation({
-      variables: {
-        attributes: {
-          formType,
-          ...(isDetailed
-            ? {
-                ministryCellPhone:
-                  goalMiscConstants.REIMBURSEMENTS_WITH_MAXIMUM?.PHONE?.fee,
-                ministryInternet:
-                  goalMiscConstants.REIMBURSEMENTS_WITH_MAXIMUM?.INTERNET?.fee,
-              }
-            : {}),
+    try {
+      const { data } = await createPdsGoalCalculation({
+        variables: {
+          attributes: {
+            formType,
+            ...(isDetailed
+              ? {
+                  ministryCellPhone:
+                    goalMiscConstants.REIMBURSEMENTS_WITH_MAXIMUM?.PHONE?.fee,
+                  ministryInternet:
+                    goalMiscConstants.REIMBURSEMENTS_WITH_MAXIMUM?.INTERNET?.fee,
+                }
+              : {}),
+          },
         },
-      },
-    });
-    const calculation =
-      data?.createDesignationSupportCalculation?.designationSupportCalculation;
+      });
+      const calculation =
+        data?.createDesignationSupportCalculation?.designationSupportCalculation;
 
-    if (calculation) {
-      setDialogOpen(false);
-      router.push(
-        `/accountLists/${accountListId}/hrTools/pdsGoalCalculator/${calculation.id}`,
-      );
+      if (calculation) {
+        setDialogOpen(false);
+        router.push(
+          `/accountLists/${accountListId}/hrTools/pdsGoalCalculator/${calculation.id}`,
+        );
+      }
+    } catch (error) {
+      enqueueSnackbar(t('Failed to create goal. Please try again.'), {
+        variant: 'error',
+      });
     }
   };
 

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
@@ -53,19 +53,31 @@ export const PdsGoalsList: React.FC = () => {
 
   const handleCreateGoal = async (formType: DesignationSupportFormType) => {
     const isDetailed = formType === DesignationSupportFormType.Detailed;
+    let detailedDefaults: {
+      ministryCellPhone: number;
+      ministryInternet: number;
+    } | null = null;
+    if (isDetailed) {
+      const reimbursements = goalMiscConstants.REIMBURSEMENTS_WITH_MAXIMUM;
+      const phoneFee = reimbursements?.PHONE?.fee;
+      const internetFee = reimbursements?.INTERNET?.fee;
+      if (phoneFee === undefined || internetFee === undefined) {
+        enqueueSnackbar(t('Failed to create goal. Please try again.'), {
+          variant: 'error',
+        });
+        return;
+      }
+      detailedDefaults = {
+        ministryCellPhone: phoneFee,
+        ministryInternet: internetFee,
+      };
+    }
     try {
       const { data } = await createPdsGoalCalculation({
         variables: {
           attributes: {
             formType,
-            ...(isDetailed
-              ? {
-                  ministryCellPhone:
-                    goalMiscConstants.REIMBURSEMENTS_WITH_MAXIMUM?.PHONE?.fee,
-                  ministryInternet:
-                    goalMiscConstants.REIMBURSEMENTS_WITH_MAXIMUM?.INTERNET?.fee,
-                }
-              : {}),
+            ...(detailedDefaults ?? {}),
           },
         },
       });

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import { Box, Button, CircularProgress, Stack, styled } from '@mui/material';
+import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import { DesignationSupportFormType } from 'src/graphql/types.generated';
@@ -28,6 +29,7 @@ const PlaceholderImage = styled('img')(({ theme }) => ({
 export const PdsGoalsList: React.FC = () => {
   const { t } = useTranslation();
   const router = useRouter();
+  const { enqueueSnackbar } = useSnackbar();
   const accountListId = useAccountListId() ?? '';
 
   const { data: userData } = useGetUserQuery();
@@ -59,6 +61,12 @@ export const PdsGoalsList: React.FC = () => {
       const phoneFee = reimbursements?.PHONE?.fee;
       const internetFee = reimbursements?.INTERNET?.fee;
       if (phoneFee === undefined || internetFee === undefined) {
+        enqueueSnackbar(
+          t(
+            'Could not load required defaults. Please try again or pick Simple.',
+          ),
+          { variant: 'error' },
+        );
         return;
       }
       detailedDefaults = {

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
@@ -73,6 +73,7 @@ export const PdsGoalsList: React.FC = () => {
           ...(detailedDefaults ?? {}),
         },
       },
+      refetchQueries: ['PdsGoalCalculations'],
     });
     const calculation =
       data?.createDesignationSupportCalculation?.designationSupportCalculation;

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
@@ -1,13 +1,15 @@
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useState } from 'react';
 import { Box, Button, CircularProgress, Stack, styled } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useFetchAllPages } from 'src/hooks/useFetchAllPages';
 import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
 import illustration6graybg from 'src/images/drawkit/grape/drawkit-grape-pack-illustration-6-gray-bg.svg';
 import { PdsGoalCard } from '../GoalCard/PdsGoalCard';
+import { CreateGoalDialog } from './CreateGoalDialog';
 import {
   useCreatePdsGoalCalculationMutation,
   usePdsGoalCalculationsQuery,
@@ -38,20 +40,29 @@ export const PdsGoalsList: React.FC = () => {
     error,
     pageInfo: data?.designationSupportCalculations.pageInfo,
   });
-  const [createPdsGoalCalculation] = useCreatePdsGoalCalculationMutation();
+  const [createPdsGoalCalculation, { loading: creating }] =
+    useCreatePdsGoalCalculationMutation();
   const { goalMiscConstants, loading: constantsLoading } =
     useGoalCalculatorConstants();
 
+  const [dialogOpen, setDialogOpen] = useState(false);
+
   const goals = data?.designationSupportCalculations.nodes;
 
-  const handleCreateGoal = async () => {
+  const handleCreateGoal = async (formType: DesignationSupportFormType) => {
+    const isDetailed = formType === DesignationSupportFormType.Detailed;
     const { data } = await createPdsGoalCalculation({
       variables: {
         attributes: {
-          ministryCellPhone:
-            goalMiscConstants.REIMBURSEMENTS_WITH_MAXIMUM?.PHONE?.fee,
-          ministryInternet:
-            goalMiscConstants.REIMBURSEMENTS_WITH_MAXIMUM?.INTERNET?.fee,
+          formType,
+          ...(isDetailed
+            ? {
+                ministryCellPhone:
+                  goalMiscConstants.REIMBURSEMENTS_WITH_MAXIMUM?.PHONE?.fee,
+                ministryInternet:
+                  goalMiscConstants.REIMBURSEMENTS_WITH_MAXIMUM?.INTERNET?.fee,
+              }
+            : {}),
         },
       },
     });
@@ -59,6 +70,7 @@ export const PdsGoalsList: React.FC = () => {
       data?.createDesignationSupportCalculation?.designationSupportCalculation;
 
     if (calculation) {
+      setDialogOpen(false);
       router.push(
         `/accountLists/${accountListId}/hrTools/pdsGoalCalculator/${calculation.id}`,
       );
@@ -71,12 +83,19 @@ export const PdsGoalsList: React.FC = () => {
       <Stack direction="row" gap={2} pb={3}>
         <Button
           variant="contained"
-          onClick={handleCreateGoal}
+          onClick={() => setDialogOpen(true)}
           disabled={constantsLoading}
         >
           {t('Create a New Goal')}
         </Button>
       </Stack>
+
+      <CreateGoalDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onCreate={handleCreateGoal}
+        creating={creating}
+      />
 
       {loading ? (
         <CircularProgress />

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
-import { ApolloErgonoMockMap } from 'graphql-ergonomock';
 import { MockLinkCallHandler } from 'graphql-ergonomock/dist/apollo/MockLink';
 import { merge, mergeWith } from 'lodash';
 import { SnackbarProvider } from 'notistack';
@@ -120,7 +119,6 @@ export interface PdsGoalCalculatorTestWrapperProps {
   userMock?: GetUserMock;
   constantsMock?: GoalCalculatorConstantsMock;
   supportRaisedMock?: number;
-  mocksOverride?: ApolloErgonoMockMap;
   onCall?: MockLinkCallHandler;
   router?: React.ComponentProps<typeof TestRouter>['router'];
 }
@@ -136,7 +134,6 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
   userMock,
   constantsMock,
   supportRaisedMock,
-  mocksOverride,
   onCall,
   router,
 }) => {
@@ -245,7 +242,6 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
                     Array.isArray(srcValue) ? srcValue : undefined,
                 ),
               },
-              ...mocksOverride,
             }}
             onCall={onCall}
           >

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
@@ -8,6 +8,7 @@ import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider, gqlMock } from '__tests__/util/graphqlMocking';
 import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import {
+  DesignationSupportFormType,
   DesignationSupportSalaryType,
   DesignationSupportStatus,
   MpdGoalMiscConstantCategoryEnum,
@@ -41,6 +42,7 @@ const calculationsDefault = gqlMock<
         {
           id: 'goal-1',
           name: 'Test Goal',
+          formType: DesignationSupportFormType.Detailed,
           status: DesignationSupportStatus.FullTime,
           salaryOrHourly: DesignationSupportSalaryType.Salaried,
           payRate: 50000,
@@ -73,6 +75,7 @@ const calculationDefault = gqlMock<
     designationSupportCalculation: {
       id: 'goal-1',
       name: 'Test Goal',
+      formType: DesignationSupportFormType.Detailed,
       status: DesignationSupportStatus.FullTime,
       salaryOrHourly: DesignationSupportSalaryType.Salaried,
       payRate: 50000,

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
+import { ApolloErgonoMockMap } from 'graphql-ergonomock';
 import { MockLinkCallHandler } from 'graphql-ergonomock/dist/apollo/MockLink';
 import { merge, mergeWith } from 'lodash';
 import { SnackbarProvider } from 'notistack';
@@ -119,6 +120,7 @@ export interface PdsGoalCalculatorTestWrapperProps {
   userMock?: GetUserMock;
   constantsMock?: GoalCalculatorConstantsMock;
   supportRaisedMock?: number;
+  mocksOverride?: ApolloErgonoMockMap;
   onCall?: MockLinkCallHandler;
   router?: React.ComponentProps<typeof TestRouter>['router'];
 }
@@ -134,6 +136,7 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
   userMock,
   constantsMock,
   supportRaisedMock,
+  mocksOverride,
   onCall,
   router,
 }) => {
@@ -242,6 +245,7 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
                     Array.isArray(srcValue) ? srcValue : undefined,
                 ),
               },
+              ...mocksOverride,
             }}
             onCall={onCall}
           >

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
+  DesignationSupportFormType,
   DesignationSupportSalaryType,
   DesignationSupportStatus,
 } from 'src/graphql/types.generated';
@@ -411,5 +412,91 @@ describe('SetupStep', () => {
     expect(
       await findByRole('spinbutton', { name: 'Hours Worked' }),
     ).toBeInTheDocument();
+  });
+
+  it('renders the Form Type select with both options', async () => {
+    const { findByRole, getByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={{
+          ...fullTimeSalariedMock,
+          formType: DesignationSupportFormType.Detailed,
+        }}
+      >
+        <SetupStep />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    const select = await findByRole('combobox', { name: /Form Type/ });
+    await waitFor(() => expect(select).toHaveTextContent('Default'));
+    userEvent.click(select);
+
+    expect(getByRole('option', { name: 'Default' })).toBeInTheDocument();
+    expect(getByRole('option', { name: 'Simple' })).toBeInTheDocument();
+  });
+
+  it('shows 403b Contribution Percentage field when formType is Detailed', async () => {
+    const { findByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={{
+          ...fullTimeSalariedMock,
+          formType: DesignationSupportFormType.Detailed,
+        }}
+      >
+        <SetupStep />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    expect(
+      await findByRole('textbox', { name: '403b Contribution Percentage' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides 403b Contribution Percentage field when formType is Simple', async () => {
+    const { findByRole, queryByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={{
+          ...fullTimeSalariedMock,
+          formType: DesignationSupportFormType.Simple,
+        }}
+      >
+        <SetupStep />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    // Wait for the Form Type select to reflect the loaded Simple value
+    const formTypeSelect = await findByRole('combobox', { name: /Form Type/ });
+    await waitFor(() => expect(formTypeSelect).toHaveTextContent('Simple'));
+
+    expect(
+      queryByRole('textbox', { name: '403b Contribution Percentage' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('fires UpdatePdsGoalCalculation with formType when toggled to Simple', async () => {
+    const { findByRole, getByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={{
+          ...fullTimeSalariedMock,
+          formType: DesignationSupportFormType.Detailed,
+        }}
+        onCall={mutationSpy}
+      >
+        <SetupStep />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    const select = await findByRole('combobox', { name: /Form Type/ });
+    await waitFor(() => expect(select).toHaveTextContent('Default'));
+    userEvent.click(select);
+    userEvent.click(getByRole('option', { name: 'Simple' }));
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation', {
+        attributes: {
+          id: 'goal-1',
+          formType: 'SIMPLE',
+        },
+      }),
+    );
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
@@ -499,4 +499,21 @@ describe('SetupStep', () => {
       }),
     );
   });
+
+  it('shows the 403b Contribution Percentage field when formType is null (legacy goal)', async () => {
+    const { findByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={{
+          ...fullTimeSalariedMock,
+          formType: null,
+        }}
+      >
+        <SetupStep />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    expect(
+      await findByRole('textbox', { name: '403b Contribution Percentage' }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
@@ -6,7 +6,10 @@ import {
   DesignationSupportSalaryType,
   DesignationSupportStatus,
 } from 'src/graphql/types.generated';
-import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
+import {
+  PdsGoalCalculatorTestWrapper,
+  PdsGoalCalculatorTestWrapperProps,
+} from '../PdsGoalCalculatorTestWrapper';
 import { usePdsGoalCalculator } from '../Shared/PdsGoalCalculatorContext';
 import { SetupStep } from './SetupStep';
 
@@ -45,13 +48,24 @@ const partTimeHourlyMock = {
   benefits: null,
 };
 
+const setupTree = (
+  props: Partial<PdsGoalCalculatorTestWrapperProps> = {},
+  extraChildren?: React.ReactNode,
+) => (
+  <PdsGoalCalculatorTestWrapper {...props}>
+    <SetupStep />
+    {extraChildren}
+  </PdsGoalCalculatorTestWrapper>
+);
+
+const renderSetup = (
+  props?: Partial<PdsGoalCalculatorTestWrapperProps>,
+  extraChildren?: React.ReactNode,
+) => render(setupTree(props, extraChildren));
+
 describe('SetupStep', () => {
   it('disables fields while calculation data is loading', async () => {
-    const { findByRole } = render(
-      <PdsGoalCalculatorTestWrapper calculationMock={undefined}>
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole } = renderSetup({ calculationMock: undefined });
 
     // When calculation is undefined (loading), autosave fields should be disabled
     const goalName = await findByRole('textbox', { name: 'Goal Name' });
@@ -59,16 +73,12 @@ describe('SetupStep', () => {
   });
 
   it('shows validation errors for multiple empty required fields simultaneously', async () => {
-    const { findByRole, findByText } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={{
-          ...fullTimeHourlyMock,
-          name: 'Test Goal',
-        }}
-      >
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole, findByText } = renderSetup({
+      calculationMock: {
+        ...fullTimeHourlyMock,
+        name: 'Test Goal',
+      },
+    });
 
     const goalNameInput = await findByRole('textbox', { name: 'Goal Name' });
     await waitFor(() => expect(goalNameInput).toHaveValue('Test Goal'));
@@ -94,93 +104,69 @@ describe('SetupStep', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders all visible fields for full-time salaried (Benefits shown, Hours Worked hidden)', async () => {
-    const { findByRole, queryByRole } = render(
-      <PdsGoalCalculatorTestWrapper calculationMock={fullTimeSalariedMock}>
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+  it.each([
+    {
+      name: 'full-time salaried',
+      calculationMock: fullTimeSalariedMock,
+      benefits: 'visible' as const,
+      hoursWorked: 'hidden' as const,
+    },
+    {
+      name: 'part-time salaried',
+      calculationMock: partTimeSalariedMock,
+      benefits: 'hidden' as const,
+      hoursWorked: 'hidden' as const,
+    },
+    {
+      name: 'full-time hourly',
+      calculationMock: fullTimeHourlyMock,
+      benefits: 'visible' as const,
+      hoursWorked: 'visible' as const,
+    },
+    {
+      name: 'part-time hourly',
+      calculationMock: partTimeHourlyMock,
+      benefits: 'hidden' as const,
+      hoursWorked: 'visible' as const,
+    },
+  ])(
+    'shows Benefits=$benefits and Hours Worked=$hoursWorked for $name',
+    async ({ calculationMock, benefits, hoursWorked }) => {
+      const { findByRole, queryByRole } = renderSetup({ calculationMock });
 
-    expect(
-      await findByRole('textbox', { name: 'Goal Name' }),
-    ).toBeInTheDocument();
-    expect(
-      await findByRole('spinbutton', { name: 'Pay Rate' }),
-    ).toBeInTheDocument();
-    expect(
-      await findByRole('spinbutton', { name: 'Benefits' }),
-    ).toBeInTheDocument();
-    expect(
-      await findByRole('textbox', { name: '403b Contribution Percentage' }),
-    ).toBeInTheDocument();
-    expect(
-      await findByRole('combobox', { name: 'Geographic Multiplier' }),
-    ).toBeInTheDocument();
+      // Wait for the form to load before asserting on conditional fields
+      await findByRole('textbox', { name: 'Goal Name' });
 
-    // Hours Worked should be hidden for salaried
-    await waitFor(() => {
-      expect(
-        queryByRole('spinbutton', { name: 'Hours Worked' }),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it('hides Benefits when Part-time', async () => {
-    const { findByRole, queryByRole } = render(
-      <PdsGoalCalculatorTestWrapper calculationMock={partTimeSalariedMock}>
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
-
-    expect(
-      await findByRole('textbox', { name: 'Goal Name' }),
-    ).toBeInTheDocument();
-
-    // Benefits should be hidden for part-time
-    await waitFor(() => {
-      expect(
-        queryByRole('spinbutton', { name: 'Benefits' }),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it('shows Hours Worked when Hourly', async () => {
-    const { findByRole } = render(
-      <PdsGoalCalculatorTestWrapper calculationMock={fullTimeHourlyMock}>
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
-
-    expect(
-      await findByRole('spinbutton', { name: 'Hours Worked' }),
-    ).toBeInTheDocument();
-  });
+      await waitFor(() =>
+        expect({
+          benefits: queryByRole('spinbutton', { name: 'Benefits' })
+            ? 'visible'
+            : 'hidden',
+          hoursWorked: queryByRole('spinbutton', { name: 'Hours Worked' })
+            ? 'visible'
+            : 'hidden',
+        }).toEqual({ benefits, hoursWorked }),
+      );
+    },
+  );
 
   it('shows dynamic Pay Rate helper text based on salary type', async () => {
-    const { findByRole, findByText, rerender } = render(
-      <PdsGoalCalculatorTestWrapper calculationMock={fullTimeSalariedMock}>
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole, findByText, rerender } = renderSetup({
+      calculationMock: fullTimeSalariedMock,
+    });
 
     await findByRole('spinbutton', { name: 'Pay Rate' });
     expect(await findByText('Enter yearly salary')).toBeInTheDocument();
 
-    rerender(
-      <PdsGoalCalculatorTestWrapper calculationMock={fullTimeHourlyMock}>
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    rerender(setupTree({ calculationMock: fullTimeHourlyMock }));
 
     expect(await findByText('Enter hourly rate')).toBeInTheDocument();
   });
 
   it('403b field is disabled', async () => {
-    const { findByRole } = render(
-      <PdsGoalCalculatorTestWrapper calculationMock={fullTimeSalariedMock}>
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole } = renderSetup({
+      calculationMock: fullTimeSalariedMock,
+    });
 
     expect(
       await findByRole('textbox', { name: '403b Contribution Percentage' }),
@@ -188,19 +174,15 @@ describe('SetupStep', () => {
   });
 
   it('displays the sum of tax-deferred and Roth 403b contribution percentages', async () => {
-    const { findByRole } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={fullTimeSalariedMock}
-        hcmUserMock={{
-          fourOThreeB: {
-            currentTaxDeferredContributionPercentage: 5,
-            currentRothContributionPercentage: 3,
-          },
-        }}
-      >
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole } = renderSetup({
+      calculationMock: fullTimeSalariedMock,
+      hcmUserMock: {
+        fourOThreeB: {
+          currentTaxDeferredContributionPercentage: 5,
+          currentRothContributionPercentage: 3,
+        },
+      },
+    });
 
     await waitFor(async () =>
       expect(
@@ -212,14 +194,10 @@ describe('SetupStep', () => {
   });
 
   it('403b field is empty when hcm data has no 403b entry', async () => {
-    const { findByRole } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={fullTimeSalariedMock}
-        hcmUserMock={null}
-      >
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole } = renderSetup({
+      calculationMock: fullTimeSalariedMock,
+      hcmUserMock: null,
+    });
 
     expect(
       await findByRole('textbox', {
@@ -229,19 +207,15 @@ describe('SetupStep', () => {
   });
 
   it('displays the logged-in user first name and avatar', async () => {
-    const { getByTestId, getByAltText } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={fullTimeSalariedMock}
-        userMock={{
-          user: {
-            firstName: 'Jane',
-            avatar: 'https://example.com/jane.png',
-          },
-        }}
-      >
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { getByTestId, getByAltText } = renderSetup({
+      calculationMock: fullTimeSalariedMock,
+      userMock: {
+        user: {
+          firstName: 'Jane',
+          avatar: 'https://example.com/jane.png',
+        },
+      },
+    });
 
     await waitFor(() =>
       expect(getByTestId('info-name-typography')).toHaveTextContent('Jane'),
@@ -253,11 +227,9 @@ describe('SetupStep', () => {
   });
 
   it('Geographic Multiplier autocomplete renders', async () => {
-    const { findByRole } = render(
-      <PdsGoalCalculatorTestWrapper calculationMock={fullTimeSalariedMock}>
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole } = renderSetup({
+      calculationMock: fullTimeSalariedMock,
+    });
 
     expect(
       await findByRole('combobox', { name: 'Geographic Multiplier' }),
@@ -265,14 +237,10 @@ describe('SetupStep', () => {
   });
 
   it('fires mutation when Goal Name is changed', async () => {
-    const { findByRole } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={{ ...fullTimeSalariedMock, name: 'Test Goal' }}
-        onCall={mutationSpy}
-      >
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole } = renderSetup({
+      calculationMock: { ...fullTimeSalariedMock, name: 'Test Goal' },
+      onCall: mutationSpy,
+    });
 
     const input = await findByRole('textbox', { name: 'Goal Name' });
     await waitFor(() => expect(input).toHaveValue('Test Goal'));
@@ -292,14 +260,10 @@ describe('SetupStep', () => {
   });
 
   it('fires mutation when Geographic Multiplier is selected', async () => {
-    const { findByRole } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={fullTimeSalariedMock}
-        onCall={mutationSpy}
-      >
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole } = renderSetup({
+      calculationMock: fullTimeSalariedMock,
+      onCall: mutationSpy,
+    });
 
     const input = await findByRole('combobox', {
       name: 'Geographic Multiplier',
@@ -320,11 +284,9 @@ describe('SetupStep', () => {
   });
 
   it('renders the calculator icon button next to Hours Worked', async () => {
-    const { findByLabelText } = render(
-      <PdsGoalCalculatorTestWrapper calculationMock={fullTimeHourlyMock}>
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByLabelText } = renderSetup({
+      calculationMock: fullTimeHourlyMock,
+    });
 
     expect(
       await findByLabelText('Open hours per week calculator'),
@@ -332,11 +294,9 @@ describe('SetupStep', () => {
   });
 
   it('opens the hours per week calculator in the right panel when the icon is clicked', async () => {
-    const { findByLabelText, findByText, queryByText } = render(
-      <PdsGoalCalculatorTestWrapper calculationMock={fullTimeHourlyMock}>
-        <SetupStep />
-        <RightPanelProbe />
-      </PdsGoalCalculatorTestWrapper>,
+    const { findByLabelText, findByText, queryByText } = renderSetup(
+      { calculationMock: fullTimeHourlyMock },
+      <RightPanelProbe />,
     );
 
     expect(queryByText('Hours Per Week Calculator')).not.toBeInTheDocument();
@@ -347,13 +307,9 @@ describe('SetupStep', () => {
   });
 
   it('hides Hours Worked and adapts validation when switching from Hourly to Salaried', async () => {
-    const { findByRole, queryByRole, rerender } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={{ ...fullTimeHourlyMock, hoursWorkedPerWeek: null }}
-      >
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole, queryByRole, rerender } = renderSetup({
+      calculationMock: { ...fullTimeHourlyMock, hoursWorkedPerWeek: null },
+    });
 
     // Hours Worked is visible and required when Hourly
     const hoursInput = await findByRole('spinbutton', {
@@ -362,11 +318,7 @@ describe('SetupStep', () => {
     expect(hoursInput).toBeInTheDocument();
 
     // Switch to Salaried — Hours Worked should disappear
-    rerender(
-      <PdsGoalCalculatorTestWrapper calculationMock={fullTimeSalariedMock}>
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    rerender(setupTree({ calculationMock: fullTimeSalariedMock }));
 
     await waitFor(() => {
       expect(
@@ -381,13 +333,9 @@ describe('SetupStep', () => {
   });
 
   it('hides Benefits and adapts validation when switching from Full-time to Part-time', async () => {
-    const { findByRole, queryByRole, rerender } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={{ ...fullTimeHourlyMock, benefits: null }}
-      >
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole, queryByRole, rerender } = renderSetup({
+      calculationMock: { ...fullTimeHourlyMock, benefits: null },
+    });
 
     // Benefits is visible and required when Full-time
     const benefitsInput = await findByRole('spinbutton', {
@@ -396,11 +344,7 @@ describe('SetupStep', () => {
     expect(benefitsInput).toBeInTheDocument();
 
     // Switch to Part-time Hourly — Benefits should disappear
-    rerender(
-      <PdsGoalCalculatorTestWrapper calculationMock={partTimeHourlyMock}>
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    rerender(setupTree({ calculationMock: partTimeHourlyMock }));
 
     await waitFor(() => {
       expect(
@@ -415,16 +359,12 @@ describe('SetupStep', () => {
   });
 
   it('renders the Form Type select with both options', async () => {
-    const { findByRole, getByRole } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={{
-          ...fullTimeSalariedMock,
-          formType: DesignationSupportFormType.Detailed,
-        }}
-      >
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole, getByRole } = renderSetup({
+      calculationMock: {
+        ...fullTimeSalariedMock,
+        formType: DesignationSupportFormType.Detailed,
+      },
+    });
 
     const select = await findByRole('combobox', { name: /Form Type/ });
     await waitFor(() => expect(select).toHaveTextContent('Default'));
@@ -435,16 +375,12 @@ describe('SetupStep', () => {
   });
 
   it('shows 403b Contribution Percentage field when formType is Detailed', async () => {
-    const { findByRole } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={{
-          ...fullTimeSalariedMock,
-          formType: DesignationSupportFormType.Detailed,
-        }}
-      >
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole } = renderSetup({
+      calculationMock: {
+        ...fullTimeSalariedMock,
+        formType: DesignationSupportFormType.Detailed,
+      },
+    });
 
     expect(
       await findByRole('textbox', { name: '403b Contribution Percentage' }),
@@ -452,16 +388,12 @@ describe('SetupStep', () => {
   });
 
   it('hides 403b Contribution Percentage field when formType is Simple', async () => {
-    const { findByRole, queryByRole } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={{
-          ...fullTimeSalariedMock,
-          formType: DesignationSupportFormType.Simple,
-        }}
-      >
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole, queryByRole } = renderSetup({
+      calculationMock: {
+        ...fullTimeSalariedMock,
+        formType: DesignationSupportFormType.Simple,
+      },
+    });
 
     // Wait for the Form Type select to reflect the loaded Simple value
     const formTypeSelect = await findByRole('combobox', { name: /Form Type/ });
@@ -473,17 +405,13 @@ describe('SetupStep', () => {
   });
 
   it('fires UpdatePdsGoalCalculation with formType when toggled to Simple', async () => {
-    const { findByRole, getByRole } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={{
-          ...fullTimeSalariedMock,
-          formType: DesignationSupportFormType.Detailed,
-        }}
-        onCall={mutationSpy}
-      >
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole, getByRole } = renderSetup({
+      calculationMock: {
+        ...fullTimeSalariedMock,
+        formType: DesignationSupportFormType.Detailed,
+      },
+      onCall: mutationSpy,
+    });
 
     const select = await findByRole('combobox', { name: /Form Type/ });
     await waitFor(() => expect(select).toHaveTextContent('Default'));
@@ -501,16 +429,12 @@ describe('SetupStep', () => {
   });
 
   it('shows the 403b Contribution Percentage field when formType is null (legacy goal)', async () => {
-    const { findByRole } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={{
-          ...fullTimeSalariedMock,
-          formType: null,
-        }}
-      >
-        <SetupStep />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByRole } = renderSetup({
+      calculationMock: {
+        ...fullTimeSalariedMock,
+        formType: null,
+      },
+    });
 
     expect(
       await findByRole('textbox', { name: '403b Contribution Percentage' }),

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -47,7 +47,10 @@ export const SetupStep: React.FC = () => {
   const schema = useMemo(
     () =>
       yup.object({
-        formType: yup.string().optional(),
+        formType: yup
+          .string()
+          .oneOf(Object.values(DesignationSupportFormType))
+          .optional(),
         name: yup.string().required(t('Goal Name is a required field')),
         status: yup
           .string()

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -31,6 +31,7 @@ import {
 import { AutosaveTextField } from '../Shared/Autosave/AutosaveTextField';
 import { useSaveField } from '../Shared/Autosave/useSaveField';
 import { usePdsGoalCalculator } from '../Shared/PdsGoalCalculatorContext';
+import { isSimpleFormType } from '../Shared/formType';
 import { HoursPerWeekGrid } from './HoursPerWeekGrid/HoursPerWeekGrid';
 
 export const SetupStep: React.FC = () => {
@@ -38,18 +39,13 @@ export const SetupStep: React.FC = () => {
   const theme = useTheme();
   const { calculation, hcmUser, setRightPanelContent } = usePdsGoalCalculator();
   const { data: userData } = useGetUserQuery();
-  const fourOThreeB = hcmUser?.fourOThreeB;
-  const totalFourOThreeBContributionPercentage = fourOThreeB
-    ? (fourOThreeB.currentTaxDeferredContributionPercentage ?? 0) +
-      (fourOThreeB.currentRothContributionPercentage ?? 0)
-    : null;
-
   const schema = useMemo(
     () =>
       yup.object({
         formType: yup
           .string()
           .oneOf(Object.values(DesignationSupportFormType))
+          .nullable()
           .optional(),
         name: yup.string().required(t('Goal Name is a required field')),
         status: yup
@@ -92,8 +88,7 @@ export const SetupStep: React.FC = () => {
   const isSalaried =
     calculation?.salaryOrHourly === DesignationSupportSalaryType.Salaried;
   const isPartTime = calculation?.status === DesignationSupportStatus.PartTime;
-  const isSimpleForm =
-    calculation?.formType === DesignationSupportFormType.Simple;
+  const isSimpleForm = isSimpleFormType(calculation?.formType);
 
   const payRateHelperText = isSalaried
     ? t('Enter yearly salary')
@@ -151,6 +146,9 @@ export const SetupStep: React.FC = () => {
               schema={schema}
               select
               label={t('Form Type')}
+              helperText={t(
+                'Default includes reimbursable expenses and 403b contributions; Simple omits them.',
+              )}
             >
               <MenuItem value={DesignationSupportFormType.Detailed}>
                 {t('Default')}
@@ -255,7 +253,14 @@ export const SetupStep: React.FC = () => {
                 variant="outlined"
                 label={t('403b Contribution Percentage')}
                 disabled
-                value={totalFourOThreeBContributionPercentage ?? ''}
+                value={
+                  hcmUser?.fourOThreeB
+                    ? (hcmUser.fourOThreeB
+                        .currentTaxDeferredContributionPercentage ?? 0) +
+                      (hcmUser.fourOThreeB.currentRothContributionPercentage ??
+                        0)
+                    : ''
+                }
                 helperText={t(
                   'Retrieved from Principal. A combined percentage of your current tax deferred and Roth contributions.',
                 )}

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -147,7 +147,7 @@ export const SetupStep: React.FC = () => {
               select
               label={t('Form Type')}
               helperText={t(
-                'Default includes reimbursable expenses and 403b contributions; Simple omits them.',
+                'Default includes reimbursable expenses and 403b contributions in the goal total. Simple excludes them; existing entries are preserved and will count again if you switch back.',
               )}
             >
               <MenuItem value={DesignationSupportFormType.Detailed}>

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -31,7 +31,6 @@ import {
 import { AutosaveTextField } from '../Shared/Autosave/AutosaveTextField';
 import { useSaveField } from '../Shared/Autosave/useSaveField';
 import { usePdsGoalCalculator } from '../Shared/PdsGoalCalculatorContext';
-import { isSimpleFormType } from '../Shared/formType';
 import { HoursPerWeekGrid } from './HoursPerWeekGrid/HoursPerWeekGrid';
 
 export const SetupStep: React.FC = () => {
@@ -88,7 +87,8 @@ export const SetupStep: React.FC = () => {
   const isSalaried =
     calculation?.salaryOrHourly === DesignationSupportSalaryType.Salaried;
   const isPartTime = calculation?.status === DesignationSupportStatus.PartTime;
-  const isSimpleForm = isSimpleFormType(calculation?.formType);
+  const isSimpleForm =
+    calculation?.formType === DesignationSupportFormType.Simple;
 
   const payRateHelperText = isSalaried
     ? t('Enter yearly salary')

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import {
+  DesignationSupportFormType,
   DesignationSupportSalaryType,
   DesignationSupportStatus,
 } from 'src/graphql/types.generated';
@@ -46,6 +47,7 @@ export const SetupStep: React.FC = () => {
   const schema = useMemo(
     () =>
       yup.object({
+        formType: yup.string().optional(),
         name: yup.string().required(t('Goal Name is a required field')),
         status: yup
           .string()
@@ -87,6 +89,8 @@ export const SetupStep: React.FC = () => {
   const isSalaried =
     calculation?.salaryOrHourly === DesignationSupportSalaryType.Salaried;
   const isPartTime = calculation?.status === DesignationSupportStatus.PartTime;
+  const isSimpleForm =
+    calculation?.formType === DesignationSupportFormType.Simple;
 
   const payRateHelperText = isSalaried
     ? t('Enter yearly salary')
@@ -138,6 +142,22 @@ export const SetupStep: React.FC = () => {
           </Typography>
         </Box>
         <Grid container spacing={3}>
+          <Grid item xs={12}>
+            <AutosaveTextField
+              fieldName="formType"
+              schema={schema}
+              select
+              label={t('Form Type')}
+            >
+              <MenuItem value={DesignationSupportFormType.Detailed}>
+                {t('Default')}
+              </MenuItem>
+              <MenuItem value={DesignationSupportFormType.Simple}>
+                {t('Simple')}
+              </MenuItem>
+            </AutosaveTextField>
+          </Grid>
+
           <Grid item xs={12}>
             <AutosaveTextField
               fieldName="status"
@@ -224,22 +244,24 @@ export const SetupStep: React.FC = () => {
             </Grid>
           )}
 
-          <Grid item xs={12}>
-            <TextField
-              fullWidth
-              size="small"
-              variant="outlined"
-              label={t('403b Contribution Percentage')}
-              disabled
-              value={totalFourOThreeBContributionPercentage ?? ''}
-              helperText={t(
-                'Retrieved from Principal. A combined percentage of your current tax deferred and Roth contributions.',
-              )}
-              InputProps={{
-                endAdornment: <PercentageAdornment />,
-              }}
-            />
-          </Grid>
+          {!isSimpleForm && (
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                size="small"
+                variant="outlined"
+                label={t('403b Contribution Percentage')}
+                disabled
+                value={totalFourOThreeBContributionPercentage ?? ''}
+                helperText={t(
+                  'Retrieved from Principal. A combined percentage of your current tax deferred and Roth contributions.',
+                )}
+                InputProps={{
+                  endAdornment: <PercentageAdornment />,
+                }}
+              />
+            </Grid>
+          )}
 
           <Grid item xs={12}>
             <Autocomplete

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/AutosaveTextField.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/AutosaveTextField.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MenuItem } from '@mui/material';
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as yup from 'yup';
 import {
@@ -199,6 +199,60 @@ describe('AutosaveTextField', () => {
 
     expect(input).toHaveAccessibleDescription(
       'Pay Rate must be a positive number',
+    );
+  });
+
+  it('hides validation error for an empty untouched field', async () => {
+    const requiredSchema = yup.object({
+      name: yup.string().required('Goal Name is required'),
+    });
+    const { findByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={{ ...calculationMock, name: '' }}
+        onCall={mutationSpy}
+      >
+        <AutosaveTextField
+          label="Goal Name"
+          fieldName="name"
+          schema={requiredSchema}
+          helperText="Enter the goal name"
+        />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    const input = await findByRole('textbox', { name: 'Goal Name' });
+    await waitFor(() => expect(input).toHaveValue(''));
+
+    expect(input).toHaveAccessibleDescription('Enter the goal name');
+    expect(input).not.toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('shows validation error after the field is touched', async () => {
+    const requiredSchema = yup.object({
+      name: yup.string().required('Goal Name is required'),
+    });
+    const { findByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={{ ...calculationMock, name: '' }}
+        onCall={mutationSpy}
+      >
+        <AutosaveTextField
+          label="Goal Name"
+          fieldName="name"
+          schema={requiredSchema}
+          helperText="Enter the goal name"
+        />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    const input = await findByRole('textbox', { name: 'Goal Name' });
+    await waitFor(() => expect(input).toHaveValue(''));
+
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(input).toHaveAccessibleDescription('Goal Name is required'),
     );
   });
 

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/AutosaveTextField.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/AutosaveTextField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { TextField, TextFieldProps } from '@mui/material';
 import * as yup from 'yup';
 import { DesignationSupportCalculationUpdateInput } from 'src/graphql/types.generated';
@@ -23,6 +23,11 @@ export const AutosaveTextField: React.FC<AutosaveTextFieldProps> = ({
     schema,
     saveOnChange: props.select,
   });
+  const [touched, setTouched] = useState(false);
+
+  const showValidationError = Boolean(
+    fieldProps.error && (touched || fieldProps.value !== ''),
+  );
 
   return (
     <TextField
@@ -31,8 +36,19 @@ export const AutosaveTextField: React.FC<AutosaveTextFieldProps> = ({
       variant="outlined"
       {...fieldProps}
       {...props}
+      onChange={(event) => {
+        setTouched(true);
+        fieldProps.onChange?.(event as React.ChangeEvent<HTMLInputElement>);
+      }}
+      onBlur={() => {
+        setTouched(true);
+        fieldProps.onBlur?.();
+      }}
       disabled={fieldProps.disabled || props.disabled}
-      helperText={fieldProps.helperText ?? props.helperText}
+      error={showValidationError || undefined}
+      helperText={
+        showValidationError ? fieldProps.helperText : props.helperText
+      }
     />
   );
 };

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.test.tsx
@@ -11,6 +11,7 @@ import { usePdsGoalAutoSave } from './usePdsGoalAutoSave';
 const schema = yup.object({
   name: yup.string().required('Goal Name is required'),
   payRate: yup.number().nullable().min(0),
+  formType: yup.string().nullable(),
 });
 
 const mutationSpy = jest.fn();
@@ -118,5 +119,52 @@ describe('usePdsGoalAutoSave', () => {
     );
 
     await waitFor(() => expect(result.current.value).toBe('50000'));
+  });
+
+  it('disables saveOnChange fields while a save is in flight', async () => {
+    const { result } = renderHook(
+      () =>
+        usePdsGoalAutoSave({
+          fieldName: 'formType',
+          schema,
+          saveOnChange: true,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => expect(result.current.disabled).toBe(false));
+
+    act(() => {
+      result.current.onChange({
+        target: { value: 'simple' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    await waitFor(() => expect(result.current.disabled).toBe(true));
+    await waitFor(() => expect(result.current.disabled).toBe(false));
+  });
+
+  it('does not disable blur-driven fields while a save is in flight', async () => {
+    const { result } = renderHook(
+      () => usePdsGoalAutoSave({ fieldName: 'name', schema }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => expect(result.current.value).toBe('Test Goal'));
+
+    act(() => {
+      result.current.onChange({
+        target: { value: 'Updated Goal' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+    act(() => {
+      result.current.onBlur();
+    });
+
+    expect(result.current.disabled).toBe(false);
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation'),
+    );
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.ts
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.ts
@@ -15,13 +15,17 @@ export const usePdsGoalAutoSave = ({
   ...options
 }: UsePdsAutoSaveOptions) => {
   const saveField = useSaveField();
-  const { calculation } = usePdsGoalCalculator();
+  const { calculation, isMutating } = usePdsGoalCalculator();
 
   return useAutoSave({
     value: calculation?.[fieldName] as string | number | null | undefined,
     saveValue: (value) => saveField({ [fieldName]: value }),
     fieldName,
-    disabled: !calculation,
     ...options,
+    // Block change-driven (select) autosaves while a save is in flight: rapid
+    // back-and-forth toggles can otherwise land out of order in the Apollo
+    // cache. formType is the load-bearing case — its value reshapes the goal
+    // calculation, so a stale final value silently understates the total.
+    disabled: !calculation || (options.saveOnChange === true && isMutating),
   });
 };

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
@@ -1,26 +1,103 @@
 import React from 'react';
-import { act, renderHook } from '@testing-library/react';
+import SettingsIcon from '@mui/icons-material/Settings';
+import { act, render, renderHook } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PdsGoalCalculatorStepEnum } from '../PdsGoalCalculatorHelper';
 import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
 import { usePdsGoalCalculator } from './PdsGoalCalculatorContext';
+import { useSteps } from './useSteps';
+import type { PdsGoalCalculatorStep } from './useSteps';
+
+jest.mock('./useSteps', () => ({
+  __esModule: true,
+  ...jest.requireActual('./useSteps'),
+  useSteps: jest.fn(),
+}));
+
+const mockedUseSteps = useSteps as jest.MockedFunction<typeof useSteps>;
+
+const stub = (step: PdsGoalCalculatorStepEnum): PdsGoalCalculatorStep => ({
+  step,
+  title: step,
+  icon: <SettingsIcon />,
+  sections: [],
+});
+
+const detailedSteps: PdsGoalCalculatorStep[] = [
+  stub(PdsGoalCalculatorStepEnum.Setup),
+  stub(PdsGoalCalculatorStepEnum.ReimbursableExpenses),
+  stub(PdsGoalCalculatorStepEnum.SupportItem),
+  stub(PdsGoalCalculatorStepEnum.SummaryReport),
+];
+
+const simpleSteps: PdsGoalCalculatorStep[] = [
+  stub(PdsGoalCalculatorStepEnum.Setup),
+  stub(PdsGoalCalculatorStepEnum.SupportItem),
+  stub(PdsGoalCalculatorStepEnum.SummaryReport),
+];
+
+const minimalSteps: PdsGoalCalculatorStep[] = [
+  stub(PdsGoalCalculatorStepEnum.Setup),
+  stub(PdsGoalCalculatorStepEnum.SummaryReport),
+];
+
+const renderUsePdsGoalCalculator = () =>
+  renderHook(() => usePdsGoalCalculator(), {
+    wrapper: ({ children }) => (
+      <PdsGoalCalculatorTestWrapper>{children}</PdsGoalCalculatorTestWrapper>
+    ),
+  });
+
+const StepProbe: React.FC = () => {
+  const { currentStep, stepIndex, steps, handleStepChange } =
+    usePdsGoalCalculator();
+  return (
+    <div>
+      <div data-testid="current-step">{currentStep?.step ?? 'none'}</div>
+      <div data-testid="step-index">{stepIndex}</div>
+      <div data-testid="step-count">{steps.length}</div>
+      <button
+        type="button"
+        onClick={() =>
+          handleStepChange(PdsGoalCalculatorStepEnum.ReimbursableExpenses)
+        }
+      >
+        go to reimbursable
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          handleStepChange(PdsGoalCalculatorStepEnum.SummaryReport)
+        }
+      >
+        go to summary
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          handleStepChange(PdsGoalCalculatorStepEnum.SupportItem)
+        }
+      >
+        go to support item
+      </button>
+    </div>
+  );
+};
+
+beforeEach(() => {
+  mockedUseSteps.mockReturnValue(detailedSteps);
+});
 
 describe('PdsGoalCalculatorContext', () => {
   it('provides steps and current step', () => {
-    const { result } = renderHook(() => usePdsGoalCalculator(), {
-      wrapper: ({ children }) => (
-        <PdsGoalCalculatorTestWrapper>{children}</PdsGoalCalculatorTestWrapper>
-      ),
-    });
+    const { result } = renderUsePdsGoalCalculator();
 
     expect(result.current.steps).toHaveLength(4);
     expect(result.current.currentStep.step).toBe('setup');
   });
 
   it('handleContinue advances to the next step', () => {
-    const { result } = renderHook(() => usePdsGoalCalculator(), {
-      wrapper: ({ children }) => (
-        <PdsGoalCalculatorTestWrapper>{children}</PdsGoalCalculatorTestWrapper>
-      ),
-    });
+    const { result } = renderUsePdsGoalCalculator();
 
     expect(result.current.stepIndex).toBe(0);
 
@@ -29,11 +106,7 @@ describe('PdsGoalCalculatorContext', () => {
   });
 
   it('handlePreviousStep goes back to the previous step', () => {
-    const { result } = renderHook(() => usePdsGoalCalculator(), {
-      wrapper: ({ children }) => (
-        <PdsGoalCalculatorTestWrapper>{children}</PdsGoalCalculatorTestWrapper>
-      ),
-    });
+    const { result } = renderUsePdsGoalCalculator();
 
     act(() => result.current.handleContinue());
     expect(result.current.stepIndex).toBe(1);
@@ -43,15 +116,74 @@ describe('PdsGoalCalculatorContext', () => {
   });
 
   it('handlePreviousStep does nothing on the first step', () => {
-    const { result } = renderHook(() => usePdsGoalCalculator(), {
-      wrapper: ({ children }) => (
-        <PdsGoalCalculatorTestWrapper>{children}</PdsGoalCalculatorTestWrapper>
-      ),
-    });
+    const { result } = renderUsePdsGoalCalculator();
 
     expect(result.current.stepIndex).toBe(0);
 
     act(() => result.current.handlePreviousStep());
     expect(result.current.stepIndex).toBe(0);
+  });
+
+  describe('preserves the user step when the steps array changes', () => {
+    it.each([
+      {
+        name: 'keeps the user on SummaryReport when steps shrink Detailed → Simple',
+        initialSteps: detailedSteps,
+        click: 'go to summary',
+        newSteps: simpleSteps,
+        expectedStep: PdsGoalCalculatorStepEnum.SummaryReport,
+        expectedIndex: '2',
+      },
+      {
+        name: 'falls back to Setup when current step does not exist in new form',
+        initialSteps: detailedSteps,
+        click: 'go to reimbursable',
+        newSteps: simpleSteps,
+        expectedStep: PdsGoalCalculatorStepEnum.Setup,
+        expectedIndex: '0',
+      },
+      {
+        name: 'reconciles to the first step when an active step past index 1 disappears',
+        initialSteps: detailedSteps,
+        click: 'go to support item',
+        newSteps: minimalSteps,
+        expectedStep: PdsGoalCalculatorStepEnum.Setup,
+        expectedIndex: '0',
+      },
+      {
+        name: 'keeps the user on SupportItem when steps grow Simple → Detailed',
+        initialSteps: simpleSteps,
+        click: 'go to support item',
+        newSteps: detailedSteps,
+        expectedStep: PdsGoalCalculatorStepEnum.SupportItem,
+        expectedIndex: '2',
+      },
+    ])(
+      '$name',
+      async ({ initialSteps, click, newSteps, expectedStep, expectedIndex }) => {
+        mockedUseSteps.mockReturnValue(initialSteps);
+        const { findByTestId, getByRole, rerender } = render(
+          <PdsGoalCalculatorTestWrapper>
+            <StepProbe />
+          </PdsGoalCalculatorTestWrapper>,
+        );
+
+        userEvent.click(getByRole('button', { name: click }));
+
+        mockedUseSteps.mockReturnValue(newSteps);
+        rerender(
+          <PdsGoalCalculatorTestWrapper>
+            <StepProbe />
+          </PdsGoalCalculatorTestWrapper>,
+        );
+
+        expect(await findByTestId('current-step')).toHaveTextContent(
+          expectedStep,
+        );
+        expect(await findByTestId('step-index')).toHaveTextContent(
+          expectedIndex,
+        );
+      },
+    );
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
@@ -1,21 +1,22 @@
 import React from 'react';
 import SettingsIcon from '@mui/icons-material/Settings';
-import { act, render, renderHook } from '@testing-library/react';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
 import { PdsGoalCalculatorStepEnum } from '../PdsGoalCalculatorHelper';
 import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
 import { usePdsGoalCalculator } from './PdsGoalCalculatorContext';
 import { useSteps } from './useSteps';
-import type {
-  PdsGoalCalculatorStep,
-  PdsGoalCalculatorSteps,
-} from './useSteps';
+import type { PdsGoalCalculatorStep, PdsGoalCalculatorSteps } from './useSteps';
 
 jest.mock('./useSteps', () => ({
   __esModule: true,
   ...jest.requireActual('./useSteps'),
   useSteps: jest.fn(),
 }));
+
+const { useSteps: actualUseSteps } =
+  jest.requireActual<typeof import('./useSteps')>('./useSteps');
 
 const mockedUseSteps = useSteps as jest.MockedFunction<typeof useSteps>;
 
@@ -77,9 +78,7 @@ const StepProbe: React.FC = () => {
       </button>
       <button
         type="button"
-        onClick={() =>
-          handleStepChange(PdsGoalCalculatorStepEnum.SupportItem)
-        }
+        onClick={() => handleStepChange(PdsGoalCalculatorStepEnum.SupportItem)}
       >
         go to support item
       </button>
@@ -88,15 +87,34 @@ const StepProbe: React.FC = () => {
 };
 
 beforeEach(() => {
-  mockedUseSteps.mockReturnValue(detailedSteps);
+  mockedUseSteps.mockImplementation(actualUseSteps);
 });
 
 describe('PdsGoalCalculatorContext', () => {
-  it('provides steps and current step', () => {
+  it('provides steps and current step', async () => {
     const { result } = renderUsePdsGoalCalculator();
 
-    expect(result.current.steps).toHaveLength(4);
+    await waitFor(() => expect(result.current.steps).toHaveLength(4));
     expect(result.current.currentStep.step).toBe('setup');
+  });
+
+  it('passes calculation.formType through to useSteps (Simple → 3 steps)', async () => {
+    const { result } = renderHook(() => usePdsGoalCalculator(), {
+      wrapper: ({ children }) => (
+        <PdsGoalCalculatorTestWrapper
+          calculationMock={{ formType: DesignationSupportFormType.Simple }}
+        >
+          {children}
+        </PdsGoalCalculatorTestWrapper>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.steps).toHaveLength(3));
+    expect(result.current.steps.map((s) => s.step)).toEqual([
+      PdsGoalCalculatorStepEnum.Setup,
+      PdsGoalCalculatorStepEnum.SupportItem,
+      PdsGoalCalculatorStepEnum.SummaryReport,
+    ]);
   });
 
   it('handleContinue advances to the next step', () => {
@@ -202,11 +220,10 @@ describe('PdsGoalCalculatorContext', () => {
           expectedIndex,
         );
 
-        if (expectSnackbar) {
-          expect(await findByText(reconcileMessage)).toBeInTheDocument();
-        } else {
-          expect(queryByText(reconcileMessage)).not.toBeInTheDocument();
-        }
+        const snackbar = expectSnackbar
+          ? await findByText(reconcileMessage)
+          : queryByText(reconcileMessage);
+        expect(Boolean(snackbar)).toBe(expectSnackbar);
       },
     );
 
@@ -218,9 +235,7 @@ describe('PdsGoalCalculatorContext', () => {
         </PdsGoalCalculatorTestWrapper>,
       );
 
-      userEvent.click(
-        getByRole('button', { name: 'go to reimbursable' }),
-      );
+      userEvent.click(getByRole('button', { name: 'go to reimbursable' }));
 
       mockedUseSteps.mockReturnValue(simpleSteps);
       rerender(

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
@@ -147,7 +147,7 @@ describe('PdsGoalCalculatorContext', () => {
 
   describe('preserves the user step when the steps array changes', () => {
     const reconcileMessage =
-      'Returned to Setup because that step is not available in this form type.';
+      'Returned to Setup because the current step is no longer available.';
 
     it.each([
       {

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
@@ -6,7 +6,10 @@ import { PdsGoalCalculatorStepEnum } from '../PdsGoalCalculatorHelper';
 import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
 import { usePdsGoalCalculator } from './PdsGoalCalculatorContext';
 import { useSteps } from './useSteps';
-import type { PdsGoalCalculatorStep } from './useSteps';
+import type {
+  PdsGoalCalculatorStep,
+  PdsGoalCalculatorSteps,
+} from './useSteps';
 
 jest.mock('./useSteps', () => ({
   __esModule: true,
@@ -23,20 +26,20 @@ const stub = (step: PdsGoalCalculatorStepEnum): PdsGoalCalculatorStep => ({
   sections: [],
 });
 
-const detailedSteps: PdsGoalCalculatorStep[] = [
+const detailedSteps: PdsGoalCalculatorSteps = [
   stub(PdsGoalCalculatorStepEnum.Setup),
   stub(PdsGoalCalculatorStepEnum.ReimbursableExpenses),
   stub(PdsGoalCalculatorStepEnum.SupportItem),
   stub(PdsGoalCalculatorStepEnum.SummaryReport),
 ];
 
-const simpleSteps: PdsGoalCalculatorStep[] = [
+const simpleSteps: PdsGoalCalculatorSteps = [
   stub(PdsGoalCalculatorStepEnum.Setup),
   stub(PdsGoalCalculatorStepEnum.SupportItem),
   stub(PdsGoalCalculatorStepEnum.SummaryReport),
 ];
 
-const minimalSteps: PdsGoalCalculatorStep[] = [
+const minimalSteps: PdsGoalCalculatorSteps = [
   stub(PdsGoalCalculatorStepEnum.Setup),
   stub(PdsGoalCalculatorStepEnum.SummaryReport),
 ];
@@ -53,7 +56,7 @@ const StepProbe: React.FC = () => {
     usePdsGoalCalculator();
   return (
     <div>
-      <div data-testid="current-step">{currentStep?.step ?? 'none'}</div>
+      <div data-testid="current-step">{currentStep.step}</div>
       <div data-testid="step-index">{stepIndex}</div>
       <div data-testid="step-count">{steps.length}</div>
       <button
@@ -125,6 +128,9 @@ describe('PdsGoalCalculatorContext', () => {
   });
 
   describe('preserves the user step when the steps array changes', () => {
+    const reconcileMessage =
+      'Returned to Setup because that step is not available in this form type.';
+
     it.each([
       {
         name: 'keeps the user on SummaryReport when steps shrink Detailed → Simple',
@@ -133,22 +139,25 @@ describe('PdsGoalCalculatorContext', () => {
         newSteps: simpleSteps,
         expectedStep: PdsGoalCalculatorStepEnum.SummaryReport,
         expectedIndex: '2',
+        expectSnackbar: false,
       },
       {
-        name: 'falls back to Setup when current step does not exist in new form',
+        name: 'falls back to Setup and notifies when current step does not exist in new form',
         initialSteps: detailedSteps,
         click: 'go to reimbursable',
         newSteps: simpleSteps,
         expectedStep: PdsGoalCalculatorStepEnum.Setup,
         expectedIndex: '0',
+        expectSnackbar: true,
       },
       {
-        name: 'reconciles to the first step when an active step past index 1 disappears',
+        name: 'reconciles to the first step and notifies when an active step past index 1 disappears',
         initialSteps: detailedSteps,
         click: 'go to support item',
         newSteps: minimalSteps,
         expectedStep: PdsGoalCalculatorStepEnum.Setup,
         expectedIndex: '0',
+        expectSnackbar: true,
       },
       {
         name: 'keeps the user on SupportItem when steps grow Simple → Detailed',
@@ -157,16 +166,25 @@ describe('PdsGoalCalculatorContext', () => {
         newSteps: detailedSteps,
         expectedStep: PdsGoalCalculatorStepEnum.SupportItem,
         expectedIndex: '2',
+        expectSnackbar: false,
       },
     ])(
       '$name',
-      async ({ initialSteps, click, newSteps, expectedStep, expectedIndex }) => {
+      async ({
+        initialSteps,
+        click,
+        newSteps,
+        expectedStep,
+        expectedIndex,
+        expectSnackbar,
+      }) => {
         mockedUseSteps.mockReturnValue(initialSteps);
-        const { findByTestId, getByRole, rerender } = render(
-          <PdsGoalCalculatorTestWrapper>
-            <StepProbe />
-          </PdsGoalCalculatorTestWrapper>,
-        );
+        const { findByTestId, findByText, getByRole, queryByText, rerender } =
+          render(
+            <PdsGoalCalculatorTestWrapper>
+              <StepProbe />
+            </PdsGoalCalculatorTestWrapper>,
+          );
 
         userEvent.click(getByRole('button', { name: click }));
 
@@ -183,7 +201,49 @@ describe('PdsGoalCalculatorContext', () => {
         expect(await findByTestId('step-index')).toHaveTextContent(
           expectedIndex,
         );
+
+        if (expectSnackbar) {
+          expect(await findByText(reconcileMessage)).toBeInTheDocument();
+        } else {
+          expect(queryByText(reconcileMessage)).not.toBeInTheDocument();
+        }
       },
     );
+
+    it('reconciles activeStep state so toggling formType back does not teleport the user', async () => {
+      mockedUseSteps.mockReturnValue(detailedSteps);
+      const { findByTestId, getByRole, rerender } = render(
+        <PdsGoalCalculatorTestWrapper>
+          <StepProbe />
+        </PdsGoalCalculatorTestWrapper>,
+      );
+
+      userEvent.click(
+        getByRole('button', { name: 'go to reimbursable' }),
+      );
+
+      mockedUseSteps.mockReturnValue(simpleSteps);
+      rerender(
+        <PdsGoalCalculatorTestWrapper>
+          <StepProbe />
+        </PdsGoalCalculatorTestWrapper>,
+      );
+
+      expect(await findByTestId('current-step')).toHaveTextContent(
+        PdsGoalCalculatorStepEnum.Setup,
+      );
+
+      mockedUseSteps.mockReturnValue(detailedSteps);
+      rerender(
+        <PdsGoalCalculatorTestWrapper>
+          <StepProbe />
+        </PdsGoalCalculatorTestWrapper>,
+      );
+
+      expect(await findByTestId('current-step')).toHaveTextContent(
+        PdsGoalCalculatorStepEnum.Setup,
+      );
+      expect(await findByTestId('step-index')).toHaveTextContent('0');
+    });
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -2,7 +2,6 @@ import { useRouter } from 'next/router';
 import React, {
   createContext,
   useCallback,
-  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -85,27 +84,29 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
   const summaryData = usePdsSummaryData(calculation, hcmUser);
 
   const steps = useSteps(calculation?.formType);
-  const [stepIndex, setStepIndex] = useState(0);
+  // Track the user's place by step enum, not numeric index, so that a change
+  // to the steps array (e.g. formType switch Detailed → Simple, dropping the
+  // ReimbursableExpenses step) preserves their step when it still exists and
+  // falls back to Setup only when it doesn't.
+  const [activeStep, setActiveStep] = useState<PdsGoalCalculatorStepEnum>(
+    PdsGoalCalculatorStepEnum.Setup,
+  );
   const [rightPanelContent, setRightPanelContent] =
     useState<React.ReactNode>(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(true);
   const { trackMutation, isMutating } = useTrackMutation();
 
-  // Clamp stepIndex to valid range when the steps array shrinks (e.g. formType
-  // switches from Detailed to Simple, dropping the ReimbursableExpenses step).
-  useEffect(() => {
-    if (stepIndex >= steps.length) {
-      setStepIndex(0);
-    }
-  }, [steps.length, stepIndex]);
+  const stepIndex = useMemo(() => {
+    const idx = steps.findIndex((s) => s.step === activeStep);
+    return idx === -1 ? 0 : idx;
+  }, [steps, activeStep]);
 
   const currentStep = steps[stepIndex];
 
   const handleStepChange = useCallback(
     (newStep: PdsGoalCalculatorStepEnum) => {
-      const newIndex = steps.findIndex((step) => step.step === newStep);
-      if (newIndex !== -1) {
-        setStepIndex(newIndex);
+      if (steps.some((step) => step.step === newStep)) {
+        setActiveStep(newStep);
       } else {
         enqueueSnackbar(t('The selected step does not exist.'), {
           variant: 'error',
@@ -117,15 +118,15 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
 
   const handleContinue = useCallback(() => {
     if (stepIndex < steps.length - 1) {
-      setStepIndex(stepIndex + 1);
+      setActiveStep(steps[stepIndex + 1].step);
     }
   }, [stepIndex, steps]);
 
   const handlePreviousStep = useCallback(() => {
     if (stepIndex > 0) {
-      setStepIndex(stepIndex - 1);
+      setActiveStep(steps[stepIndex - 1].step);
     }
-  }, [stepIndex]);
+  }, [stepIndex, steps]);
 
   const closeRightPanel = useCallback(() => {
     setRightPanelContent(null);

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import React, {
   createContext,
   useCallback,
+  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -18,10 +19,14 @@ import {
   usePdsSummaryData,
 } from '../calculations/usePdsSummaryData';
 import { HcmUserQuery, useHcmUserQuery } from './HCM.generated';
-import { PdsGoalCalculatorStep, useSteps } from './useSteps';
+import {
+  PdsGoalCalculatorStep,
+  PdsGoalCalculatorSteps,
+  useSteps,
+} from './useSteps';
 
 export type PdsGoalCalculatorType = {
-  steps: PdsGoalCalculatorStep[];
+  steps: PdsGoalCalculatorSteps;
   currentStep: PdsGoalCalculatorStep;
 
   calculation?: PdsGoalCalculationFieldsFragment;
@@ -86,8 +91,9 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
   const steps = useSteps(calculation?.formType);
   // Track the user's place by step enum, not numeric index, so that a change
   // to the steps array (e.g. formType switch Detailed → Simple, dropping the
-  // ReimbursableExpenses step) preserves their step when it still exists and
-  // falls back to Setup only when it doesn't.
+  // ReimbursableExpenses step) preserves their step when it still exists.
+  // When it doesn't exist, the effect below reconciles activeStep to the first
+  // step and notifies the user.
   const [activeStep, setActiveStep] = useState<PdsGoalCalculatorStepEnum>(
     PdsGoalCalculatorStepEnum.Setup,
   );
@@ -96,12 +102,27 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(true);
   const { trackMutation, isMutating } = useTrackMutation();
 
+  useEffect(() => {
+    if (steps.some((s) => s.step === activeStep)) {
+      return;
+    }
+    setActiveStep(steps[0]?.step ?? PdsGoalCalculatorStepEnum.Setup);
+    enqueueSnackbar(
+      t(
+        'Returned to Setup because that step is not available in this form type.',
+      ),
+      { variant: 'info' },
+    );
+  }, [steps, activeStep, enqueueSnackbar, t]);
+
   const stepIndex = useMemo(() => {
     const idx = steps.findIndex((s) => s.step === activeStep);
     return idx === -1 ? 0 : idx;
   }, [steps, activeStep]);
 
-  const currentStep = steps[stepIndex];
+  // steps is a non-empty tuple, so steps[0] is guaranteed defined; the fallback
+  // protects against an out-of-range stepIndex.
+  const currentStep = steps[stepIndex] ?? steps[0];
 
   const handleStepChange = useCallback(
     (newStep: PdsGoalCalculatorStepEnum) => {

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -1,5 +1,11 @@
 import { useRouter } from 'next/router';
-import React, { createContext, useCallback, useMemo, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { useTrackMutation } from 'src/hooks/useTrackMutation';
@@ -84,6 +90,14 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
     useState<React.ReactNode>(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(true);
   const { trackMutation, isMutating } = useTrackMutation();
+
+  // Clamp stepIndex to valid range when the steps array shrinks (e.g. formType
+  // switches from Detailed to Simple, dropping the ReimbursableExpenses step).
+  useEffect(() => {
+    if (stepIndex >= steps.length) {
+      setStepIndex(0);
+    }
+  }, [steps.length, stepIndex]);
 
   const currentStep = steps[stepIndex];
 

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -111,9 +111,7 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
     }
     setActiveStep(steps[0]?.step ?? PdsGoalCalculatorStepEnum.Setup);
     enqueueSnackbar(
-      t(
-        'Returned to Setup because that step is not available in this form type.',
-      ),
+      t('Returned to Setup because the current step is no longer available.'),
       { variant: 'info' },
     );
   }, [steps, activeStep, enqueueSnackbar, t]);

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -78,7 +78,7 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
 
   const summaryData = usePdsSummaryData(calculation, hcmUser);
 
-  const steps = useSteps();
+  const steps = useSteps(calculation?.formType);
   const [stepIndex, setStepIndex] = useState(0);
   const [rightPanelContent, setRightPanelContent] =
     useState<React.ReactNode>(null);

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
 import { useTrackMutation } from 'src/hooks/useTrackMutation';
 import {
   PdsGoalCalculationFieldsFragment,
@@ -88,7 +89,9 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
 
   const summaryData = usePdsSummaryData(calculation, hcmUser);
 
-  const steps = useSteps(calculation?.formType);
+  const steps = useSteps(
+    calculation?.formType ?? DesignationSupportFormType.Detailed,
+  );
   // Track the user's place by step enum, not numeric index, so that a change
   // to the steps array (e.g. formType switch Detailed → Simple, dropping the
   // ReimbursableExpenses step) preserves their step when it still exists.

--- a/src/components/HrTools/PdsGoalCalculator/Shared/formType.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/formType.test.ts
@@ -1,0 +1,12 @@
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
+import { isSimpleFormType } from './formType';
+
+describe('isSimpleFormType', () => {
+  it('returns true for Simple form type', () => {
+    expect(isSimpleFormType(DesignationSupportFormType.Simple)).toBe(true);
+  });
+
+  it('returns false for Detailed form type', () => {
+    expect(isSimpleFormType(DesignationSupportFormType.Detailed)).toBe(false);
+  });
+});

--- a/src/components/HrTools/PdsGoalCalculator/Shared/formType.ts
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/formType.ts
@@ -1,0 +1,10 @@
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
+
+export const isSimpleFormType = (
+  formType: DesignationSupportFormType | null | undefined,
+): boolean => formType === DesignationSupportFormType.Simple;
+
+export const isDesignationSupportFormType = (
+  value: string,
+): value is DesignationSupportFormType =>
+  (Object.values(DesignationSupportFormType) as string[]).includes(value);

--- a/src/components/HrTools/PdsGoalCalculator/Shared/formType.ts
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/formType.ts
@@ -1,5 +1,5 @@
 import { DesignationSupportFormType } from 'src/graphql/types.generated';
 
 export const isSimpleFormType = (
-  formType: DesignationSupportFormType | null | undefined,
+  formType: DesignationSupportFormType,
 ): boolean => formType === DesignationSupportFormType.Simple;

--- a/src/components/HrTools/PdsGoalCalculator/Shared/formType.ts
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/formType.ts
@@ -3,8 +3,3 @@ import { DesignationSupportFormType } from 'src/graphql/types.generated';
 export const isSimpleFormType = (
   formType: DesignationSupportFormType | null | undefined,
 ): boolean => formType === DesignationSupportFormType.Simple;
-
-export const isDesignationSupportFormType = (
-  value: string,
-): value is DesignationSupportFormType =>
-  (Object.values(DesignationSupportFormType) as string[]).includes(value);

--- a/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.test.tsx
@@ -8,7 +8,7 @@ describe('useSteps', () => {
     const { result } = renderHook(() =>
       useSteps(DesignationSupportFormType.Detailed),
     );
-    expect(result.current.map((s) => s.step)).toEqual([
+    expect(result.current.map((step) => step.step)).toEqual([
       PdsGoalCalculatorStepEnum.Setup,
       PdsGoalCalculatorStepEnum.ReimbursableExpenses,
       PdsGoalCalculatorStepEnum.SupportItem,
@@ -20,7 +20,7 @@ describe('useSteps', () => {
     const { result } = renderHook(() =>
       useSteps(DesignationSupportFormType.Simple),
     );
-    expect(result.current.map((s) => s.step)).toEqual([
+    expect(result.current.map((step) => step.step)).toEqual([
       PdsGoalCalculatorStepEnum.Setup,
       PdsGoalCalculatorStepEnum.SupportItem,
       PdsGoalCalculatorStepEnum.SummaryReport,
@@ -29,7 +29,7 @@ describe('useSteps', () => {
 
   it('returns four steps (Detailed behavior) when formType is null/undefined', () => {
     const { result } = renderHook(() => useSteps(null));
-    expect(result.current.map((s) => s.step)).toEqual([
+    expect(result.current.map((step) => step.step)).toEqual([
       PdsGoalCalculatorStepEnum.Setup,
       PdsGoalCalculatorStepEnum.ReimbursableExpenses,
       PdsGoalCalculatorStepEnum.SupportItem,

--- a/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.test.tsx
@@ -26,5 +26,4 @@ describe('useSteps', () => {
       PdsGoalCalculatorStepEnum.SummaryReport,
     ]);
   });
-
 });

--- a/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.test.tsx
@@ -27,13 +27,4 @@ describe('useSteps', () => {
     ]);
   });
 
-  it('returns four steps (Detailed behavior) when formType is null/undefined', () => {
-    const { result } = renderHook(() => useSteps(null));
-    expect(result.current.map((step) => step.step)).toEqual([
-      PdsGoalCalculatorStepEnum.Setup,
-      PdsGoalCalculatorStepEnum.ReimbursableExpenses,
-      PdsGoalCalculatorStepEnum.SupportItem,
-      PdsGoalCalculatorStepEnum.SummaryReport,
-    ]);
-  });
 });

--- a/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
+import { PdsGoalCalculatorStepEnum } from '../PdsGoalCalculatorHelper';
+import { useSteps } from './useSteps';
+
+describe('useSteps', () => {
+  it('returns four steps when formType is Detailed', () => {
+    const { result } = renderHook(() =>
+      useSteps(DesignationSupportFormType.Detailed),
+    );
+    expect(result.current.map((s) => s.step)).toEqual([
+      PdsGoalCalculatorStepEnum.Setup,
+      PdsGoalCalculatorStepEnum.ReimbursableExpenses,
+      PdsGoalCalculatorStepEnum.SupportItem,
+      PdsGoalCalculatorStepEnum.SummaryReport,
+    ]);
+  });
+
+  it('omits the Reimbursable Expenses step when formType is Simple', () => {
+    const { result } = renderHook(() =>
+      useSteps(DesignationSupportFormType.Simple),
+    );
+    expect(result.current.map((s) => s.step)).toEqual([
+      PdsGoalCalculatorStepEnum.Setup,
+      PdsGoalCalculatorStepEnum.SupportItem,
+      PdsGoalCalculatorStepEnum.SummaryReport,
+    ]);
+  });
+
+  it('returns four steps (Detailed behavior) when formType is null/undefined', () => {
+    const { result } = renderHook(() => useSteps(null));
+    expect(result.current.map((s) => s.step)).toEqual([
+      PdsGoalCalculatorStepEnum.Setup,
+      PdsGoalCalculatorStepEnum.ReimbursableExpenses,
+      PdsGoalCalculatorStepEnum.SupportItem,
+      PdsGoalCalculatorStepEnum.SummaryReport,
+    ]);
+  });
+});

--- a/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.tsx
@@ -6,6 +6,7 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import { useTranslation } from 'react-i18next';
 import { DesignationSupportFormType } from 'src/graphql/types.generated';
 import { PdsGoalCalculatorStepEnum } from '../PdsGoalCalculatorHelper';
+import { isSimpleFormType } from './formType';
 
 export interface PdsGoalCalculatorSection {
   title: string;
@@ -25,7 +26,7 @@ export const useSteps = (
   const { t } = useTranslation();
 
   return useMemo(() => {
-    const isSimple = formType === DesignationSupportFormType.Simple;
+    const isSimple = isSimpleFormType(formType);
 
     const allSteps: PdsGoalCalculatorStep[] = [
       {

--- a/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.tsx
@@ -20,52 +20,52 @@ export interface PdsGoalCalculatorStep {
   sections: PdsGoalCalculatorSection[];
 }
 
+export type PdsGoalCalculatorSteps = [
+  PdsGoalCalculatorStep,
+  ...PdsGoalCalculatorStep[],
+];
+
 export const useSteps = (
   formType: DesignationSupportFormType | null | undefined,
-): PdsGoalCalculatorStep[] => {
+): PdsGoalCalculatorSteps => {
   const { t } = useTranslation();
 
   return useMemo(() => {
     const isSimple = isSimpleFormType(formType);
 
-    const allSteps: PdsGoalCalculatorStep[] = [
-      {
-        step: PdsGoalCalculatorStepEnum.Setup,
-        title: t('Settings'),
-        icon: <SettingsIcon />,
-        sections: [{ title: t('Setup'), complete: false }],
-      },
-      {
-        step: PdsGoalCalculatorStepEnum.ReimbursableExpenses,
-        title: t('Reimbursable Expenses'),
-        icon: <ReceiptLongIcon />,
-        sections: [
-          { title: t('Monthly Reimbursable Expenses'), complete: false },
-          { title: t('Annual Reimbursable Expenses'), complete: false },
-        ],
-      },
-      {
-        step: PdsGoalCalculatorStepEnum.SupportItem,
-        title: t('Support Item'),
-        icon: <AttachMoneyIcon />,
-        sections: [
-          { title: t('Salary'), complete: false },
-          { title: t('Other'), complete: false },
-        ],
-      },
-      {
-        step: PdsGoalCalculatorStepEnum.SummaryReport,
-        title: t('Summary Report'),
-        icon: <RequestQuoteIcon />,
-        sections: [{ title: t('MPD Goal'), complete: false }],
-      },
-    ];
+    const setup: PdsGoalCalculatorStep = {
+      step: PdsGoalCalculatorStepEnum.Setup,
+      title: t('Settings'),
+      icon: <SettingsIcon />,
+      sections: [{ title: t('Setup'), complete: false }],
+    };
+    const reimbursableExpenses: PdsGoalCalculatorStep = {
+      step: PdsGoalCalculatorStepEnum.ReimbursableExpenses,
+      title: t('Reimbursable Expenses'),
+      icon: <ReceiptLongIcon />,
+      sections: [
+        { title: t('Monthly Reimbursable Expenses'), complete: false },
+        { title: t('Annual Reimbursable Expenses'), complete: false },
+      ],
+    };
+    const supportItem: PdsGoalCalculatorStep = {
+      step: PdsGoalCalculatorStepEnum.SupportItem,
+      title: t('Support Item'),
+      icon: <AttachMoneyIcon />,
+      sections: [
+        { title: t('Salary'), complete: false },
+        { title: t('Other'), complete: false },
+      ],
+    };
+    const summaryReport: PdsGoalCalculatorStep = {
+      step: PdsGoalCalculatorStepEnum.SummaryReport,
+      title: t('Summary Report'),
+      icon: <RequestQuoteIcon />,
+      sections: [{ title: t('MPD Goal'), complete: false }],
+    };
 
     return isSimple
-      ? allSteps.filter(
-          (step) =>
-            step.step !== PdsGoalCalculatorStepEnum.ReimbursableExpenses,
-        )
-      : allSteps;
+      ? [setup, supportItem, summaryReport]
+      : [setup, reimbursableExpenses, supportItem, summaryReport];
   }, [t, formType]);
 };

--- a/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.tsx
@@ -26,7 +26,7 @@ export type PdsGoalCalculatorSteps = [
 ];
 
 export const useSteps = (
-  formType: DesignationSupportFormType | null | undefined,
+  formType: DesignationSupportFormType,
 ): PdsGoalCalculatorSteps => {
   const { t } = useTranslation();
 

--- a/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/useSteps.tsx
@@ -4,6 +4,7 @@ import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import RequestQuoteIcon from '@mui/icons-material/RequestQuote';
 import SettingsIcon from '@mui/icons-material/Settings';
 import { useTranslation } from 'react-i18next';
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
 import { PdsGoalCalculatorStepEnum } from '../PdsGoalCalculatorHelper';
 
 export interface PdsGoalCalculatorSection {
@@ -18,11 +19,15 @@ export interface PdsGoalCalculatorStep {
   sections: PdsGoalCalculatorSection[];
 }
 
-export const useSteps = (): PdsGoalCalculatorStep[] => {
+export const useSteps = (
+  formType: DesignationSupportFormType | null | undefined,
+): PdsGoalCalculatorStep[] => {
   const { t } = useTranslation();
 
-  const steps = useMemo(
-    () => [
+  return useMemo(() => {
+    const isSimple = formType === DesignationSupportFormType.Simple;
+
+    const allSteps: PdsGoalCalculatorStep[] = [
       {
         step: PdsGoalCalculatorStepEnum.Setup,
         title: t('Settings'),
@@ -53,9 +58,13 @@ export const useSteps = (): PdsGoalCalculatorStep[] => {
         icon: <RequestQuoteIcon />,
         sections: [{ title: t('MPD Goal'), complete: false }],
       },
-    ],
-    [t],
-  );
+    ];
 
-  return steps;
+    return isSimple
+      ? allSteps.filter(
+          (step) =>
+            step.step !== PdsGoalCalculatorStepEnum.ReimbursableExpenses,
+        )
+      : allSteps;
+  }, [t, formType]);
 };

--- a/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import {
+  DesignationSupportFormType,
   DesignationSupportSalaryType,
   DesignationSupportStatus,
 } from 'src/graphql/types.generated';
@@ -167,5 +168,68 @@ describe('PdsSummaryTable', () => {
       name: 'Solid Monthly Support Developed',
     }).parentElement;
     expect(supportRaisedRow).toHaveClass('progress-start');
+  });
+
+  it('omits Reimbursable Expenses and 403b Contributions rows when formType is Simple', async () => {
+    const { findByRole, queryByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={{
+          ...salariedFullTimeMock,
+          formType: DesignationSupportFormType.Simple,
+        }}
+      >
+        <PdsSummaryTable supportRaised={1000} />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    // Wait for the grid to render
+    await findByRole('gridcell', { name: 'Salary Subtotal' });
+
+    expect(
+      queryByRole('gridcell', { name: 'Reimbursable Expenses' }),
+    ).not.toBeInTheDocument();
+    expect(
+      queryByRole('gridcell', { name: '403b Contributions' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders Benefits / Work Comp + totals rows when formType is Simple', async () => {
+    const { findByRole, getByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={{
+          ...salariedFullTimeMock,
+          formType: DesignationSupportFormType.Simple,
+        }}
+      >
+        <PdsSummaryTable supportRaised={0} />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await findByRole('gridcell', { name: 'Benefits' });
+
+    expect(getByRole('gridcell', { name: 'Other Subtotal' })).toBeInTheDocument();
+    expect(getByRole('gridcell', { name: 'Total Goal' })).toBeInTheDocument();
+  });
+
+  it('renders Reimbursable Expenses and 403b Contributions rows when formType is Detailed', async () => {
+    const { findByRole, getByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={{
+          ...salariedFullTimeMock,
+          formType: DesignationSupportFormType.Detailed,
+        }}
+      >
+        <PdsSummaryTable supportRaised={1000} />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await findByRole('gridcell', { name: 'Reimbursable Expenses' });
+
+    expect(
+      getByRole('gridcell', { name: 'Reimbursable Expenses' }),
+    ).toBeInTheDocument();
+    expect(
+      getByRole('gridcell', { name: '403b Contributions' }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.test.tsx
@@ -211,6 +211,32 @@ describe('PdsSummaryTable', () => {
     expect(getByRole('gridcell', { name: 'Total Goal' })).toBeInTheDocument();
   });
 
+  it('renders Work Comp without Benefits or detailed rows when formType is Simple and status is PartTime', async () => {
+    const { findByRole, getByRole, queryByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={{
+          ...hourlyPartTimeMock,
+          formType: DesignationSupportFormType.Simple,
+        }}
+      >
+        <PdsSummaryTable supportRaised={0} />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await findByRole('gridcell', { name: 'Work Comp' });
+
+    expect(getByRole('gridcell', { name: 'Work Comp' })).toBeInTheDocument();
+    expect(
+      queryByRole('gridcell', { name: 'Benefits' }),
+    ).not.toBeInTheDocument();
+    expect(
+      queryByRole('gridcell', { name: 'Reimbursable Expenses' }),
+    ).not.toBeInTheDocument();
+    expect(
+      queryByRole('gridcell', { name: '403b Contributions' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('renders Reimbursable Expenses and 403b Contributions rows when formType is Detailed', async () => {
     const { findByRole, getByRole } = render(
       <PdsGoalCalculatorTestWrapper

--- a/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.test.tsx
@@ -207,7 +207,9 @@ describe('PdsSummaryTable', () => {
 
     await findByRole('gridcell', { name: 'Benefits' });
 
-    expect(getByRole('gridcell', { name: 'Other Subtotal' })).toBeInTheDocument();
+    expect(
+      getByRole('gridcell', { name: 'Other Subtotal' }),
+    ).toBeInTheDocument();
     expect(getByRole('gridcell', { name: 'Total Goal' })).toBeInTheDocument();
   });
 

--- a/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.tsx
@@ -2,7 +2,10 @@ import React, { useCallback, useMemo } from 'react';
 import { styled } from '@mui/material/styles';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { useTranslation } from 'react-i18next';
-import { DesignationSupportStatus } from 'src/graphql/types.generated';
+import {
+  DesignationSupportFormType,
+  DesignationSupportStatus,
+} from 'src/graphql/types.generated';
 import { useLocale } from 'src/hooks/useLocale';
 import { useDataGridLocaleText } from 'src/hooks/useMuiLocaleText';
 import {
@@ -85,6 +88,8 @@ export const PdsSummaryTable: React.FC<PdsSummaryTableProps> = ({
 
     const isFullTime = calculation.status === DesignationSupportStatus.FullTime;
     const isPartTime = calculation.status === DesignationSupportStatus.PartTime;
+    const isSimple =
+      calculation.formType === DesignationSupportFormType.Simple;
 
     const rows: PdsSummaryRow[] = [
       // Salary section
@@ -104,16 +109,20 @@ export const PdsSummaryTable: React.FC<PdsSummaryTableProps> = ({
         amount: salaryTotals.subtotal,
       },
       // Other expenses section
-      {
-        line: '2A',
-        category: t('Reimbursable Expenses'),
-        amount: otherTotals.reimbursableExpenses,
-      },
-      {
-        line: '2B',
-        category: t('403b Contributions'),
-        amount: otherTotals.fourOThreeBContributions,
-      },
+      ...(isSimple
+        ? []
+        : [
+            {
+              line: '2A',
+              category: t('Reimbursable Expenses'),
+              amount: otherTotals.reimbursableExpenses,
+            },
+            {
+              line: '2B',
+              category: t('403b Contributions'),
+              amount: otherTotals.fourOThreeBContributions,
+            },
+          ]),
       ...(isPartTime
         ? [
             {

--- a/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.tsx
@@ -2,7 +2,10 @@ import React, { useCallback, useMemo } from 'react';
 import { styled } from '@mui/material/styles';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { useTranslation } from 'react-i18next';
-import { DesignationSupportStatus } from 'src/graphql/types.generated';
+import {
+  DesignationSupportFormType,
+  DesignationSupportStatus,
+} from 'src/graphql/types.generated';
 import { useLocale } from 'src/hooks/useLocale';
 import { useDataGridLocaleText } from 'src/hooks/useMuiLocaleText';
 import {
@@ -86,7 +89,9 @@ export const PdsSummaryTable: React.FC<PdsSummaryTableProps> = ({
 
     const isFullTime = calculation.status === DesignationSupportStatus.FullTime;
     const isPartTime = calculation.status === DesignationSupportStatus.PartTime;
-    const isSimple = isSimpleFormType(calculation.formType);
+    const isSimple = isSimpleFormType(
+      calculation.formType ?? DesignationSupportFormType.Detailed,
+    );
 
     const rows: PdsSummaryRow[] = [
       // Salary section

--- a/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.tsx
@@ -128,7 +128,7 @@ export const PdsSummaryTable: React.FC<PdsSummaryTableProps> = ({
       ...(isPartTime
         ? [
             {
-              line: isSimple ? '2A' : '2C',
+              line: '2C',
               category: t('Work Comp'),
               amount: otherTotals.workComp,
             },
@@ -137,7 +137,7 @@ export const PdsSummaryTable: React.FC<PdsSummaryTableProps> = ({
       ...(isFullTime
         ? [
             {
-              line: isSimple ? '2A' : '2C',
+              line: '2C',
               category: t('Benefits'),
               amount: otherTotals.benefits,
             },

--- a/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SummaryReport/PdsSummaryTable.tsx
@@ -2,10 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { styled } from '@mui/material/styles';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { useTranslation } from 'react-i18next';
-import {
-  DesignationSupportFormType,
-  DesignationSupportStatus,
-} from 'src/graphql/types.generated';
+import { DesignationSupportStatus } from 'src/graphql/types.generated';
 import { useLocale } from 'src/hooks/useLocale';
 import { useDataGridLocaleText } from 'src/hooks/useMuiLocaleText';
 import {
@@ -15,6 +12,7 @@ import {
 } from 'src/lib/intlFormat';
 import { safeProgressRatio } from '../../GoalCalculator/Shared/safeProgressRatio';
 import { usePdsGoalCalculator } from '../Shared/PdsGoalCalculatorContext';
+import { isSimpleFormType } from '../Shared/formType';
 import { PdsSummaryHeaderCards } from './PdsSummaryHeaderCards';
 
 interface PdsSummaryRow {
@@ -88,8 +86,7 @@ export const PdsSummaryTable: React.FC<PdsSummaryTableProps> = ({
 
     const isFullTime = calculation.status === DesignationSupportStatus.FullTime;
     const isPartTime = calculation.status === DesignationSupportStatus.PartTime;
-    const isSimple =
-      calculation.formType === DesignationSupportFormType.Simple;
+    const isSimple = isSimpleFormType(calculation.formType);
 
     const rows: PdsSummaryRow[] = [
       // Salary section
@@ -126,7 +123,7 @@ export const PdsSummaryTable: React.FC<PdsSummaryTableProps> = ({
       ...(isPartTime
         ? [
             {
-              line: '2C',
+              line: isSimple ? '2A' : '2C',
               category: t('Work Comp'),
               amount: otherTotals.workComp,
             },
@@ -135,7 +132,7 @@ export const PdsSummaryTable: React.FC<PdsSummaryTableProps> = ({
       ...(isFullTime
         ? [
             {
-              line: '2C',
+              line: isSimple ? '2A' : '2C',
               category: t('Benefits'),
               amount: otherTotals.benefits,
             },

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/OtherSection.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/OtherSection.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import {
+  DesignationSupportFormType,
   DesignationSupportSalaryType,
   DesignationSupportStatus,
 } from 'src/graphql/types.generated';
@@ -160,6 +161,26 @@ describe('OtherSection', () => {
       // 403b percentage = (5 + 3) / 100 = 0.08
       // 403b contributions = 5000 * 0.08 = 400
       expect(getByTestId('other-403b-contributions')).toHaveTextContent('$400');
+    });
+  });
+
+  describe('simple form type', () => {
+    it('hides reimbursable expenses and 403b contributions rows', async () => {
+      const simpleMock: PdsGoalCalculationMock = {
+        ...fullTimeMock,
+        formType: DesignationSupportFormType.Simple,
+      };
+
+      const { findByTestId, queryByTestId } = render(
+        <TestComponent calculationMock={simpleMock} />,
+      );
+
+      await findByTestId('other-subtotal');
+
+      expect(
+        queryByTestId('other-reimbursable-expenses'),
+      ).not.toBeInTheDocument();
+      expect(queryByTestId('other-403b-contributions')).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/otherBreakdown.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/otherBreakdown.test.tsx
@@ -1,6 +1,9 @@
 import { DataGrid } from '@mui/x-data-grid';
 import { render } from '@testing-library/react';
-import { DesignationSupportStatus } from 'src/graphql/types.generated';
+import {
+  DesignationSupportFormType,
+  DesignationSupportStatus,
+} from 'src/graphql/types.generated';
 import i18n from 'src/lib/i18n';
 import {
   OtherExpensesConstants,
@@ -130,6 +133,47 @@ describe('buildOtherBreakdownRows', () => {
     rows.forEach((row) => {
       expect(row.testId).toBeDefined();
     });
+  });
+
+  it('omits reimbursable expenses and 403b contributions when formType is Simple', () => {
+    const simpleCalculation: OtherExpensesFields = {
+      ...fullTimeCalculation,
+      formType: DesignationSupportFormType.Simple,
+    };
+
+    const rows = buildOtherBreakdownRows(
+      simpleCalculation,
+      constants,
+      'en-US',
+      i18n.t,
+    );
+
+    expect(rows.map((row) => row.id)).toEqual([
+      'benefits',
+      'subtotal',
+      'attrition',
+      'credit-card-fees',
+      'assessment',
+    ]);
+  });
+
+  it('uses a subtotal formula without reimbursable/403b in Simple form', () => {
+    const simpleCalculation: OtherExpensesFields = {
+      ...fullTimeCalculation,
+      formType: DesignationSupportFormType.Simple,
+    };
+
+    const rows = buildOtherBreakdownRows(
+      simpleCalculation,
+      constants,
+      'en-US',
+      i18n.t,
+    );
+
+    const subtotal = rows.find((row) => row.id === 'subtotal');
+    expect(subtotal?.formula).toBe(
+      'Gross Monthly Pay Subtotal + Work Comp + Benefits',
+    );
   });
 });
 

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/otherBreakdown.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/otherBreakdown.tsx
@@ -5,6 +5,7 @@ import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { TFunction } from 'i18next';
 import { DesignationSupportStatus } from 'src/graphql/types.generated';
 import { currencyFormat, percentageFormat } from 'src/lib/intlFormat';
+import { isSimpleFormType } from '../Shared/formType';
 import {
   OtherExpensesConstants,
   OtherExpensesFields,
@@ -40,28 +41,34 @@ export const buildOtherBreakdownRows = (
     constants,
   );
 
+  const isSimple = isSimpleFormType(calculation.formType);
+
   const rows: OtherBreakdownRow[] = [
-    {
-      id: 'reimbursable-expenses',
-      category: t('Reimbursable Expenses'),
-      formula: t(
-        'The greater of $300/month or the amount calculated in the Reimbursable Expenses step',
-      ),
-      amount: totals.reimbursableExpenses,
-      testId: 'other-reimbursable-expenses',
-      tooltip: t(
-        'To change this amount, update the Reimbursable Expenses step',
-      ),
-    },
-    {
-      id: '403b-contributions',
-      category: t('403b Contributions if Applicable'),
-      formula: t(
-        'Gross Monthly Pay from Salary section × 403b Contribution Percentage from Setup section',
-      ),
-      amount: totals.fourOThreeBContributions,
-      testId: 'other-403b-contributions',
-    },
+    ...(isSimple
+      ? []
+      : [
+          {
+            id: 'reimbursable-expenses',
+            category: t('Reimbursable Expenses'),
+            formula: t(
+              'The greater of $300/month or the amount calculated in the Reimbursable Expenses step',
+            ),
+            amount: totals.reimbursableExpenses,
+            testId: 'other-reimbursable-expenses',
+            tooltip: t(
+              'To change this amount, update the Reimbursable Expenses step',
+            ),
+          },
+          {
+            id: '403b-contributions',
+            category: t('403b Contributions if Applicable'),
+            formula: t(
+              'Gross Monthly Pay from Salary section × 403b Contribution Percentage from Setup section',
+            ),
+            amount: totals.fourOThreeBContributions,
+            testId: 'other-403b-contributions',
+          },
+        ]),
     ...(calculation.status === DesignationSupportStatus.PartTime
       ? [
           {
@@ -85,9 +92,11 @@ export const buildOtherBreakdownRows = (
     {
       id: 'subtotal',
       category: t('Subtotal'),
-      formula: t(
-        'Gross Monthly Pay Subtotal + Reimbursable Expenses + 403b Contributions + Work Comp + Benefits',
-      ),
+      formula: isSimple
+        ? t('Gross Monthly Pay Subtotal + Work Comp + Benefits')
+        : t(
+            'Gross Monthly Pay Subtotal + Reimbursable Expenses + 403b Contributions + Work Comp + Benefits',
+          ),
       amount: totals.subtotal,
       testId: 'other-subtotal',
       bold: true,

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/otherBreakdown.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/otherBreakdown.tsx
@@ -3,7 +3,10 @@ import InfoIcon from '@mui/icons-material/Info';
 import { Box, Tooltip, styled } from '@mui/material';
 import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { TFunction } from 'i18next';
-import { DesignationSupportStatus } from 'src/graphql/types.generated';
+import {
+  DesignationSupportFormType,
+  DesignationSupportStatus,
+} from 'src/graphql/types.generated';
 import { currencyFormat, percentageFormat } from 'src/lib/intlFormat';
 import { isSimpleFormType } from '../Shared/formType';
 import {
@@ -41,7 +44,9 @@ export const buildOtherBreakdownRows = (
     constants,
   );
 
-  const isSimple = isSimpleFormType(calculation.formType);
+  const isSimple = isSimpleFormType(
+    calculation.formType ?? DesignationSupportFormType.Detailed,
+  );
 
   const rows: OtherBreakdownRow[] = [
     ...(isSimple

--- a/src/components/HrTools/PdsGoalCalculator/calculations/OtherExpenses.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/OtherExpenses.ts
@@ -1,8 +1,12 @@
-import { DesignationSupportStatus } from 'src/graphql/types.generated';
+import {
+  DesignationSupportFormType,
+  DesignationSupportStatus,
+} from 'src/graphql/types.generated';
 
 export interface OtherExpensesFields {
   status?: DesignationSupportStatus | null;
   benefits?: number | null;
+  formType?: DesignationSupportFormType | null;
 }
 
 export interface OtherExpensesConstants {

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.test.ts
@@ -1,4 +1,5 @@
 import {
+  DesignationSupportFormType,
   DesignationSupportSalaryType,
   DesignationSupportStatus,
 } from 'src/graphql/types.generated';
@@ -73,5 +74,26 @@ describe('calculatePdsGoalTotal', () => {
     });
     const withoutGeo = calculatePdsGoalTotal(goal, defaultConstants);
     expect(withGeo).toBeGreaterThan(withoutGeo);
+  });
+
+  it('excludes reimbursable expenses and 403b when formType is Simple', () => {
+    const detailed = makeGoal({ formType: DesignationSupportFormType.Detailed });
+    const simple = makeGoal({ formType: DesignationSupportFormType.Simple });
+
+    const detailedTotal = calculatePdsGoalTotal(detailed, defaultConstants);
+    const simpleTotal = calculatePdsGoalTotal(simple, defaultConstants);
+
+    // Simple skips reimbursable + 403b lines, so its assessment is strictly lower
+    // than Detailed when those values are non-zero.
+    expect(simpleTotal).toBeLessThan(detailedTotal);
+    expect(simpleTotal).toBeGreaterThan(0);
+  });
+
+  it('treats null formType the same as Detailed (legacy goals)', () => {
+    const legacy = makeGoal({ formType: null });
+    const detailed = makeGoal({ formType: DesignationSupportFormType.Detailed });
+    expect(calculatePdsGoalTotal(legacy, defaultConstants)).toBeCloseTo(
+      calculatePdsGoalTotal(detailed, defaultConstants),
+    );
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.test.ts
@@ -77,16 +77,14 @@ describe('calculatePdsGoalTotal', () => {
   });
 
   it('excludes reimbursable expenses and 403b when formType is Simple', () => {
-    const detailed = makeGoal({ formType: DesignationSupportFormType.Detailed });
     const simple = makeGoal({ formType: DesignationSupportFormType.Simple });
-
-    const detailedTotal = calculatePdsGoalTotal(detailed, defaultConstants);
-    const simpleTotal = calculatePdsGoalTotal(simple, defaultConstants);
-
-    // Simple skips reimbursable + 403b lines, so its assessment is strictly lower
-    // than Detailed when those values are non-zero.
-    expect(simpleTotal).toBeLessThan(detailedTotal);
-    expect(simpleTotal).toBeGreaterThan(0);
+    const result = calculatePdsGoalTotal(simple, defaultConstants);
+    // With reimbursableTotal=0 and fourOThreeBPercentage=0:
+    //   subtotal = 5400 (salary) + 0 + 0 + 0 + 1500 (benefits) = 6900
+    //   attrition = 6900 * 0.06 = 414
+    //   creditCardFees = (6900 + 414) * 0.06 = 438.84
+    //   assessment = (6900 + 438.84 + 414) * 0.12 ≈ 930.34
+    expect(result).toBeCloseTo(930.34, 1);
   });
 
   it('treats null formType the same as Detailed (legacy goals)', () => {

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.test.ts
@@ -89,7 +89,9 @@ describe('calculatePdsGoalTotal', () => {
 
   it('treats null formType the same as Detailed (legacy goals)', () => {
     const legacy = makeGoal({ formType: null });
-    const detailed = makeGoal({ formType: DesignationSupportFormType.Detailed });
+    const detailed = makeGoal({
+      formType: DesignationSupportFormType.Detailed,
+    });
     expect(calculatePdsGoalTotal(legacy, defaultConstants)).toBeCloseTo(
       calculatePdsGoalTotal(detailed, defaultConstants),
     );

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
@@ -4,13 +4,19 @@ import {
   GoalMiscConstants,
 } from 'src/hooks/useGoalCalculatorConstants';
 import { HcmUserQuery } from '../Shared/HCM.generated';
-import { OtherExpensesFields, calculateOtherExpenses } from './OtherExpenses';
+import { isSimpleFormType } from '../Shared/formType';
+import {
+  OtherExpensesConstants,
+  OtherExpensesFields,
+  calculateOtherExpenses,
+} from './OtherExpenses';
 import {
   ReimbursableCalculationFields,
   calculateReimbursableTotals,
 } from './reimbursableExpenses';
 import {
   SalaryCalculationFields,
+  SalaryTotals,
   calculateSalaryTotals,
 } from './salaryCalculation';
 
@@ -75,22 +81,15 @@ export const buildPdsGoalConstants = (
   };
 };
 
-export const calculatePdsGoalTotal = (
-  calculation: PdsGoalTotalFields,
+export const buildOtherExpensesConstants = (
+  formType: DesignationSupportFormType | null | undefined,
   constants: PdsGoalTotalConstants,
-): number => {
-  const isSimple =
-    calculation.formType === DesignationSupportFormType.Simple;
-
-  const salaryTotals = calculateSalaryTotals(calculation, {
-    geographicMultiplier: constants.geographicMultiplier,
-    employerFicaRate: constants.employerFicaRate,
-  });
-
-  const reimbursableTotals = calculateReimbursableTotals(calculation);
-
-  const otherExpenses = calculateOtherExpenses(calculation, {
-    reimbursableTotal: isSimple ? 0 : reimbursableTotals.total,
+  salaryTotals: SalaryTotals,
+  reimbursableTotal: number,
+): OtherExpensesConstants => {
+  const isSimple = isSimpleFormType(formType);
+  return {
+    reimbursableTotal: isSimple ? 0 : reimbursableTotal,
     salarySubtotal: salaryTotals.subtotal,
     fourOThreeBPercentage: isSimple ? 0 : constants.fourOThreeBPercentage,
     grossMonthlyPay: salaryTotals.grossMonthlyPay,
@@ -98,7 +97,29 @@ export const calculatePdsGoalTotal = (
     attritionRate: constants.attritionRate,
     creditCardFeeRate: constants.creditCardFeeRate,
     adminRate: constants.adminRate,
+  };
+};
+
+export const calculatePdsGoalTotal = (
+  calculation: PdsGoalTotalFields,
+  constants: PdsGoalTotalConstants,
+): number => {
+  const salaryTotals = calculateSalaryTotals(calculation, {
+    geographicMultiplier: constants.geographicMultiplier,
+    employerFicaRate: constants.employerFicaRate,
   });
+
+  const reimbursableTotal = calculateReimbursableTotals(calculation).total;
+
+  const otherExpenses = calculateOtherExpenses(
+    calculation,
+    buildOtherExpensesConstants(
+      calculation.formType,
+      constants,
+      salaryTotals,
+      reimbursableTotal,
+    ),
+  );
 
   return otherExpenses.assessment;
 };

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
@@ -22,9 +22,7 @@ import {
 
 export type PdsGoalTotalFields = SalaryCalculationFields &
   ReimbursableCalculationFields &
-  OtherExpensesFields & {
-    formType?: DesignationSupportFormType | null;
-  };
+  OtherExpensesFields;
 
 export interface PdsGoalTotalConstants {
   employerFicaRate: number;

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
@@ -82,7 +82,7 @@ export const buildPdsGoalConstants = (
 };
 
 export const buildOtherExpensesConstants = (
-  formType: DesignationSupportFormType | null | undefined,
+  formType: DesignationSupportFormType,
   constants: PdsGoalTotalConstants,
   salaryTotals: SalaryTotals,
   reimbursableTotal: number,
@@ -114,7 +114,7 @@ export const calculatePdsGoalTotal = (
   const otherExpenses = calculateOtherExpenses(
     calculation,
     buildOtherExpensesConstants(
-      calculation.formType,
+      calculation.formType ?? DesignationSupportFormType.Detailed,
       constants,
       salaryTotals,
       reimbursableTotal,

--- a/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/calculatePdsGoalTotal.ts
@@ -1,3 +1,4 @@
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
 import {
   GoalGeographicConstantMap,
   GoalMiscConstants,
@@ -15,7 +16,9 @@ import {
 
 export type PdsGoalTotalFields = SalaryCalculationFields &
   ReimbursableCalculationFields &
-  OtherExpensesFields;
+  OtherExpensesFields & {
+    formType?: DesignationSupportFormType | null;
+  };
 
 export interface PdsGoalTotalConstants {
   employerFicaRate: number;
@@ -76,6 +79,9 @@ export const calculatePdsGoalTotal = (
   calculation: PdsGoalTotalFields,
   constants: PdsGoalTotalConstants,
 ): number => {
+  const isSimple =
+    calculation.formType === DesignationSupportFormType.Simple;
+
   const salaryTotals = calculateSalaryTotals(calculation, {
     geographicMultiplier: constants.geographicMultiplier,
     employerFicaRate: constants.employerFicaRate,
@@ -84,9 +90,9 @@ export const calculatePdsGoalTotal = (
   const reimbursableTotals = calculateReimbursableTotals(calculation);
 
   const otherExpenses = calculateOtherExpenses(calculation, {
-    reimbursableTotal: reimbursableTotals.total,
+    reimbursableTotal: isSimple ? 0 : reimbursableTotals.total,
     salarySubtotal: salaryTotals.subtotal,
-    fourOThreeBPercentage: constants.fourOThreeBPercentage,
+    fourOThreeBPercentage: isSimple ? 0 : constants.fourOThreeBPercentage,
     grossMonthlyPay: salaryTotals.grossMonthlyPay,
     workCompPercentage: constants.workCompPercentage,
     attritionRate: constants.attritionRate,

--- a/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.test.ts
@@ -387,9 +387,9 @@ describe('usePdsSummaryData', () => {
       expect(result.current?.otherConstants.reimbursableTotal).toBeGreaterThan(
         0,
       );
-      expect(
-        result.current?.otherConstants.fourOThreeBPercentage,
-      ).toBeCloseTo(0.08);
+      expect(result.current?.otherConstants.fourOThreeBPercentage).toBeCloseTo(
+        0.08,
+      );
     });
 
     it('uses saved values when formType is null/undefined (legacy goals default to Detailed behavior)', () => {
@@ -403,9 +403,9 @@ describe('usePdsSummaryData', () => {
       expect(result.current?.otherConstants.reimbursableTotal).toBeGreaterThan(
         0,
       );
-      expect(
-        result.current?.otherConstants.fourOThreeBPercentage,
-      ).toBeCloseTo(0.08);
+      expect(result.current?.otherConstants.fourOThreeBPercentage).toBeCloseTo(
+        0.08,
+      );
     });
   });
 

--- a/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { gqlMock } from '__tests__/util/graphqlMocking';
 import {
+  DesignationSupportFormType,
   DesignationSupportSalaryType,
   DesignationSupportStatus,
   MpdGoalMiscConstantCategoryEnum,
@@ -97,6 +98,7 @@ const defaultCalculation = gqlMock<PdsGoalCalculationFieldsFragment>(
     mocks: {
       salaryOrHourly: DesignationSupportSalaryType.Salaried,
       status: DesignationSupportStatus.FullTime,
+      formType: DesignationSupportFormType.Detailed,
       payRate: 60000,
       benefits: 1500,
       ministryCellPhone: 100,
@@ -330,6 +332,76 @@ describe('usePdsSummaryData', () => {
       expect(data).toHaveProperty('otherConstants');
       expect(data).toHaveProperty('overallTotal');
       expect(data).toHaveProperty('geographicMultiplier');
+    });
+  });
+
+  describe('Simple form type', () => {
+    it('zeroes reimbursableTotal in otherConstants when formType is Simple', () => {
+      const calc = {
+        ...defaultCalculation,
+        formType: DesignationSupportFormType.Simple,
+      };
+      const { result } = renderHook(() =>
+        usePdsSummaryData(calc, defaultHcmUser),
+      );
+      expect(result.current?.otherConstants.reimbursableTotal).toBe(0);
+    });
+
+    it('zeroes fourOThreeBPercentage in otherConstants when formType is Simple', () => {
+      const calc = {
+        ...defaultCalculation,
+        formType: DesignationSupportFormType.Simple,
+      };
+      const { result } = renderHook(() =>
+        usePdsSummaryData(calc, defaultHcmUser),
+      );
+      expect(result.current?.otherConstants.fourOThreeBPercentage).toBe(0);
+    });
+
+    it('still computes reimbursableTotals (saved values are preserved)', () => {
+      const calc = {
+        ...defaultCalculation,
+        formType: DesignationSupportFormType.Simple,
+      };
+      const { result } = renderHook(() =>
+        usePdsSummaryData(calc, defaultHcmUser),
+      );
+      // The reimbursableTotals object is still computed (data isn't lost),
+      // but the otherConstants.reimbursableTotal that feeds the Other Expenses
+      // calculation is zeroed.
+      expect(result.current?.reimbursableTotals.total).toBeGreaterThan(0);
+    });
+
+    it('uses saved reimbursable + 403b values when formType is Detailed', () => {
+      const calc = {
+        ...defaultCalculation,
+        formType: DesignationSupportFormType.Detailed,
+      };
+      const { result } = renderHook(() =>
+        usePdsSummaryData(calc, defaultHcmUser),
+      );
+      expect(result.current?.otherConstants.reimbursableTotal).toBeGreaterThan(
+        0,
+      );
+      expect(
+        result.current?.otherConstants.fourOThreeBPercentage,
+      ).toBeCloseTo(0.08);
+    });
+
+    it('uses saved values when formType is null/undefined (legacy goals default to Detailed behavior)', () => {
+      const calc = {
+        ...defaultCalculation,
+        formType: null,
+      };
+      const { result } = renderHook(() =>
+        usePdsSummaryData(calc, defaultHcmUser),
+      );
+      expect(result.current?.otherConstants.reimbursableTotal).toBeGreaterThan(
+        0,
+      );
+      expect(
+        result.current?.otherConstants.fourOThreeBPercentage,
+      ).toBeCloseTo(0.08);
     });
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.test.ts
@@ -17,6 +17,10 @@ import {
   PdsGoalCalculationFieldsFragmentDoc,
 } from '../GoalsList/PdsGoalCalculations.generated';
 import { HcmUserDocument, HcmUserQuery } from '../Shared/HCM.generated';
+import {
+  PdsGoalTotalConstants,
+  calculatePdsGoalTotal,
+} from './calculatePdsGoalTotal';
 import { usePdsSummaryData } from './usePdsSummaryData';
 
 jest.mock('src/hooks/useGoalCalculatorConstants');
@@ -403,5 +407,35 @@ describe('usePdsSummaryData', () => {
         result.current?.otherConstants.fourOThreeBPercentage,
       ).toBeCloseTo(0.08);
     });
+  });
+
+  describe('consistency with calculatePdsGoalTotal', () => {
+    // Mirrors what buildPdsGoalConstants would derive from the mocked
+    // useGoalCalculatorConstants + defaultHcmUser, so we can call
+    // calculatePdsGoalTotal directly without the hook.
+    const directConstants: PdsGoalTotalConstants = {
+      employerFicaRate: EMPLOYER_FICA_RATE,
+      workCompPercentage: WORK_COMP_PERCENTAGE,
+      attritionRate: ATTRITION_RATE,
+      creditCardFeeRate: CREDIT_CARD_FEE_RATE,
+      adminRate: ADMIN_RATE,
+      fourOThreeBPercentage: 0.08,
+      geographicMultiplier: 0,
+    };
+
+    it.each([
+      DesignationSupportFormType.Detailed,
+      DesignationSupportFormType.Simple,
+    ])(
+      'calculatePdsGoalTotal matches usePdsSummaryData.otherTotals.assessment when formType is %s',
+      (formType) => {
+        const calc = { ...defaultCalculation, formType };
+        const { result } = renderHook(() =>
+          usePdsSummaryData(calc, defaultHcmUser),
+        );
+        const direct = calculatePdsGoalTotal(calc, directConstants);
+        expect(direct).toBeCloseTo(result.current!.otherTotals.assessment, 5);
+      },
+    );
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
 import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
 import { PdsGoalCalculationFieldsFragment } from '../GoalsList/PdsGoalCalculations.generated';
 import { HcmUserQuery } from '../Shared/HCM.generated';
@@ -73,10 +74,13 @@ export const usePdsSummaryData = (
     const rothPct =
       (hcmUser?.fourOThreeB?.currentRothContributionPercentage ?? 0) / 100;
 
+    const isSimple =
+      calculation.formType === DesignationSupportFormType.Simple;
+
     const otherConstants: OtherExpensesConstants = {
-      reimbursableTotal: reimbursableTotals.total,
+      reimbursableTotal: isSimple ? 0 : reimbursableTotals.total,
       salarySubtotal: salaryTotals.subtotal,
-      fourOThreeBPercentage: taxDeferredPct + rothPct,
+      fourOThreeBPercentage: isSimple ? 0 : taxDeferredPct + rothPct,
       grossMonthlyPay: salaryTotals.grossMonthlyPay,
       workCompPercentage,
       attritionRate,

--- a/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.ts
@@ -24,21 +24,8 @@ import {
 export interface PdsSummaryData {
   salaryTotals: SalaryTotals;
   salaryConstants: SalaryConstants;
-  /**
-   * Reimbursable totals computed from the saved calculation data, preserved
-   * across formType changes so a user switching Detailed → Simple → Detailed
-   * doesn't lose what they entered. NOT the effective value used in downstream
-   * Other Expenses math — for that, use `otherConstants.reimbursableTotal`,
-   * which is zeroed when `formType === Simple`.
-   */
   reimbursableTotals: ReimbursableTotals;
   otherTotals: OtherExpensesTotals;
-  /**
-   * Inputs fed into `calculateOtherExpenses`. `reimbursableTotal` and
-   * `fourOThreeBPercentage` here are zeroed when `formType === Simple`
-   * (Simple goals exclude reimbursables and 403b from the goal calc), so they
-   * differ from `reimbursableTotals.total` and the user's HCM 403b percentages.
-   */
   otherConstants: OtherExpensesConstants;
   overallTotal: number;
   geographicMultiplier: number;

--- a/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { DesignationSupportFormType } from 'src/graphql/types.generated';
 import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
 import { PdsGoalCalculationFieldsFragment } from '../GoalsList/PdsGoalCalculations.generated';
 import { HcmUserQuery } from '../Shared/HCM.generated';
@@ -61,7 +62,7 @@ export const usePdsSummaryData = (
     const reimbursableTotals = calculateReimbursableTotals(calculation);
 
     const otherConstants = buildOtherExpensesConstants(
-      calculation.formType,
+      calculation.formType ?? DesignationSupportFormType.Detailed,
       constants,
       salaryTotals,
       reimbursableTotals.total,

--- a/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.ts
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { DesignationSupportFormType } from 'src/graphql/types.generated';
 import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
 import { PdsGoalCalculationFieldsFragment } from '../GoalsList/PdsGoalCalculations.generated';
 import { HcmUserQuery } from '../Shared/HCM.generated';
@@ -8,6 +7,10 @@ import {
   OtherExpensesTotals,
   calculateOtherExpenses,
 } from './OtherExpenses';
+import {
+  buildOtherExpensesConstants,
+  buildPdsGoalConstants,
+} from './calculatePdsGoalTotal';
 import {
   ReimbursableTotals,
   calculateReimbursableTotals,
@@ -21,8 +24,21 @@ import {
 export interface PdsSummaryData {
   salaryTotals: SalaryTotals;
   salaryConstants: SalaryConstants;
+  /**
+   * Reimbursable totals computed from the saved calculation data, preserved
+   * across formType changes so a user switching Detailed → Simple → Detailed
+   * doesn't lose what they entered. NOT the effective value used in downstream
+   * Other Expenses math — for that, use `otherConstants.reimbursableTotal`,
+   * which is zeroed when `formType === Simple`.
+   */
   reimbursableTotals: ReimbursableTotals;
   otherTotals: OtherExpensesTotals;
+  /**
+   * Inputs fed into `calculateOtherExpenses`. `reimbursableTotal` and
+   * `fourOThreeBPercentage` here are zeroed when `formType === Simple`
+   * (Simple goals exclude reimbursables and 403b from the goal calc), so they
+   * differ from `reimbursableTotals.total` and the user's HCM 403b percentages.
+   */
   otherConstants: OtherExpensesConstants;
   overallTotal: number;
   geographicMultiplier: number;
@@ -40,53 +56,29 @@ export const usePdsSummaryData = (
       return null;
     }
 
-    const additionalRates = goalMiscConstants.ADDITIONAL_RATES;
-    const employerFicaRate = additionalRates?.EMPLOYER_FICA_RATE?.fee;
-    const workCompPercentage =
-      additionalRates?.PART_TIME_WORK_COMPENSATION?.fee;
-    const attritionRate = goalMiscConstants.RATES?.ATTRITION_RATE?.fee;
-    const creditCardFeeRate = additionalRates?.CREDIT_CARD_FEE_RATE?.fee;
-    const adminRate = goalMiscConstants.RATES?.ADMIN_RATE?.fee;
-
-    if (
-      employerFicaRate === undefined ||
-      workCompPercentage === undefined ||
-      attritionRate === undefined ||
-      creditCardFeeRate === undefined ||
-      adminRate === undefined
-    ) {
+    const constants = buildPdsGoalConstants(
+      goalMiscConstants,
+      goalGeographicConstantMap,
+      calculation.geographicLocation,
+      hcmUser?.fourOThreeB,
+    );
+    if (!constants) {
       return null;
     }
 
-    const geographicMultiplier =
-      goalGeographicConstantMap.get(calculation.geographicLocation ?? '') ?? 0;
-
     const salaryConstants: SalaryConstants = {
-      geographicMultiplier,
-      employerFicaRate,
+      geographicMultiplier: constants.geographicMultiplier,
+      employerFicaRate: constants.employerFicaRate,
     };
     const salaryTotals = calculateSalaryTotals(calculation, salaryConstants);
     const reimbursableTotals = calculateReimbursableTotals(calculation);
 
-    const taxDeferredPct =
-      (hcmUser?.fourOThreeB?.currentTaxDeferredContributionPercentage ?? 0) /
-      100;
-    const rothPct =
-      (hcmUser?.fourOThreeB?.currentRothContributionPercentage ?? 0) / 100;
-
-    const isSimple =
-      calculation.formType === DesignationSupportFormType.Simple;
-
-    const otherConstants: OtherExpensesConstants = {
-      reimbursableTotal: isSimple ? 0 : reimbursableTotals.total,
-      salarySubtotal: salaryTotals.subtotal,
-      fourOThreeBPercentage: isSimple ? 0 : taxDeferredPct + rothPct,
-      grossMonthlyPay: salaryTotals.grossMonthlyPay,
-      workCompPercentage,
-      attritionRate,
-      creditCardFeeRate,
-      adminRate,
-    };
+    const otherConstants = buildOtherExpensesConstants(
+      calculation.formType,
+      constants,
+      salaryTotals,
+      reimbursableTotals.total,
+    );
     const otherTotals = calculateOtherExpenses(calculation, otherConstants);
 
     const overallTotal =
@@ -102,7 +94,7 @@ export const usePdsSummaryData = (
       otherTotals,
       otherConstants,
       overallTotal,
-      geographicMultiplier,
+      geographicMultiplier: constants.geographicMultiplier,
     };
   }, [calculation, hcmUser, goalMiscConstants, goalGeographicConstantMap]);
 };

--- a/src/components/Reports/Shared/GoalCard/GoalCard.test.tsx
+++ b/src/components/Reports/Shared/GoalCard/GoalCard.test.tsx
@@ -97,4 +97,18 @@ describe('GoalCard', () => {
 
     expect(mutationSpy).not.toHaveBeenCalled();
   });
+
+  it('renders the badge when provided', () => {
+    const { getByText } = renderCard({
+      badge: <span>Default</span>,
+    });
+
+    expect(getByText('Default')).toBeInTheDocument();
+  });
+
+  it('renders without a badge when none is provided', () => {
+    const { queryByText } = renderCard();
+
+    expect(queryByText('Default')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/Reports/Shared/GoalCard/GoalCard.tsx
+++ b/src/components/Reports/Shared/GoalCard/GoalCard.tsx
@@ -107,7 +107,9 @@ export const GoalCard: React.FC<GoalCardProps> = ({
       />
 
       <StyledCard>
-        <StyledHeaderBox sx={{ flexDirection: 'column', gap: 1 }}>
+        <StyledHeaderBox
+          sx={badge ? { flexDirection: 'column', gap: 1 } : undefined}
+        >
           <Tooltip title={displayName}>
             <Typography
               data-testid="goal-name"

--- a/src/components/Reports/Shared/GoalCard/GoalCard.tsx
+++ b/src/components/Reports/Shared/GoalCard/GoalCard.tsx
@@ -62,6 +62,7 @@ export interface GoalCardProps {
   updatedAt: string;
   viewHref: string;
   onDelete: () => Promise<void>;
+  badge?: React.ReactNode;
 }
 
 export const GoalCard: React.FC<GoalCardProps> = ({
@@ -72,6 +73,7 @@ export const GoalCard: React.FC<GoalCardProps> = ({
   updatedAt,
   viewHref,
   onDelete,
+  badge,
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
@@ -105,7 +107,7 @@ export const GoalCard: React.FC<GoalCardProps> = ({
       />
 
       <StyledCard>
-        <StyledHeaderBox>
+        <StyledHeaderBox sx={{ flexDirection: 'column', gap: 1 }}>
           <Tooltip title={displayName}>
             <Typography
               data-testid="goal-name"
@@ -116,6 +118,7 @@ export const GoalCard: React.FC<GoalCardProps> = ({
               {displayName}
             </Typography>
           </Tooltip>
+          {badge}
         </StyledHeaderBox>
 
         <Divider />

--- a/src/components/Reports/Shared/GoalCard/GoalCard.tsx
+++ b/src/components/Reports/Shared/GoalCard/GoalCard.tsx
@@ -107,15 +107,16 @@ export const GoalCard: React.FC<GoalCardProps> = ({
       />
 
       <StyledCard>
-        <StyledHeaderBox
-          sx={badge ? { flexDirection: 'column', gap: 1 } : undefined}
-        >
+        <StyledHeaderBox sx={badge ? { gap: 1 } : undefined}>
           <Tooltip title={displayName}>
             <Typography
               data-testid="goal-name"
               variant="h6"
               noWrap
-              sx={{ width: '100%', textAlign: 'center' }}
+              sx={{
+                textAlign: 'center',
+                ...(badge ? { minWidth: 0 } : { width: '100%' }),
+              }}
             >
               {displayName}
             </Typography>


### PR DESCRIPTION
## Description

Wires the existing API field `DesignationSupportCalculation.formType` (values `DETAILED` and `SIMPLE`) through the PDS Goal Calculator UI so users can choose between a full Default view and a streamlined Simple view at goal creation time and switch between them later from the Settings step.

- New `CreateGoalDialog` opens when the user clicks **Create a New Goal** on the goals list — the user must explicitly pick **Default** or **Simple** before the goal is created. The chosen form type is sent as `formType` on the create mutation.
- Each `PdsGoalCard` shows a small **Default** / **Simple** chip near the goal name so users can identify form types from the list. Legacy goals with a null `formType` show no chip.
- `SetupStep` has a new **Form Type** select (right under **Goal Name**) that lets the user toggle between Default and Simple at any time. Switching is silent — saved field values are preserved on the record so toggling back restores the original calculation instantly.
- When `formType === Simple`:
  - The **Reimbursable Expenses** step is filtered out of the side-panel step list
  - The disabled **403b Contribution Percentage** display field is hidden in the Setup step
  - Lines **2A** (Reimbursable Expenses) and **2B** (403b Contributions) are hidden in the summary table
  - The summary calculation (`usePdsSummaryData`) and per-card total calculation (`calculatePdsGoalTotal`) zero out `reimbursableTotal` and `fourOThreeBPercentage` when building the constants for `calculateOtherExpenses` (the pure helper itself is unchanged)
- Defensive `useEffect` clamps `stepIndex` to 0 if the steps array shrinks after a `formType` change, preventing a `currentStep === undefined` crash.
- Create-mutation error path: failures show an error snackbar, the dialog stays open, and the Create button re-enables so the user can retry.

Related to [MPDX-9475](https://jira.cru.org/browse/MPDX-9475).

## Testing

### Goal creation

- Go to the PDS Goal Calculator goals list
- Click **Create a New Goal** — a dialog opens with two radio cards (**Default** and **Simple**) and short descriptions of each
- Confirm the **Create** button is disabled until a form type is picked
- Pick **Simple** and click **Create** — you land on a new goal with **3 steps** in the side panel (no Reimbursable Expenses)
- Repeat with **Default** — you land on a goal with **4 steps**

### Form type toggle

- On a Simple goal, go to **Settings** — confirm the **403b Contribution Percentage** field is not shown
- Change **Form Type** to **Default** — confirm the side panel updates to include **Reimbursable Expenses** and the 403b field reappears
- Switch back to **Simple** — confirm everything hides again. If you previously entered reimbursable values, they remain on the record (toggle back to Default to verify they are restored).

### Summary report

- On a **Simple** goal, go to **Summary Report** — confirm rows **2A** (Reimbursable Expenses) and **2B** (403b Contributions) are not present
- Confirm the **Total Goal** is correspondingly lower than for the same inputs in Default mode

### Goal card

- Return to the goals list — confirm each card shows a **Default** or **Simple** chip according to its form type
- Existing goals created before this feature shipped show no chip (legacy `formType: null` behavior)

## Checklist:

- [x] I have given my PR a title with the format \"MPDX-(JIRA#) (summary sentence max 80 chars)\"
- [x] I have applied the appropriate labels (_Add the label \"Preview\" to automatically create a preview environment_)
- [x] I have run the Claude Code \`/pr-review\` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history