### PR TITLE
[MPDX-9560] - Rename MHA Calculation Form to MHA Calculation Tool

### DIFF
--- a/pages/accountLists/[accountListId]/hrTools/mhaCalculator/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/mhaCalculator/index.page.tsx
@@ -33,7 +33,7 @@ const MinisterHousingAllowancePage: React.FC = () => {
   return (
     <>
       <Head>
-        <title>{`${appName} | ${t('HR Tools | MHA Calculation Form')}`}</title>
+        <title>{`${appName} | ${t('HR Tools | MHA Calculation Tool')}`}</title>
       </Head>
       <UserTypeAccess
         requireStaffAccount

--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
@@ -164,7 +164,7 @@ describe('NavMenu', () => {
       getByRole('menuitem', { name: 'MPD Goal Calculator' }),
     ).toBeInTheDocument();
     expect(
-      getByRole('menuitem', { name: 'MHA Calculation Form' }),
+      getByRole('menuitem', { name: 'MHA Calculation Tool' }),
     ).toBeInTheDocument();
     expect(
       getByRole('menuitem', { name: 'Additional Salary Request' }),

--- a/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
@@ -515,7 +515,7 @@ describe('MultiPageMenu', () => {
       expect(getByText('Salary Calculation Form')).toBeInTheDocument();
       expect(getByText('Savings Fund Transfer')).toBeInTheDocument();
       expect(getByText('MPD Goal Calculator')).toBeInTheDocument();
-      expect(getByText('MHA Calculation Form')).toBeInTheDocument();
+      expect(getByText('MHA Calculation Tool')).toBeInTheDocument();
       expect(getByText('Additional Salary Request')).toBeInTheDocument();
       expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
     });

--- a/src/hooks/useHrToolsNavItems.ts
+++ b/src/hooks/useHrToolsNavItems.ts
@@ -30,7 +30,7 @@ export function useHrToolsNavItems(): NavItems[] {
     },
     {
       id: 'mhaCalculator',
-      title: t('MHA Calculation Form'),
+      title: t('MHA Calculation Tool'),
       hideItem: inMhaIneligibleGroup,
     },
     {


### PR DESCRIPTION
## Description

- Renames the "MHA Calculation Form" menu item and page title to "MHA Calculation Tool" to match updated product terminology.
- Updates the HR Tools nav item label in `useHrToolsNavItems`.
- Updates the `<title>` tag on the MHA Calculator page.
- Updates affected tests (`NavMenu.test.tsx`, `MultiPageMenu.test.tsx`) to match the new label.

Related ticket: [MPDX-9560](https://jira.cru.org/browse/MPDX-9560)

## Testing

- Sign in and open the top nav HR Tools menu.
- Verify the entry previously labeled "MHA Calculation Form" now reads "MHA Calculation Tool".
- Click the entry and confirm it navigates to the MHA Calculator page.
- Verify the browser tab title shows "... | HR Tools | MHA Calculation Tool".
- Open the HR Tools sidebar (MultiPageMenu) and confirm the same label appears there.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history