### PR TITLE
MPDX-9599 - Fix "Changing the fund resets the month filter"  and other fixes

### DIFF
--- a/src/components/Reports/StaffExpenseReport/Helpers/getMonthRange.test.ts
+++ b/src/components/Reports/StaffExpenseReport/Helpers/getMonthRange.test.ts
@@ -1,0 +1,62 @@
+import { DateTime } from 'luxon';
+import { getStaffExpenseMonthRange } from './getMonthRange';
+
+const baseTime = DateTime.fromISO('2020-01-15');
+
+describe('getStaffExpenseMonthRange', () => {
+  it('falls back to baseTime month when filters is null', () => {
+    expect(getStaffExpenseMonthRange(null, baseTime)).toEqual({
+      startMonth: '2020-01-01',
+      endMonth: '2020-01-31',
+    });
+  });
+
+  it('falls back to baseTime month when filters is undefined', () => {
+    expect(getStaffExpenseMonthRange(undefined, baseTime)).toEqual({
+      startMonth: '2020-01-01',
+      endMonth: '2020-01-31',
+    });
+  });
+
+  it('falls back to baseTime month when both dates are null', () => {
+    expect(
+      getStaffExpenseMonthRange({ startDate: null, endDate: null }, baseTime),
+    ).toEqual({
+      startMonth: '2020-01-01',
+      endMonth: '2020-01-31',
+    });
+  });
+
+  it('uses startDate and endDate months when both are present', () => {
+    const filters = {
+      startDate: DateTime.fromISO('2025-03-10'),
+      endDate: DateTime.fromISO('2025-05-20'),
+    };
+    expect(getStaffExpenseMonthRange(filters, baseTime)).toEqual({
+      startMonth: '2025-03-01',
+      endMonth: '2025-05-31',
+    });
+  });
+
+  it('uses startDate month and baseTime endMonth when only startDate is present', () => {
+    const filters = {
+      startDate: DateTime.fromISO('2025-03-10'),
+      endDate: null,
+    };
+    expect(getStaffExpenseMonthRange(filters, baseTime)).toEqual({
+      startMonth: '2025-03-01',
+      endMonth: '2020-01-31',
+    });
+  });
+
+  it('uses endDate month for both startMonth and endMonth when only endDate is present', () => {
+    const filters = {
+      startDate: null,
+      endDate: DateTime.fromISO('2025-05-20'),
+    };
+    expect(getStaffExpenseMonthRange(filters, baseTime)).toEqual({
+      startMonth: '2025-05-01',
+      endMonth: '2025-05-31',
+    });
+  });
+});

--- a/src/components/Reports/StaffExpenseReport/Helpers/getMonthRange.ts
+++ b/src/components/Reports/StaffExpenseReport/Helpers/getMonthRange.ts
@@ -1,0 +1,19 @@
+import { DateTime } from 'luxon';
+
+interface DateWindow {
+  startDate?: DateTime | null;
+  endDate?: DateTime | null;
+}
+
+export const getStaffExpenseMonthRange = (
+  filters: DateWindow | null | undefined,
+  baseTime: DateTime,
+): { startMonth: string | null; endMonth: string | null } => ({
+  startMonth:
+    filters?.startDate?.startOf('month').toISODate() ??
+    filters?.endDate?.startOf('month').toISODate() ??
+    baseTime.startOf('month').toISODate(),
+  endMonth:
+    filters?.endDate?.endOf('month').toISODate() ??
+    baseTime.endOf('month').toISODate(),
+});

--- a/src/components/Reports/StaffExpenseReport/SettingsDialog/SettingsDialog.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/SettingsDialog/SettingsDialog.test.tsx
@@ -11,14 +11,20 @@ import { ReportsStaffExpensesQuery } from '../GetStaffExpense.generated';
 import { DateRange } from '../Helpers/StaffReportEnum';
 import { Filters, SettingsDialog, SettingsDialogProps } from './SettingsDialog';
 
