### PR TITLE
MPDX-9600 - Staff Expense Report: Sort Income and Expenses in CSV exports by date

### DIFF
--- a/src/components/Reports/StaffExpenseReport/DownloadButtonGroup/downloadReport.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/DownloadButtonGroup/downloadReport.test.tsx
@@ -1,7 +1,7 @@
 import { StaffExpenseCategoryEnum } from 'src/graphql/types.generated';
 import { ReportType } from '../Helpers/StaffReportEnum';
 import { Transaction } from '../Helpers/filterTransactions';
-import { createCsvReport } from './downloadReport';
+import { createCsvReport, dateSortTransactions } from './downloadReport';
 
 const mockData: Transaction[] = [
   {
@@ -9,7 +9,7 @@ const mockData: Transaction[] = [
     category: StaffExpenseCategoryEnum.MinistryReimbursement,
     displayCategory: 'Ministry Reimbursement',
     fundType: 'Primary',
-    transactedAt: '2025-07-01',
+    transactedAt: '2025-10-01',
     amount: -2724,
   },
   {
@@ -112,5 +112,15 @@ describe('downloadReport', () => {
     expect(appendChildMock).toHaveBeenCalledWith(realLink);
     expect(clickMock).toHaveBeenCalled();
     expect(removeChildMock).toHaveBeenCalledWith(realLink);
+  });
+
+  describe('dateSortTransactions', () => {
+    it('sorts transactions by ascending date', () => {
+      expect(
+        dateSortTransactions(mockData).map(
+          (transaction) => transaction.transactedAt,
+        ),
+      ).toEqual(['2025-08-01', '2025-09-01', '2025-10-01']);
+    });
   });
 });

--- a/src/components/Reports/StaffExpenseReport/DownloadButtonGroup/downloadReport.tsx
+++ b/src/components/Reports/StaffExpenseReport/DownloadButtonGroup/downloadReport.tsx
@@ -11,10 +11,11 @@ const createTable = (
   transactions: Transaction[],
   locale: string,
 ) => {
+  const dateSortedTransactions = dateSortTransactions(transactions);
   const csvData = [
     [title],
     csvHeader,
-    ...transactions.map((transaction) => [
+    ...dateSortedTransactions.map((transaction) => [
       dateFormat(DateTime.fromISO(transaction.transactedAt), locale),
       transaction.displayCategory,
       currencyFormat(transaction.amount, 'USD', locale),
@@ -23,6 +24,12 @@ const createTable = (
 
   return csvData;
 };
+
+export function dateSortTransactions(transactions: Transaction[]) {
+  return [...transactions].sort((transactionA, transactionB) =>
+    transactionA.transactedAt.localeCompare(transactionB.transactedAt),
+  );
+}
 
 function createCombinedReport(
   transactions: Transaction[],


### PR DESCRIPTION
## Description

- It is easier to read transactions as a chronological timeline as opposed to by category.
List any PRs that this PR is dependent on and any Jira tickets that this PR is related to.
https://jira.cru.org/browse/MPDX-9600

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Impersonate someone with income and expenses
- Go to `hrTools/staffExpense`
- Export an income CSV, an expense CSV, and a dual income/expense CSV

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
