### PR TITLE
MPDX-9544 Frontend - Add validation to ensure the Requested Gross Salary for SOSA staff doesn't exceed their cap

### DIFF
--- a/src/components/HrTools/SalaryCalculator/Autosave/AutosaveTextField.tsx
+++ b/src/components/HrTools/SalaryCalculator/Autosave/AutosaveTextField.tsx
@@ -13,11 +13,21 @@ export interface AutosaveTextFieldProps
   > {
   fieldName: Exclude<keyof SalaryRequestUpdateInput, 'manuallySplitCap'>;
   schema: yup.Schema;
+  /** Additional error flag from the parent; OR'd with the field's own validation error */
+  error?: boolean;
+
+  /**
+   * Save on every keystroke instead of on blur. Defaults to true for select
+   * boxes; opt-in for text inputs where immediate feedback is required.
+   */
+  saveOnChange?: boolean;
 }
 
 export const AutosaveTextField: React.FC<AutosaveTextFieldProps> = ({
   fieldName,
   schema,
+  error: externalError,
+  saveOnChange,
   ...props
 }) => {
   const saveField = useSaveField();
@@ -28,10 +38,17 @@ export const AutosaveTextField: React.FC<AutosaveTextFieldProps> = ({
     saveValue: (value) => saveField({ [fieldName]: value }),
     fieldName,
     schema,
-    // Select boxes should save on change instead of on blur
-    saveOnChange: props.select,
+    saveOnChange: saveOnChange ?? !!props.select,
     disabled: !calculation,
   });
 
-  return <TextField size="small" fullWidth {...fieldProps} {...props} />;
+  return (
+    <TextField
+      size="small"
+      fullWidth
+      {...fieldProps}
+      {...props}
+      error={!!externalError || !!fieldProps.error}
+    />
+  );
 };

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculation/ApprovalProcessCard/ApprovalProcessCard.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculation/ApprovalProcessCard/ApprovalProcessCard.test.tsx
@@ -1,4 +1,5 @@
 import { render, waitFor } from '@testing-library/react';
