### PR TITLE
MPDX-9597 UI - Add validation for required salary cap fields in MaxAllowableStep

### DIFF
--- a/src/components/HrTools/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.test.tsx
@@ -165,6 +165,25 @@ describe('MaxAllowableSection', () => {
         'Your combined maximum allowable salary exceeds your maximum allowable salary of $125,000.00',
       );
     });
+
+    it('shows required errors when split cap fields are empty', async () => {
+      const { findByText } = render(
+        <TestComponent
+          salaryRequestMock={{
+            manuallySplitCap: true,
+            salaryCap: null,
+            spouseSalaryCap: null,
+          }}
+        />,
+      );
+
+      expect(
+        await findByText('Maximum Allowable Salary is required'),
+      ).toBeInTheDocument();
+      expect(
+        await findByText('Spouse Maximum Allowable Salary is required'),
+      ).toBeInTheDocument();
+    });
   });
 
   it('shows message to users with exception cap', async () => {

--- a/src/components/HrTools/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.tsx
+++ b/src/components/HrTools/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.tsx
@@ -70,10 +70,12 @@ export const MaxAllowableStep: React.FC = () => {
 
     return yup.object({
       salaryCap: amount(t('Maximum Allowable Salary'), t, {
+        required: true,
         max: calculations?.hardCap,
         maxMessage,
       }),
       spouseSalaryCap: amount(t('Spouse Maximum Allowable Salary'), t, {
+        required: true,
         max: calculations?.hardCap,
         maxMessage,
       }),


### PR DESCRIPTION
## Description

- Makes the manually split chosen cap values required. These values are necessary for submission.
- https://jira.cru.org/browse/MPDX-9597

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to Salary Calculator > Your Information > Maximum Allowable Salary (CAP) section, select the checkbox to split the cap, and ensure that the input fields display as required.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
