### PR TITLE
No-Jira - PDS Goal Calculator: Quick Geographic Location fix 

### DIFF
--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/salaryBreakdown.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/salaryBreakdown.test.tsx
@@ -99,6 +99,28 @@ describe('buildSalaryBreakdownRows', () => {
     expect(byId['total']).toBeCloseTo(4680.0, 2);
   });
 
+  it('shows "Monthly Base" formula when geographic multiplier is 0', () => {
+    const rows = buildSalaryBreakdownRows(
+      salariedCalculation,
+      { ...constants, geographicMultiplier: 0 },
+      'en-US',
+      i18n.t,
+    );
+    const row = rows.find((r) => r.id === 'gross-monthly-pay');
+    expect(row?.formula).toBe('Monthly Base');
+  });
+
+  it('shows "Monthly Base × Geographic Multiplier (rate)" formula when multiplier is non-zero', () => {
+    const rows = buildSalaryBreakdownRows(
+      salariedCalculation,
+      { ...constants, geographicMultiplier: 0.06 },
+      'en-US',
+      i18n.t,
+    );
+    const row = rows.find((r) => r.id === 'gross-monthly-pay');
+    expect(row?.formula).toBe('Monthly Base × Geographic Multiplier (106%)');
+  });
+
   it('inserts hours-per-week and monthly-base rows for hourly', () => {
     const rows = buildSalaryBreakdownRows(
       hourlyCalculation,

--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/salaryBreakdown.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/salaryBreakdown.tsx
@@ -76,9 +76,12 @@ export const buildSalaryBreakdownRows = (
     {
       id: 'gross-monthly-pay',
       category: t('Gross Monthly Pay'),
-      formula: t('Monthly Base × Geographic Multiplier ({{rate}})', {
-        rate: percentageFormat(1 + geographicMultiplier, locale),
-      }),
+      formula:
+        geographicMultiplier === 0
+          ? t('Monthly Base')
+          : t('Monthly Base × Geographic Multiplier ({{rate}})', {
+              rate: percentageFormat(1 + geographicMultiplier, locale),
+            }),
       amount: grossMonthlyPay,
       format: 'currency',
       testId: 'gross-monthly-pay',


### PR DESCRIPTION
## Description

We want to hide the geographic multiplier row information when there is no multiplier set.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to ...
- Do ...
- Check that ...

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
