### PR TITLE
MPDX-9577 Move form-type chip to its own line in PDS goal card

### DIFF
--- a/src/components/Reports/Shared/GoalCard/GoalCard.tsx
+++ b/src/components/Reports/Shared/GoalCard/GoalCard.tsx
@@ -107,16 +107,15 @@ export const GoalCard: React.FC<GoalCardProps> = ({
       />
 
       <StyledCard>
-        <StyledHeaderBox sx={badge ? { gap: 1 } : undefined}>
+        <StyledHeaderBox
+          sx={badge ? { flexDirection: 'column', gap: 1 } : undefined}
+        >
           <Tooltip title={displayName}>
             <Typography
               data-testid="goal-name"
               variant="h6"
               noWrap
-              sx={{
-                textAlign: 'center',
-                ...(badge ? { minWidth: 0 } : { width: '100%' }),
-              }}
+              sx={{ textAlign: 'center', width: '100%' }}
             >
               {displayName}
             </Typography>


### PR DESCRIPTION
## Description

- Stack the Simple/Default form-type chip below the goal name in the shared `GoalCard` so it occupies its own line instead of sharing the header row.
- Restores full width to the goal name when a badge is present, keeping long names readable.
- Related ticket: [MPDX-9577](https://jira.cru.org/browse/MPDX-9577)

## Testing

- Go to the PDS Goal Calculator goals list (`/accountLists/[id]/hrTools/pdsGoalCalculator`).
- Verify each goal card shows the goal name on one line and the "Simple" or "Default" chip centered on the line below.
- Verify the MPD Goal Calculator goal cards (no badge) are unchanged.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)