### PR TITLE
SAA-645 Require note on savings fund transfer form

### DIFF
--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -170,61 +170,41 @@ describe('TransferModal', () => {
       ).toBeInTheDocument();
     });
 
-    it('should require a note for one-time transfers', async () => {
-      const { getByRole, findByText } = render(<Components />);
+    it.each([
+      { label: 'empty', input: '' },
+      { label: 'whitespace-only', input: '   ' },
+    ])(
+      'should reject $label notes on one-time transfers',
+      async ({ input }) => {
+        const { getByRole, findByText } = render(<Components />);
 
-      userEvent.click(getByRole('combobox', { name: /from account/i }));
-      userEvent.click(getByRole('option', { name: /staff account/i }));
-      userEvent.click(getByRole('combobox', { name: /to account/i }));
-      userEvent.click(getByRole('option', { name: /staff savings/i }));
+        userEvent.click(getByRole('combobox', { name: /from account/i }));
+        userEvent.click(getByRole('option', { name: /staff account/i }));
+        userEvent.click(getByRole('combobox', { name: /to account/i }));
+        userEvent.click(getByRole('option', { name: /staff savings/i }));
 
-      const amountField = getByRole('spinbutton', { name: /amount/i });
-      userEvent.clear(amountField);
-      userEvent.type(amountField, '100');
+        const amountField = getByRole('spinbutton', { name: /amount/i });
+        userEvent.clear(amountField);
+        userEvent.type(amountField, '100');
 
-      // User clears the prefilled note before submitting.
-      const noteField = getByRole('textbox', { name: /note/i });
-      userEvent.clear(noteField);
+        const noteField = getByRole('textbox', { name: /note/i });
+        userEvent.clear(noteField);
+        if (input) {
+          userEvent.type(noteField, input);
+        }
 
-      userEvent.click(getByRole('button', { name: /submit/i }));
+        userEvent.click(getByRole('button', { name: /submit/i }));
 
-      expect(await findByText('Note is required')).toBeInTheDocument();
-      expect(mutationSpy).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          operation: expect.objectContaining({
-            operationName: 'CreateTransfer',
+        expect(await findByText('Note is required')).toBeInTheDocument();
+        expect(mutationSpy).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            operation: expect.objectContaining({
+              operationName: 'CreateTransfer',
+            }),
           }),
-        }),
-      );
-    });
-
-    it('should reject whitespace-only notes on one-time transfers', async () => {
-      const { getByRole, findByText } = render(<Components />);
-
-      userEvent.click(getByRole('combobox', { name: /from account/i }));
-      userEvent.click(getByRole('option', { name: /staff account/i }));
-      userEvent.click(getByRole('combobox', { name: /to account/i }));
-      userEvent.click(getByRole('option', { name: /staff savings/i }));
-
-      const amountField = getByRole('spinbutton', { name: /amount/i });
-      userEvent.clear(amountField);
-      userEvent.type(amountField, '100');
-
-      const noteField = getByRole('textbox', { name: /note/i });
-      userEvent.clear(noteField);
-      userEvent.type(noteField, '   ');
-
-      userEvent.click(getByRole('button', { name: /submit/i }));
-
-      expect(await findByText('Note is required')).toBeInTheDocument();
-      expect(mutationSpy).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          operation: expect.objectContaining({
-            operationName: 'CreateTransfer',
-          }),
-        }),
-      );
-    });
+        );
+      },
+    );
 
     it('should validate end date is after transfer date for recurring transfers', async () => {
       const { getByRole, findByLabelText, getByLabelText, findByText } = render(

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -65,11 +65,13 @@ const transferDefaultData: TransferModalData['transfer'] = {
 interface ComponentsProps {
   transfer?: TransferModalData['transfer'];
   type?: TransferTypeEnum;
+  lastName?: string;
 }
 
 const Components = ({
   transfer = transferDefaultData,
   type,
+  lastName = 'Doe',
 }: ComponentsProps) => (
   <SnackbarProvider>
     <ThemeProvider theme={theme}>
@@ -90,6 +92,7 @@ const Components = ({
                 }}
                 funds={fundsMock}
                 handleClose={handleClose}
+                lastName={lastName}
               />
             </StaffSavingFundProvider>
           </GqlMockedProvider>
@@ -179,7 +182,10 @@ describe('TransferModal', () => {
       userEvent.clear(amountField);
       userEvent.type(amountField, '100');
 
-      // Note intentionally left blank.
+      // User clears the prefilled note before submitting.
+      const noteField = getByRole('textbox', { name: /note/i });
+      userEvent.clear(noteField);
+
       userEvent.click(getByRole('button', { name: /submit/i }));
 
       expect(await findByText('Note is required')).toBeInTheDocument();
@@ -286,6 +292,20 @@ describe('TransferModal', () => {
   });
 
   describe('Inputs', () => {
+    it('should default the note to "<lastName> Savings Fund Transfer in MPDX" on new one-time transfers', () => {
+      const { getByRole } = render(<Components lastName="Sleight" />);
+
+      const noteField = getByRole('textbox', { name: /note/i });
+      expect(noteField).toHaveValue('Sleight Savings Fund Transfer in MPDX');
+    });
+
+    it('should not default the note when lastName is missing', () => {
+      const { getByRole } = render(<Components lastName="" />);
+
+      const noteField = getByRole('textbox', { name: /note/i });
+      expect(noteField).toHaveValue('');
+    });
+
     it('should populate initial values from data prop', () => {
       const dataWithValues: TransferModalData['transfer'] = {
         transferFrom: '70056dcb-1a0f-4279-b710-928bcdff811a',
@@ -482,6 +502,7 @@ describe('TransferModal', () => {
       userEvent.clear(amountField);
       userEvent.type(amountField, '100');
 
+      userEvent.clear(noteField);
       userEvent.type(noteField, 'Test note');
 
       userEvent.click(getByRole('button', { name: /submit/i }));

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -8,12 +8,7 @@ import { DateTime } from 'luxon';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import {
-  GetUserDocument,
-  GetUserQuery,
-} from 'src/components/User/GetUser.generated';
-import { UserTypeEnum } from 'src/graphql/types.generated';
-import { createCache } from 'src/lib/apollo/cache';
+import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import theme from 'src/theme';
 import { StaffSavingFundProvider } from '../../StaffSavingFund/StaffSavingFundContext';
 import {
@@ -74,27 +69,6 @@ interface ComponentsProps {
   lastName?: string;
 }
 
-const buildCacheWithUser = (lastName: string) => {
-  const cache = createCache();
-  cache.writeQuery<GetUserQuery>({
-    query: GetUserDocument,
-    data: {
-      user: {
-        __typename: 'User',
-        id: 'test-user-id',
-        firstName: '',
-        lastName,
-        avatar: '',
-        staffAccountId: null,
-        primaryDesignation: null,
-        userType: UserTypeEnum.UsStaff,
-        preferences: null,
-      },
-    },
-  });
-  return cache;
-};
-
 const Components = ({
   transfer = transferDefaultData,
   type,
@@ -105,11 +79,16 @@ const Components = ({
       <LocalizationProvider dateAdapter={AdapterLuxon}>
         <TestRouter router={router}>
           <GqlMockedProvider<{
+            GetUser: GetUserQuery;
             createRecurringTransfer: CreateRecurringTransferMutation;
             createTransfer: CreateTransferMutation;
             updateRecurringTransfer: UpdateRecurringTransferMutation;
           }>
-            cache={buildCacheWithUser(lastName)}
+            mocks={{
+              GetUser: {
+                user: { lastName },
+              },
+            }}
             onCall={mutationSpy}
           >
             <StaffSavingFundProvider>
@@ -129,9 +108,15 @@ const Components = ({
   </SnackbarProvider>
 );
 
+const renderModal = async (props: ComponentsProps = {}) => {
+  const result = render(<Components {...props} />);
+  await result.findByText(/Fund Transfer/);
+  return result;
+};
+
 describe('TransferModal', () => {
-  it('should render the modal with correct inputs', () => {
-    const { getByRole, getByText } = render(<Components />);
+  it('should render the modal with correct inputs', async () => {
+    const { getByRole, getByText } = await renderModal();
 
     expect(getByText('New Fund Transfer')).toBeInTheDocument();
     expect(
@@ -145,8 +130,8 @@ describe('TransferModal', () => {
     expect(getByRole('spinbutton', { name: /amount/i })).toBeInTheDocument();
   });
 
-  it('should close modal when cancel button is clicked', () => {
-    const { getByRole } = render(<Components />);
+  it('should close modal when cancel button is clicked', async () => {
+    const { getByRole } = await renderModal();
 
     userEvent.click(getByRole('button', { name: /cancel/i }));
 
@@ -155,7 +140,7 @@ describe('TransferModal', () => {
 
   describe('Handle submit and validation', () => {
     it('should show validation errors for required fields', async () => {
-      const { getByRole, findByText } = render(<Components />);
+      const { getByRole, findByText } = await renderModal();
 
       const toAccount = getByRole('combobox', { name: /to account/i });
       const amountField = getByRole('spinbutton', { name: /amount/i });
@@ -174,7 +159,7 @@ describe('TransferModal', () => {
     });
 
     it('should validate amount is greater than $0.01', async () => {
-      const { getByRole, findByText } = render(<Components />);
+      const { getByRole, findByText } = await renderModal();
 
       const amountField = getByRole('spinbutton', { name: /amount/i });
 
@@ -203,7 +188,7 @@ describe('TransferModal', () => {
     ])(
       'should reject $label notes on one-time transfers',
       async ({ input }) => {
-        const { getByRole, findByText } = render(<Components />);
+        const { getByRole, findByText } = await renderModal();
 
         userEvent.click(getByRole('combobox', { name: /from account/i }));
         userEvent.click(getByRole('option', { name: /staff account/i }));
@@ -234,9 +219,8 @@ describe('TransferModal', () => {
     );
 
     it('should validate end date is after transfer date for recurring transfers', async () => {
-      const { getByRole, findByLabelText, getByLabelText, findByText } = render(
-        <Components />,
-      );
+      const { getByRole, findByLabelText, getByLabelText, findByText } =
+        await renderModal();
 
       userEvent.click(getByRole('radio', { name: /monthly/i }));
       expect(getByRole('radio', { name: /monthly/i })).toBeChecked();
@@ -263,7 +247,7 @@ describe('TransferModal', () => {
     });
 
     it('should submit form with valid data', async () => {
-      const { getByRole } = render(<Components />);
+      const { getByRole } = await renderModal();
 
       const fromAccount = getByRole('combobox', { name: /from account/i });
       const toAccount = getByRole('combobox', { name: /to account/i });
@@ -294,7 +278,7 @@ describe('TransferModal', () => {
     });
 
     it('should handle form submission successfully', async () => {
-      const { getByRole } = render(<Components />);
+      const { getByRole } = await renderModal();
 
       const fromAccount = getByRole('combobox', { name: /from account/i });
       const toAccount = getByRole('combobox', { name: /to account/i });
@@ -327,35 +311,35 @@ describe('TransferModal', () => {
   });
 
   describe('Inputs', () => {
-    it('should default the note to "<lastName> Savings Fund Transfer in MPDX" on new one-time transfers', () => {
-      const { getByRole } = render(<Components lastName="Sleight" />);
+    it('should default the note to "<lastName> Savings Fund Transfer in MPDX" on new one-time transfers', async () => {
+      const { getByRole } = await renderModal({ lastName: 'Sleight' });
 
       const noteField = getByRole('textbox', { name: /note/i });
       expect(noteField).toHaveValue('Sleight Savings Fund Transfer in MPDX');
     });
 
-    it('should not default the note when lastName is missing', () => {
-      const { getByRole } = render(<Components lastName="" />);
+    it('should not default the note when lastName is missing', async () => {
+      const { getByRole } = await renderModal({ lastName: '' });
 
       const noteField = getByRole('textbox', { name: /note/i });
       expect(noteField).toHaveValue('');
     });
 
-    it('should trim lastName when building the default note', () => {
-      const { getByRole } = render(<Components lastName="  Sleight  " />);
+    it('should trim lastName when building the default note', async () => {
+      const { getByRole } = await renderModal({ lastName: '  Sleight  ' });
 
       const noteField = getByRole('textbox', { name: /note/i });
       expect(noteField).toHaveValue('Sleight Savings Fund Transfer in MPDX');
     });
 
-    it('should not default the note when lastName is only whitespace', () => {
-      const { getByRole } = render(<Components lastName="   " />);
+    it('should not default the note when lastName is only whitespace', async () => {
+      const { getByRole } = await renderModal({ lastName: '   ' });
 
       const noteField = getByRole('textbox', { name: /note/i });
       expect(noteField).toHaveValue('');
     });
 
-    it('should populate initial values from data prop', () => {
+    it('should populate initial values from data prop', async () => {
       const dataWithValues: TransferModalData['transfer'] = {
         transferFrom: '70056dcb-1a0f-4279-b710-928bcdff811a',
         transferTo: '408caf15-cdfd-41d1-8778-aa42a6561b85',
@@ -366,16 +350,14 @@ describe('TransferModal', () => {
         note: 'Test note',
       };
 
-      const { getByDisplayValue, getByLabelText } = render(
-        <Components transfer={dataWithValues} type={TransferTypeEnum.Edit} />,
-      );
+      const { getByDisplayValue, getByLabelText } = await renderModal({ transfer: dataWithValues, type: TransferTypeEnum.Edit });
 
       expect(getByDisplayValue('500')).toBeInTheDocument();
       expect(getByLabelText(/end date/i)).toHaveValue('');
     });
 
     it('should validate that from and to accounts are different', async () => {
-      const { getByRole, queryByRole, getAllByRole } = render(<Components />);
+      const { getByRole, queryByRole, getAllByRole } = await renderModal();
 
       const [fromAccount, toAccount] = getAllByRole('combobox');
 
@@ -397,7 +379,7 @@ describe('TransferModal', () => {
     });
 
     it('should swap accounts when swap button is clicked', async () => {
-      const { getByRole, getByTestId } = render(<Components />);
+      const { getByRole, getByTestId } = await renderModal();
 
       const icon = getByTestId('SwapHorizIcon');
       const swapButton = icon.closest('button');
@@ -426,7 +408,7 @@ describe('TransferModal', () => {
     });
 
     it('should show/hide end date based on schedule selection', async () => {
-      const { getByRole, queryByRole, getByLabelText } = render(<Components />);
+      const { getByRole, queryByRole, getByLabelText } = await renderModal();
 
       expect(
         queryByRole('textbox', { name: /end date/i }),
@@ -448,7 +430,7 @@ describe('TransferModal', () => {
     });
 
     it('should show error message when monthly schedule is selected', async () => {
-      const { getByRole, getByLabelText, findByText } = render(<Components />);
+      const { getByRole, getByLabelText, findByText } = await renderModal();
 
       userEvent.click(getByRole('radio', { name: /monthly/i }));
       expect(getByRole('radio', { name: /monthly/i })).toBeChecked();
@@ -474,9 +456,7 @@ describe('TransferModal', () => {
         note: 'Test note',
       };
 
-      const { getByLabelText, findByText } = render(
-        <Components transfer={dataWithValues} type={TransferTypeEnum.Edit} />,
-      );
+      const { getByLabelText, findByText } = await renderModal({ transfer: dataWithValues, type: TransferTypeEnum.Edit });
 
       const transferDate = getByLabelText(/transfer date/i);
 
@@ -491,7 +471,7 @@ describe('TransferModal', () => {
     });
 
     it('should show information box when amount exceeds limit', async () => {
-      const { getByRole, findByRole } = render(<Components />);
+      const { getByRole, findByRole } = await renderModal();
 
       const fromAccount = getByRole('combobox', { name: /from account/i });
       const toAccount = getByRole('combobox', { name: /to account/i });
@@ -517,14 +497,14 @@ describe('TransferModal', () => {
       ).toBeInTheDocument();
     });
 
-    it('should show proper currency symbol in amount field', () => {
-      const { getByText } = render(<Components />);
+    it('should show proper currency symbol in amount field', async () => {
+      const { getByText } = await renderModal();
 
       expect(getByText('$')).toBeInTheDocument();
     });
 
     it('should handle different schedule types', async () => {
-      const { getByRole } = render(<Components />);
+      const { getByRole } = await renderModal();
 
       expect(getByRole('radio', { name: /one time/i })).toBeChecked();
 
@@ -537,7 +517,7 @@ describe('TransferModal', () => {
 
   describe('Mutations', () => {
     it('should create a one-time transfer', async () => {
-      const { getByRole } = render(<Components />);
+      const { getByRole } = await renderModal();
 
       const amountField = getByRole('spinbutton', { name: /amount/i });
       const noteField = getByRole('textbox', { name: /note/i });
@@ -574,7 +554,7 @@ describe('TransferModal', () => {
     });
 
     it('should create a recurring transfer', async () => {
-      const { getByRole, getByLabelText } = render(<Components />);
+      const { getByRole, getByLabelText } = await renderModal();
 
       const amountField = getByRole('spinbutton', { name: /amount/i });
 
@@ -636,9 +616,7 @@ describe('TransferModal', () => {
         recurringId: 'recurring-id',
       };
 
-      const { getByRole, getByLabelText } = render(
-        <Components transfer={dataWithValues} type={TransferTypeEnum.Edit} />,
-      );
+      const { getByRole, getByLabelText } = await renderModal({ transfer: dataWithValues, type: TransferTypeEnum.Edit });
 
       const amountField = getByRole('spinbutton', { name: /amount/i });
 
@@ -689,8 +667,8 @@ describe('TransferModal', () => {
   });
 
   describe('New Mode', () => {
-    it('should display selects', () => {
-      const { getByRole } = render(<Components type={TransferTypeEnum.New} />);
+    it('should display selects', async () => {
+      const { getByRole } = await renderModal({ type: TransferTypeEnum.New });
 
       const fromAccount = getByRole('combobox', { name: /from account/i });
       const toAccount = getByRole('combobox', { name: /to account/i });

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -8,6 +8,12 @@ import { DateTime } from 'luxon';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import {
+  GetUserDocument,
+  GetUserQuery,
+} from 'src/components/User/GetUser.generated';
+import { UserTypeEnum } from 'src/graphql/types.generated';
+import { createCache } from 'src/lib/apollo/cache';
 import theme from 'src/theme';
 import { StaffSavingFundProvider } from '../../StaffSavingFund/StaffSavingFundContext';
 import {
@@ -68,6 +74,27 @@ interface ComponentsProps {
   lastName?: string;
 }
 
+const buildCacheWithUser = (lastName: string) => {
+  const cache = createCache();
+  cache.writeQuery<GetUserQuery>({
+    query: GetUserDocument,
+    data: {
+      user: {
+        __typename: 'User',
+        id: 'test-user-id',
+        firstName: '',
+        lastName,
+        avatar: '',
+        staffAccountId: null,
+        primaryDesignation: null,
+        userType: UserTypeEnum.UsStaff,
+        preferences: null,
+      },
+    },
+  });
+  return cache;
+};
+
 const Components = ({
   transfer = transferDefaultData,
   type,
@@ -82,6 +109,7 @@ const Components = ({
             createTransfer: CreateTransferMutation;
             updateRecurringTransfer: UpdateRecurringTransferMutation;
           }>
+            cache={buildCacheWithUser(lastName)}
             onCall={mutationSpy}
           >
             <StaffSavingFundProvider>
@@ -92,7 +120,6 @@ const Components = ({
                 }}
                 funds={fundsMock}
                 handleClose={handleClose}
-                lastName={lastName}
               />
             </StaffSavingFundProvider>
           </GqlMockedProvider>

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -350,7 +350,10 @@ describe('TransferModal', () => {
         note: 'Test note',
       };
 
-      const { getByDisplayValue, getByLabelText } = await renderModal({ transfer: dataWithValues, type: TransferTypeEnum.Edit });
+      const { getByDisplayValue, getByLabelText } = await renderModal({
+        transfer: dataWithValues,
+        type: TransferTypeEnum.Edit,
+      });
 
       expect(getByDisplayValue('500')).toBeInTheDocument();
       expect(getByLabelText(/end date/i)).toHaveValue('');
@@ -456,7 +459,10 @@ describe('TransferModal', () => {
         note: 'Test note',
       };
 
-      const { getByLabelText, findByText } = await renderModal({ transfer: dataWithValues, type: TransferTypeEnum.Edit });
+      const { getByLabelText, findByText } = await renderModal({
+        transfer: dataWithValues,
+        type: TransferTypeEnum.Edit,
+      });
 
       const transferDate = getByLabelText(/transfer date/i);
 
@@ -616,7 +622,10 @@ describe('TransferModal', () => {
         recurringId: 'recurring-id',
       };
 
-      const { getByRole, getByLabelText } = await renderModal({ transfer: dataWithValues, type: TransferTypeEnum.Edit });
+      const { getByRole, getByLabelText } = await renderModal({
+        transfer: dataWithValues,
+        type: TransferTypeEnum.Edit,
+      });
 
       const amountField = getByRole('spinbutton', { name: /amount/i });
 

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -167,6 +167,31 @@ describe('TransferModal', () => {
       ).toBeInTheDocument();
     });
 
+    it('should require a note for one-time transfers', async () => {
+      const { getByRole, findByText } = render(<Components />);
+
+      userEvent.click(getByRole('combobox', { name: /from account/i }));
+      userEvent.click(getByRole('option', { name: /staff account/i }));
+      userEvent.click(getByRole('combobox', { name: /to account/i }));
+      userEvent.click(getByRole('option', { name: /staff savings/i }));
+
+      const amountField = getByRole('spinbutton', { name: /amount/i });
+      userEvent.clear(amountField);
+      userEvent.type(amountField, '100');
+
+      // Note intentionally left blank.
+      userEvent.click(getByRole('button', { name: /submit/i }));
+
+      expect(await findByText('Note is required')).toBeInTheDocument();
+      expect(mutationSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: expect.objectContaining({
+            operationName: 'CreateTransfer',
+          }),
+        }),
+      );
+    });
+
     it('should validate end date is after transfer date for recurring transfers', async () => {
       const { getByRole, findByLabelText, getByLabelText, findByText } = render(
         <Components />,
@@ -202,6 +227,7 @@ describe('TransferModal', () => {
       const fromAccount = getByRole('combobox', { name: /from account/i });
       const toAccount = getByRole('combobox', { name: /to account/i });
       const amountField = getByRole('spinbutton', { name: /amount/i });
+      const noteField = getByRole('textbox', { name: /note/i });
 
       userEvent.click(fromAccount);
       userEvent.click(getByRole('option', { name: /staff account/i }));
@@ -211,6 +237,8 @@ describe('TransferModal', () => {
 
       userEvent.clear(amountField);
       userEvent.type(amountField, '100');
+
+      userEvent.type(noteField, 'Test note');
 
       userEvent.click(getByRole('button', { name: /submit/i }));
 
@@ -230,6 +258,7 @@ describe('TransferModal', () => {
       const fromAccount = getByRole('combobox', { name: /from account/i });
       const toAccount = getByRole('combobox', { name: /to account/i });
       const amountField = getByRole('spinbutton', { name: /amount/i });
+      const noteField = getByRole('textbox', { name: /note/i });
       const submitButton = getByRole('button', { name: /submit/i });
 
       userEvent.click(fromAccount);
@@ -240,6 +269,8 @@ describe('TransferModal', () => {
 
       userEvent.clear(amountField);
       userEvent.type(amountField, '100');
+
+      userEvent.type(noteField, 'Test note');
 
       userEvent.click(submitButton);
 
@@ -440,6 +471,7 @@ describe('TransferModal', () => {
       const { getByRole } = render(<Components />);
 
       const amountField = getByRole('spinbutton', { name: /amount/i });
+      const noteField = getByRole('textbox', { name: /note/i });
 
       userEvent.click(getByRole('combobox', { name: /from account/i }));
       userEvent.click(getByRole('option', { name: /staff account/i }));
@@ -449,6 +481,8 @@ describe('TransferModal', () => {
 
       userEvent.clear(amountField);
       userEvent.type(amountField, '100');
+
+      userEvent.type(noteField, 'Test note');
 
       userEvent.click(getByRole('button', { name: /submit/i }));
 
@@ -461,7 +495,7 @@ describe('TransferModal', () => {
                 amount: 100,
                 sourceFundTypeName: 'Staff Account',
                 destinationFundTypeName: 'Staff Savings',
-                description: '',
+                description: 'Test note',
               }),
             }),
           }),

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -198,6 +198,34 @@ describe('TransferModal', () => {
       );
     });
 
+    it('should reject whitespace-only notes on one-time transfers', async () => {
+      const { getByRole, findByText } = render(<Components />);
+
+      userEvent.click(getByRole('combobox', { name: /from account/i }));
+      userEvent.click(getByRole('option', { name: /staff account/i }));
+      userEvent.click(getByRole('combobox', { name: /to account/i }));
+      userEvent.click(getByRole('option', { name: /staff savings/i }));
+
+      const amountField = getByRole('spinbutton', { name: /amount/i });
+      userEvent.clear(amountField);
+      userEvent.type(amountField, '100');
+
+      const noteField = getByRole('textbox', { name: /note/i });
+      userEvent.clear(noteField);
+      userEvent.type(noteField, '   ');
+
+      userEvent.click(getByRole('button', { name: /submit/i }));
+
+      expect(await findByText('Note is required')).toBeInTheDocument();
+      expect(mutationSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: expect.objectContaining({
+            operationName: 'CreateTransfer',
+          }),
+        }),
+      );
+    });
+
     it('should validate end date is after transfer date for recurring transfers', async () => {
       const { getByRole, findByLabelText, getByLabelText, findByText } = render(
         <Components />,
@@ -301,6 +329,20 @@ describe('TransferModal', () => {
 
     it('should not default the note when lastName is missing', () => {
       const { getByRole } = render(<Components lastName="" />);
+
+      const noteField = getByRole('textbox', { name: /note/i });
+      expect(noteField).toHaveValue('');
+    });
+
+    it('should trim lastName when building the default note', () => {
+      const { getByRole } = render(<Components lastName="  Sleight  " />);
+
+      const noteField = getByRole('textbox', { name: /note/i });
+      expect(noteField).toHaveValue('Sleight Savings Fund Transfer in MPDX');
+    });
+
+    it('should not default the note when lastName is only whitespace', () => {
+      const { getByRole } = render(<Components lastName="   " />);
 
       const noteField = getByRole('textbox', { name: /note/i });
       expect(noteField).toHaveValue('');

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -149,12 +149,14 @@ interface TransferModalProps {
   data: TransferModalData;
   funds: FundFieldsFragment[];
   handleClose: () => void;
+  lastName?: string;
 }
 
 export const TransferModal: React.FC<TransferModalProps> = ({
   data,
   funds,
   handleClose,
+  lastName,
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
@@ -176,6 +178,10 @@ export const TransferModal: React.FC<TransferModalProps> = ({
 
   const type = data.type || TransferTypeEnum.New;
   const isNew = type === TransferTypeEnum.New;
+
+  const defaultNote = lastName
+    ? t('{{lastName}} Savings Fund Transfer in MPDX', { lastName })
+    : '';
 
   const title =
     type === TransferTypeEnum.New
@@ -264,7 +270,7 @@ export const TransferModal: React.FC<TransferModalProps> = ({
           status: data.transfer.status ?? '',
           transferDate: data.transfer.transferDate ?? getToday(),
           endDate: data.transfer.endDate ?? null,
-          note: data.transfer.note ?? '',
+          note: data.transfer.note || defaultNote,
           isEditing: Boolean(data.transfer.id),
           originalStart: data.transfer.transferDate ?? null,
         }}

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -174,7 +174,12 @@ export const TransferModal: React.FC<TransferModalProps> = ({
   const type = data.type || TransferTypeEnum.New;
   const isNew = type === TransferTypeEnum.New;
 
-  const { data: userData } = useGetUserQuery();
+  const { data: userData, loading: userLoading } = useGetUserQuery();
+
+  if (userLoading) {
+    return null;
+  }
+
   const trimmedLastName = userData?.user?.lastName?.trim();
   const defaultNote = trimmedLastName
     ? t('{{lastName}} Savings Fund Transfer in MPDX', {

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -135,7 +135,15 @@ const transferSchema = (locale: string) =>
       .number()
       .required(i18n.t('Amount is required'))
       .min(0.01, i18n.t('Amount must be at least $0.01')),
-    note: yup.string().nullable(),
+    note: yup.string().when('schedule', {
+      is: ScheduleEnum.OneTime,
+      then: (schema) =>
+        schema
+          .trim()
+          .min(1, i18n.t('Note is required'))
+          .required(i18n.t('Note is required')),
+      otherwise: (schema) => schema.nullable(),
+    }),
   });
 interface TransferModalProps {
   data: TransferModalData;
@@ -525,11 +533,17 @@ export const TransferModal: React.FC<TransferModalProps> = ({
                     <FormControl fullWidth>
                       <TextField
                         id="transfer-note"
-                        label={t('Note (Optional)')}
+                        label={t('Note')}
                         name="note"
                         disabled={!isNew}
                         value={note}
                         onChange={handleChange}
+                        onBlur={handleBlur}
+                        error={touched.note && Boolean(errors.note)}
+                        helperText={
+                          touched.note && errors.note ? errors.note : ''
+                        }
+                        required
                         fullWidth
                       />
                     </FormControl>

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -30,6 +30,7 @@ import {
   SubmitButton,
 } from 'src/components/Shared/Modal/ActionButtons/ActionButtons';
 import Modal from 'src/components/Shared/Modal/Modal';
+import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import { useLocale } from 'src/hooks/useLocale';
 import i18n from 'src/lib/i18n';
 import { currencyFormat, dateFormat } from 'src/lib/intlFormat';
@@ -137,11 +138,7 @@ const transferSchema = (locale: string) =>
       .min(0.01, i18n.t('Amount must be at least $0.01')),
     note: yup.string().when('schedule', {
       is: ScheduleEnum.OneTime,
-      then: (schema) =>
-        schema
-          .trim()
-          .min(1, i18n.t('Note is required'))
-          .required(i18n.t('Note is required')),
+      then: (schema) => schema.trim().required(i18n.t('Note is required')),
       otherwise: (schema) => schema.nullable(),
     }),
   });
@@ -149,14 +146,12 @@ interface TransferModalProps {
   data: TransferModalData;
   funds: FundFieldsFragment[];
   handleClose: () => void;
-  lastName?: string;
 }
 
 export const TransferModal: React.FC<TransferModalProps> = ({
   data,
   funds,
   handleClose,
-  lastName,
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
@@ -179,7 +174,8 @@ export const TransferModal: React.FC<TransferModalProps> = ({
   const type = data.type || TransferTypeEnum.New;
   const isNew = type === TransferTypeEnum.New;
 
-  const trimmedLastName = lastName?.trim();
+  const { data: userData } = useGetUserQuery();
+  const trimmedLastName = userData?.user?.lastName?.trim();
   const defaultNote = trimmedLastName
     ? t('{{lastName}} Savings Fund Transfer in MPDX', {
         lastName: trimmedLastName,

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -179,8 +179,11 @@ export const TransferModal: React.FC<TransferModalProps> = ({
   const type = data.type || TransferTypeEnum.New;
   const isNew = type === TransferTypeEnum.New;
 
-  const defaultNote = lastName
-    ? t('{{lastName}} Savings Fund Transfer in MPDX', { lastName })
+  const trimmedLastName = lastName?.trim();
+  const defaultNote = trimmedLastName
+    ? t('{{lastName}} Savings Fund Transfer in MPDX', {
+        lastName: trimmedLastName,
+      })
     : '';
 
   const title =

--- a/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
@@ -24,6 +24,7 @@ import {
   MultiPageHeader,
 } from 'src/components/Shared/MultiPageLayout/MultiPageHeader';
 import { useStaffAccountQuery } from 'src/components/Shared/StaffAccount/StaffAccount.generated';
+import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import theme from 'src/theme';
 import {
   StaffSavingFundContext,
@@ -84,6 +85,7 @@ export const TransfersPage: React.FC<TransfersPageProps> = ({ title }) => {
 
   const { data: staffAccountData, error: staffAccountError } =
     useStaffAccountQuery();
+  const { data: userData } = useGetUserQuery();
 
   const { data: reportData, loading: reportLoading } =
     useReportsSavingsFundTransferQuery();
@@ -342,6 +344,7 @@ export const TransfersPage: React.FC<TransfersPageProps> = ({ title }) => {
             handleClose={() => setModalData(null)}
             data={modalData}
             funds={funds}
+            lastName={userData?.user?.lastName ?? undefined}
           />
         )}
       </Box>

--- a/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
@@ -24,7 +24,6 @@ import {
   MultiPageHeader,
 } from 'src/components/Shared/MultiPageLayout/MultiPageHeader';
 import { useStaffAccountQuery } from 'src/components/Shared/StaffAccount/StaffAccount.generated';
-import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import theme from 'src/theme';
 import {
   StaffSavingFundContext,
@@ -85,7 +84,6 @@ export const TransfersPage: React.FC<TransfersPageProps> = ({ title }) => {
 
   const { data: staffAccountData, error: staffAccountError } =
     useStaffAccountQuery();
-  const { data: userData } = useGetUserQuery();
 
   const { data: reportData, loading: reportLoading } =
     useReportsSavingsFundTransferQuery();
@@ -344,7 +342,6 @@ export const TransfersPage: React.FC<TransfersPageProps> = ({ title }) => {
             handleClose={() => setModalData(null)}
             data={modalData}
             funds={funds}
-            lastName={userData?.user?.lastName ?? undefined}
           />
         )}
       </Box>


### PR DESCRIPTION
## Description

- Makes the Note field required on one-time fund transfers (previously labeled "Note (Optional)", which produced a confusing SAA 422 when left blank).
- Defaults the Note to `<lastName> Savings Fund Transfer in MPDX` using the current user's `lastName`. Editable — clearing it triggers the required-field error.
- Front-end enforcement only; recurring transfers are unaffected (their description is server-synthesized).

**Related:** [SAA-645](https://jira.cru.org/browse/SAA-645)

## Testing

- Open **HR Tools → Savings Fund Transfer → New Transfer**, **One Time** schedule.
- Confirm Note is pre-filled with `<your-last-name> Savings Fund Transfer in MPDX`.
- Submit unchanged → succeeds.
- Open another new transfer, clear Note (or enter only whitespace), submit → "Note is required" inline error, no submission.
- Switch to **Monthly** schedule — no Note field shown, recurring submits normally.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)" — using `SAA-645` since this work is tracked in the SAA project's Jira
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
