### PR TITLE
MPDX-PDS-cleanup: error handling and rounding fixes in PDS calculator

### DIFF
--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.test.tsx
@@ -16,10 +16,10 @@ describe('PdsGoalCard', () => {
     //   reimbursable    = max(300, 0)     =  300     (REIMBURSABLE_FLOOR)
     //   subtotal        = 4500 + 300 + 0 (403b) + 0 (workComp) + 1500 (benefits) = 6300
     //   attrition       = 6300 * 0.06     =  378
-    //   creditCardFees  = 6678 / 0.94 - 6678         ≈  426.26
+    //   creditCardFees  = 6678 / 0.94 - 6678         ≈  426.26, rounded to 426
     //   adminBase       = 6300 + 378 + 426.26        ≈ 7104.26
-    //   assessment      = 7104.26 / 0.88 - 7104.26   ≈  968.76
-    //   overallTotal    = 6300 + 378 + 426.26 + 968.76 ≈ 8073.02
+    //   assessment      = 7104.26 / 0.88 - 7104.26   ≈  968.76, rounded to 969
+    //   overallTotal    = 6300 + 378 + 426 + 969     =  8073
     const { findByText } = render(
       <PdsGoalCalculatorTestWrapper
         withProvider={false}
@@ -31,7 +31,7 @@ describe('PdsGoalCard', () => {
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    expect(await findByText('$8,073.02')).toBeInTheDocument();
+    expect(await findByText('$8,073')).toBeInTheDocument();
   });
 
   it('builds the View link with the PDS goal calculator path', async () => {

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
@@ -353,5 +353,35 @@ describe('PdsGoalCalculator', () => {
       await findByText(/Successfully updated your monthly goal/);
       expect(finishButton).toBeDisabled();
     });
+
+    it('shows an error snackbar and re-enables Finish when the mutation fails', async () => {
+      const { findByRole, findByText, queryByText } = render(
+        <PdsGoalCalculatorTestWrapper
+          calculationMock={simpleFormMock}
+          updateAccountPreferencesError
+        >
+          <PdsGoalCalculator />
+        </PdsGoalCalculatorTestWrapper>,
+      );
+
+      await advanceToLastStep(findByRole);
+
+      const finishButton = await findByRole('button', {
+        name: 'Finish & Apply Goal',
+      });
+      userEvent.click(finishButton);
+
+      expect(
+        await findByText(
+          /Error while updating your monthly goal - Failed to update account preferences/,
+        ),
+      ).toBeInTheDocument();
+      // Success snackbar must not fire — `submitted` must stay false so the
+      // user can retry.
+      expect(
+        queryByText(/Successfully updated your monthly goal/),
+      ).not.toBeInTheDocument();
+      await waitFor(() => expect(finishButton).not.toBeDisabled());
+    });
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { ApolloError } from '@apollo/client';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { DirectionButtons } from 'src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons';
@@ -77,7 +78,7 @@ const MainContent: React.FC = () => {
     if (!accountListId || !summaryData?.overallTotal) {
       return;
     }
-    const monthlyGoal = Math.round(summaryData.overallTotal);
+    const monthlyGoal = summaryData.overallTotal;
     await updateAccountPreferences({
       variables: {
         input: {
@@ -96,6 +97,14 @@ const MainContent: React.FC = () => {
             formattedTotal: currencyFormat(monthlyGoal, 'USD', locale),
           }),
           { variant: 'success' },
+        );
+      },
+      onError: (err: ApolloError) => {
+        enqueueSnackbar(
+          t('Error while updating your monthly goal - {{error}}', {
+            error: err.message,
+          }),
+          { variant: 'error' },
         );
       },
     });

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
+import { GraphQLError } from 'graphql';
 import { MockLinkCallHandler } from 'graphql-ergonomock/dist/apollo/MockLink';
 import { merge, mergeWith } from 'lodash';
 import { SnackbarProvider } from 'notistack';
 import { DeepPartial } from 'ts-essentials';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider, gqlMock } from '__tests__/util/graphqlMocking';
+import { UpdateAccountPreferencesMutation } from 'src/components/Settings/preferences/accordions/UpdateAccountPreferences.generated';
 import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import {
   DesignationSupportFormType,
@@ -24,6 +26,7 @@ import {
   PdsGoalCalculationsDocument,
   PdsGoalCalculationsQuery,
   PdsGoalCalculationsQueryVariables,
+  UpdatePdsGoalCalculationMutation,
 } from './GoalsList/PdsGoalCalculations.generated';
 import {
   HcmUserDocument,
@@ -50,15 +53,15 @@ const calculationsDefault = gqlMock<
           averageHoursPerWeek: 0,
           benefits: 1500,
           geographicLocation: null,
-          ministryCellPhone: 0,
-          ministryInternet: 0,
-          mpdNewsletter: 0,
-          mpdMiscellaneous: 0,
-          accountTransfers: 0,
-          otherMonthlyReimbursements: 0,
-          conferenceRetreatCosts: 0,
-          ministryTravelMeals: 0,
-          otherAnnualReimbursements: 0,
+          ministryCellPhone: null,
+          ministryInternet: null,
+          mpdNewsletter: null,
+          mpdMiscellaneous: null,
+          accountTransfers: null,
+          otherMonthlyReimbursements: null,
+          conferenceRetreatCosts: null,
+          ministryTravelMeals: null,
+          otherAnnualReimbursements: null,
           designationSupportHoursItems: [],
         },
       ],
@@ -94,15 +97,15 @@ const calculationDefault = gqlMock<
       averageHoursPerWeek: 0,
       benefits: 1500,
       geographicLocation: null,
-      ministryCellPhone: 0,
-      ministryInternet: 0,
-      mpdNewsletter: 0,
-      mpdMiscellaneous: 0,
-      accountTransfers: 0,
-      otherMonthlyReimbursements: 0,
-      conferenceRetreatCosts: 0,
-      ministryTravelMeals: 0,
-      otherAnnualReimbursements: 0,
+      ministryCellPhone: null,
+      ministryInternet: null,
+      mpdNewsletter: null,
+      mpdMiscellaneous: null,
+      accountTransfers: null,
+      otherMonthlyReimbursements: null,
+      conferenceRetreatCosts: null,
+      ministryTravelMeals: null,
+      otherAnnualReimbursements: null,
       designationSupportHoursItems: [],
     },
   },
@@ -141,6 +144,9 @@ export interface PdsGoalCalculatorTestWrapperProps {
   userMock?: GetUserMock;
   constantsMock?: GoalCalculatorConstantsMock;
   supportRaisedMock?: number;
+  supportRaisedError?: boolean;
+  updateAccountPreferencesError?: boolean;
+  updatePdsGoalCalculationError?: boolean;
   onCall?: MockLinkCallHandler;
   router?: React.ComponentProps<typeof TestRouter>['router'];
 }
@@ -156,6 +162,9 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
   userMock,
   constantsMock,
   supportRaisedMock,
+  supportRaisedError,
+  updateAccountPreferencesError,
+  updatePdsGoalCalculationError,
   onCall,
   router,
 }) => {
@@ -175,6 +184,8 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
             HcmUser: HcmUserQuery;
             GetUser: GetUserQuery;
             AccountListSupportRaised: AccountListSupportRaisedQuery;
+            UpdateAccountPreferences: UpdateAccountPreferencesMutation;
+            UpdatePdsGoalCalculation: UpdatePdsGoalCalculationMutation;
           }>
             mocks={{
               PdsGoalCalculations: {
@@ -198,16 +209,52 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
                     : [merge({}, hcmUserDefault.hcm[0], hcmUserMock)],
               },
               ...(userMock ? { GetUser: userMock } : {}),
-              ...(supportRaisedMock !== undefined
+              ...(updateAccountPreferencesError
                 ? {
-                    AccountListSupportRaised: {
-                      accountList: {
-                        id: 'account-list-1',
-                        receivedPledges: supportRaisedMock,
-                      },
+                    UpdateAccountPreferences: {
+                      updateAccountList: (() => {
+                        throw new GraphQLError(
+                          'Failed to update account preferences',
+                        );
+                      }) as unknown as NonNullable<
+                        UpdateAccountPreferencesMutation['updateAccountList']
+                      >,
                     },
                   }
                 : {}),
+              ...(updatePdsGoalCalculationError
+                ? {
+                    UpdatePdsGoalCalculation: {
+                      updateDesignationSupportCalculation: (() => {
+                        throw new GraphQLError(
+                          'Failed to update calculation',
+                        );
+                      }) as unknown as NonNullable<
+                        UpdatePdsGoalCalculationMutation['updateDesignationSupportCalculation']
+                      >,
+                    },
+                  }
+                : {}),
+              ...(supportRaisedError
+                ? {
+                    AccountListSupportRaised: {
+                      accountList: (() => {
+                        throw new GraphQLError(
+                          'Failed to load support raised',
+                        );
+                      }) as unknown as AccountListSupportRaisedQuery['accountList'],
+                    },
+                  }
+                : supportRaisedMock !== undefined
+                  ? {
+                      AccountListSupportRaised: {
+                        accountList: {
+                          id: 'account-list-1',
+                          receivedPledges: supportRaisedMock,
+                        },
+                      },
+                    }
+                  : {}),
               GoalCalculatorConstants: {
                 constant: mergeWith(
                   {},

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.test.tsx
@@ -88,6 +88,7 @@ describe('ReimbursableExpensesGrid', () => {
     expect(await findByRole('alert')).toHaveTextContent(
       'Amount must be positive',
     );
+    expect(mutationSpy).not.toHaveGraphqlOperation('UpdatePdsGoalCalculation');
 
     await editAmountCell(findByRole, 'MPD Newsletter', '20');
 

--- a/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/ReimbursableExpenses/ReimbursableExpensesGrid.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import InfoIcon from '@mui/icons-material/Info';
 import {
   Box,
@@ -56,6 +57,8 @@ const ErrorCell = styled(Box)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
+  gap: theme.spacing(0.5),
+  color: theme.palette.error.main,
 }));
 
 export const ReimbursableExpensesGrid: React.FC<
@@ -159,7 +162,12 @@ export const ReimbursableExpensesGrid: React.FC<
     const formatted = currencyFormat(params.value ?? 0, 'USD', locale);
 
     if (error) {
-      return <ErrorCell title={error}>{formatted}</ErrorCell>;
+      return (
+        <ErrorCell>
+          <ErrorOutlineIcon fontSize="small" aria-hidden="true" />
+          <span>{formatted}</span>
+        </ErrorCell>
+      );
     }
 
     if (params.id === 'total' && subtotalTestId) {

--- a/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.test.tsx
@@ -42,12 +42,6 @@ const defaultCalculationMock: PdsGoalCalculationMock = {
 
 const mutationSpy = jest.fn();
 
-const waitForDataToLoad = async () => {
-  await waitFor(() =>
-    expect(mutationSpy).toHaveGraphqlOperation('PdsGoalCalculation'),
-  );
-};
-
 describe('HoursPerWeekGrid', () => {
   beforeEach(() => {
     mutationSpy.mockClear();
@@ -64,7 +58,6 @@ describe('HoursPerWeekGrid', () => {
     );
 
     expect(await findByText('Hours Per Week Calculator')).toBeInTheDocument();
-    await waitForDataToLoad();
     expect(await findByText('Regular Week')).toBeInTheDocument();
     expect(getByText('Travel')).toBeInTheDocument();
     expect(getByText('Unpaid Vacation')).toBeInTheDocument();
@@ -82,7 +75,6 @@ describe('HoursPerWeekGrid', () => {
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    await waitForDataToLoad();
     // Regular Week 40hrs * 48wks = 1920 total hours, 48 total weeks
     // Average = 1920 / 48 = 40.00
     expect(await findByText('40.00')).toBeInTheDocument();
@@ -98,7 +90,6 @@ describe('HoursPerWeekGrid', () => {
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    await waitForDataToLoad();
     await findByText('Regular Week');
     userEvent.click(getByText('Add Entry'));
 
@@ -121,7 +112,7 @@ describe('HoursPerWeekGrid', () => {
   });
 
   it('does not show Apply button when onApply is not provided', async () => {
-    const { queryByText } = render(
+    const { findByText, queryByText } = render(
       <PdsGoalCalculatorTestWrapper
         calculationMock={defaultCalculationMock}
         onCall={mutationSpy}
@@ -130,7 +121,7 @@ describe('HoursPerWeekGrid', () => {
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    await waitForDataToLoad();
+    await findByText('Regular Week');
     expect(queryByText('Apply to Hours Worked')).not.toBeInTheDocument();
   });
 
@@ -145,7 +136,6 @@ describe('HoursPerWeekGrid', () => {
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    await waitForDataToLoad();
     await findByText('Regular Week');
 
     // Default entries have 48 weeks total, 4 remaining
@@ -166,8 +156,6 @@ describe('HoursPerWeekGrid', () => {
         <HoursPerWeekGrid />
       </PdsGoalCalculatorTestWrapper>,
     );
-
-    await waitForDataToLoad();
 
     // Edit Regular Week hours from 40 to 20
     const regularRow = (await findByText('Regular Week')).closest(
@@ -209,8 +197,6 @@ describe('HoursPerWeekGrid', () => {
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    await waitForDataToLoad();
-
     // Edit Regular Week hours from 40 to 20
     const regularRow = (await findByText('Regular Week')).closest(
       '[role="row"]',
@@ -246,8 +232,6 @@ describe('HoursPerWeekGrid', () => {
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    await waitForDataToLoad();
-
     // Edit Travel weeks from 0 to 4 (48 + 4 = 52)
     const travelRow = (await findByText('Travel')).closest('[role="row"]');
     const weeksCell = travelRow?.querySelector('[data-field="weeks"]');
@@ -282,8 +266,6 @@ describe('HoursPerWeekGrid', () => {
         <HoursPerWeekGrid onApply={onApply} />
       </PdsGoalCalculatorTestWrapper>,
     );
-
-    await waitForDataToLoad();
 
     // Edit Travel weeks from 0 to 4 (48 + 4 = 52 total)
     const travelRow = (await findByText('Travel')).closest('[role="row"]');
@@ -327,7 +309,6 @@ describe('HoursPerWeekGrid', () => {
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    await waitForDataToLoad();
     await findByText('Regular Week');
     userEvent.click(getByText('Add Entry'));
 
@@ -344,8 +325,6 @@ describe('HoursPerWeekGrid', () => {
           <HoursPerWeekGrid />
         </PdsGoalCalculatorTestWrapper>,
       );
-
-    await waitForDataToLoad();
 
     const regularRow = (await findByText('Regular Week')).closest(
       '[role="row"]',
@@ -375,8 +354,6 @@ describe('HoursPerWeekGrid', () => {
         <HoursPerWeekGrid />
       </PdsGoalCalculatorTestWrapper>,
     );
-
-    await waitForDataToLoad();
 
     // Default: Regular Week has 48 weeks, Travel and Vacation have 0
     // Edit Travel weeks to 10 — should be clamped to 4 (52 - 48 = 4 remaining)
@@ -408,7 +385,6 @@ describe('HoursPerWeekGrid', () => {
       </PdsGoalCalculatorTestWrapper>,
     );
 
-    await waitForDataToLoad();
     await findByText('Regular Week');
     userEvent.click(getByText('Add Entry'));
     expect(await findByText('New Entry')).toBeInTheDocument();

--- a/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/HoursPerWeekGrid/HoursPerWeekGrid.tsx
@@ -62,6 +62,8 @@ interface HoursPerWeekGridProps {
 
 const MAX_TOTAL_WEEKS = 52;
 
+const roundHundredths = (n: number) => Math.round(n * 100) / 100;
+
 export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
   onApply,
 }) => {
@@ -121,7 +123,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
     // matches the value submitted via saveField/onApply. Math.round uses
     // half-away-from-zero; Intl.NumberFormat uses half-to-even — they only
     // agree because the formatter receives this already-rounded value.
-    return Math.round((totalHours / totalWeeks) * 100) / 100;
+    return roundHundredths(totalHours / totalWeeks);
   }, [totalHours, totalWeeks]);
 
   const weeksRemaining = MAX_TOTAL_WEEKS - totalWeeks;
@@ -276,9 +278,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         0,
       );
       const newAverage =
-        newTotalWeeks > 0
-          ? Math.round((newTotalHours / newTotalWeeks) * 100) / 100
-          : 0;
+        newTotalWeeks > 0 ? roundHundredths(newTotalHours / newTotalWeeks) : 0;
 
       try {
         if (!entryId.startsWith('temp-') && !entryId.startsWith('default-')) {
@@ -291,7 +291,7 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         }
         saveField({
           averageHoursPerWeek: newAverage,
-        });
+        }).catch(() => {});
       } catch {
         setEntries(previousEntries);
         enqueueSnackbar(t('Failed to delete entry. Please try again.'), {
@@ -342,12 +342,10 @@ export const HoursPerWeekGrid: React.FC<HoursPerWeekGridProps> = ({
         0,
       );
       const newAverage =
-        newTotalWeeks > 0
-          ? Math.round((newTotalHours / newTotalWeeks) * 100) / 100
-          : 0;
+        newTotalWeeks > 0 ? roundHundredths(newTotalHours / newTotalWeeks) : 0;
       saveField({
         averageHoursPerWeek: newAverage,
-      });
+      }).catch(() => {});
 
       return { ...newRow, weeks: Math.max(0, clampedWeeks) };
     },

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -114,7 +114,7 @@ export const SetupStep: React.FC = () => {
     setRightPanelContent(
       <HoursPerWeekGrid
         onApply={(average) => {
-          saveField({ hoursWorkedPerWeek: average });
+          saveField({ hoursWorkedPerWeek: average }).catch(() => {});
         }}
       />,
     );
@@ -219,7 +219,10 @@ export const SetupStep: React.FC = () => {
                 const newValue = event.target
                   .value as DesignationSupportSalaryType;
                 if (newValue !== calculation?.salaryOrHourly) {
-                  saveField({ salaryOrHourly: newValue, payRate: null });
+                  saveField({
+                    salaryOrHourly: newValue,
+                    payRate: null,
+                  }).catch(() => {});
                 }
               }}
             >
@@ -317,9 +320,9 @@ export const SetupStep: React.FC = () => {
               options={locations}
               getOptionLabel={getLocationLabel}
               value={calculation?.geographicLocation ?? 'None'}
-              onChange={(_, newValue: string | null) =>
-                saveField({ geographicLocation: newValue })
-              }
+              onChange={(_, newValue: string | null) => {
+                saveField({ geographicLocation: newValue }).catch(() => {});
+              }}
               disabled={!calculation}
               size="small"
               renderInput={(params: AutocompleteRenderInputParams) => (

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/useSaveField.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/useSaveField.test.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { PdsGoalCalculatorTestWrapper } from '../../PdsGoalCalculatorTestWrapper';
+import { usePdsGoalCalculator } from '../PdsGoalCalculatorContext';
 import { useSaveField } from './useSaveField';
+
+const mockEnqueue = jest.fn();
+jest.mock('notistack', () => ({
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  ...jest.requireActual('notistack'),
+  useSnackbar: () => ({ enqueueSnackbar: mockEnqueue }),
+}));
 
 const mutationSpy = jest.fn();
 
@@ -18,7 +27,28 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   </PdsGoalCalculatorTestWrapper>
 );
 
+const ErrorWrapper: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => (
+  <PdsGoalCalculatorTestWrapper
+    calculationMock={{
+      id: 'goal-1',
+      name: 'Test Goal',
+      payRate: 50000,
+    }}
+    onCall={mutationSpy}
+    updatePdsGoalCalculationError
+  >
+    {children}
+  </PdsGoalCalculatorTestWrapper>
+);
+
 describe('useSaveField', () => {
+  beforeEach(() => {
+    mockEnqueue.mockClear();
+    mutationSpy.mockClear();
+  });
+
   it('should update the calculation when a value changes', async () => {
     const { result } = renderHook(useSaveField, { wrapper: Wrapper });
 
@@ -35,6 +65,46 @@ describe('useSaveField', () => {
           name: 'New Name',
         },
       }),
+    );
+  });
+
+  it('shows an error snackbar and rolls back the optimistic update when the mutation fails', async () => {
+    const { result } = renderHook(
+      () => ({
+        saveField: useSaveField(),
+        calculation: usePdsGoalCalculator().calculation,
+      }),
+      { wrapper: ErrorWrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current.calculation?.name).toBe('Test Goal'),
+    );
+
+    let savePromise!: Promise<unknown>;
+    act(() => {
+      savePromise = result.current.saveField({ name: 'New Name' });
+    });
+
+    // The optimistic response is written to the cache immediately, so the
+    // calculation in context briefly reflects the in-flight value.
+    await waitFor(() =>
+      expect(result.current.calculation?.name).toBe('New Name'),
+    );
+
+    await act(async () => {
+      await expect(savePromise).rejects.toThrow();
+    });
+
+    // After the mutation fails, Apollo rolls the optimistic update back and
+    // the cache returns to the original value.
+    await waitFor(() =>
+      expect(result.current.calculation?.name).toBe('Test Goal'),
+    );
+
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      'Failed to save changes. Please try again.',
+      { variant: 'error' },
     );
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/useSaveField.ts
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/useSaveField.ts
@@ -44,12 +44,18 @@ export const useSaveField = () => {
                 },
               },
             },
+            refetchQueries: ['PdsGoalCalculations'],
+            awaitRefetchQueries: false,
           }),
         );
-      } catch {
+      } catch (error) {
         enqueueSnackbar(t('Failed to save changes. Please try again.'), {
           variant: 'error',
         });
+        // Re-throw so callers (e.g. useAutoSave) can revert local field
+        // state back to the cache value after Apollo rolls back the
+        // optimistic update.
+        throw error;
       }
     },
     [calculation, trackMutation, updatePdsGoalCalculation, enqueueSnackbar, t],

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -201,10 +201,8 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
       handleStepChange,
       handleContinue,
       handlePreviousStep,
-      setRightPanelContent,
       closeRightPanel,
       toggleDrawer,
-      setIsDrawerOpen,
     ],
   );
 

--- a/src/components/HrTools/PdsGoalCalculator/SummaryReport/SummaryReportStep.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SummaryReport/SummaryReportStep.test.tsx
@@ -27,4 +27,19 @@ describe('SummaryReportStep', () => {
 
     expect(await findByRole('heading', { name: '100%' })).toBeInTheDocument();
   });
+
+  it('renders an error alert when the support raised query fails', async () => {
+    const { findByText, queryByRole } = render(
+      <PdsGoalCalculatorTestWrapper supportRaisedError>
+        <SummaryReportStep />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    expect(
+      await findByText('Failed to load support progress. Please try again.'),
+    ).toBeInTheDocument();
+    expect(
+      queryByRole('grid', { name: 'PDS Goal Summary' }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/HrTools/PdsGoalCalculator/SummaryReport/SummaryReportStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SummaryReport/SummaryReportStep.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import { Alert, Box, CircularProgress, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import Loading from 'src/components/Loading';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useAccountListSupportRaisedQuery } from '../../GoalCalculator/Shared/GoalLineItems.generated';
 import { usePdsGoalCalculator } from '../Shared/PdsGoalCalculatorContext';
@@ -11,13 +10,17 @@ export const SummaryReportStep: React.FC = () => {
   const { t } = useTranslation();
   const accountListId = useAccountListId() ?? '';
   const { calculationLoading } = usePdsGoalCalculator();
-  const { data } = useAccountListSupportRaisedQuery({
+  const { data, error } = useAccountListSupportRaisedQuery({
     variables: { accountListId },
   });
   const supportRaised = data?.accountList.receivedPledges ?? 0;
 
   if (calculationLoading) {
-    return <Loading loading />;
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
   }
 
   return (
@@ -32,7 +35,13 @@ export const SummaryReportStep: React.FC = () => {
           )}
         </Typography>
       </Box>
-      <PdsSummaryTable supportRaised={supportRaised} />
+      {error ? (
+        <Alert severity="error">
+          {t('Failed to load support progress. Please try again.')}
+        </Alert>
+      ) : (
+        <PdsSummaryTable supportRaised={supportRaised} />
+      )}
     </>
   );
 };

--- a/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.test.ts
@@ -282,17 +282,22 @@ describe('usePdsSummaryData', () => {
   });
 
   describe('overall total', () => {
-    it('sums subtotal + attrition + creditCardFees + assessment', () => {
+    it('rounds each of subtotal, attrition, creditCardFees, assessment so the displayed lines sum exactly to overallTotal', () => {
       const { result } = renderHook(() =>
         usePdsSummaryData(defaultCalculation, defaultHcmUser),
       );
       const data = result.current.data!;
-      const expected =
+      expect(Number.isInteger(data.otherTotals.subtotal)).toBe(true);
+      expect(Number.isInteger(data.otherTotals.attrition)).toBe(true);
+      expect(Number.isInteger(data.otherTotals.creditCardFees)).toBe(true);
+      expect(Number.isInteger(data.otherTotals.assessment)).toBe(true);
+      expect(data.overallTotal).toBe(
         data.otherTotals.subtotal +
-        data.otherTotals.attrition +
-        data.otherTotals.creditCardFees +
-        data.otherTotals.assessment;
-      expect(data.overallTotal).toBeCloseTo(expected);
+          data.otherTotals.attrition +
+          data.otherTotals.creditCardFees +
+          data.otherTotals.assessment,
+      );
+      expect(Number.isInteger(data.overallTotal)).toBe(true);
     });
 
     it('computes correct overallTotal for a full-time salaried employee', () => {
@@ -309,14 +314,14 @@ describe('usePdsSummaryData', () => {
       // workComp = 0 (full-time)
       // otherSubtotal = 5400 + 500 + 400 + 0 + 1500 = 7800
       // attrition = 7800 * 0.06 = 468
-      // creditCardFees = (7800 + 468) / (1 - 0.06) - (7800 + 468) ≈ 527.74
+      // creditCardFees = (7800 + 468) / (1 - 0.06) - (7800 + 468) ≈ 527.74, rounded to 528
       // adminBase = 7800 + 468 + 527.74 ≈ 8795.74
-      // assessment = adminBase / 0.88 - adminBase ≈ 1199.42
-      // overallTotal = 7800 + 468 + 527.74 + 1199.42 ≈ 9995.16
+      // assessment = adminBase / 0.88 - adminBase ≈ 1199.42, rounded to 1199
+      // overallTotal = 7800 + 468 + 528 + 1199 = 9995
       const { result } = renderHook(() =>
         usePdsSummaryData(defaultCalculation, defaultHcmUser),
       );
-      expect(result.current.data?.overallTotal).toBeCloseTo(9995.16, 0);
+      expect(result.current.data?.overallTotal).toBe(9995);
     });
 
     it('computes correct overallTotal for a part-time hourly employee', () => {
@@ -331,12 +336,12 @@ describe('usePdsSummaryData', () => {
       // 403b = 2166.667 * 0.08 = 173.333
       // workComp = 2166.667 * 0.17 = 368.333 (part-time)
       // benefits = 0 (part-time, ignores calculation.benefits)
-      // subtotal = 2340 + 500 + 173.333 + 368.333 + 0 = 3381.667
-      // attrition = 3381.667 * 0.06 = 202.9
-      // creditCardFees = (3381.667 + 202.9) / (1 - 0.06) - (3381.667 + 202.9) ≈ 228.80
+      // subtotal = 2340 + 500 + 173.333 + 368.333 + 0 = 3381.667, rounded to 3382
+      // attrition = 3381.667 * 0.06 = 202.9, rounded to 203
+      // creditCardFees = (3381.667 + 202.9) / (1 - 0.06) - (3381.667 + 202.9) ≈ 228.80, rounded to 229
       // adminBase ≈ 3813.37
-      // assessment = adminBase / (1 - 0.12) - adminBase ≈ 520.00
-      // overallTotal ≈ 3381.667 + 202.9 + 228.80 + 520.00 ≈ 4333.37
+      // assessment = adminBase / (1 - 0.12) - adminBase ≈ 520.00, rounded to 520
+      // overallTotal = 3382 + 203 + 229 + 520 = 4334
       const calc = {
         ...defaultCalculation,
         salaryOrHourly: DesignationSupportSalaryType.Hourly,
@@ -348,7 +353,7 @@ describe('usePdsSummaryData', () => {
       const { result } = renderHook(() =>
         usePdsSummaryData(calc, defaultHcmUser),
       );
-      expect(result.current.data?.overallTotal).toBeCloseTo(4333.37, 0);
+      expect(result.current.data?.overallTotal).toBe(4334);
       expect(result.current.data?.otherTotals.workComp).toBeCloseTo(368.33, 2);
       expect(result.current.data?.otherTotals.benefits).toBe(0);
     });

--- a/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.ts
@@ -74,7 +74,18 @@ export const usePdsSummaryData = (
       salaryTotals,
       reimbursableTotals.total,
     );
-    const otherTotals = calculateOtherExpenses(calculation, otherConstants);
+    const rawOtherTotals = calculateOtherExpenses(calculation, otherConstants);
+
+    // Round the four gross-up components once at the display boundary so the
+    // line items rendered in the summary table sum exactly to overallTotal
+    // (and match what gets submitted as the monthly goal).
+    const otherTotals = {
+      ...rawOtherTotals,
+      subtotal: Math.round(rawOtherTotals.subtotal),
+      attrition: Math.round(rawOtherTotals.attrition),
+      creditCardFees: Math.round(rawOtherTotals.creditCardFees),
+      assessment: Math.round(rawOtherTotals.assessment),
+    };
 
     const overallTotal =
       otherTotals.subtotal +

--- a/src/components/Shared/Autosave/useAutosave.test.tsx
+++ b/src/components/Shared/Autosave/useAutosave.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MenuItem, TextField } from '@mui/material';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as yup from 'yup';
 import i18n from 'src/lib/i18n';
@@ -8,6 +8,11 @@ import { amount } from 'src/lib/yupHelpers';
 import { useAutoSave } from './useAutosave';
 
 const saveValue = jest.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  saveValue.mockReset();
+  saveValue.mockResolvedValue(undefined);
+});
 
 interface TestComponentProps {
   disabled?: boolean;
@@ -86,6 +91,20 @@ describe('AutosaveTextField', () => {
     expect(saveValue).toHaveBeenCalledWith(null);
   });
 
+  it('reverts the displayed value when saving fails on blur', async () => {
+    saveValue.mockRejectedValueOnce(new Error('save failed'));
+
+    const { getByRole } = render(<TestComponent />);
+
+    const input = getByRole('textbox', { name: 'Field' });
+    userEvent.clear(input);
+    userEvent.type(input, '200');
+    input.blur();
+
+    expect(saveValue).toHaveBeenCalledWith(200);
+    await waitFor(() => expect(input).toHaveValue('100'));
+  });
+
   it('does not save when value does not change', () => {
     const { getByRole } = render(<TestComponent />);
 
@@ -146,6 +165,19 @@ describe('AutosaveTextField', () => {
 
       expect(input).toHaveAccessibleDescription('Field must be positive');
       expect(saveValue).not.toHaveBeenCalled();
+    });
+
+    it('reverts the displayed value when saving fails on change', async () => {
+      saveValue.mockRejectedValueOnce(new Error('save failed'));
+
+      const { getByRole } = render(<SelectTestComponent />);
+
+      const input = getByRole('combobox', { name: 'Field' });
+      userEvent.click(input);
+      userEvent.click(getByRole('option', { name: '200' }));
+
+      expect(saveValue).toHaveBeenCalledWith(200);
+      await waitFor(() => expect(input).toHaveTextContent('100'));
     });
   });
 });

--- a/src/components/Shared/Autosave/useAutosave.ts
+++ b/src/components/Shared/Autosave/useAutosave.ts
@@ -66,6 +66,15 @@ export const useAutoSave = <Value extends string | number>({
     };
   }, [fieldName, errorMessage, markValid, markInvalid]);
 
+  // If a save fails (e.g. Apollo rolls back the optimistic response),
+  // revert the local input back to the canonical value from the cache so
+  // it doesn't keep showing what the user typed.
+  const revertOnFailure = (savePromise: Promise<unknown>) => {
+    savePromise.catch(() => {
+      setInternalValue(value?.toString() ?? '');
+    });
+  };
+
   return {
     value: internalValue,
     onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -75,13 +84,13 @@ export const useAutoSave = <Value extends string | number>({
       if (saveOnChange) {
         const { parsedValue, errorMessage } = parseValue(newValue);
         if (errorMessage === null && parsedValue !== value) {
-          saveValue(parsedValue);
+          revertOnFailure(saveValue(parsedValue));
         }
       }
     },
     onBlur: () => {
       if (!saveOnChange && errorMessage === null && parsedValue !== value) {
-        saveValue(parsedValue);
+        revertOnFailure(saveValue(parsedValue));
       }
     },
     disabled,


### PR DESCRIPTION
## Description

Cleanup pass on the PDS Goal Calculator to tighten error handling, surface failures to users, and fix display rounding so the summary table line items sum exactly to the submitted monthly goal.

- Surface mutation failures via snackbar / Alert instead of swallowing them silently (`PdsGoalCalculator`, `SummaryReportStep`)
- Re-throw errors from `useSaveField` and revert the local input back to the cached value in `useAutoSave` when a save fails, so the UI no longer shows what the user typed after Apollo rolls back the optimistic response
- Refetch `PdsGoalCalculations` after each autosave to keep dependent queries in sync
- Round the four gross-up components (`subtotal`, `attrition`, `creditCardFees`, `assessment`) at the display boundary in `usePdsSummaryData` so the table line items sum exactly to `overallTotal` and the submitted monthly goal — and drop the now-redundant `Math.round` at submit time
- Replace the deprecated `Loading` component with a `CircularProgress` in `SummaryReportStep` and add an `<Alert>` error state for the support-raised query
- Replace the icon-only title-attribute error indicator in `ReimbursableExpensesGrid` with a visible `ErrorOutlineIcon` for better a11y
- Extract a `roundHundredths` helper in `HoursPerWeekGrid` and add explicit `.catch(() => {})` on fire-and-forget autosave calls so unhandled promise rejections don't surface
- Trim stale `setRightPanelContent` / `setIsDrawerOpen` from the `PdsGoalCalculatorContext` memo dependency array

No Jira ticket — pure cleanup pass.

## Testing

- Open the PDS Goal Calculator on an account list
- In the Setup step, change Hours Per Week, Salary/Hourly, Pay Rate, and Geographic Location — confirm each change saves and the right-hand panel reflects the new value
- Open Chrome DevTools → Network → Offline, then edit any Setup field — confirm the input reverts to the previous value and an error snackbar appears
- In the Reimbursable Expenses step, enter a negative amount in a row — confirm the red error icon + value render in the cell and no mutation fires
- Navigate to the Summary Report step — confirm the line items in the summary table sum exactly to the displayed "Overall Total"
- Click "Save monthly goal" on the summary — confirm a success snackbar; with the network offline, confirm an error snackbar with the failure message
- Force the `AccountListSupportRaised` query to error (e.g. via DevTools network throttling/block) — confirm the Alert error state renders in place of the summary table

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history