+import { UserPersonTypeEnum } from 'pages/api/graphql-rest.page.generated';
 import { ProgressiveApprovalTierEnum } from 'src/graphql/types.generated';
 import {
   SalaryCalculatorTestWrapper,
@@ -67,6 +68,40 @@ If this is correct, please provide reasoning for why Jane's Salary should exceed
       );
       expect(
         getByRole('textbox', { name: 'Additional info' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('SOSA blockOnCap', () => {
+    const sosaUser = {
+      staffInfo: {
+        userPersonType: UserPersonTypeEnum.EmployeeStaffNonRmoSpouse,
+      },
+    };
+    const overCapMock = {
+      calculations: { requestedGross: 40000, effectiveCap: 30000 },
+      progressiveApprovalTier: {
+        tier: ProgressiveApprovalTierEnum.VicePresident,
+      },
+    };
+
+    it('renders nothing when the SOSA user is over their effective cap', async () => {
+      const { queryByRole } = render(
+        <TestComponent hcmUser={sosaUser} salaryRequestMock={overCapMock} />,
+      );
+
+      await waitFor(() =>
+        expect(queryByRole('textbox')).not.toBeInTheDocument(),
+      );
+    });
+
+    it('renders the card when the user is not SOSA, even if over cap', async () => {
+      const { findByRole } = render(
+        <TestComponent salaryRequestMock={overCapMock} />,
+      );
+
+      expect(
+        await findByRole('textbox', { name: 'Additional info' }),
       ).toBeInTheDocument();
     });
   });

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculation/ApprovalProcessCard/ApprovalProcessCard.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculation/ApprovalProcessCard/ApprovalProcessCard.tsx
@@ -9,11 +9,13 @@ import { useSalaryCalculator } from '../../SalaryCalculatorContext/SalaryCalcula
 import { StepCard } from '../../Shared/StepCard';
 import { StyledCardHeader } from '../StyledCardHeader';
 import { useCaps } from '../useCaps';
+import { useSosaBlockOverCap } from '../useSosaBlockOverCap';
 
 export const ApprovalProcessCard: React.FC = () => {
   const { t } = useTranslation();
   const { calculation, hcmSpouse } = useSalaryCalculator();
   const { overCapPerson } = useCaps();
+  const { blockOnCap } = useSosaBlockOverCap();
 
   const schema = useMemo(
     () =>
@@ -26,7 +28,7 @@ export const ApprovalProcessCard: React.FC = () => {
   const spouseName = hcmSpouse?.staffInfo.preferredName;
 
   const tier = calculation?.progressiveApprovalTier?.tier;
-  if (!tier) {
+  if (!tier || blockOnCap) {
     return null;
   }
 

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { DeepPartial } from 'ts-essentials';
+import { UserPersonTypeEnum } from 'pages/api/graphql-rest.page.generated';
+import { AutosaveForm } from 'src/components/Shared/Autosave/AutosaveForm';
 import { SalaryCalculationQuery } from '../../SalaryCalculatorContext/SalaryCalculation.generated';
 import {
   SalaryCalculatorTestWrapper,
@@ -33,7 +35,9 @@ const TestComponent: React.FC<SalaryCalculatorTestWrapperProps> = (props) => (
     }}
     {...props}
   >
-    <RequestedSalaryCard />
+    <AutosaveForm>
+      <RequestedSalaryCard />
+    </AutosaveForm>
   </SalaryCalculatorTestWrapper>
 );
 
@@ -162,6 +166,58 @@ As you set your salary level, the amount you receive should reflect the amount o
             .map((cell) => cell.textContent),
         ).toEqual(expectedCells),
       );
+    });
+  });
+
+  describe('SOSA over-cap Alert', () => {
+    const sosaUser = {
+      staffInfo: {
+        userPersonType: UserPersonTypeEnum.EmployeeStaffNonRmoSpouse,
+      },
+    };
+    const overCapMock: DeepPartial<SalaryCalculationQuery['salaryRequest']> = {
+      calculations: {
+        minimumRequiredSalary: 10002,
+        minimumRequestedSalary: 10003,
+        effectiveCap: 10004,
+        requestedGross: 15000,
+      },
+    };
+
+    it('renders when the SOSA user is over their effective cap', async () => {
+      const { findByRole } = render(
+        <TestComponent
+          hasSpouse={false}
+          hcmUser={{ ...sosaUser, currentSalary: { grossSalaryAmount: 10001 } }}
+          salaryRequestMock={overCapMock}
+        />,
+      );
+
+      expect(await findByRole('alert')).toHaveTextContent(
+        'Your request requires additional approvals and cannot be submitted online. SOSA staff can have requests exceeding the $10,004.00 cap approved for certain geographic locations with the appropriate levels of approval.Please contact payroll@cru.org for further assistance.',
+      );
+      expect(
+        await findByRole('link', { name: 'payroll@cru.org' }),
+      ).toHaveAttribute('href', 'mailto:payroll@cru.org');
+    });
+
+    it('does not render when the user is SOSA but under their cap', async () => {
+      const { queryByRole } = render(
+        <TestComponent
+          hasSpouse={false}
+          hcmUser={{ ...sosaUser, currentSalary: { grossSalaryAmount: 10001 } }}
+        />,
+      );
+
+      await waitFor(() => expect(queryByRole('alert')).not.toBeInTheDocument());
+    });
+
+    it('does not render when the user is not SOSA, even if over cap', async () => {
+      const { queryByRole } = render(
+        <TestComponent hasSpouse={false} salaryRequestMock={overCapMock} />,
+      );
+
+      await waitFor(() => expect(queryByRole('alert')).not.toBeInTheDocument());
     });
   });
 });

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.tsx
@@ -1,7 +1,9 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import {
+  Alert,
   CardContent,
   CardHeader,
+  Link,
   Table,
   TableBody,
   TableCell,
@@ -10,6 +12,7 @@ import {
 } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
 import * as yup from 'yup';
+import { useAutosaveForm } from 'src/components/Shared/Autosave/AutosaveForm';
 import { amount } from 'src/lib/yupHelpers';
 import { AutosaveTextField } from '../../Autosave/AutosaveTextField';
 import { CalculationFieldsFragment } from '../../SalaryCalculatorContext/SalaryCalculation.generated';
@@ -17,6 +20,8 @@ import { useSalaryCalculator } from '../../SalaryCalculatorContext/SalaryCalcula
 import { EffectiveDateNote } from '../../Shared/EffectiveDateNote';
 import { StepCard, StepTableHead } from '../../Shared/StepCard';
 import { useFormatters } from '../../Shared/useFormatters';
+import { useCaps } from '../useCaps';
+import { useSosaBlockOverCap } from '../useSosaBlockOverCap';
 
 export const RequestedSalaryCard: React.FC = () => {
   const { t } = useTranslation();
@@ -26,6 +31,19 @@ export const RequestedSalaryCard: React.FC = () => {
     hcmSpouse,
   } = useSalaryCalculator();
   const { formatCurrency } = useFormatters();
+  const { overCapPerson } = useCaps();
+  const { isUserSosa, blockOnCap } = useSosaBlockOverCap();
+  const { markValid, markInvalid } = useAutosaveForm();
+
+  // Disable the Continue button while the saved gross exceeds the SOSA cap.
+  useEffect(() => {
+    if (blockOnCap) {
+      markInvalid('over-cap');
+    } else {
+      markValid('over-cap');
+    }
+    return () => markValid('over-cap');
+  }, [blockOnCap, markValid, markInvalid]);
 
   const minimumSalaryValue =
     salaryCalculation?.calculations.minimumRequestedSalary;
@@ -160,6 +178,8 @@ export const RequestedSalaryCard: React.FC = () => {
                   schema={schema}
                   label={t('Requested salary')}
                   required
+                  error={blockOnCap}
+                  saveOnChange={isUserSosa}
                 />
               </TableCell>
               {hcmSpouse && (
@@ -175,6 +195,22 @@ export const RequestedSalaryCard: React.FC = () => {
             </TableRow>
           </TableBody>
         </Table>
+
+        {blockOnCap && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            <Trans t={t}>
+              Your request requires additional approvals and cannot be submitted
+              online. SOSA staff can have requests exceeding the{' '}
+              {{ cap: overCapPerson?.effectiveCap }} cap approved for certain
+              geographic locations with the appropriate levels of approval.
+              <br />
+              <br />
+              Please contact{' '}
+              <Link href="mailto:payroll@cru.org">payroll@cru.org</Link> for
+              further assistance.
+            </Trans>
+          </Alert>
+        )}
       </CardContent>
     </StepCard>
   );

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculation/useCaps.ts
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculation/useCaps.ts
@@ -1,7 +1,7 @@
 import { useSalaryCalculator } from '../SalaryCalculatorContext/SalaryCalculatorContext';
 import { useFormatters } from '../Shared/useFormatters';
 
-interface OverCapPerson {
+export interface OverCapPerson {
   /** The name of the person whose salary is over their effective cap */
   name: string | null;
 
@@ -12,6 +12,9 @@ interface OverCapPerson {
 interface UseCapsResult {
   /** The sum of the users' requested gross salaries */
   combinedGross: number;
+
+  /** Whether the user is over their effective cap */
+  overUserCap: boolean;
 
   /** The person whose salary is over their effective cap */
   overCapPerson: OverCapPerson | null;
@@ -44,6 +47,7 @@ export const useCaps = (): UseCapsResult => {
 
   return {
     combinedGross,
+    overUserCap,
     overCapPerson,
   };
 };

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculation/useSosaBlockOverCap.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculation/useSosaBlockOverCap.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { DeepPartial } from 'ts-essentials';
+import { UserPersonTypeEnum } from 'pages/api/graphql-rest.page.generated';
+import { SalaryCalculationQuery } from '../SalaryCalculatorContext/SalaryCalculation.generated';
+import { SalaryCalculatorTestWrapper } from '../SalaryCalculatorTestWrapper';
+import { useSosaBlockOverCap } from './useSosaBlockOverCap';
+
+const sosaUser = {
+  staffInfo: { userPersonType: UserPersonTypeEnum.EmployeeStaffNonRmoSpouse },
+};
+
+const overCapMock: DeepPartial<SalaryCalculationQuery['salaryRequest']> = {
+  calculations: { effectiveCap: 10004, requestedGross: 15000 },
+};
+
+const renderUseSosaBlockOverCap = (
+  props: Parameters<typeof SalaryCalculatorTestWrapper>[0],
+) =>
+  renderHook(() => useSosaBlockOverCap(), {
+    wrapper: ({ children }) => (
+      <SalaryCalculatorTestWrapper {...props}>
+        {children}
+      </SalaryCalculatorTestWrapper>
+    ),
+  });
+
+describe('useSosaBlockOverCap', () => {
+  it('blocks when a SOSA user is over their cap', async () => {
+    const { result } = renderUseSosaBlockOverCap({
+      hasSpouse: false,
+      hcmUser: sosaUser,
+      salaryRequestMock: overCapMock,
+    });
+
+    await waitFor(() => expect(result.current.blockOnCap).toBe(true));
+  });
+
+  it('does not block when a SOSA user is under their cap', async () => {
+    const { result } = renderUseSosaBlockOverCap({
+      hasSpouse: false,
+      hcmUser: sosaUser,
+      salaryRequestMock: {
+        calculations: { effectiveCap: 10004, requestedGross: 10003 },
+      },
+    });
+
+    await waitFor(() => expect(result.current.isUserSosa).toBe(true));
+    expect(result.current.blockOnCap).toBe(false);
+  });
+
+  it('does not block when a SOSA user is exactly at their cap', async () => {
+    const { result } = renderUseSosaBlockOverCap({
+      hasSpouse: false,
+      hcmUser: sosaUser,
+      salaryRequestMock: {
+        calculations: { effectiveCap: 10004, requestedGross: 10004 },
+      },
+    });
+
+    await waitFor(() => expect(result.current.isUserSosa).toBe(true));
+    expect(result.current.blockOnCap).toBe(false);
+  });
+
+  it('does not block when the user is not SOSA, even if over cap', async () => {
+    const { result } = renderUseSosaBlockOverCap({
+      hasSpouse: false,
+      salaryRequestMock: overCapMock,
+    });
+
+    await waitFor(() => expect(result.current.isUserSosa).toBe(false));
+    expect(result.current.blockOnCap).toBe(false);
+  });
+});

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculation/useSosaBlockOverCap.ts
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculation/useSosaBlockOverCap.ts
@@ -1,0 +1,27 @@
+import { UserPersonTypeEnum } from 'pages/api/graphql-rest.page.generated';
+import { useSalaryCalculator } from '../SalaryCalculatorContext/SalaryCalculatorContext';
+import { useCaps } from './useCaps';
+
+interface UseSosaBlockOverCapResult {
+  /** Whether the user is a SOSA employee (Employee Staff Non-RMO Spouse) */
+  isUserSosa: boolean;
+
+  /** Whether the user is a SOSA employee whose saved gross exceeds their effective cap */
+  blockOnCap: boolean;
+}
+
+/**
+ * Determine whether a SOSA user's requested gross salary exceeds their
+ * effective cap. Requests over their cap may not be submitted online.
+ */
+export const useSosaBlockOverCap = (): UseSosaBlockOverCapResult => {
+  const { hcmUser } = useSalaryCalculator();
+  const { overUserCap } = useCaps();
+
+  const isUserSosa =
+    hcmUser?.staffInfo.userPersonType ===
+    UserPersonTypeEnum.EmployeeStaffNonRmoSpouse;
+  const blockOnCap = isUserSosa && overUserCap;
+
+  return { isUserSosa, blockOnCap };
+};


### PR DESCRIPTION
## Description

- We don't want SOSA staff to be able to continue their form if their gross requested salary exceeds their cap.
- This needs to be done against their gross requested salary, and not their base requested salary.
    - Because of this, I chose not to do Formik field validation on the user input for their requested salary, as this can easily cause drift between the frontend and backend values and lock the user into an error state. 
    - The alternative solution if we want to allow input field validation is doing the calculations in the frontend for validation instead of depending on API state.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Use one of the test data emails that is SOSA and ensure that they cannot continue past step 3 if their gross requested salary exceeds their cap.
- Determine if the `Alert` is sufficient in notifying the user.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
