### PR TITLE
Fix calculation of gross monthly pay by removing unnecessary multiplier

### DIFF
--- a/src/components/HrTools/PdsGoalCalculator/calculations/salaryCalculation.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/salaryCalculation.test.ts
@@ -48,12 +48,17 @@ describe('calculateSalaryTotals', () => {
       expect(result.grossMonthlyPay).toBeCloseTo(5300);
     });
 
-    it('applies a full-multiplier-shape geographic multiplier (e.g., 1.01 = 1% boost)', () => {
-      const result = calculateSalaryTotals(salaried(), {
-        geographicMultiplier: 1.01,
+    it('multiplies monthlyBase by geographicMultiplier to produce grossMonthlyPay', () => {
+      const payRate = 60000;
+      const geographicMultiplier = 1.01;
+      const result = calculateSalaryTotals(salaried({ payRate }), {
+        geographicMultiplier,
         employerFicaRate: FICA_RATE,
       });
-      expect(result.grossMonthlyPay).toBeCloseTo(5050);
+      expect(result.monthlyBase).toBe(payRate / 12);
+      expect(result.grossMonthlyPay).toBeCloseTo(
+        (payRate / 12) * geographicMultiplier,
+      );
     });
 
     it('ignores hoursWorkedPerWeek', () => {

--- a/src/components/HrTools/PdsGoalCalculator/calculations/salaryCalculation.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/salaryCalculation.test.ts
@@ -48,6 +48,14 @@ describe('calculateSalaryTotals', () => {
       expect(result.grossMonthlyPay).toBeCloseTo(5300);
     });
 
+    it('applies a full-multiplier-shape geographic multiplier (e.g., 1.01 = 1% boost)', () => {
+      const result = calculateSalaryTotals(salaried(), {
+        geographicMultiplier: 1.01,
+        employerFicaRate: FICA_RATE,
+      });
+      expect(result.grossMonthlyPay).toBeCloseTo(5050);
+    });
+
     it('ignores hoursWorkedPerWeek', () => {
       const result = calculateSalaryTotals(
         salaried({ hoursWorkedPerWeek: 40 }),

--- a/src/components/HrTools/PdsGoalCalculator/calculations/salaryCalculation.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/salaryCalculation.ts
@@ -31,7 +31,7 @@ export const calculateSalaryTotals = (
     calculation.salaryOrHourly === DesignationSupportSalaryType.Salaried;
 
   const monthlyBase = isSalaried ? payRate / 12 : (payRate * hours * 52) / 12;
-  const grossMonthlyPay = monthlyBase * (1 + geographicMultiplier);
+  const grossMonthlyPay = monthlyBase * geographicMultiplier;
   const employerFica = grossMonthlyPay * employerFicaRate;
   const subtotal = grossMonthlyPay + employerFica;
 


### PR DESCRIPTION
## Description

Geographic multiplier almost doubles because of the extra 1 in PDS Goal Calculator

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `pdsGoalCalculator`
- Create a PDS Goal
- Check that the calculations add up correctly for the gross monthly pay now.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
