### PR TITLE
[MPDX-9594] - Clarify PDS Goal Calculator Pay Rate label and units

### DIFF
--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
@@ -96,7 +96,9 @@ describe('PdsGoalCalculator', () => {
     });
     // Switching Pay Type clears payRate, so the user must re-enter it before
     // Continue becomes enabled.
-    const payRateInput = await findByRole('spinbutton', { name: 'Pay Rate' });
+    const payRateInput = await findByRole('spinbutton', {
+      name: 'Annual Pay Rate',
+    });
     userEvent.type(payRateInput, '50000');
 
     await waitFor(() => expect(continueButton).not.toBeDisabled());

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
@@ -195,13 +195,13 @@ describe('SetupStep', () => {
 
     await findByRole('spinbutton', { name: 'Annual Pay Rate' });
     expect(await findByText('Enter yearly salary')).toBeInTheDocument();
-    expect(await findByText('/ year')).toBeInTheDocument();
+    expect(await findByText('per year')).toBeInTheDocument();
 
     rerender(setupTree({ calculationMock: fullTimeHourlyMock }));
 
     await findByRole('spinbutton', { name: 'Hourly Pay Rate' });
     expect(await findByText('Enter hourly rate')).toBeInTheDocument();
-    expect(await findByText('/ hour')).toBeInTheDocument();
+    expect(await findByText('per hour')).toBeInTheDocument();
   });
 
   it('403b field is disabled', async () => {

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
@@ -85,7 +85,9 @@ describe('SetupStep', () => {
 
     userEvent.clear(goalNameInput);
 
-    const payRateInput = await findByRole('spinbutton', { name: 'Pay Rate' });
+    const payRateInput = await findByRole('spinbutton', {
+      name: 'Hourly Pay Rate',
+    });
     userEvent.clear(payRateInput);
 
     const hoursInput = await findByRole('spinbutton', {
@@ -182,21 +184,24 @@ describe('SetupStep', () => {
     await findByRole('textbox', { name: 'Goal Name' });
 
     expect(
-      queryByRole('spinbutton', { name: 'Pay Rate' }),
+      queryByRole('spinbutton', { name: /Pay Rate/ }),
     ).not.toBeInTheDocument();
   });
 
-  it('shows dynamic Pay Rate helper text based on salary type', async () => {
+  it('shows dynamic Pay Rate label and helper text based on salary type', async () => {
     const { findByRole, findByText, rerender } = renderSetup({
       calculationMock: fullTimeSalariedMock,
     });
 
-    await findByRole('spinbutton', { name: 'Pay Rate' });
+    await findByRole('spinbutton', { name: 'Annual Pay Rate' });
     expect(await findByText('Enter yearly salary')).toBeInTheDocument();
+    expect(await findByText('/ year')).toBeInTheDocument();
 
     rerender(setupTree({ calculationMock: fullTimeHourlyMock }));
 
+    await findByRole('spinbutton', { name: 'Hourly Pay Rate' });
     expect(await findByText('Enter hourly rate')).toBeInTheDocument();
+    expect(await findByText('/ hour')).toBeInTheDocument();
   });
 
   it('403b field is disabled', async () => {

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -107,6 +107,8 @@ export const SetupStep: React.FC = () => {
   const payRateHelperText = isSalaried
     ? t('Enter yearly salary')
     : t('Enter hourly rate');
+  const payRateLabel = isSalaried ? t('Annual Pay Rate') : t('Hourly Pay Rate');
+  const payRateUnitSuffix = isSalaried ? t('/ year') : t('/ hour');
 
   const handleOpenHoursCalculator = () => {
     setRightPanelContent(
@@ -235,11 +237,16 @@ export const SetupStep: React.FC = () => {
               <AutosaveTextField
                 fieldName="payRate"
                 schema={schema}
-                label={t('Pay Rate')}
+                label={payRateLabel}
                 type="number"
                 helperText={payRateHelperText}
                 InputProps={{
                   startAdornment: <CurrencyAdornment />,
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      {payRateUnitSuffix}
+                    </InputAdornment>
+                  ),
                 }}
               />
             </Grid>

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -108,7 +108,7 @@ export const SetupStep: React.FC = () => {
     ? t('Enter yearly salary')
     : t('Enter hourly rate');
   const payRateLabel = isSalaried ? t('Annual Pay Rate') : t('Hourly Pay Rate');
-  const payRateUnitSuffix = isSalaried ? t('/ year') : t('/ hour');
+  const payRateUnitSuffix = isSalaried ? t('per year') : t('per hour');
 
   const handleOpenHoursCalculator = () => {
     setRightPanelContent(


### PR DESCRIPTION
## Description

- Replaces the generic "Pay Rate" label in the PDS Goal Calculator Setup step with a dynamic label ("Annual Pay Rate" for salaried, "Hourly Pay Rate" for hourly) so the field's meaning matches the selected pay type.
- Adds an end adornment showing the unit ("/ year" or "/ hour") alongside the existing currency start adornment, making the entered value's period explicit.
- Updates the related `SetupStep` and `PdsGoalCalculator` tests to query the field by its new dynamic name and to assert both the label change and the unit suffix render correctly when toggling between salaried and hourly.

Related ticket: [MPDX-9594](https://jira.cru.org/browse/MPDX-9594)

## Testing

- Go to the HR Tools → PDS Goal Calculator
- Start (or continue) a goal and reach the Setup step
- Set Pay Type to **Salaried** and confirm the Pay Rate field is labeled **"Annual Pay Rate"**, shows the currency symbol as a start adornment, and shows **"/ year"** as the end adornment with the helper text "Enter yearly salary"
- Switch Pay Type to **Hourly** and confirm the same field re-labels to **"Hourly Pay Rate"**, the end adornment becomes **"/ hour"**, and the helper text changes to "Enter hourly rate"
- Verify that the Pay Rate field is cleared when toggling Pay Type and that Continue remains disabled until a new Pay Rate is entered
- Confirm the field is hidden entirely when no Pay Type is selected

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history