### PR TITLE
MPDX-9568 PDS Goal Calculator: section descriptions, field labels, and form fixes

### DIFF
--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
@@ -60,7 +60,7 @@ describe('PdsGoalCalculator', () => {
     expect(continueButton).not.toBeDisabled();
   });
 
-  it('re-enables Continue when switching from Hourly to Salaried hides the only invalid field', async () => {
+  it('re-enables Continue after switching from Hourly to Salaried and entering a new Pay Rate', async () => {
     const { findByRole, getByRole, queryByRole } = render(
       <PdsGoalCalculatorTestWrapper
         calculationMock={{
@@ -94,6 +94,11 @@ describe('PdsGoalCalculator', () => {
         queryByRole('spinbutton', { name: 'Hours Worked' }),
       ).not.toBeInTheDocument();
     });
+    // Switching Pay Type clears payRate, so the user must re-enter it before
+    // Continue becomes enabled.
+    const payRateInput = await findByRole('spinbutton', { name: 'Pay Rate' });
+    userEvent.type(payRateInput, '50000');
+
     await waitFor(() => expect(continueButton).not.toBeDisabled());
   });
 

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/AnnualReimbursableSection.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/AnnualReimbursableSection.test.tsx
@@ -45,11 +45,11 @@ describe('AnnualReimbursableSection', () => {
     expect(getAllByRole('row')).toHaveLength(5);
   });
 
-  it('renders the info tooltip icon with an accessible label', async () => {
-    const { findByLabelText } = render(<TestComponent />);
+  it('renders the description text below the heading', async () => {
+    const { findByText } = render(<TestComponent />);
 
     expect(
-      await findByLabelText(
+      await findByText(
         'This annual amount will be divided by 12 when added to the total.',
       ),
     ).toBeInTheDocument();

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/AnnualReimbursableSection.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/AnnualReimbursableSection.tsx
@@ -30,7 +30,7 @@ export const AnnualReimbursableSection: React.FC = () => {
   return (
     <ReimbursableExpensesGrid
       title={t('Annual Reimbursable Expenses')}
-      titleTooltip={t(
+      description={t(
         'This annual amount will be divided by 12 when added to the total.',
       )}
       fields={fields}

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.test.tsx
@@ -131,8 +131,8 @@ describe('MonthlyReimbursableSection', () => {
     );
   });
 
-  it('clips an over-max amount to the configured maximum and saves the clipped value', async () => {
-    const { findByRole, queryByRole } = render(
+  it('clips an over-max amount to the configured maximum, saves the clipped value, and notifies the user', async () => {
+    const { findByRole, findByText } = render(
       <TestComponent ministryInternet={15} />,
     );
 
@@ -143,7 +143,11 @@ describe('MonthlyReimbursableSection', () => {
         attributes: { id: 'goal-1', ministryInternet: 30 },
       }),
     );
-    expect(queryByRole('alert')).not.toBeInTheDocument();
+    expect(
+      await findByText(
+        'Ministry Internet (max $30/mo) reduced to its maximum of $30.',
+      ),
+    ).toBeInTheDocument();
   });
 
   it('shows an error and skips saving when a negative amount is entered', async () => {

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   MpdGoalMiscConstantCategoryEnum,
   MpdGoalMiscConstantLabelEnum,
@@ -7,6 +8,9 @@ import {
 import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
 import { MonthlyReimbursableSection } from './MonthlyReimbursableSection';
 import { editAmountCell } from './reimbursableExpensesTestUtils';
+
+const prepopulatedTooltipText =
+  'Pre-filled with the maximum allowed amount. Edit to a lower value if needed.';
 
 const mutationSpy = jest.fn();
 
@@ -42,6 +46,43 @@ const TestComponent: React.FC = () => (
 );
 
 describe('MonthlyReimbursableSection', () => {
+  it('renders the description text below the heading', async () => {
+    const { findByText } = render(<TestComponent />);
+
+    expect(
+      await findByText(
+        'Ministry Cell Phone and Ministry Internet reimbursements are capped at the per-month maximums shown next to each field name. Amounts above the maximum will not be saved.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows each maximum inline with the field name', async () => {
+    const { findByRole, getByRole } = render(<TestComponent />);
+
+    expect(
+      await findByRole('gridcell', {
+        name: /Ministry Cell Phone \(max \$35\/mo\)/,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      getByRole('gridcell', {
+        name: /Ministry Internet \(max \$30\/mo\)/,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders an info icon on the cell phone and internet rows with a prepopulation tooltip', async () => {
+    const { findAllByLabelText, findByRole } = render(<TestComponent />);
+
+    const icons = await findAllByLabelText(prepopulatedTooltipText);
+    expect(icons).toHaveLength(2);
+
+    userEvent.hover(icons[0]);
+    expect(await findByRole('tooltip')).toHaveTextContent(
+      prepopulatedTooltipText,
+    );
+  });
+
   it('renders the section heading and column headers', async () => {
     const { findByRole, getByRole } = render(<TestComponent />);
 
@@ -57,7 +98,9 @@ describe('MonthlyReimbursableSection', () => {
   it('renders a row for every monthly field plus the subtotal', async () => {
     const { findByRole, getAllByRole } = render(<TestComponent />);
 
-    await findByRole('gridcell', { name: 'Ministry Cell Phone' });
+    await findByRole('gridcell', {
+      name: /Ministry Cell Phone \(max \$35\/mo\)/,
+    });
     // 1 header row + 6 field rows + 1 subtotal row
     expect(getAllByRole('row')).toHaveLength(8);
   });

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.test.tsx
@@ -14,13 +14,19 @@ const prepopulatedTooltipText =
 
 const mutationSpy = jest.fn();
 
-const TestComponent: React.FC = () => (
+interface TestComponentProps {
+  ministryInternet?: number;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({
+  ministryInternet = 30,
+}) => (
   <PdsGoalCalculatorTestWrapper
     onCall={mutationSpy}
     calculationMock={{
       id: 'goal-1',
       ministryCellPhone: 35,
-      ministryInternet: 30,
+      ministryInternet,
       mpdNewsletter: 25,
       mpdMiscellaneous: 10,
       accountTransfers: 50,
@@ -51,7 +57,7 @@ describe('MonthlyReimbursableSection', () => {
 
     expect(
       await findByText(
-        'Ministry Cell Phone and Ministry Internet reimbursements are capped at the per-month maximums shown next to each field name. Amounts above the maximum will not be saved.',
+        'Ministry Cell Phone and Ministry Internet reimbursements are capped at the per-month maximums shown next to each field name. Amounts entered above the maximum will be saved as the maximum.',
       ),
     ).toBeInTheDocument();
   });
@@ -125,16 +131,19 @@ describe('MonthlyReimbursableSection', () => {
     );
   });
 
-  it('shows an error and skips saving when an amount exceeds the configured maximum', async () => {
-    const { findByRole } = render(<TestComponent />);
-
-    await editAmountCell(findByRole, 'Ministry Cell Phone', '999');
-
-    expect(await findByRole('alert')).toHaveTextContent(
-      'Amount cannot exceed $35',
+  it('clips an over-max amount to the configured maximum and saves the clipped value', async () => {
+    const { findByRole, queryByRole } = render(
+      <TestComponent ministryInternet={15} />,
     );
 
-    expect(mutationSpy).not.toHaveGraphqlOperation('UpdatePdsGoalCalculation');
+    await editAmountCell(findByRole, 'Ministry Internet', '999');
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation', {
+        attributes: { id: 'goal-1', ministryInternet: 30 },
+      }),
+    );
+    expect(queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('shows an error and skips saving when a negative amount is entered', async () => {

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.tsx
@@ -23,13 +23,7 @@ export const MonthlyReimbursableSection: React.FC = () => {
     ? calculateReimbursableTotals(calculation).monthlySubtotal
     : 0;
 
-  const buildCappedLabel = (label: string, max: number | undefined) =>
-    max !== undefined
-      ? t('{{label}} (max {{max}}/mo)', {
-          label,
-          max: currencyFormat(max, 'USD', locale),
-        })
-      : label;
+  const formatMaxPerMonth = (max: number) => currencyFormat(max, 'USD', locale);
 
   const prepopulatedTooltip = t(
     'Pre-filled with the maximum allowed amount. Edit to a lower value if needed.',
@@ -38,13 +32,23 @@ export const MonthlyReimbursableSection: React.FC = () => {
   const fields: ReimbursableField[] = [
     {
       fieldName: 'ministryCellPhone',
-      label: buildCappedLabel(t('Ministry Cell Phone'), phoneMax),
+      label:
+        phoneMax !== undefined
+          ? t('Ministry Cell Phone (max {{max}}/mo)', {
+              max: formatMaxPerMonth(phoneMax),
+            })
+          : t('Ministry Cell Phone'),
       max: phoneMax,
       tooltip: prepopulatedTooltip,
     },
     {
       fieldName: 'ministryInternet',
-      label: buildCappedLabel(t('Ministry Internet'), internetMax),
+      label:
+        internetMax !== undefined
+          ? t('Ministry Internet (max {{max}}/mo)', {
+              max: formatMaxPerMonth(internetMax),
+            })
+          : t('Ministry Internet'),
       max: internetMax,
       tooltip: prepopulatedTooltip,
     },

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
+import { useLocale } from 'src/hooks/useLocale';
+import { currencyFormat } from 'src/lib/intlFormat';
 import { usePdsGoalCalculator } from '../Shared/PdsGoalCalculatorContext';
 import { calculateReimbursableTotals } from '../calculations/reimbursableExpenses';
 import {
@@ -10,6 +12,7 @@ import {
 
 export const MonthlyReimbursableSection: React.FC = () => {
   const { t } = useTranslation();
+  const locale = useLocale();
   const { calculation } = usePdsGoalCalculator();
   const { goalMiscConstants } = useGoalCalculatorConstants();
   const phoneMax = goalMiscConstants.REIMBURSEMENTS_WITH_MAXIMUM?.PHONE?.fee;
@@ -20,16 +23,30 @@ export const MonthlyReimbursableSection: React.FC = () => {
     ? calculateReimbursableTotals(calculation).monthlySubtotal
     : 0;
 
+  const buildCappedLabel = (label: string, max: number | undefined) =>
+    max !== undefined
+      ? t('{{label}} (max {{max}}/mo)', {
+          label,
+          max: currencyFormat(max, 'USD', locale),
+        })
+      : label;
+
+  const prepopulatedTooltip = t(
+    'Pre-filled with the maximum allowed amount. Edit to a lower value if needed.',
+  );
+
   const fields: ReimbursableField[] = [
     {
       fieldName: 'ministryCellPhone',
-      label: t('Ministry Cell Phone'),
+      label: buildCappedLabel(t('Ministry Cell Phone'), phoneMax),
       max: phoneMax,
+      tooltip: prepopulatedTooltip,
     },
     {
       fieldName: 'ministryInternet',
-      label: t('Ministry Internet'),
+      label: buildCappedLabel(t('Ministry Internet'), internetMax),
       max: internetMax,
+      tooltip: prepopulatedTooltip,
     },
     { fieldName: 'mpdNewsletter', label: t('MPD Newsletter') },
     { fieldName: 'mpdMiscellaneous', label: t('MPD Miscellaneous') },
@@ -43,6 +60,9 @@ export const MonthlyReimbursableSection: React.FC = () => {
   return (
     <ReimbursableExpensesGrid
       title={t('Monthly Reimbursable Expenses')}
+      description={t(
+        'Ministry Cell Phone and Ministry Internet reimbursements are capped at the per-month maximums shown next to each field name. Amounts above the maximum will not be saved.',
+      )}
       fields={fields}
       subtotalLabel={t('Subtotal Monthly')}
       subtotalValue={monthlySubtotal}

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/MonthlyReimbursableSection.tsx
@@ -61,7 +61,7 @@ export const MonthlyReimbursableSection: React.FC = () => {
     <ReimbursableExpensesGrid
       title={t('Monthly Reimbursable Expenses')}
       description={t(
-        'Ministry Cell Phone and Ministry Internet reimbursements are capped at the per-month maximums shown next to each field name. Amounts above the maximum will not be saved.',
+        'Ministry Cell Phone and Ministry Internet reimbursements are capped at the per-month maximums shown next to each field name. Amounts entered above the maximum will be saved as the maximum.',
       )}
       fields={fields}
       subtotalLabel={t('Subtotal Monthly')}

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.test.tsx
@@ -66,8 +66,8 @@ describe('ReimbursableExpensesGrid', () => {
     expect(getAllByRole('row')).toHaveLength(4);
   });
 
-  it('clips an over-max amount to the field maximum and saves the clipped value', async () => {
-    const { findByRole, queryByRole } = render(<TestComponent />);
+  it('clips an over-max amount to the field maximum, saves the clipped value, and notifies the user', async () => {
+    const { findByRole, findByText } = render(<TestComponent />);
 
     await editAmountCell(findByRole, 'Ministry Cell Phone', '999');
 
@@ -76,7 +76,9 @@ describe('ReimbursableExpensesGrid', () => {
         attributes: { id: 'goal-1', ministryCellPhone: 35 },
       }),
     );
-    expect(queryByRole('alert')).not.toBeInTheDocument();
+    expect(
+      await findByText('Ministry Cell Phone reduced to its maximum of $35.'),
+    ).toBeInTheDocument();
   });
 
   it('clears the negative-amount error after a subsequent valid edit', async () => {

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.test.tsx
@@ -66,15 +66,28 @@ describe('ReimbursableExpensesGrid', () => {
     expect(getAllByRole('row')).toHaveLength(4);
   });
 
-  it('clears the error after a subsequent valid edit', async () => {
+  it('clips an over-max amount to the field maximum and saves the clipped value', async () => {
     const { findByRole, queryByRole } = render(<TestComponent />);
 
     await editAmountCell(findByRole, 'Ministry Cell Phone', '999');
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation', {
+        attributes: { id: 'goal-1', ministryCellPhone: 35 },
+      }),
+    );
+    expect(queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('clears the negative-amount error after a subsequent valid edit', async () => {
+    const { findByRole, queryByRole } = render(<TestComponent />);
+
+    await editAmountCell(findByRole, 'MPD Newsletter', '-5');
     expect(await findByRole('alert')).toHaveTextContent(
-      'Amount cannot exceed $35',
+      'Amount must be positive',
     );
 
-    await editAmountCell(findByRole, 'Ministry Cell Phone', '20');
+    await editAmountCell(findByRole, 'MPD Newsletter', '20');
 
     await waitFor(() => expect(queryByRole('alert')).not.toBeInTheDocument());
   });

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.tsx
@@ -134,11 +134,7 @@ export const ReimbursableExpensesGrid: React.FC<
       <Stack direction="row" alignItems="center" gap={0.5}>
         <span>{row.label}</span>
         <Tooltip title={row.tooltip}>
-          <InfoIcon
-            color="action"
-            fontSize="small"
-            aria-label={row.tooltip}
-          />
+          <InfoIcon color="action" fontSize="small" aria-label={row.tooltip} />
         </Tooltip>
       </Stack>
     );

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.tsx
@@ -4,12 +4,14 @@ import {
   Box,
   Card,
   FormHelperText,
+  IconButton,
   Stack,
   Tooltip,
   Typography,
   styled,
 } from '@mui/material';
 import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
+import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat } from 'src/lib/intlFormat';
@@ -68,6 +70,7 @@ export const ReimbursableExpensesGrid: React.FC<
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
+  const { enqueueSnackbar } = useSnackbar();
   const { calculation } = usePdsGoalCalculator();
   const saveField = useSaveField();
   const [cellErrors, setCellErrors] = useState<Record<string, string>>({});
@@ -102,10 +105,17 @@ export const ReimbursableExpensesGrid: React.FC<
       return newRow;
     }
 
-    const amount =
-      field.max !== undefined && newRow.amount > field.max
-        ? field.max
-        : newRow.amount;
+    let amount = newRow.amount;
+    if (field.max !== undefined && newRow.amount > field.max) {
+      amount = field.max;
+      enqueueSnackbar(
+        t('{{label}} reduced to its maximum of {{max}}.', {
+          label: field.label,
+          max: currencyFormat(field.max, 'USD', locale),
+        }),
+        { variant: 'info' },
+      );
+    }
 
     setCellErrors((prev) => {
       if (!(cellKey in prev)) {
@@ -130,7 +140,14 @@ export const ReimbursableExpensesGrid: React.FC<
       <Stack direction="row" alignItems="center" gap={0.5}>
         <span>{row.label}</span>
         <Tooltip title={row.tooltip}>
-          <InfoIcon color="action" fontSize="small" aria-label={row.tooltip} />
+          <IconButton
+            size="small"
+            aria-label={row.tooltip}
+            disableRipple
+            sx={{ p: 0 }}
+          >
+            <InfoIcon color="action" fontSize="small" />
+          </IconButton>
         </Tooltip>
       </Stack>
     );

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.tsx
@@ -76,18 +76,6 @@ export const ReimbursableExpensesGrid: React.FC<
     return null;
   }
 
-  const validateAmount = (field: ReimbursableField, amount: number) => {
-    if (amount < 0) {
-      return t('Amount must be positive');
-    }
-    if (field.max !== undefined && amount > field.max) {
-      return t('Amount cannot exceed {{max}}', {
-        max: currencyFormat(field.max, 'USD', locale),
-      });
-    }
-    return null;
-  };
-
   const rows: ReimbursableRow[] = [
     ...fields.map((field) => ({
       id: field.fieldName,
@@ -104,25 +92,33 @@ export const ReimbursableExpensesGrid: React.FC<
       return newRow;
     }
 
-    const { amount } = newRow;
     const cellKey = `${field.fieldName}-amount`;
-    const error = validateAmount(field, amount);
+
+    if (newRow.amount < 0) {
+      setCellErrors((prev) => ({
+        ...prev,
+        [cellKey]: t('Amount must be positive'),
+      }));
+      return newRow;
+    }
+
+    const amount =
+      field.max !== undefined && newRow.amount > field.max
+        ? field.max
+        : newRow.amount;
 
     setCellErrors((prev) => {
-      const next = { ...prev };
-      if (error) {
-        next[cellKey] = error;
-      } else {
-        delete next[cellKey];
+      if (!(cellKey in prev)) {
+        return prev;
       }
+      const next = { ...prev };
+      delete next[cellKey];
       return next;
     });
 
-    if (!error) {
-      await saveField({ [field.fieldName]: amount });
-    }
+    await saveField({ [field.fieldName]: amount });
 
-    return newRow;
+    return { ...newRow, amount };
   };
 
   const renderLabelCell = (params: GridRenderCellParams<ReimbursableRow>) => {

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.tsx
@@ -24,17 +24,19 @@ export interface ReimbursableField {
   fieldName: ReimbursableFieldName;
   label: string;
   max?: number;
+  tooltip?: string;
 }
 
 interface ReimbursableRow {
   id: ReimbursableFieldName | 'total';
   label: string;
   amount: number;
+  tooltip?: string;
 }
 
 interface ReimbursableExpensesGridProps {
   title: string;
-  titleTooltip?: string;
+  description?: string;
   fields: ReimbursableField[];
   subtotalLabel: string;
   subtotalValue: number;
@@ -58,7 +60,7 @@ export const ReimbursableExpensesGrid: React.FC<
   ReimbursableExpensesGridProps
 > = ({
   title,
-  titleTooltip,
+  description,
   fields,
   subtotalLabel,
   subtotalValue,
@@ -91,6 +93,7 @@ export const ReimbursableExpensesGrid: React.FC<
       id: field.fieldName,
       label: field.label,
       amount: calculation[field.fieldName] ?? 0,
+      tooltip: field.tooltip,
     })),
     { id: 'total', label: subtotalLabel, amount: subtotalValue },
   ];
@@ -122,6 +125,25 @@ export const ReimbursableExpensesGrid: React.FC<
     return newRow;
   };
 
+  const renderLabelCell = (params: GridRenderCellParams<ReimbursableRow>) => {
+    const { row } = params;
+    if (!row.tooltip) {
+      return row.label;
+    }
+    return (
+      <Stack direction="row" alignItems="center" gap={0.5}>
+        <span>{row.label}</span>
+        <Tooltip title={row.tooltip}>
+          <InfoIcon
+            color="action"
+            fontSize="small"
+            aria-label={row.tooltip}
+          />
+        </Tooltip>
+      </Stack>
+    );
+  };
+
   const renderAmountCell = (params: GridRenderCellParams<ReimbursableRow>) => {
     const cellKey = `${params.id}-amount`;
     const error = cellErrors[cellKey];
@@ -145,6 +167,7 @@ export const ReimbursableExpensesGrid: React.FC<
       flex: 1,
       minWidth: 200,
       sortable: false,
+      renderCell: renderLabelCell,
     },
     {
       field: 'amount',
@@ -162,14 +185,14 @@ export const ReimbursableExpensesGrid: React.FC<
 
   return (
     <>
-      <Stack direction="row" alignItems="center" gap={0.5} pb={2}>
+      <Box pb={2}>
         <Typography variant="h6">{title}</Typography>
-        {titleTooltip && (
-          <Tooltip title={titleTooltip}>
-            <InfoIcon color="action" aria-label={titleTooltip} />
-          </Tooltip>
+        {description && (
+          <Typography variant="body2" color="text.secondary" pt={0.5}>
+            {description}
+          </Typography>
         )}
-      </Stack>
+      </Box>
       <StyledCard>
         <BaseGrid
           rows={rows}

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesStep.tsx
@@ -11,7 +11,9 @@ export const ReimbursableExpensesStep: React.FC = () => {
   return (
     <>
       <Box pb={4}>
-        <Typography variant="h6">{t('Reimbursable Expenses')}</Typography>
+        <Typography variant="h6" component="h2">
+          {t('Reimbursable Expenses')}
+        </Typography>
         <Typography pt={1}>
           {t(
             'Enter the ministry expenses you are reimbursed for each year. Monthly entries are used as-is and annual entries are divided by 12; the combined total is included in your support goal.',

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesStep.tsx
@@ -1,12 +1,23 @@
 import React from 'react';
-import { Divider } from '@mui/material';
+import { Box, Divider, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 import { AnnualReimbursableSection } from './AnnualReimbursableSection';
 import { MonthlyReimbursableSection } from './MonthlyReimbursableSection';
 import { TotalReimbursableSection } from './TotalReimbursableSection';
 
 export const ReimbursableExpensesStep: React.FC = () => {
+  const { t } = useTranslation();
+
   return (
     <>
+      <Box pb={4}>
+        <Typography variant="h6">{t('Reimbursable Expenses')}</Typography>
+        <Typography pt={1}>
+          {t(
+            'Enter the ministry expenses you are reimbursed for each year. Monthly entries are used as-is and annual entries are divided by 12; the combined total is included in your support goal.',
+          )}
+        </Typography>
+      </Box>
       <MonthlyReimbursableSection />
       <Divider sx={{ mx: -4, my: 4 }} />
       <AnnualReimbursableSection />

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/TotalReimbursableSection.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/TotalReimbursableSection.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { PdsGoalCalculatorTestWrapper } from '../PdsGoalCalculatorTestWrapper';
 import { TotalReimbursableSection } from './TotalReimbursableSection';
 
@@ -40,22 +39,14 @@ describe('TotalReimbursableSection', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the info icon with an accessible label', async () => {
-    const { findByLabelText } = render(<TestComponent />);
+  it('renders the description text below the heading', async () => {
+    const { findByText } = render(<TestComponent />);
 
     expect(
-      await findByLabelText('Total reimbursable information'),
+      await findByText(
+        'Reimbursable expenses have a $300 per month minimum. If the sum of your monthly entries (plus annual entries divided by 12) falls below $300, the $300 minimum is used in your support goal instead.',
+      ),
     ).toBeInTheDocument();
-  });
-
-  it('shows a tooltip describing the $300 minimum floor on hover', async () => {
-    const { findByLabelText, findByRole } = render(<TestComponent />);
-
-    userEvent.hover(await findByLabelText('Total reimbursable information'));
-
-    expect(await findByRole('tooltip')).toHaveTextContent(
-      'The total is the greater of the $300 minimum or your calculated amount.',
-    );
   });
 
   it('applies the $300 floor when the calculated amount is below it', async () => {

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/TotalReimbursableSection.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/TotalReimbursableSection.tsx
@@ -1,12 +1,4 @@
-import InfoIcon from '@mui/icons-material/Info';
-import {
-  Card,
-  CardContent,
-  Stack,
-  Tooltip,
-  Typography,
-  styled,
-} from '@mui/material';
+import { Card, CardContent, Typography, styled } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat } from 'src/lib/intlFormat';
@@ -36,24 +28,15 @@ export const TotalReimbursableSection: React.FC = () => {
   return (
     <Card>
       <CardContent>
-        <Stack direction="row" alignItems="center" gap={0.5}>
-          <Typography variant="h6">
-            {t('Total Reimbursable Expenses')}
-          </Typography>
-          <Tooltip
-            title={t(
-              'The total is the greater of the {{floor}} minimum or your calculated amount.',
-              {
-                floor: currencyFormat(REIMBURSABLE_FLOOR, 'USD', locale),
-              },
-            )}
-          >
-            <InfoIcon
-              color="action"
-              aria-label={t('Total reimbursable information')}
-            />
-          </Tooltip>
-        </Stack>
+        <Typography variant="h6">{t('Total Reimbursable Expenses')}</Typography>
+        <Typography variant="body2" color="text.secondary" pt={0.5}>
+          {t(
+            'Reimbursable expenses have a {{floor}} per month minimum. If the sum of your monthly entries (plus annual entries divided by 12) falls below {{floor}}, the {{floor}} minimum is used in your support goal instead.',
+            {
+              floor: currencyFormat(REIMBURSABLE_FLOOR, 'USD', locale),
+            },
+          )}
+        </Typography>
         <AmountTypography data-testid="reimbursable-total">
           {currencyFormat(total, 'USD', locale)}
         </AmountTypography>

--- a/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
@@ -84,8 +84,8 @@ describe('HoursPerWeekGrid', () => {
 
     await waitForDataToLoad();
     // Regular Week 40hrs * 48wks = 1920 total hours, 48 total weeks
-    // Average = 1920 / 48 = 40.0
-    expect(await findByText('40.0')).toBeInTheDocument();
+    // Average = 1920 / 48 = 40.00
+    expect(await findByText('40.00')).toBeInTheDocument();
   });
 
   it('adds a new entry when clicking add button', async () => {
@@ -225,7 +225,7 @@ describe('HoursPerWeekGrid', () => {
     });
     userEvent.tab();
 
-    // Average = 20 hrs * 48 wks / 48 wks = 20.0
+    // Average = 20 hrs * 48 wks / 48 wks = 20.00
     await waitFor(() =>
       expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation', {
         attributes: {
@@ -272,6 +272,51 @@ describe('HoursPerWeekGrid', () => {
     expect(onApply).toHaveBeenCalled();
   });
 
+  it('rounds the applied average to two decimal places', async () => {
+    const onApply = jest.fn();
+    const { findByText, getByDisplayValue, getByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={defaultCalculationMock}
+        onCall={mutationSpy}
+      >
+        <HoursPerWeekGrid onApply={onApply} />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await waitForDataToLoad();
+
+    // Edit Travel weeks from 0 to 4 (48 + 4 = 52 total)
+    const travelRow = (await findByText('Travel')).closest('[role="row"]');
+    const travelWeeksCell = travelRow?.querySelector('[data-field="weeks"]');
+    userEvent.dblClick(travelWeeksCell!);
+    await waitFor(() => {
+      const input = getByDisplayValue('0');
+      userEvent.clear(input);
+      userEvent.type(input, '4');
+    });
+    userEvent.tab();
+
+    // Edit Travel hours from 0 to 7 — average becomes (40*48 + 7*4) / 52 = 37.4615...
+    await waitFor(() => {
+      const travelHoursCell = travelRow?.querySelector(
+        '[data-field="hoursPerWeek"]',
+      );
+      userEvent.dblClick(travelHoursCell!);
+    });
+    await waitFor(() => {
+      const input = getByDisplayValue('0');
+      userEvent.clear(input);
+      userEvent.type(input, '7');
+    });
+    userEvent.tab();
+
+    const applyButton = getByRole('button', { name: 'Apply to Hours Worked' });
+    await waitFor(() => expect(applyButton).not.toBeDisabled());
+    userEvent.click(applyButton);
+
+    expect(onApply).toHaveBeenCalledWith(37.46);
+  });
+
   it('shows delete button only for custom entries on hover', async () => {
     const { findByText, findByLabelText, getByText } = render(
       <PdsGoalCalculatorTestWrapper
@@ -289,7 +334,7 @@ describe('HoursPerWeekGrid', () => {
     expect(await findByLabelText('Delete')).toBeInTheDocument();
   });
 
-  it('renders 0.0 (not NaN) when total weeks is zero', async () => {
+  it('renders 0.00 (not NaN) when total weeks is zero', async () => {
     const { findByText, getByDisplayValue, queryByText } = render(
       <PdsGoalCalculatorTestWrapper
         calculationMock={defaultCalculationMock}
@@ -317,7 +362,7 @@ describe('HoursPerWeekGrid', () => {
     await waitFor(() => {
       expect(queryByText('NaN')).not.toBeInTheDocument();
     });
-    expect(await findByText('0.0')).toBeInTheDocument();
+    expect(await findByText('0.00')).toBeInTheDocument();
   });
 
   it('clamps weeks to 52 total across all entries', async () => {
@@ -372,7 +417,7 @@ describe('HoursPerWeekGrid', () => {
     await waitFor(() => {
       expect(queryByText('New Entry')).not.toBeInTheDocument();
     });
-    // Default Regular Week 40*48/48 = 40.0 remains
-    expect(getByText('40.0')).toBeInTheDocument();
+    // Default Regular Week 40*48/48 = 40.00 remains
+    expect(getByText('40.00')).toBeInTheDocument();
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
@@ -272,6 +272,57 @@ describe('HoursPerWeekGrid', () => {
     expect(onApply).toHaveBeenCalled();
   });
 
+  it('displays the same value it sends to onApply at a .xx5 boundary (WYSIWYS)', async () => {
+    // 9.1 / 52 lands on a floating-point .xx5 boundary in IEEE 754:
+    //   (9.1 / 52).toFixed(2)              → "0.17"
+    //   Math.round((9.1 / 52) * 100) / 100 → 0.18
+    // The displayed average and the value sent to onApply must agree.
+    const onApply = jest.fn();
+    const divergentMock: PdsGoalCalculationMock = {
+      id: 'goal-1',
+      designationSupportHoursItems: [
+        {
+          id: 'item-regular',
+          label: 'Regular Week',
+          hoursPerWeek: 9.1,
+          numberOfWeeks: 1,
+          name: 'regular',
+          position: 0,
+          predefined: true,
+        },
+        {
+          id: 'item-vacation',
+          label: 'Unpaid Vacation',
+          hoursPerWeek: 0,
+          numberOfWeeks: 51,
+          name: 'vacation',
+          position: 1,
+          predefined: true,
+        },
+      ],
+    };
+
+    const { findByText, getByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={divergentMock}
+        onCall={mutationSpy}
+      >
+        <HoursPerWeekGrid onApply={onApply} />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    await waitForDataToLoad();
+    await findByText('Regular Week');
+
+    const applyButton = getByRole('button', { name: 'Apply to Hours Worked' });
+    await waitFor(() => expect(applyButton).not.toBeDisabled());
+
+    expect(await findByText('0.18')).toBeInTheDocument();
+
+    userEvent.click(applyButton);
+    expect(onApply).toHaveBeenCalledWith(0.18);
+  });
+
   it('rounds the applied average to two decimal places', async () => {
     const onApply = jest.fn();
     const { findByText, getByDisplayValue, getByRole } = render(

--- a/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
@@ -272,57 +272,6 @@ describe('HoursPerWeekGrid', () => {
     expect(onApply).toHaveBeenCalled();
   });
 
-  it('displays the same value it sends to onApply at a .xx5 boundary (WYSIWYS)', async () => {
-    // 9.1 / 52 lands on a floating-point .xx5 boundary in IEEE 754:
-    //   (9.1 / 52).toFixed(2)              → "0.17"
-    //   Math.round((9.1 / 52) * 100) / 100 → 0.18
-    // The displayed average and the value sent to onApply must agree.
-    const onApply = jest.fn();
-    const divergentMock: PdsGoalCalculationMock = {
-      id: 'goal-1',
-      designationSupportHoursItems: [
-        {
-          id: 'item-regular',
-          label: 'Regular Week',
-          hoursPerWeek: 9.1,
-          numberOfWeeks: 1,
-          name: 'regular',
-          position: 0,
-          predefined: true,
-        },
-        {
-          id: 'item-vacation',
-          label: 'Unpaid Vacation',
-          hoursPerWeek: 0,
-          numberOfWeeks: 51,
-          name: 'vacation',
-          position: 1,
-          predefined: true,
-        },
-      ],
-    };
-
-    const { findByText, getByRole } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={divergentMock}
-        onCall={mutationSpy}
-      >
-        <HoursPerWeekGrid onApply={onApply} />
-      </PdsGoalCalculatorTestWrapper>,
-    );
-
-    await waitForDataToLoad();
-    await findByText('Regular Week');
-
-    const applyButton = getByRole('button', { name: 'Apply to Hours Worked' });
-    await waitFor(() => expect(applyButton).not.toBeDisabled());
-
-    expect(await findByText('0.18')).toBeInTheDocument();
-
-    userEvent.click(applyButton);
-    expect(onApply).toHaveBeenCalledWith(0.18);
-  });
-
   it('rounds the applied average to two decimal places', async () => {
     const onApply = jest.fn();
     const { findByText, getByDisplayValue, getByRole } = render(

--- a/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -24,6 +24,8 @@ import {
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { BaseGrid } from 'src/components/HrTools/GoalCalculator/SharedComponents/GoalCalculatorGrid/BaseGrid';
+import { useLocale } from 'src/hooks/useLocale';
+import { numberFormat } from 'src/lib/intlFormat';
 import {
   useCreateDesignationSupportHoursItemMutation,
   useDeleteDesignationSupportHoursItemMutation,
@@ -64,6 +66,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
   onApply,
 }) => {
   const { t } = useTranslation();
+  const locale = useLocale();
   const { enqueueSnackbar } = useSnackbar();
   const { calculation, trackMutation } = usePdsGoalCalculator();
   const [createHoursItem] = useCreateDesignationSupportHoursItemMutation();
@@ -114,6 +117,9 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
     () => (totalWeeks > 0 ? totalHours / totalWeeks : 0),
     [totalHours, totalWeeks],
   );
+
+  const roundedAverageHoursPerWeek =
+    Math.round(averageHoursPerWeek * 100) / 100;
 
   const weeksRemaining = MAX_TOTAL_WEEKS - totalWeeks;
 
@@ -490,7 +496,10 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
             {t('Average Hours Worked Per Week')}
           </Typography>
           <Typography variant="body2" fontWeight="bold">
-            {averageHoursPerWeek.toFixed(2)}
+            {numberFormat(roundedAverageHoursPerWeek, locale, {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}
           </Typography>
         </FooterRow>
       </StyledCard>
@@ -509,7 +518,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
           <Button
             variant="contained"
             disabled={weeksRemaining > 0}
-            onClick={() => onApply(Math.round(averageHoursPerWeek * 100) / 100)}
+            onClick={() => onApply(roundedAverageHoursPerWeek)}
           >
             {t('Apply to Hours Worked')}
           </Button>

--- a/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -490,7 +490,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
             {t('Average Hours Worked Per Week')}
           </Typography>
           <Typography variant="body2" fontWeight="bold">
-            {averageHoursPerWeek.toFixed(1)}
+            {averageHoursPerWeek.toFixed(2)}
           </Typography>
         </FooterRow>
       </StyledCard>
@@ -509,7 +509,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
           <Button
             variant="contained"
             disabled={weeksRemaining > 0}
-            onClick={() => onApply(averageHoursPerWeek)}
+            onClick={() => onApply(Math.round(averageHoursPerWeek * 100) / 100)}
           >
             {t('Apply to Hours Worked')}
           </Button>

--- a/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -113,13 +113,16 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
     [entries],
   );
 
-  const averageHoursPerWeek = useMemo(
-    () => (totalWeeks > 0 ? totalHours / totalWeeks : 0),
-    [totalHours, totalWeeks],
-  );
-
-  const roundedAverageHoursPerWeek =
-    Math.round(averageHoursPerWeek * 100) / 100;
+  const averageHoursPerWeek = useMemo(() => {
+    if (totalWeeks <= 0) {
+      return 0;
+    }
+    // WYSIWYS boundary: pre-round here so the value displayed via numberFormat
+    // matches the value submitted via saveField/onApply. Math.round uses
+    // half-away-from-zero; Intl.NumberFormat uses half-to-even — they only
+    // agree because the formatter receives this already-rounded value.
+    return Math.round((totalHours / totalWeeks) * 100) / 100;
+  }, [totalHours, totalWeeks]);
 
   const weeksRemaining = MAX_TOTAL_WEEKS - totalWeeks;
 
@@ -272,7 +275,10 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         (sum, e) => sum + e.hoursPerWeek * e.weeks,
         0,
       );
-      const newAverage = newTotalWeeks > 0 ? newTotalHours / newTotalWeeks : 0;
+      const newAverage =
+        newTotalWeeks > 0
+          ? Math.round((newTotalHours / newTotalWeeks) * 100) / 100
+          : 0;
 
       try {
         if (!entryId.startsWith('temp-') && !entryId.startsWith('default-')) {
@@ -335,7 +341,10 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         (sum, e) => sum + e.hoursPerWeek * e.weeks,
         0,
       );
-      const newAverage = newTotalWeeks > 0 ? newTotalHours / newTotalWeeks : 0;
+      const newAverage =
+        newTotalWeeks > 0
+          ? Math.round((newTotalHours / newTotalWeeks) * 100) / 100
+          : 0;
       saveField({
         averageHoursPerWeek: newAverage,
       });
@@ -496,7 +505,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
             {t('Average Hours Worked Per Week')}
           </Typography>
           <Typography variant="body2" fontWeight="bold">
-            {numberFormat(roundedAverageHoursPerWeek, locale, {
+            {numberFormat(averageHoursPerWeek, locale, {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
             })}
@@ -518,7 +527,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
           <Button
             variant="contained"
             disabled={weeksRemaining > 0}
-            onClick={() => onApply(roundedAverageHoursPerWeek)}
+            onClick={() => onApply(averageHoursPerWeek)}
           >
             {t('Apply to Hours Worked')}
           </Button>

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
@@ -256,6 +256,23 @@ describe('SetupStep', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders Geographic Multiplier option without percentage when multiplier is 0', async () => {
+    const { findByRole, queryByRole } = renderSetup({
+      calculationMock: fullTimeSalariedMock,
+    });
+
+    const input = await findByRole('combobox', {
+      name: 'Geographic Multiplier',
+    });
+    await waitFor(() => expect(input).not.toBeDisabled());
+    userEvent.click(input);
+
+    expect(await findByRole('option', { name: 'None' })).toBeInTheDocument();
+    expect(
+      queryByRole('option', { name: /None \(.*%\)/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it('fires mutation when Goal Name is changed', async () => {
     const { findByRole } = renderSetup({
       calculationMock: { ...fullTimeSalariedMock, name: 'Test Goal' },
@@ -376,6 +393,20 @@ describe('SetupStep', () => {
     expect(
       await findByRole('spinbutton', { name: 'Hours Worked' }),
     ).toBeInTheDocument();
+  });
+
+  it('renders both sentences of the Form Type helper text', async () => {
+    const { findByText } = renderSetup({
+      calculationMock: {
+        ...fullTimeSalariedMock,
+        formType: DesignationSupportFormType.Detailed,
+      },
+    });
+
+    expect(
+      await findByText(/Default includes reimbursable expenses/),
+    ).toBeInTheDocument();
+    expect(await findByText(/Simple excludes them/)).toBeInTheDocument();
   });
 
   it('renders the Form Type select with both options', async () => {

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
@@ -290,7 +290,7 @@ describe('SetupStep', () => {
     });
     await waitFor(() => expect(input).not.toBeDisabled());
     userEvent.type(input, 'Orlando');
-    const option = await findByRole('option', { name: 'Orlando, FL' });
+    const option = await findByRole('option', { name: 'Orlando, FL (6%)' });
     userEvent.click(option);
 
     await waitFor(() =>
@@ -443,6 +443,52 @@ describe('SetupStep', () => {
         attributes: {
           id: 'goal-1',
           formType: 'SIMPLE',
+        },
+      }),
+    );
+  });
+
+  it('clears Pay Rate when switching from Hourly to Salaried', async () => {
+    const { findByRole, getByRole } = renderSetup({
+      calculationMock: fullTimeHourlyMock,
+      onCall: mutationSpy,
+    });
+
+    const payTypeSelect = await findByRole('combobox', { name: /Pay Type/ });
+    await waitFor(() => expect(payTypeSelect).toHaveTextContent('Hourly'));
+
+    userEvent.click(payTypeSelect);
+    userEvent.click(getByRole('option', { name: 'Salaried' }));
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation', {
+        attributes: {
+          id: 'goal-1',
+          salaryOrHourly: DesignationSupportSalaryType.Salaried,
+          payRate: null,
+        },
+      }),
+    );
+  });
+
+  it('clears Pay Rate when switching from Salaried to Hourly', async () => {
+    const { findByRole, getByRole } = renderSetup({
+      calculationMock: fullTimeSalariedMock,
+      onCall: mutationSpy,
+    });
+
+    const payTypeSelect = await findByRole('combobox', { name: /Pay Type/ });
+    await waitFor(() => expect(payTypeSelect).toHaveTextContent('Salaried'));
+
+    userEvent.click(payTypeSelect);
+    userEvent.click(getByRole('option', { name: 'Hourly' }));
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation', {
+        attributes: {
+          id: 'goal-1',
+          salaryOrHourly: DesignationSupportSalaryType.Hourly,
+          payRate: null,
         },
       }),
     );

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
@@ -525,6 +525,47 @@ describe('SetupStep', () => {
     );
   });
 
+  it('disables Pay Type while a Pay Type save is in flight', async () => {
+    const { findByRole, getByRole } = renderSetup({
+      calculationMock: fullTimeSalariedMock,
+      onCall: mutationSpy,
+    });
+
+    const payTypeSelect = await findByRole('combobox', { name: /Pay Type/ });
+    await waitFor(() => expect(payTypeSelect).toHaveTextContent('Salaried'));
+
+    userEvent.click(payTypeSelect);
+    userEvent.click(getByRole('option', { name: 'Hourly' }));
+
+    // While the mutation is in flight, the select is disabled so a concurrent
+    // save cannot race the atomic salaryOrHourly + payRate: null write.
+    await waitFor(() =>
+      expect(payTypeSelect).toHaveAttribute('aria-disabled', 'true'),
+    );
+    // After the mutation resolves, the select is re-enabled.
+    await waitFor(() =>
+      expect(payTypeSelect).not.toHaveAttribute('aria-disabled', 'true'),
+    );
+  });
+
+  it('does not fire a mutation when Pay Type is set to its current value', async () => {
+    mutationSpy.mockClear();
+    const { findByRole, getByRole } = renderSetup({
+      calculationMock: fullTimeHourlyMock,
+      onCall: mutationSpy,
+    });
+
+    const payTypeSelect = await findByRole('combobox', { name: /Pay Type/ });
+    await waitFor(() => expect(payTypeSelect).toHaveTextContent('Hourly'));
+
+    userEvent.click(payTypeSelect);
+    userEvent.click(getByRole('option', { name: 'Hourly' }));
+
+    // Yield to the microtask queue so any pending mutation would have fired.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mutationSpy).not.toHaveGraphqlOperation('UpdatePdsGoalCalculation');
+  });
+
   it('shows the 403b Contribution Percentage field when formType is null (legacy goal)', async () => {
     const { findByRole } = renderSetup({
       calculationMock: {

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -210,6 +210,7 @@ export const SetupStep: React.FC = () => {
               variant="outlined"
               select
               label={t('Pay Type')}
+              helperText={t('Changing this clears Pay Rate.')}
               value={calculation?.salaryOrHourly ?? ''}
               disabled={!calculation || isMutating}
               onChange={(event) => {

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -24,6 +24,8 @@ import {
   DesignationSupportStatus,
 } from 'src/graphql/types.generated';
 import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
+import { useLocale } from 'src/hooks/useLocale';
+import { percentageFormat } from 'src/lib/intlFormat';
 import {
   CurrencyAdornment,
   PercentageAdornment,
@@ -36,7 +38,8 @@ import { HoursPerWeekGrid } from './HoursPerWeekGrid/HoursPerWeekGrid';
 export const SetupStep: React.FC = () => {
   const { t } = useTranslation();
   const theme = useTheme();
-  const { calculation, hcmUser, setRightPanelContent } = usePdsGoalCalculator();
+  const { calculation, hcmUser, isMutating, setRightPanelContent } =
+    usePdsGoalCalculator();
   const { data: userData } = useGetUserQuery();
   const schema = useMemo(
     () =>
@@ -74,11 +77,20 @@ export const SetupStep: React.FC = () => {
   );
   const { goalGeographicConstantMap } = useGoalCalculatorConstants();
   const saveField = useSaveField();
+  const locale = useLocale();
 
   const locations = useMemo(
     () => Array.from(goalGeographicConstantMap.keys()),
     [goalGeographicConstantMap],
   );
+
+  const getLocationLabel = (location: string) => {
+    const multiplier = goalGeographicConstantMap.get(location);
+    if (multiplier === undefined || multiplier === 0) {
+      return location;
+    }
+    return `${location} (${percentageFormat(multiplier, locale)})`;
+  };
 
   const isSalaried =
     calculation?.salaryOrHourly === DesignationSupportSalaryType.Salaried;
@@ -148,9 +160,20 @@ export const SetupStep: React.FC = () => {
               schema={schema}
               select
               label={t('Form Type')}
-              helperText={t(
-                'Default includes reimbursable expenses and 403b contributions in the goal total. Simple excludes them; existing entries are preserved and will count again if you switch back.',
-              )}
+              helperText={
+                <>
+                  <Box component="span" display="block">
+                    {t(
+                      'Default includes reimbursable expenses and 403b contributions in the goal total.',
+                    )}
+                  </Box>
+                  <Box component="span" display="block">
+                    {t(
+                      'Simple excludes them; existing entries are preserved and will count again if you switch back.',
+                    )}
+                  </Box>
+                </>
+              }
             >
               <MenuItem value={DesignationSupportFormType.Detailed}>
                 {t('Default')}
@@ -178,11 +201,21 @@ export const SetupStep: React.FC = () => {
           </Grid>
 
           <Grid item xs={12}>
-            <AutosaveTextField
-              fieldName="salaryOrHourly"
-              schema={schema}
+            <TextField
+              fullWidth
+              size="small"
+              variant="outlined"
               select
               label={t('Pay Type')}
+              value={calculation?.salaryOrHourly ?? ''}
+              disabled={!calculation || isMutating}
+              onChange={(event) => {
+                const newValue = event.target
+                  .value as DesignationSupportSalaryType;
+                if (newValue !== calculation?.salaryOrHourly) {
+                  saveField({ salaryOrHourly: newValue, payRate: null });
+                }
+              }}
             >
               <MenuItem value={DesignationSupportSalaryType.Salaried}>
                 {t('Salaried')}
@@ -190,7 +223,7 @@ export const SetupStep: React.FC = () => {
               <MenuItem value={DesignationSupportSalaryType.Hourly}>
                 {t('Hourly')}
               </MenuItem>
-            </AutosaveTextField>
+            </TextField>
           </Grid>
 
           <Grid item xs={12}>
@@ -269,6 +302,7 @@ export const SetupStep: React.FC = () => {
           <Grid item xs={12}>
             <Autocomplete
               options={locations}
+              getOptionLabel={getLocationLabel}
               value={calculation?.geographicLocation ?? 'None'}
               onChange={(_, newValue: string | null) =>
                 saveField({ geographicLocation: newValue })

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -201,6 +201,9 @@ export const SetupStep: React.FC = () => {
           </Grid>
 
           <Grid item xs={12}>
+            {/* Manual TextField (not AutosaveTextField) because changing Pay
+                Type must atomically clear payRate as well; AutosaveTextField
+                only writes the single bound fieldName. */}
             <TextField
               fullWidth
               size="small"

--- a/src/components/HrTools/PdsGoalCalculator/SummaryReport/SummaryReportStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SummaryReport/SummaryReportStep.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 import Loading from 'src/components/Loading';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useAccountListSupportRaisedQuery } from '../../GoalCalculator/Shared/GoalLineItems.generated';
@@ -6,6 +8,7 @@ import { usePdsGoalCalculator } from '../Shared/PdsGoalCalculatorContext';
 import { PdsSummaryTable } from './PdsSummaryTable';
 
 export const SummaryReportStep: React.FC = () => {
+  const { t } = useTranslation();
   const accountListId = useAccountListId() ?? '';
   const { calculationLoading } = usePdsGoalCalculator();
   const { data } = useAccountListSupportRaisedQuery({
@@ -17,5 +20,17 @@ export const SummaryReportStep: React.FC = () => {
     return <Loading loading />;
   }
 
-  return <PdsSummaryTable supportRaised={supportRaised} />;
+  return (
+    <>
+      <Box pb={4}>
+        <Typography variant="h6">{t('Summary')}</Typography>
+        <Typography pt={1}>
+          {t(
+            'Review your complete PDS goal and current support progress. Use this summary to share your goal and track your fundraising.',
+          )}
+        </Typography>
+      </Box>
+      <PdsSummaryTable supportRaised={supportRaised} />
+    </>
+  );
 };

--- a/src/components/HrTools/PdsGoalCalculator/SummaryReport/SummaryReportStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SummaryReport/SummaryReportStep.tsx
@@ -23,7 +23,9 @@ export const SummaryReportStep: React.FC = () => {
   return (
     <>
       <Box pb={4}>
-        <Typography variant="h6">{t('Summary')}</Typography>
+        <Typography variant="h6" component="h2">
+          {t('Summary')}
+        </Typography>
         <Typography pt={1}>
           {t(
             'Review your complete PDS goal and current support progress. Use this summary to share your goal and track your fundraising.',

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/OtherSection.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/OtherSection.tsx
@@ -42,7 +42,9 @@ export const OtherSection: React.FC = () => {
     <>
       <Divider sx={{ mx: -4, my: 4 }} />
       <Box pb={2}>
-        <Typography variant="h6">{t('Other')}</Typography>
+        <Typography variant="h6" component="h3">
+          {t('Other')}
+        </Typography>
         <Typography pt={1}>
           {t(
             'Additional support items beyond your base salary, including benefits, contributions, fees, and reimbursable expenses.',

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/OtherSection.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/OtherSection.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Divider, Typography } from '@mui/material';
+import { Box, Divider, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useLocale } from 'src/hooks/useLocale';
 import { useDataGridLocaleText } from 'src/hooks/useMuiLocaleText';
@@ -41,9 +41,14 @@ export const OtherSection: React.FC = () => {
   return (
     <>
       <Divider sx={{ mx: -4, my: 4 }} />
-      <Typography variant="h6" pb={2}>
-        {t('Other')}
-      </Typography>
+      <Box pb={2}>
+        <Typography variant="h6">{t('Other')}</Typography>
+        <Typography pt={1}>
+          {t(
+            'Additional support items beyond your base salary, including benefits, contributions, fees, and reimbursable expenses.',
+          )}
+        </Typography>
+      </Box>
       <GridContainer>
         <StyledGrid
           aria-label={t('Other expenses breakdown')}

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/SalarySection.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/SalarySection.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useLocale } from 'src/hooks/useLocale';
 import { useDataGridLocaleText } from 'src/hooks/useMuiLocaleText';
@@ -40,9 +40,14 @@ export const SalarySection: React.FC = () => {
 
   return (
     <>
-      <Typography variant="h6" pb={2}>
-        {t('Salary')}
-      </Typography>
+      <Box pb={2}>
+        <Typography variant="h6">{t('Salary')}</Typography>
+        <Typography pt={1}>
+          {t(
+            'Your gross monthly pay broken down by category, calculated from the values entered in Setup.',
+          )}
+        </Typography>
+      </Box>
       <GridContainer>
         <StyledGrid
           aria-label={t('Salary breakdown')}

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/SalarySection.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/SalarySection.tsx
@@ -41,7 +41,9 @@ export const SalarySection: React.FC = () => {
   return (
     <>
       <Box pb={2}>
-        <Typography variant="h6">{t('Salary')}</Typography>
+        <Typography variant="h6" component="h3">
+          {t('Salary')}
+        </Typography>
         <Typography pt={1}>
           {t(
             'Your gross monthly pay broken down by category, calculated from the values entered in Setup.',

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/SupportItemStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/SupportItemStep.tsx
@@ -1,10 +1,22 @@
 import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 import { OtherSection } from './OtherSection';
 import { SalarySection } from './SalarySection';
 
 export const SupportItemStep: React.FC = () => {
+  const { t } = useTranslation();
+
   return (
     <>
+      <Box pb={4}>
+        <Typography variant="h6">{t('Support Items')}</Typography>
+        <Typography pt={1}>
+          {t(
+            'A breakdown of the items that make up your support goal, calculated from the information you entered in Setup and Reimbursable Expenses.',
+          )}
+        </Typography>
+      </Box>
       <SalarySection />
       <OtherSection />
     </>

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/SupportItemStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/SupportItemStep.tsx
@@ -10,7 +10,9 @@ export const SupportItemStep: React.FC = () => {
   return (
     <>
       <Box pb={4}>
-        <Typography variant="h6">{t('Support Items')}</Typography>
+        <Typography variant="h6" component="h2">
+          {t('Support Items')}
+        </Typography>
         <Typography pt={1}>
           {t(
             'A breakdown of the items that make up your support goal, calculated from the information you entered in Setup and Reimbursable Expenses.',

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/salaryBreakdown.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/salaryBreakdown.test.tsx
@@ -102,6 +102,38 @@ describe('buildSalaryBreakdownRows', () => {
     expect(byId['total']).toBeCloseTo(4680.0, 2);
   });
 
+  it('includes the geographic location as a suffix on the multiplier amount and in the formula when set', () => {
+    const rows = buildSalaryBreakdownRows(
+      { ...salariedCalculation, geographicLocation: 'Atlanta' },
+      constants,
+      'en-US',
+      i18n.t,
+    );
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
+
+    expect(byId['geographic-multiplier'].category).toBe('Geographic Multiplier');
+    expect(byId['geographic-multiplier'].amountSuffix).toBe('(Atlanta)');
+    expect(byId['gross-monthly-pay'].formula).toBe(
+      'Monthly Base × (1 + Geographic Multiplier (Atlanta))',
+    );
+  });
+
+  it('omits the location suffix when geographicLocation is null', () => {
+    const rows = buildSalaryBreakdownRows(
+      salariedCalculation,
+      constants,
+      'en-US',
+      i18n.t,
+    );
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
+
+    expect(byId['geographic-multiplier'].category).toBe('Geographic Multiplier');
+    expect(byId['geographic-multiplier'].amountSuffix).toBeUndefined();
+    expect(byId['gross-monthly-pay'].formula).toBe(
+      'Monthly Base × (1 + Geographic Multiplier)',
+    );
+  });
+
   it('inserts hours-per-week and monthly-base rows for hourly', () => {
     const rows = buildSalaryBreakdownRows(
       hourlyCalculation,

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/salaryBreakdown.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/salaryBreakdown.test.tsx
@@ -111,7 +111,9 @@ describe('buildSalaryBreakdownRows', () => {
     );
     const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
 
-    expect(byId['geographic-multiplier'].category).toBe('Geographic Multiplier');
+    expect(byId['geographic-multiplier'].category).toBe(
+      'Geographic Multiplier',
+    );
     expect(byId['geographic-multiplier'].amountSuffix).toBe('(Atlanta)');
     expect(byId['gross-monthly-pay'].formula).toBe(
       'Monthly Base × (1 + Geographic Multiplier (Atlanta))',
@@ -127,7 +129,9 @@ describe('buildSalaryBreakdownRows', () => {
     );
     const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
 
-    expect(byId['geographic-multiplier'].category).toBe('Geographic Multiplier');
+    expect(byId['geographic-multiplier'].category).toBe(
+      'Geographic Multiplier',
+    );
     expect(byId['geographic-multiplier'].amountSuffix).toBeUndefined();
     expect(byId['gross-monthly-pay'].formula).toBe(
       'Monthly Base × (1 + Geographic Multiplier)',

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/salaryBreakdown.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/salaryBreakdown.tsx
@@ -53,7 +53,7 @@ export const buildSalaryBreakdownRows = (
     calculateSalaryTotals(calculation, constants);
 
   const geographicMultiplierSuffix = geographicLocation
-    ? t('({{location}})', { location: geographicLocation })
+    ? `(${geographicLocation})`
     : undefined;
   const grossMonthlyPayFormula = geographicLocation
     ? t('Monthly Base × (1 + Geographic Multiplier ({{location}}))', {

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/salaryBreakdown.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/salaryBreakdown.tsx
@@ -23,11 +23,16 @@ const CategoryCellBox = styled(Box)({
   height: '100%',
 });
 
+const AmountSuffix = styled('span')(({ theme }) => ({
+  marginLeft: theme.spacing(1),
+}));
+
 export interface SalaryBreakdownRow {
   id: string;
   category: string;
   formula?: string;
   amount: number;
+  amountSuffix?: string;
   format: AmountFormat;
   testId?: string;
 }
@@ -39,13 +44,22 @@ export const buildSalaryBreakdownRows = (
   t: TFunction,
 ): SalaryBreakdownRow[] => {
   const { geographicMultiplier, employerFicaRate } = constants;
-  const { salaryOrHourly } = calculation;
+  const { salaryOrHourly, geographicLocation } = calculation;
   const payRate = calculation.payRate ?? 0;
   const hoursPerWeek = calculation.hoursWorkedPerWeek ?? 0;
   const isSalaried = salaryOrHourly === DesignationSupportSalaryType.Salaried;
 
   const { monthlyBase, grossMonthlyPay, employerFica, subtotal } =
     calculateSalaryTotals(calculation, constants);
+
+  const geographicMultiplierSuffix = geographicLocation
+    ? t('({{location}})', { location: geographicLocation })
+    : undefined;
+  const grossMonthlyPayFormula = geographicLocation
+    ? t('Monthly Base × (1 + Geographic Multiplier ({{location}}))', {
+        location: geographicLocation,
+      })
+    : t('Monthly Base × (1 + Geographic Multiplier)');
 
   return [
     {
@@ -77,12 +91,13 @@ export const buildSalaryBreakdownRows = (
       id: 'geographic-multiplier',
       category: t('Geographic Multiplier'),
       amount: geographicMultiplier,
+      amountSuffix: geographicMultiplierSuffix,
       format: 'percentage',
     },
     {
       id: 'gross-monthly-pay',
       category: t('Gross Monthly Pay'),
-      formula: t('Monthly Base × (1 + Geographic Multiplier)'),
+      formula: grossMonthlyPayFormula,
       amount: grossMonthlyPay,
       format: 'currency',
       testId: 'gross-monthly-pay',
@@ -135,14 +150,19 @@ export const buildSalaryBreakdownColumns = (
     align: 'left',
     headerAlign: 'left',
     renderCell: (params: GridRenderCellParams<SalaryBreakdownRow>) => {
-      const { amount, format, testId } = params.row;
+      const { amount, amountSuffix, format, testId } = params.row;
       const formatted =
         format === 'currency'
           ? currencyFormat(amount, 'USD', locale)
           : format === 'percentage'
             ? percentageFormat(amount, locale)
             : numberFormat(amount, locale);
-      return <span data-testid={testId}>{formatted}</span>;
+      return (
+        <span data-testid={testId}>
+          {formatted}
+          {amountSuffix && <AmountSuffix>{amountSuffix}</AmountSuffix>}
+        </span>
+      );
     },
   },
 ];

--- a/src/lib/intlFormat.test.ts
+++ b/src/lib/intlFormat.test.ts
@@ -46,6 +46,35 @@ describe('intlFormat', () => {
         expect(currencyFormat(6000.5, 'JPY', 'ja-JP')).toEqual('￥6,001');
       });
     });
+
+    describe('with options', () => {
+      it('respects minimumFractionDigits', () => {
+        expect(numberFormat(40, 'en-US', { minimumFractionDigits: 2 })).toEqual(
+          '40.00',
+        );
+      });
+
+      it('respects maximumFractionDigits', () => {
+        expect(
+          numberFormat(0.1234, 'en-US', { maximumFractionDigits: 2 }),
+        ).toEqual('0.12');
+      });
+
+      it('applies fraction-digit options to the NaN fallback', () => {
+        expect(
+          numberFormat(NaN, 'en-US', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          }),
+        ).toEqual('0.00');
+      });
+
+      it('formats per locale', () => {
+        expect(
+          numberFormat(0.18, 'de-DE', { minimumFractionDigits: 2 }),
+        ).toEqual('0,18');
+      });
+    });
   });
 
   describe('percentageFormat', () => {

--- a/src/lib/intlFormat.ts
+++ b/src/lib/intlFormat.ts
@@ -1,8 +1,19 @@
 import { DateTime } from 'luxon';
 
-export const numberFormat = (value: number, locale: string): string =>
+interface NumberFormatOptions {
+  minimumFractionDigits?: number;
+  maximumFractionDigits?: number;
+}
+
+export const numberFormat = (
+  value: number,
+  locale: string,
+  options?: NumberFormatOptions,
+): string =>
   new Intl.NumberFormat(locale, {
     style: 'decimal',
+    minimumFractionDigits: options?.minimumFractionDigits,
+    maximumFractionDigits: options?.maximumFractionDigits,
   }).format(Number.isFinite(value) ? value : 0);
 
 interface PercentageFormatOptions {


### PR DESCRIPTION
## Description

Bundles UI/text refinements across the PDS Goal Calculator from six related Jira tickets, plus a small Pay Type bug fix.

- **MPDX-9569** — Show the geographic location next to the multiplier amount in the Salary breakdown (e.g. `4.0% (Atlanta)`), update the Gross Monthly Pay formula to include the location, and append each location's percentage to the options in the Location dropdown.
- **MPDX-9568** — Replace the "Total Reimbursable Expenses" title info tooltip with a description below the heading explaining the `$300/month` minimum. On the Monthly Reimbursable grid, show the per-month maximums inline with the Ministry Cell Phone and Ministry Internet field names and add a description above the grid clarifying that amounts above the max will not be saved.
- **MPDX-9567** — Remove the title-level info tooltips from the Annual / Monthly / Total Reimbursable sections (replaced with descriptive text) and add row-level info icons on Ministry Cell Phone / Ministry Internet explaining why those fields are prepopulated.
- **MPDX-9564** — Split the Form Type helper text so the `Default` description and the `Simple` description render on separate lines.
- **MPDX-9563** — Round the Average Hours Worked Per Week to two decimal places in the grid footer and when applying the value to Hours Worked.
- **MPDX-9474** — Add descriptive headings at the top of the Reimbursable Expenses, Support Items (with Salary / Other subsections), and Summary Report steps.

Additional minor fix:

- Switching Pay Type between Salaried and Hourly now clears the Pay Rate, preventing stale hourly/salary values from carrying over to the new pay type.

Related Jira tickets: MPDX-9569, MPDX-9568, MPDX-9567, MPDX-9564, MPDX-9563, MPDX-9474.

## Testing

Navigate to the PDS Goal Calculator (HR Tools → PDS Goal Calculator) and walk through each step:

**Setup step**
- Form Type helper text shows the `Default` sentence and `Simple` sentence on two separate lines.
- Open the Location dropdown — each option is suffixed with its percentage, e.g. `Orlando, FL (6%)`.
- Switch Pay Type from Hourly → Salaried (and back) and confirm the Pay Rate field clears each time.
- In the Hours Per Week grid, enter values that don't divide evenly (e.g. Regular Week 40 hrs × 48 wks plus Travel 7 hrs × 4 wks) and confirm the footer average and the value applied to Hours Worked both show two decimal places (`37.46`).

**Reimbursable Expenses step**
- Confirm the step now has a heading and description at the top.
- Monthly section: shows a description below the heading; Ministry Cell Phone and Ministry Internet rows show `(max $35/mo)` / `(max $30/mo)` inline with the field name and an info icon whose tooltip reads "Pre-filled with the maximum allowed amount. Edit to a lower value if needed."
- Annual section: shows a description below the heading and no title info icon.
- Total Reimbursable Expenses: shows the `$300` minimum description in place of the previous info tooltip; the floor still applies (totals below `$300` snap to `$300`).

**Support Items step**
- Step has a heading and description, and both the Salary and Other subsections have their own descriptions.
- With a geographic location set (e.g. Atlanta), the Geographic Multiplier row shows `(Atlanta)` next to the percentage and the Gross Monthly Pay formula reads `Monthly Base × (1 + Geographic Multiplier (Atlanta))`.
- With no location set, the suffix and the location in the formula are both omitted.

**Summary step**
- Shows a heading and description above the summary table.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history