-const TestComponent: React.FC<SettingsDialogProps> = ({
+const mutationSpy = jest.fn();
+const TestComponent: React.FC<
+  SettingsDialogProps & { onCallMock?: jest.Mock }
+> = ({
   isOpen,
   onClose,
   selectedFilters,
   selectedFundType,
+  time,
+  onCallMock,
 }) => (
   <TestRouter>
     <GqlMockedProvider<{ ReportsStaffExpenses: ReportsStaffExpensesQuery }>
+      onCall={onCallMock}
       mocks={{
         ReportsStaffExpenses: {
           reportsStaffExpenses: {
@@ -46,9 +52,7 @@ const TestComponent: React.FC<SettingsDialogProps> = ({
                         breakdownByMonth: [
                           {
                             transactions: [
-                              {
-                                transactedAt: DateTime.now().toISO(),
-                              },
+                              { transactedAt: DateTime.now().toISO() },
                             ],
                           },
                         ],
@@ -62,9 +66,7 @@ const TestComponent: React.FC<SettingsDialogProps> = ({
                         breakdownByMonth: [
                           {
                             transactions: [
-                              {
-                                transactedAt: DateTime.now().toISO(),
-                              },
+                              { transactedAt: DateTime.now().toISO() },
                             ],
                           },
                         ],
@@ -84,6 +86,7 @@ const TestComponent: React.FC<SettingsDialogProps> = ({
           onClose={onClose}
           selectedFilters={selectedFilters}
           selectedFundType={selectedFundType}
+          time={time}
         />
       </LocalizationProvider>
     </GqlMockedProvider>
@@ -417,5 +420,33 @@ describe('SettingsDialog', () => {
     );
 
     expect(await findByLabelText('Benefits')).not.toBeChecked();
+  });
+
+  it('should query using the time prop month when no date filter is set', async () => {
+    const time = DateTime.fromISO('2025-10-01');
+
+    render(
+      <TestComponent {...defaultProps} time={time} onCallMock={mutationSpy} />,
+    );
+
+    await waitFor(() => {
+      expect(mutationSpy).toHaveGraphqlOperation('ReportsStaffExpenses', {
+        startMonth: '2025-10-01',
+        endMonth: '2025-10-31',
+        fundTypes: ['Primary'],
+      });
+    });
+  });
+
+  it('should fall back to current month for category query when time prop is not provided', async () => {
+    render(<TestComponent {...defaultProps} onCallMock={mutationSpy} />);
+
+    await waitFor(() => {
+      expect(mutationSpy).toHaveGraphqlOperation('ReportsStaffExpenses', {
+        startMonth: '2020-01-01',
+        endMonth: '2020-01-31',
+        fundTypes: ['Primary'],
+      });
+    });
   });
 });

--- a/src/components/Reports/StaffExpenseReport/SettingsDialog/SettingsDialog.tsx
+++ b/src/components/Reports/StaffExpenseReport/SettingsDialog/SettingsDialog.tsx
@@ -33,6 +33,7 @@ export interface SettingsDialogProps {
   selectedFilters?: Filters;
   selectedFundType: string | null;
   onClose: (filters?: Filters) => void;
+  time?: DateTime;
 }
 
 export interface Filters {
@@ -121,11 +122,15 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
   onClose,
   selectedFilters,
   selectedFundType,
+  time,
 }) => {
   const { t } = useTranslation();
   const [previewFilters, setPreviewFilters] = useState<Filters | null>(null);
 
-  const currentTime = useMemo(() => DateTime.now().startOf('month'), []);
+  const currentTime = useMemo(
+    () => time ?? DateTime.now().startOf('month'),
+    [time],
+  );
 
   const handleClose = () => {
     setPreviewFilters(null);
@@ -143,6 +148,8 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
     error: categoryError,
   } = useReportsStaffExpensesQuery({
     variables: getQueryVariables(previewFilters ?? selectedFilters ?? null),
+    skip: !isOpen,
+    fetchPolicy: 'no-cache',
   });
 
   const availableCategories = useMemo(() => {

--- a/src/components/Reports/StaffExpenseReport/SettingsDialog/SettingsDialog.tsx
+++ b/src/components/Reports/StaffExpenseReport/SettingsDialog/SettingsDialog.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   Button,
   Checkbox,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -18,7 +19,6 @@ import { Form, Formik } from 'formik';
 import { DateTime } from 'luxon';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
-import Loading from 'src/components/Loading/Loading';
 import { CustomDateField } from 'src/components/Shared/DateTimePickers/CustomDateField';
 import { Fund, StaffExpenseCategoryEnum } from 'src/graphql/types.generated';
 import i18n from 'src/lib/i18n';
@@ -313,7 +313,11 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                 </Typography>
 
                 {categoryLoading ? (
-                  <Loading loading />
+                  <Box
+                    sx={{ display: 'flex', justifyContent: 'center', py: 2 }}
+                  >
+                    <CircularProgress size={24} />
+                  </Box>
                 ) : categoryError ? (
                   <Alert severity="error">
                     {t('Failed to load categories. Please try again.')}

--- a/src/components/Reports/StaffExpenseReport/SettingsDialog/SettingsDialog.tsx
+++ b/src/components/Reports/StaffExpenseReport/SettingsDialog/SettingsDialog.tsx
@@ -26,6 +26,7 @@ import { getLocalizedCategory } from '../../Shared/Helpers/transformStaffExpense
 import { useReportsStaffExpensesQuery } from '../GetStaffExpense.generated';
 import { DateRange } from '../Helpers/StaffReportEnum';
 import { getAvailableCategories } from '../Helpers/filterTransactions';
+import { getStaffExpenseMonthRange } from '../Helpers/getMonthRange';
 
 export interface SettingsDialogProps {
   isOpen: boolean;
@@ -133,13 +134,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
 
   const getQueryVariables = (filterParams: Filters | null) => ({
     fundTypes: selectedFundType ? [selectedFundType] : null,
-    startMonth:
-      filterParams?.startDate?.startOf('month').toISODate() ??
-      filterParams?.endDate?.startOf('month').toISODate() ??
-      currentTime.startOf('month').toISODate(),
-    endMonth:
-      filterParams?.endDate?.endOf('month').toISODate() ??
-      currentTime.endOf('month').toISODate(),
+    ...getStaffExpenseMonthRange(filterParams, currentTime),
   });
 
   const {

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
@@ -4,6 +4,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Settings } from 'luxon';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
@@ -274,4 +275,62 @@ describe('StaffExpenseReport', () => {
       expect(getAllByRole('row')).toHaveLength(2);
     });
   });
+
+  it('shows month title and navigation when only category filters are applied', async () => {
+    const { getByRole, findByRole, findByLabelText, queryByText } = render(
+      <TestComponent />,
+    );
+
+    userEvent.click(getByRole('button', { name: 'Filter Settings' }));
+
+    userEvent.click(await findByLabelText('Assessment'));
+    userEvent.click(await findByRole('button', { name: 'Apply Filters' }));
+
+    expect(
+      await findByRole('heading', { name: 'January 2020', level: 6 }),
+    ).toBeInTheDocument();
+    expect(
+      await findByRole('button', { name: 'Previous Month' }),
+    ).toBeInTheDocument();
+    expect(
+      await findByRole('button', { name: 'Next Month' }),
+    ).toBeInTheDocument();
+    expect(queryByText('Clear Filters')).not.toBeInTheDocument();
+  });
+
+  it('shows filter date range title and hides month navigation when date filters are applied', async () => {
+    const originalNow = Settings.now;
+    Settings.now = () => new Date(2020, 0, 20).valueOf();
+
+    const { getByRole, findByRole, getByLabelText, queryByRole } = render(
+      <TestComponent />,
+    );
+
+    userEvent.click(getByRole('button', { name: 'Filter Settings' }));
+    await findByRole('heading', { name: 'Report Settings' });
+
+    userEvent.click(getByLabelText('Select Date Range'));
+    userEvent.click(getByRole('option', { name: 'Month to Date' }));
+
+    await waitFor(() =>
+      expect(getByRole('button', { name: 'Apply Filters' })).not.toBeDisabled(),
+    );
+    userEvent.click(getByRole('button', { name: 'Apply Filters' }));
+
+    expect(
+      await findByRole('heading', {
+        level: 6,
+        name: 'January 1, 2020 - January 20, 2020',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      queryByRole('button', { name: 'Previous Month' }),
+    ).not.toBeInTheDocument();
+    expect(
+      queryByRole('button', { name: 'Next Month' }),
+    ).not.toBeInTheDocument();
+
+    Settings.now = originalNow;
+  }, 10000);
 });

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
@@ -337,7 +337,7 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
       <SimpleScreenOnly mt={2}>
         <Container>
           <StyledTimeNavBox>
-            {!filters ? (
+            {!isFilterDateSelected ? (
               <Typography variant="h6">{timeTitle}</Typography>
             ) : (
               <Typography variant="h6">{filterTimeTitle}</Typography>
@@ -419,6 +419,7 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
           selectedFilters={filters || undefined}
           selectedFundType={selectedFundType}
           isOpen={isSettingsOpen}
+          time={time}
           onClose={(newFilters) => {
             setFilters(newFilters ?? null);
             setIsSettingsOpen(false);

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
@@ -45,6 +45,7 @@ import {
   getIconColorForFundType,
   getIconForFundType,
 } from './Helpers/fundTypeHelpers';
+import { getStaffExpenseMonthRange } from './Helpers/getMonthRange';
 import { Filters, SettingsDialog } from './SettingsDialog/SettingsDialog';
 import { PrintTables } from './Tables/PrintTables';
 import { StaffReportTable } from './Tables/StaffReportTable';
@@ -98,13 +99,7 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
   const { data, loading } = useReportsStaffExpensesQuery({
     variables: {
       fundTypes: ['Primary', 'Savings', 'Staff Conference Savings'],
-      startMonth:
-        filters?.startDate?.startOf('month').toISODate() ??
-        filters?.endDate?.startOf('month').toISODate() ??
-        time.startOf('month').toISODate(),
-      endMonth:
-        filters?.endDate?.endOf('month').toISODate() ??
-        time.endOf('month').toISODate(),
+      ...getStaffExpenseMonthRange(filters, time),
     },
   });
 


### PR DESCRIPTION
## Description

- Fixes the issue where changing the fund type resets the user set month filter.
- Fixes the issue where users can't filter by category when navigating months normally.
- Fixes the issue where setting 'None' in the date range filter fails to resolve back to the normal month-by-month flow

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `reports/staffExpense`
- Test behavior of switching between fund types, ensuring that any existing date filters aren't reset.
- Test that selecting 'None' for the date range filter in settings correctly resolves to the month-by-month flow
- Check that category filters in the settings work well for the default month-by-month flow

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
