### PR TITLE
MPDX-9609 - PDS Calc: Add conditional rendering for Pay Rate field based on pay type

### DIFF
--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
@@ -170,6 +170,22 @@ describe('SetupStep', () => {
     );
   });
 
+  it('hides Pay Rate when pay type is not set', async () => {
+    const { findByRole, queryByRole } = renderSetup({
+      calculationMock: {
+        ...fullTimeSalariedMock,
+        salaryOrHourly: null,
+        payRate: null,
+      },
+    });
+
+    await findByRole('textbox', { name: 'Goal Name' });
+
+    expect(
+      queryByRole('spinbutton', { name: 'Pay Rate' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('shows dynamic Pay Rate helper text based on salary type', async () => {
     const { findByRole, findByText, rerender } = renderSetup({
       calculationMock: fullTimeSalariedMock,

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -92,8 +92,8 @@ export const SetupStep: React.FC = () => {
     return `${location} (${percentageFormat(multiplier, locale)})`;
   };
 
-  const isSalaried =
-    calculation?.salaryOrHourly === DesignationSupportSalaryType.Salaried;
+  const payType = calculation?.salaryOrHourly;
+  const isSalaried = payType === DesignationSupportSalaryType.Salaried;
   const isPartTime = calculation?.status === DesignationSupportStatus.PartTime;
   const isSimpleForm =
     calculation?.formType === DesignationSupportFormType.Simple;
@@ -230,18 +230,20 @@ export const SetupStep: React.FC = () => {
             </TextField>
           </Grid>
 
-          <Grid item xs={12}>
-            <AutosaveTextField
-              fieldName="payRate"
-              schema={schema}
-              label={t('Pay Rate')}
-              type="number"
-              helperText={payRateHelperText}
-              InputProps={{
-                startAdornment: <CurrencyAdornment />,
-              }}
-            />
-          </Grid>
+          {payType && (
+            <Grid item xs={12}>
+              <AutosaveTextField
+                fieldName="payRate"
+                schema={schema}
+                label={t('Pay Rate')}
+                type="number"
+                helperText={payRateHelperText}
+                InputProps={{
+                  startAdornment: <CurrencyAdornment />,
+                }}
+              />
+            </Grid>
+          )}
 
           {!isSalaried && (
             <Grid item xs={12}>


### PR DESCRIPTION
## Description

The pay rate accepts a value before pay type is set. But setting pay type clears the pay rate.
We want to hide or disable the pay rate field until pay type is set.

https://jira.cru.org/browse/MPDX-9609

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to hrTools/pdsGoalCalculator
- Test an account where the pay type cannot be determined
- Check that pay rate isn't rendered unless payType is set

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
