### PR TITLE
[MPDX-9539] Show MCC approval level from API

### DIFF
--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/getCapOverrides.test.ts
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/getCapOverrides.test.ts
@@ -5,12 +5,11 @@ const t = ((key: string) => key) as unknown as Parameters<
 >[1];
 
 describe('getCapOverrides', () => {
-  it('returns undefined title/content when not exceeding cap', () => {
+  it('returns undefined title/content when no approval needed', () => {
     const result = getCapOverrides(
       {
         splitAsr: false,
         additionalApproval: false,
-        exceedsCap: false,
         hasBoardCapException: false,
       },
       t,
@@ -24,7 +23,6 @@ describe('getCapOverrides', () => {
       {
         splitAsr: true,
         additionalApproval: false,
-        exceedsCap: false,
         hasBoardCapException: false,
       },
       t,
@@ -32,12 +30,11 @@ describe('getCapOverrides', () => {
     expect(result.title).toMatch(/exceeds your remaining allowable salary/);
   });
 
-  it('returns Progressive Approvals messaging when exceeds cap without board exception', () => {
+  it('returns Progressive Approvals messaging when additionalApproval without board exception', () => {
     const result = getCapOverrides(
       {
         splitAsr: false,
-        additionalApproval: false,
-        exceedsCap: true,
+        additionalApproval: true,
         hasBoardCapException: false,
       },
       t,
@@ -46,12 +43,11 @@ describe('getCapOverrides', () => {
     expect(result.content).toMatch(/exceed your Maximum Allowable Salary/);
   });
 
-  it('returns board-approval messaging when exceeds cap with board exception', () => {
+  it('returns board-approval messaging when approval required with board exception', () => {
     const result = getCapOverrides(
       {
         splitAsr: false,
-        additionalApproval: false,
-        exceedsCap: true,
+        additionalApproval: true,
         hasBoardCapException: true,
       },
       t,
@@ -63,27 +59,11 @@ describe('getCapOverrides', () => {
     expect(result.content).toMatch(/Additional Salary Request exceeds/);
   });
 
-  it('board exception takes precedence over additionalApproval branch', () => {
-    const result = getCapOverrides(
-      {
-        splitAsr: false,
-        additionalApproval: true,
-        exceedsCap: false,
-        hasBoardCapException: true,
-      },
-      t,
-    );
-    expect(result.content).toMatch(
-      /You have a Board approved Maximum Allowable Salary/,
-    );
-  });
-
-  it('board exception does not apply when user is not exceeding cap', () => {
+  it('board exception does not apply when no approval required', () => {
     const result = getCapOverrides(
       {
         splitAsr: false,
         additionalApproval: false,
-        exceedsCap: false,
         hasBoardCapException: true,
       },
       t,

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/getCapOverrides.ts
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/getCapOverrides.ts
@@ -3,17 +3,11 @@ import { TFunction } from 'i18next';
 interface CapOverridesOptions {
   splitAsr: boolean;
   additionalApproval: boolean;
-  exceedsCap: boolean;
   hasBoardCapException: boolean;
 }
 
 export const getCapOverrides = (
-  {
-    splitAsr,
-    additionalApproval,
-    exceedsCap,
-    hasBoardCapException,
-  }: CapOverridesOptions,
+  { splitAsr, additionalApproval, hasBoardCapException }: CapOverridesOptions,
   t: TFunction,
 ) => {
   if (splitAsr) {
@@ -25,7 +19,7 @@ export const getCapOverrides = (
     };
   }
 
-  if (additionalApproval || exceedsCap) {
+  if (additionalApproval) {
     if (hasBoardCapException) {
       return {
         title: t(

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/RequestPage.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/RequestPage.test.tsx
@@ -411,6 +411,7 @@ describe('RequestPage', () => {
           calculations: {
             currentSalaryCap: 50,
           },
+          progressiveApprovalTier: { id: 'tier-1' },
         },
       },
     } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
@@ -524,6 +525,7 @@ describe('RequestPage', () => {
             currentSalaryCap: 500,
             pendingAsrAmount: 600,
           },
+          progressiveApprovalTier: { id: 'tier-1' },
         },
       },
     } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
@@ -727,7 +729,7 @@ describe('RequestPage', () => {
             staffAccountBalance: 999999,
             pendingAsrAmount: 0,
           },
-          progressiveApprovalTier: null,
+          progressiveApprovalTier: { id: 'tier-1' },
         },
       },
     };
@@ -789,6 +791,7 @@ describe('RequestPage', () => {
                 .calculations,
               currentSalaryCap: 100000,
             },
+            progressiveApprovalTier: null,
           },
         },
       } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/RequestPage.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/RequestPage.tsx
@@ -106,8 +106,7 @@ const MainContent: React.FC = () => {
   const { title: overrideTitle, content: overrideContent } = getCapOverrides(
     {
       splitAsr: !!splitAsr,
-      additionalApproval: !!additionalApproval,
-      exceedsCap,
+      additionalApproval,
       hasBoardCapException,
     },
     t,
@@ -143,7 +142,7 @@ const MainContent: React.FC = () => {
                         spouseName={spouse?.staffInfo.preferredName ?? ''}
                       />
                     )
-                  ) : additionalApproval || exceedsCap ? (
+                  ) : additionalApproval ? (
                     <CapSubContent />
                   ) : isEdit ? (
                     t('Your updated request will be sent to payroll.')
@@ -164,7 +163,7 @@ const MainContent: React.FC = () => {
                 isValid={isValid}
                 actionRequired={isEdit}
                 isEdit={isEdit}
-                additionalApproval={additionalApproval || exceedsCap}
+                additionalApproval={additionalApproval}
                 splitAsr={splitAsr}
                 disableSubmit={
                   (splitAsr && !!errors.additionalInfo) ||

--- a/src/components/HrTools/AdditionalSalaryRequest/Shared/useSalaryCalculations.test.ts
+++ b/src/components/HrTools/AdditionalSalaryRequest/Shared/useSalaryCalculations.test.ts
@@ -394,10 +394,13 @@ describe('useSalaryCalculations', () => {
   });
 
   describe('Married - Staff Member over cap', () => {
-    const setupOverCap = (spouseCalculations: {
-      currentSalaryCap: number;
-      pendingAsrAmount: number;
-    }) => {
+    const setupOverCap = (
+      spouseCalculations: {
+        currentSalaryCap: number;
+        pendingAsrAmount: number;
+      },
+      progressiveApprovalTier: unknown = null,
+    ) => {
       mockUseAdditionalSalaryRequest.mockReturnValue({
         traditional403bPercentage: 0.12,
         roth403bPercentage: 0.1,
@@ -409,6 +412,7 @@ describe('useSalaryCalculations', () => {
               currentSalaryCap: 60000,
             },
             spouseCalculations,
+            progressiveApprovalTier,
           },
         },
       } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
@@ -455,7 +459,10 @@ describe('useSalaryCalculations', () => {
     });
 
     it('Staff Member over cap, spouse is over their cap — additionalApproval', () => {
-      setupOverCap({ currentSalaryCap: 50000, pendingAsrAmount: 15000 });
+      setupOverCap(
+        { currentSalaryCap: 50000, pendingAsrAmount: 15000 },
+        { id: 'tier-1' },
+      );
 
       const values: CompleteFormValues = {
         ...baseValues,
@@ -475,7 +482,10 @@ describe('useSalaryCalculations', () => {
     });
 
     it('Staff Member over cap, spouse is at their cap — additionalApproval', () => {
-      setupOverCap({ currentSalaryCap: 40003, pendingAsrAmount: 0 });
+      setupOverCap(
+        { currentSalaryCap: 40003, pendingAsrAmount: 0 },
+        { id: 'tier-1' },
+      );
 
       const values: CompleteFormValues = {
         ...baseValues,
@@ -496,7 +506,7 @@ describe('useSalaryCalculations', () => {
 
     it('Staff Member over cap, spouse exactly $5 below cap — treated as at cap', () => {
       const currentSalaryCap = 40000 + AT_CAP_TOLERANCE;
-      setupOverCap({ currentSalaryCap, pendingAsrAmount: 0 });
+      setupOverCap({ currentSalaryCap, pendingAsrAmount: 0 }, { id: 'tier-1' });
 
       const values: CompleteFormValues = {
         ...baseValues,
@@ -539,10 +549,13 @@ describe('useSalaryCalculations', () => {
 
   describe('Married - Staff Member at cap', () => {
     // Cases 9-12: Staff Member at cap (not over) — nothing triggers
-    const setupAtCap = (spouseCalculations: {
-      currentSalaryCap: number;
-      pendingAsrAmount: number;
-    }) => {
+    const setupAtCap = (
+      spouseCalculations: {
+        currentSalaryCap: number;
+        pendingAsrAmount: number;
+      },
+      progressiveApprovalTier: unknown = null,
+    ) => {
       mockUseAdditionalSalaryRequest.mockReturnValue({
         traditional403bPercentage: 0.12,
         roth403bPercentage: 0.1,
@@ -554,6 +567,7 @@ describe('useSalaryCalculations', () => {
               currentSalaryCap: 55000,
             },
             spouseCalculations,
+            progressiveApprovalTier,
           },
         },
       } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
@@ -598,7 +612,10 @@ describe('useSalaryCalculations', () => {
     });
 
     it('Staff Member at cap, spouse is over their cap', () => {
-      setupAtCap({ currentSalaryCap: 50000, pendingAsrAmount: 15000 });
+      setupAtCap(
+        { currentSalaryCap: 50000, pendingAsrAmount: 15000 },
+        { id: 'tier-1' },
+      );
 
       const values: CompleteFormValues = {
         ...baseValues,
@@ -638,7 +655,10 @@ describe('useSalaryCalculations', () => {
   });
 
   describe('Single staff member', () => {
-    const setupSingle = (cap: number) => {
+    const setupSingle = (
+      cap: number,
+      progressiveApprovalTier: unknown = null,
+    ) => {
       mockUseAdditionalSalaryRequest.mockReturnValue({
         traditional403bPercentage: 0.12,
         roth403bPercentage: 0.1,
@@ -647,6 +667,7 @@ describe('useSalaryCalculations', () => {
         requestData: {
           latestAdditionalSalaryRequest: {
             calculations: { currentSalaryCap: cap },
+            progressiveApprovalTier,
           },
         },
       } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
@@ -691,7 +712,7 @@ describe('useSalaryCalculations', () => {
     });
 
     it('Staff Member over cap — additionalApproval', () => {
-      setupSingle(60000);
+      setupSingle(60000, { id: 'tier-1' });
 
       const values: CompleteFormValues = {
         ...baseValues,

--- a/src/components/HrTools/AdditionalSalaryRequest/Shared/useSalaryCalculations.ts
+++ b/src/components/HrTools/AdditionalSalaryRequest/Shared/useSalaryCalculations.ts
@@ -144,8 +144,7 @@ export const useSalaryCalculations = ({
         ? 'spouse'
         : null;
     const additionalApproval =
-      (exceedsCap && (!isMarried || spouseAtCap || spouseExceedsCap)) ||
-      (userAtCap && isMarried && spouseExceedsCap);
+      !!requestData?.latestAdditionalSalaryRequest?.progressiveApprovalTier;
 
     const hasSpouseCap = isMarried && spouseIndividualCap !== null;
     const spouseCap = hasSpouseCap


### PR DESCRIPTION
## Description

Trust the approval level calculated by the API instead of calculating it ourselves.

Needed so that the approval level from https://github.com/CruGlobal/mpdx_api/pull/3315 will show in the UI.

MPDX-9539

## Testing

- Impersonate caleb.cox@cru.org
- Open the in-progress ASR
- Submit the request
- Check that it says you need MCC approval

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
