### PR TITLE
[MPDX-9561] - Submit button on PDS Goal Calculator final step

### DIFF
--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
@@ -2,11 +2,18 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
+  DesignationSupportFormType,
   DesignationSupportSalaryType,
   DesignationSupportStatus,
 } from 'src/graphql/types.generated';
 import { PdsGoalCalculator } from './PdsGoalCalculator';
 import { PdsGoalCalculatorTestWrapper } from './PdsGoalCalculatorTestWrapper';
+
+// Math.round(overallTotal) for the default PdsGoalCalculatorTestWrapper mock
+// (Salaried full-time, $50k pay rate, $1.5k benefits, default rate constants).
+// Salary subtotal $4,500 + benefits $1,500 = $6,000; after attrition / CC fees
+// / admin assessment this rounds to $7,689. See usePdsSummaryData.
+const EXPECTED_MONTHLY_GOAL = 7689;
 
 describe('PdsGoalCalculator', () => {
   it('renders the setup step by default', () => {
@@ -149,6 +156,27 @@ describe('PdsGoalCalculator', () => {
     ).toBeInTheDocument();
   });
 
+  it('disables Finish & Apply Goal on the Summary Report step when summary data is unavailable', async () => {
+    // Empty misc constants make `buildPdsGoalConstants` return null, so
+    // `summaryData` stays null even though every form field is valid. Without
+    // the guard on `disableNext`, the button would be enabled and clicking it
+    // would submit monthlyGoal: 0 — overwriting any prior real goal.
+    const { findByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        constantsMock={{ mpdGoalMiscConstants: [] }}
+      >
+        <PdsGoalCalculator />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    userEvent.click(await findByRole('button', { name: 'Summary Report' }));
+
+    const finishButton = await findByRole('button', {
+      name: /Finish & Apply Goal/i,
+    });
+    await waitFor(() => expect(finishButton).toBeDisabled());
+  });
+
   it('re-enables Continue when switching from Full-time to Part-time hides the only invalid field', async () => {
     const { findByRole, getByRole, queryByRole } = render(
       <PdsGoalCalculatorTestWrapper
@@ -183,5 +211,145 @@ describe('PdsGoalCalculator', () => {
       ).not.toBeInTheDocument();
     });
     await waitFor(() => expect(continueButton).not.toBeDisabled());
+  });
+
+  describe('submit goal flow', () => {
+    // Use Simple formType so the Detailed-only ReimbursableExpenses step is
+    // skipped (Setup → SupportItem → SummaryReport), keeping the test focused
+    // on the last-step submit rather than mid-flow navigation.
+    const simpleFormMock = {
+      formType: DesignationSupportFormType.Simple,
+    };
+
+    const advanceToLastStep = async (
+      findByRole: ReturnType<typeof render>['findByRole'],
+    ) => {
+      // Step 1 → 2: Continue is initially disabled while autosave fields
+      // register their validity; the default mock data is fully valid.
+      let next = await findByRole('button', { name: /continue/i });
+      await waitFor(() => expect(next).not.toBeDisabled());
+      userEvent.click(next);
+
+      // Step 2 → 3: SupportItem has no autosave-tracked fields, so allValid
+      // stays true and Continue is enabled immediately.
+      next = await findByRole('button', { name: /continue/i });
+      await waitFor(() => expect(next).not.toBeDisabled());
+      userEvent.click(next);
+    };
+
+    it('renders "Finish & Apply Goal" instead of "Continue" on the last step', async () => {
+      const { findByRole, queryByRole } = render(
+        <PdsGoalCalculatorTestWrapper calculationMock={simpleFormMock}>
+          <PdsGoalCalculator />
+        </PdsGoalCalculatorTestWrapper>,
+      );
+
+      await advanceToLastStep(findByRole);
+
+      expect(
+        await findByRole('button', { name: 'Finish & Apply Goal' }),
+      ).toBeInTheDocument();
+      expect(
+        queryByRole('button', { name: /^continue$/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('submits the rounded monthlyGoal for the current accountListId', async () => {
+      const mutationSpy = jest.fn();
+      const { findByRole } = render(
+        <PdsGoalCalculatorTestWrapper
+          calculationMock={simpleFormMock}
+          onCall={mutationSpy}
+        >
+          <PdsGoalCalculator />
+        </PdsGoalCalculatorTestWrapper>,
+      );
+
+      await advanceToLastStep(findByRole);
+
+      const finishButton = await findByRole('button', {
+        name: 'Finish & Apply Goal',
+      });
+      userEvent.click(finishButton);
+
+      await waitFor(() =>
+        expect(mutationSpy).toHaveGraphqlOperation('UpdateAccountPreferences', {
+          input: {
+            id: 'abc123',
+            attributes: {
+              id: 'abc123',
+              settings: { monthlyGoal: EXPECTED_MONTHLY_GOAL },
+            },
+          },
+        }),
+      );
+    });
+
+    it('shows a success snackbar with the formatted monthly goal on completion', async () => {
+      const { findByRole, findByText } = render(
+        <PdsGoalCalculatorTestWrapper calculationMock={simpleFormMock}>
+          <PdsGoalCalculator />
+        </PdsGoalCalculatorTestWrapper>,
+      );
+
+      await advanceToLastStep(findByRole);
+
+      userEvent.click(
+        await findByRole('button', { name: 'Finish & Apply Goal' }),
+      );
+
+      expect(
+        await findByText(
+          `Successfully updated your monthly goal to $${EXPECTED_MONTHLY_GOAL.toLocaleString(
+            'en-US',
+          )}!`,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('shows a "Saving..." label and disables the button while the mutation is in flight', async () => {
+      const { findByRole, getByRole } = render(
+        <PdsGoalCalculatorTestWrapper calculationMock={simpleFormMock}>
+          <PdsGoalCalculator />
+        </PdsGoalCalculatorTestWrapper>,
+      );
+
+      await advanceToLastStep(findByRole);
+
+      const finishButton = await findByRole('button', {
+        name: 'Finish & Apply Goal',
+      });
+      userEvent.click(finishButton);
+
+      // Synchronously after click, the mutation is pending — the button label
+      // becomes "Saving..." with an in-button spinner and stays disabled to
+      // prevent a double-submit.
+      const savingButton = getByRole('button', { name: 'Saving...' });
+      expect(savingButton).toBeDisabled();
+      expect(
+        savingButton.querySelector('.MuiCircularProgress-root'),
+      ).toBeInTheDocument();
+    });
+
+    it('keeps the Finish & Apply Goal button disabled after a successful submission', async () => {
+      const { findByRole, findByText } = render(
+        <PdsGoalCalculatorTestWrapper calculationMock={simpleFormMock}>
+          <PdsGoalCalculator />
+        </PdsGoalCalculatorTestWrapper>,
+      );
+
+      await advanceToLastStep(findByRole);
+
+      const finishButton = await findByRole('button', {
+        name: 'Finish & Apply Goal',
+      });
+      userEvent.click(finishButton);
+
+      // Wait for the success snackbar so we know the mutation has settled,
+      // then verify the button stays disabled — otherwise a blur+click or
+      // double-click after success would fire a second mutation.
+      await findByText(/Successfully updated your monthly goal/);
+      expect(finishButton).toBeDisabled();
+    });
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
+import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { DirectionButtons } from 'src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons';
+import { useUpdateAccountPreferencesMutation } from 'src/components/Settings/preferences/accordions/UpdateAccountPreferences.generated';
 import {
   AutosaveForm,
   useAutosaveForm,
 } from 'src/components/Shared/Autosave/AutosaveForm';
+import { useAccountListId } from 'src/hooks/useAccountListId';
+import { useLocale } from 'src/hooks/useLocale';
+import { currencyFormat } from 'src/lib/intlFormat';
 import { PdsGoalCalculatorStepEnum } from './PdsGoalCalculatorHelper';
 import { ReimbursableExpensesSectionList } from './ReimbursableExpenses/ReimbursableExpensesSectionList';
 import { ReimbursableExpensesStep } from './ReimbursableExpenses/ReimbursableExpensesStep';
@@ -49,36 +54,61 @@ const CurrentSectionList: React.FC = () => {
 
 const MainContent: React.FC = () => {
   const { t } = useTranslation();
-  const { currentStep, stepIndex, steps, handleContinue, handlePreviousStep } =
-    usePdsGoalCalculator();
+  const locale = useLocale();
+  const { enqueueSnackbar } = useSnackbar();
+  const accountListId = useAccountListId() ?? '';
+  const {
+    currentStep,
+    stepIndex,
+    steps,
+    summaryData,
+    handleContinue,
+    handlePreviousStep,
+  } = usePdsGoalCalculator();
   const { allValid } = useAutosaveForm();
+  const [updateAccountPreferences, { loading: updating }] =
+    useUpdateAccountPreferencesMutation();
 
   const isFirstStep = stepIndex === 0;
   const isLastStep = stepIndex === steps.length - 1;
 
-  const handleSubmitGoal = async () => {};
-  const validateSubmitGoal = async () => ({});
+  const handleSubmitGoal = async () => {
+    const monthlyGoal = Math.round(summaryData?.overallTotal ?? 0);
+    await updateAccountPreferences({
+      variables: {
+        input: {
+          id: accountListId,
+          attributes: {
+            id: accountListId,
+            settings: { monthlyGoal },
+          },
+        },
+      },
+      onCompleted: () => {
+        enqueueSnackbar(
+          t('Successfully updated your monthly goal to {{formattedTotal}}!', {
+            formattedTotal: currencyFormat(monthlyGoal, 'USD', locale),
+          }),
+          { variant: 'success' },
+        );
+      },
+    });
+  };
 
   return (
     <>
       <CurrentStep />
       <DirectionButtons
-        formTitle={isLastStep ? t('PDS Goal') : currentStep.title}
+        formTitle={currentStep.title}
         handleNextStep={handleContinue}
         handlePreviousStep={handlePreviousStep}
         showBackButton={!isFirstStep}
-        isSubmission={isLastStep}
-        submitForm={isLastStep ? handleSubmitGoal : undefined}
-        validateForm={isLastStep ? validateSubmitGoal : undefined}
-        overrideContent={
-          isLastStep ? t('You are submitting your PDS Goal.') : undefined
+        buttonTitle={isLastStep ? t('Finish & Apply Goal') : undefined}
+        overrideNext={isLastStep ? handleSubmitGoal : undefined}
+        disableNext={!allValid || (isLastStep && updating)}
+        disabledNextTooltip={
+          isLastStep ? t('Complete all required fields to submit') : undefined
         }
-        overrideSubContent={
-          isLastStep
-            ? t('Once submitted, your goal will be saved.')
-            : undefined
-        }
-        disableNext={!allValid}
       />
     </>
   );

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { DirectionButtons } from 'src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons';
 import {
   AutosaveForm,
@@ -47,6 +48,7 @@ const CurrentSectionList: React.FC = () => {
 };
 
 const MainContent: React.FC = () => {
+  const { t } = useTranslation();
   const { currentStep, stepIndex, steps, handleContinue, handlePreviousStep } =
     usePdsGoalCalculator();
   const { allValid } = useAutosaveForm();
@@ -54,15 +56,28 @@ const MainContent: React.FC = () => {
   const isFirstStep = stepIndex === 0;
   const isLastStep = stepIndex === steps.length - 1;
 
+  const handleSubmitGoal = async () => {};
+  const validateSubmitGoal = async () => ({});
+
   return (
     <>
       <CurrentStep />
       <DirectionButtons
-        formTitle={currentStep.title}
+        formTitle={isLastStep ? t('PDS Goal') : currentStep.title}
         handleNextStep={handleContinue}
         handlePreviousStep={handlePreviousStep}
         showBackButton={!isFirstStep}
-        hideNextButton={isLastStep}
+        isSubmission={isLastStep}
+        submitForm={isLastStep ? handleSubmitGoal : undefined}
+        validateForm={isLastStep ? validateSubmitGoal : undefined}
+        overrideContent={
+          isLastStep ? t('You are submitting your PDS Goal.') : undefined
+        }
+        overrideSubContent={
+          isLastStep
+            ? t('Once submitted, your goal will be saved.')
+            : undefined
+        }
         disableNext={!allValid}
       />
     </>

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { DirectionButtons } from 'src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons';
@@ -56,7 +56,7 @@ const MainContent: React.FC = () => {
   const { t } = useTranslation();
   const locale = useLocale();
   const { enqueueSnackbar } = useSnackbar();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const {
     currentStep,
     stepIndex,
@@ -68,12 +68,16 @@ const MainContent: React.FC = () => {
   const { allValid } = useAutosaveForm();
   const [updateAccountPreferences, { loading: updating }] =
     useUpdateAccountPreferencesMutation();
+  const [submitted, setSubmitted] = useState(false);
 
   const isFirstStep = stepIndex === 0;
   const isLastStep = stepIndex === steps.length - 1;
 
   const handleSubmitGoal = async () => {
-    const monthlyGoal = Math.round(summaryData?.overallTotal ?? 0);
+    if (!accountListId || !summaryData?.overallTotal) {
+      return;
+    }
+    const monthlyGoal = Math.round(summaryData.overallTotal);
     await updateAccountPreferences({
       variables: {
         input: {
@@ -84,7 +88,9 @@ const MainContent: React.FC = () => {
           },
         },
       },
+      refetchQueries: ['GetDashboard', 'GetDonationGraph'],
       onCompleted: () => {
+        setSubmitted(true);
         enqueueSnackbar(
           t('Successfully updated your monthly goal to {{formattedTotal}}!', {
             formattedTotal: currencyFormat(monthlyGoal, 'USD', locale),
@@ -105,10 +111,16 @@ const MainContent: React.FC = () => {
         showBackButton={!isFirstStep}
         buttonTitle={isLastStep ? t('Finish & Apply Goal') : undefined}
         overrideNext={isLastStep ? handleSubmitGoal : undefined}
-        disableNext={!allValid || (isLastStep && updating)}
+        disableNext={
+          !allValid ||
+          (isLastStep &&
+            (submitted || !summaryData?.overallTotal || !accountListId))
+        }
         disabledNextTooltip={
           isLastStep ? t('Complete all required fields to submit') : undefined
         }
+        loadingNext={isLastStep && updating}
+        loadingNextTitle={t('Saving...')}
       />
     </>
   );

--- a/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
@@ -335,14 +335,15 @@ describe('HoursPerWeekGrid', () => {
   });
 
   it('renders 0.00 (not NaN) when total weeks is zero', async () => {
-    const { findByText, getByDisplayValue, queryByText } = render(
-      <PdsGoalCalculatorTestWrapper
-        calculationMock={defaultCalculationMock}
-        onCall={mutationSpy}
-      >
-        <HoursPerWeekGrid />
-      </PdsGoalCalculatorTestWrapper>,
-    );
+    const { findByText, findAllByText, getByDisplayValue, queryByText } =
+      render(
+        <PdsGoalCalculatorTestWrapper
+          calculationMock={defaultCalculationMock}
+          onCall={mutationSpy}
+        >
+          <HoursPerWeekGrid />
+        </PdsGoalCalculatorTestWrapper>,
+      );
 
     await waitForDataToLoad();
 
@@ -362,7 +363,7 @@ describe('HoursPerWeekGrid', () => {
     await waitFor(() => {
       expect(queryByText('NaN')).not.toBeInTheDocument();
     });
-    expect(await findByText('0.00')).toBeInTheDocument();
+    expect((await findAllByText('0.00')).length).toBeGreaterThan(0);
   });
 
   it('clamps weeks to 52 total across all entries', async () => {

--- a/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -416,6 +416,11 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
           }
           return (row.hoursPerWeek ?? 0) * (row.weeks ?? 0);
         },
+        valueFormatter: (value: number) =>
+          numberFormat(value ?? 0, locale, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          }),
       },
       {
         field: 'actions',

--- a/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.test.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.test.tsx
@@ -26,6 +26,9 @@ interface TestComponentProps {
   buttonTitle?: string;
   isEdit?: boolean;
   disableNext?: boolean;
+  disabledNextTooltip?: string;
+  loadingNext?: boolean;
+  loadingNextTitle?: string;
   noDiscard?: boolean;
 }
 
@@ -36,6 +39,9 @@ const TestComponent: React.FC<TestComponentProps> = ({
   buttonTitle,
   isEdit,
   disableNext,
+  disabledNextTooltip,
+  loadingNext,
+  loadingNextTitle,
   noDiscard = false,
 }) => (
   <ThemeProvider theme={theme}>
@@ -59,6 +65,9 @@ const TestComponent: React.FC<TestComponentProps> = ({
                 buttonTitle={buttonTitle}
                 isEdit={isEdit}
                 disableNext={disableNext}
+                disabledNextTooltip={disabledNextTooltip}
+                loadingNext={loadingNext}
+                loadingNextTitle={loadingNextTitle}
               />
             </MinisterHousingAllowanceProvider>
           </Formik>
@@ -153,6 +162,63 @@ describe('DirectionButtons', () => {
     await waitFor(() => {
       expect(
         queryByText('Complete all required fields to continue'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows the custom disabledNextTooltip when provided and Next is disabled', async () => {
+    const { findByRole, findByText, queryByText } = render(
+      <TestComponent
+        disableNext={true}
+        disabledNextTooltip="Complete all required fields to submit"
+      />,
+    );
+
+    const continueButton = await findByRole('button', { name: 'Continue' });
+    expect(continueButton).toBeDisabled();
+
+    userEvent.hover(continueButton.parentElement!);
+
+    expect(
+      await findByText('Complete all required fields to submit'),
+    ).toBeInTheDocument();
+    expect(
+      queryByText('Complete all required fields to continue'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the loadingNextTitle with an in-button spinner and disables the button while loadingNext is true', async () => {
+    const { findByRole } = render(
+      <TestComponent
+        buttonTitle="Finish & Apply Goal"
+        loadingNext={true}
+        loadingNextTitle="Saving..."
+      />,
+    );
+
+    const savingButton = await findByRole('button', { name: 'Saving...' });
+    expect(savingButton).toBeDisabled();
+    expect(
+      savingButton.querySelector('.MuiCircularProgress-root'),
+    ).toBeInTheDocument();
+  });
+
+  it('suppresses the disabledNextTooltip while loadingNext is true', async () => {
+    const { findByRole, queryByText } = render(
+      <TestComponent
+        disableNext={true}
+        disabledNextTooltip="Complete all required fields to submit"
+        loadingNext={true}
+        loadingNextTitle="Saving..."
+      />,
+    );
+
+    const savingButton = await findByRole('button', { name: 'Saving...' });
+    userEvent.hover(savingButton.parentElement!);
+
+    await waitFor(() => {
+      expect(
+        queryByText('Complete all required fields to submit'),
       ).not.toBeInTheDocument();
     });
   });

--- a/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { ChevronLeft, ChevronRight } from '@mui/icons-material';
-import { Box, Button, Tooltip } from '@mui/material';
+import { Box, Button, CircularProgress, Tooltip } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { SubmitModal } from '../SubmitModal/SubmitModal';
 
@@ -24,6 +24,8 @@ interface DirectionButtonsProps {
   disableSubmit?: boolean;
   disableNext?: boolean;
   disabledNextTooltip?: string;
+  loadingNext?: boolean;
+  loadingNextTitle?: string;
   //Formik validation for submit modal
   isSubmission?: boolean;
   submitForm?: () => Promise<void>;
@@ -57,6 +59,8 @@ export const DirectionButtons: React.FC<DirectionButtonsProps> = ({
   disableSubmit,
   disableNext,
   disabledNextTooltip,
+  loadingNext,
+  loadingNextTitle,
 }) => {
   const { t } = useTranslation();
 
@@ -145,7 +149,7 @@ export const DirectionButtons: React.FC<DirectionButtonsProps> = ({
           ) : (
             <Tooltip
               title={
-                disableNext
+                disableNext && !loadingNext
                   ? (disabledNextTooltip ??
                     t('Complete all required fields to continue'))
                   : ''
@@ -155,11 +159,16 @@ export const DirectionButtons: React.FC<DirectionButtonsProps> = ({
                 <Button
                   variant="contained"
                   color="primary"
-                  endIcon={<ChevronRight />}
+                  endIcon={loadingNext ? undefined : <ChevronRight />}
+                  startIcon={
+                    loadingNext ? <CircularProgress size={20} /> : undefined
+                  }
                   onClick={overrideNext ?? handleNextStep}
-                  disabled={disableNext}
+                  disabled={disableNext || loadingNext}
                 >
-                  {buttonTitle ?? t('Continue')}
+                  {loadingNext
+                    ? (loadingNextTitle ?? buttonTitle ?? t('Continue'))
+                    : (buttonTitle ?? t('Continue'))}
                 </Button>
               </Box>
             </Tooltip>

--- a/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.tsx
@@ -23,6 +23,7 @@ interface DirectionButtonsProps {
   splitAsr?: boolean;
   disableSubmit?: boolean;
   disableNext?: boolean;
+  disabledNextTooltip?: string;
   //Formik validation for submit modal
   isSubmission?: boolean;
   submitForm?: () => Promise<void>;
@@ -55,6 +56,7 @@ export const DirectionButtons: React.FC<DirectionButtonsProps> = ({
   splitAsr,
   disableSubmit,
   disableNext,
+  disabledNextTooltip,
 }) => {
   const { t } = useTranslation();
 
@@ -143,7 +145,10 @@ export const DirectionButtons: React.FC<DirectionButtonsProps> = ({
           ) : (
             <Tooltip
               title={
-                disableNext ? t('Complete all required fields to continue') : ''
+                disableNext
+                  ? (disabledNextTooltip ??
+                    t('Complete all required fields to continue'))
+                  : ''
               }
             >
               <Box component="span">


### PR DESCRIPTION
## Description

- Adds a "Finish & Apply Goal" submit button on the last step of the PDS Goal Calculator that saves the calculated overall total as the account's `monthlyGoal` via `updateAccountPreferences`.
- On success, surfaces a localized snackbar showing the formatted goal that was applied.
- Disables the submit action while the mutation is in flight and when required fields are incomplete.
- Extends `DirectionButtons` with a `disabledNextTooltip` prop so the final step can show "Complete all required fields to submit" instead of the generic "...to continue" copy.

Work for [MPDX-9561](https://jira.cru.org/browse/MPDX-9561).

## Testing

- Go to the PDS Goal Calculator (HR Tools)
- Step through each section, filling in required fields
- On any intermediate step, hover the disabled Next button with incomplete fields and confirm the tooltip reads "Complete all required fields to continue"
- Advance to the final step
- With required fields incomplete, hover the disabled submit button and confirm the tooltip reads "Complete all required fields to submit"
- Complete all required fields and confirm the button label reads "Finish & Apply Goal"
- Click "Finish & Apply Goal" and confirm:
  - The button is disabled while the request is in flight
  - A success snackbar appears with the formatted monthly goal (e.g. "Successfully updated your monthly goal to $X,XXX!")
  - The account's monthly goal is updated (verify on the dashboard / preferences)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history