### PR TITLE
MPDX-9611 Scope PDS autosave disable to per-field saves

### DIFF
--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
@@ -79,11 +79,8 @@ describe('PdsGoalCalculator', () => {
           name: 'Test Goal',
         }}
         extraMocks={{
-          // Pin the mutation response so the post-save cache matches the
-          // expected SALARIED + payRate: null state. Without this, the
-          // auto-generated mock fills salaryOrHourly with the first enum
-          // value (HOURLY), which re-introduces the Hours Worked
-          // requirement and keeps Continue disabled after typing.
+          // Pin the mutation response so the auto-generated mock doesn't fill
+          // salaryOrHourly with HOURLY (the first enum value).
           UpdatePdsGoalCalculation: {
             updateDesignationSupportCalculation: {
               designationSupportCalculation: {
@@ -122,9 +119,7 @@ describe('PdsGoalCalculator', () => {
       ).not.toBeInTheDocument();
     });
     // Switching Pay Type clears payRate, so the user must re-enter it before
-    // Continue becomes enabled. The Pay Rate input is disabled while the
-    // atomic { salaryOrHourly, payRate: null } save is in flight, so wait
-    // for the field to be enabled before typing.
+    // Continue becomes enabled.
     const payRateInput = await findByRole('spinbutton', {
       name: 'Annual Pay Rate',
     });

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
@@ -6,6 +6,7 @@ import {
   DesignationSupportSalaryType,
   DesignationSupportStatus,
 } from 'src/graphql/types.generated';
+import { UpdatePdsGoalCalculationMutation } from './GoalsList/PdsGoalCalculations.generated';
 import { PdsGoalCalculator } from './PdsGoalCalculator';
 import { PdsGoalCalculatorTestWrapper } from './PdsGoalCalculatorTestWrapper';
 
@@ -69,7 +70,9 @@ describe('PdsGoalCalculator', () => {
 
   it('re-enables Continue after switching from Hourly to Salaried and entering a new Pay Rate', async () => {
     const { findByRole, getByRole, queryByRole } = render(
-      <PdsGoalCalculatorTestWrapper
+      <PdsGoalCalculatorTestWrapper<{
+        UpdatePdsGoalCalculation: UpdatePdsGoalCalculationMutation;
+      }>
         calculationMock={{
           salaryOrHourly: DesignationSupportSalaryType.Hourly,
           hoursWorkedPerWeek: null,
@@ -123,6 +126,8 @@ describe('PdsGoalCalculator', () => {
     const payRateInput = await findByRole('spinbutton', {
       name: 'Annual Pay Rate',
     });
+    // Pay Type's atomic save (salaryOrHourly + payRate: null) locks payRate
+    // until the mutation resolves. Wait for it before typing.
     await waitFor(() => expect(payRateInput).not.toBeDisabled());
     userEvent.type(payRateInput, '50000');
 

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
@@ -78,6 +78,26 @@ describe('PdsGoalCalculator', () => {
           benefits: 1500,
           name: 'Test Goal',
         }}
+        extraMocks={{
+          // Pin the mutation response so the post-save cache matches the
+          // expected SALARIED + payRate: null state. Without this, the
+          // auto-generated mock fills salaryOrHourly with the first enum
+          // value (HOURLY), which re-introduces the Hours Worked
+          // requirement and keeps Continue disabled after typing.
+          UpdatePdsGoalCalculation: {
+            updateDesignationSupportCalculation: {
+              designationSupportCalculation: {
+                id: 'goal-1',
+                name: 'Test Goal',
+                status: DesignationSupportStatus.FullTime,
+                salaryOrHourly: DesignationSupportSalaryType.Salaried,
+                payRate: null,
+                hoursWorkedPerWeek: null,
+                benefits: 1500,
+              },
+            },
+          },
+        }}
       >
         <PdsGoalCalculator />
       </PdsGoalCalculatorTestWrapper>,
@@ -102,10 +122,13 @@ describe('PdsGoalCalculator', () => {
       ).not.toBeInTheDocument();
     });
     // Switching Pay Type clears payRate, so the user must re-enter it before
-    // Continue becomes enabled.
+    // Continue becomes enabled. The Pay Rate input is disabled while the
+    // atomic { salaryOrHourly, payRate: null } save is in flight, so wait
+    // for the field to be enabled before typing.
     const payRateInput = await findByRole('spinbutton', {
       name: 'Annual Pay Rate',
     });
+    await waitFor(() => expect(payRateInput).not.toBeDisabled());
     userEvent.type(payRateInput, '50000');
 
     await waitFor(() => expect(continueButton).not.toBeDisabled());

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps } from 'react';
+import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { MockLinkCallHandler } from 'graphql-ergonomock/dist/apollo/MockLink';
 import { merge, mergeWith } from 'lodash';
@@ -132,7 +132,9 @@ export type GoalCalculatorConstantsMock = DeepPartial<
   GoalCalculatorConstantsQuery['constant']
 >;
 
-export interface PdsGoalCalculatorTestWrapperProps {
+export interface PdsGoalCalculatorTestWrapperProps<
+  TExtraMocks = Record<string, never>,
+> {
   children?: React.ReactNode;
   withProvider?: boolean;
   calculationsMock?: PdsGoalCalculationsMock;
@@ -141,15 +143,25 @@ export interface PdsGoalCalculatorTestWrapperProps {
   userMock?: GetUserMock;
   constantsMock?: GoalCalculatorConstantsMock;
   supportRaisedMock?: number;
-  /** Extra GqlMockedProvider mocks merged on top of the defaults. */
-  extraMocks?: ComponentProps<typeof GqlMockedProvider>['mocks'];
+  /**
+   * Extra GqlMockedProvider mocks merged on top of the defaults. Pass the
+   * operation map as a generic argument so mock shapes are type-checked:
+   * `<PdsGoalCalculatorTestWrapper<{ UpdatePdsGoalCalculation: UpdatePdsGoalCalculationMutation }> extraMocks={...} />`.
+   * Each value may be a partial mock object or a resolver function (e.g. to
+   * throw and exercise error paths).
+   */
+  extraMocks?: {
+    [K in keyof TExtraMocks]?:
+      | DeepPartial<TExtraMocks[K]>
+      | ((...args: never[]) => unknown);
+  };
   onCall?: MockLinkCallHandler;
   router?: React.ComponentProps<typeof TestRouter>['router'];
 }
 
-export const PdsGoalCalculatorTestWrapper: React.FC<
-  PdsGoalCalculatorTestWrapperProps
-> = ({
+export const PdsGoalCalculatorTestWrapper = <
+  TExtraMocks = Record<string, never>,
+>({
   children,
   withProvider = true,
   calculationsMock,
@@ -161,7 +173,7 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
   extraMocks,
   onCall,
   router,
-}) => {
+}: PdsGoalCalculatorTestWrapperProps<TExtraMocks>): React.ReactElement => {
   return (
     <ThemeProvider theme={theme}>
       <TestRouter
@@ -179,96 +191,98 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
             GetUser: GetUserQuery;
             AccountListSupportRaised: AccountListSupportRaisedQuery;
           }>
-            mocks={{
-              PdsGoalCalculations: {
-                designationSupportCalculations: merge(
-                  {},
-                  calculationsDefault,
-                  calculationsMock,
-                ),
-              },
-              PdsGoalCalculation: {
-                designationSupportCalculation: merge(
-                  {},
-                  calculationDefault,
-                  calculationMock,
-                ),
-              },
-              HcmUser: {
-                hcm:
-                  hcmUserMock === null
-                    ? []
-                    : [merge({}, hcmUserDefault.hcm[0], hcmUserMock)],
-              },
-              ...(userMock ? { GetUser: userMock } : {}),
-              ...(supportRaisedMock !== undefined
-                ? {
-                    AccountListSupportRaised: {
-                      accountList: {
-                        id: 'account-list-1',
-                        receivedPledges: supportRaisedMock,
+            mocks={merge(
+              {
+                PdsGoalCalculations: {
+                  designationSupportCalculations: merge(
+                    {},
+                    calculationsDefault,
+                    calculationsMock,
+                  ),
+                },
+                PdsGoalCalculation: {
+                  designationSupportCalculation: merge(
+                    {},
+                    calculationDefault,
+                    calculationMock,
+                  ),
+                },
+                HcmUser: {
+                  hcm:
+                    hcmUserMock === null
+                      ? []
+                      : [merge({}, hcmUserDefault.hcm[0], hcmUserMock)],
+                },
+                ...(userMock ? { GetUser: userMock } : {}),
+                ...(supportRaisedMock !== undefined
+                  ? {
+                      AccountListSupportRaised: {
+                        accountList: {
+                          id: 'account-list-1',
+                          receivedPledges: supportRaisedMock,
+                        },
                       },
+                    }
+                  : {}),
+                GoalCalculatorConstants: {
+                  constant: mergeWith(
+                    {},
+                    {
+                      mpdGoalBenefitsConstants: [],
+                      mpdGoalGeographicConstants: [
+                        {
+                          location: 'None',
+                          percentageMultiplier: 0,
+                        },
+                        {
+                          location: 'Orlando, FL',
+                          percentageMultiplier: 0.06,
+                        },
+                        {
+                          location: 'New York, NY',
+                          percentageMultiplier: 0.12,
+                        },
+                      ],
+                      mpdGoalMiscConstants: [
+                        {
+                          category:
+                            MpdGoalMiscConstantCategoryEnum.AdditionalRates,
+                          label: MpdGoalMiscConstantLabelEnum.EmployerFicaRate,
+                          fee: 0.08,
+                        },
+                        {
+                          category:
+                            MpdGoalMiscConstantCategoryEnum.AdditionalRates,
+                          label:
+                            MpdGoalMiscConstantLabelEnum.PartTimeWorkCompensation,
+                          fee: 0.17,
+                        },
+                        {
+                          category: MpdGoalMiscConstantCategoryEnum.Rates,
+                          label: MpdGoalMiscConstantLabelEnum.AttritionRate,
+                          fee: 0.06,
+                        },
+                        {
+                          category:
+                            MpdGoalMiscConstantCategoryEnum.AdditionalRates,
+                          label: MpdGoalMiscConstantLabelEnum.CreditCardFeeRate,
+                          fee: 0.06,
+                        },
+                        {
+                          category: MpdGoalMiscConstantCategoryEnum.Rates,
+                          label: MpdGoalMiscConstantLabelEnum.AdminRate,
+                          fee: 0.12,
+                        },
+                      ],
                     },
-                  }
-                : {}),
-              GoalCalculatorConstants: {
-                constant: mergeWith(
-                  {},
-                  {
-                    mpdGoalBenefitsConstants: [],
-                    mpdGoalGeographicConstants: [
-                      {
-                        location: 'None',
-                        percentageMultiplier: 0,
-                      },
-                      {
-                        location: 'Orlando, FL',
-                        percentageMultiplier: 0.06,
-                      },
-                      {
-                        location: 'New York, NY',
-                        percentageMultiplier: 0.12,
-                      },
-                    ],
-                    mpdGoalMiscConstants: [
-                      {
-                        category:
-                          MpdGoalMiscConstantCategoryEnum.AdditionalRates,
-                        label: MpdGoalMiscConstantLabelEnum.EmployerFicaRate,
-                        fee: 0.08,
-                      },
-                      {
-                        category:
-                          MpdGoalMiscConstantCategoryEnum.AdditionalRates,
-                        label:
-                          MpdGoalMiscConstantLabelEnum.PartTimeWorkCompensation,
-                        fee: 0.17,
-                      },
-                      {
-                        category: MpdGoalMiscConstantCategoryEnum.Rates,
-                        label: MpdGoalMiscConstantLabelEnum.AttritionRate,
-                        fee: 0.06,
-                      },
-                      {
-                        category:
-                          MpdGoalMiscConstantCategoryEnum.AdditionalRates,
-                        label: MpdGoalMiscConstantLabelEnum.CreditCardFeeRate,
-                        fee: 0.06,
-                      },
-                      {
-                        category: MpdGoalMiscConstantCategoryEnum.Rates,
-                        label: MpdGoalMiscConstantLabelEnum.AdminRate,
-                        fee: 0.12,
-                      },
-                    ],
-                  },
-                  constantsMock,
-                  (_objValue, srcValue) =>
-                    Array.isArray(srcValue) ? srcValue : undefined,
-                ),
+                    constantsMock,
+                    (_objValue, srcValue) =>
+                      Array.isArray(srcValue) ? srcValue : undefined,
+                  ),
+                },
               },
-              ...extraMocks,
-            }}
+              extraMocks,
+            )}
             onCall={onCall}
           >
             {withProvider ? (

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
@@ -141,11 +141,7 @@ export interface PdsGoalCalculatorTestWrapperProps {
   userMock?: GetUserMock;
   constantsMock?: GoalCalculatorConstantsMock;
   supportRaisedMock?: number;
-  /**
-   * Extra GqlMockedProvider mocks merged on top of the defaults. Useful for
-   * tests that need to control mutation responses (e.g. echo a deterministic
-   * post-save state instead of accepting auto-generated values).
-   */
+  /** Extra GqlMockedProvider mocks merged on top of the defaults. */
   extraMocks?: ComponentProps<typeof GqlMockedProvider>['mocks'];
   onCall?: MockLinkCallHandler;
   router?: React.ComponentProps<typeof TestRouter>['router'];

--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculatorTestWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { MockLinkCallHandler } from 'graphql-ergonomock/dist/apollo/MockLink';
 import { merge, mergeWith } from 'lodash';
@@ -141,6 +141,12 @@ export interface PdsGoalCalculatorTestWrapperProps {
   userMock?: GetUserMock;
   constantsMock?: GoalCalculatorConstantsMock;
   supportRaisedMock?: number;
+  /**
+   * Extra GqlMockedProvider mocks merged on top of the defaults. Useful for
+   * tests that need to control mutation responses (e.g. echo a deterministic
+   * post-save state instead of accepting auto-generated values).
+   */
+  extraMocks?: ComponentProps<typeof GqlMockedProvider>['mocks'];
   onCall?: MockLinkCallHandler;
   router?: React.ComponentProps<typeof TestRouter>['router'];
 }
@@ -156,6 +162,7 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
   userMock,
   constantsMock,
   supportRaisedMock,
+  extraMocks,
   onCall,
   router,
 }) => {
@@ -264,6 +271,7 @@ export const PdsGoalCalculatorTestWrapper: React.FC<
                     Array.isArray(srcValue) ? srcValue : undefined,
                 ),
               },
+              ...extraMocks,
             }}
             onCall={onCall}
           >

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -205,11 +205,7 @@ export const SetupStep: React.FC = () => {
           <Grid item xs={12}>
             {/* Manual TextField (not AutosaveTextField) because changing Pay
                 Type must atomically clear payRate as well; AutosaveTextField
-                only writes the single bound fieldName. Disabled on any
-                in-flight save (not just same-field) so this atomic write
-                cannot land while another field's mutation is in flight —
-                the response of either would otherwise echo the full
-                fragment and overwrite the in-flight value. */}
+                only writes the single bound fieldName. */}
             <TextField
               fullWidth
               size="small"

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -38,7 +38,7 @@ import { HoursPerWeekGrid } from './HoursPerWeekGrid/HoursPerWeekGrid';
 export const SetupStep: React.FC = () => {
   const { t } = useTranslation();
   const theme = useTheme();
-  const { calculation, hcmUser, isMutating, setRightPanelContent } =
+  const { calculation, hcmUser, isFieldSaving, setRightPanelContent } =
     usePdsGoalCalculator();
   const { data: userData } = useGetUserQuery();
   const schema = useMemo(
@@ -214,7 +214,7 @@ export const SetupStep: React.FC = () => {
               label={t('Pay Type')}
               helperText={t('Changing this clears Pay Rate.')}
               value={calculation?.salaryOrHourly ?? ''}
-              disabled={!calculation || isMutating}
+              disabled={!calculation || isFieldSaving('salaryOrHourly')}
               onChange={(event) => {
                 const newValue = event.target
                   .value as DesignationSupportSalaryType;

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -38,7 +38,7 @@ import { HoursPerWeekGrid } from './HoursPerWeekGrid/HoursPerWeekGrid';
 export const SetupStep: React.FC = () => {
   const { t } = useTranslation();
   const theme = useTheme();
-  const { calculation, hcmUser, isFieldSaving, setRightPanelContent } =
+  const { calculation, hcmUser, isMutating, setRightPanelContent } =
     usePdsGoalCalculator();
   const { data: userData } = useGetUserQuery();
   const schema = useMemo(
@@ -205,7 +205,11 @@ export const SetupStep: React.FC = () => {
           <Grid item xs={12}>
             {/* Manual TextField (not AutosaveTextField) because changing Pay
                 Type must atomically clear payRate as well; AutosaveTextField
-                only writes the single bound fieldName. */}
+                only writes the single bound fieldName. Disabled on any
+                in-flight save (not just same-field) so this atomic write
+                cannot land while another field's mutation is in flight —
+                the response of either would otherwise echo the full
+                fragment and overwrite the in-flight value. */}
             <TextField
               fullWidth
               size="small"
@@ -214,7 +218,7 @@ export const SetupStep: React.FC = () => {
               label={t('Pay Type')}
               helperText={t('Changing this clears Pay Rate.')}
               value={calculation?.salaryOrHourly ?? ''}
-              disabled={!calculation || isFieldSaving('salaryOrHourly')}
+              disabled={!calculation || isMutating}
               onChange={(event) => {
                 const newValue = event.target
                   .value as DesignationSupportSalaryType;

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/AutosaveTextField.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/AutosaveTextField.test.tsx
@@ -156,6 +156,44 @@ describe('AutosaveTextField', () => {
     expect(input).toBeDisabled();
   });
 
+  it('marks the field aria-busy while a save is in flight', async () => {
+    const { getByRole } = render(<TestComponent />);
+
+    const input = getByRole('textbox', { name: 'Test Field' });
+    await waitFor(() => expect(input).toHaveValue('Test Goal'));
+    // No save in flight on initial render.
+    expect(input).not.toHaveAttribute('aria-busy', 'true');
+
+    userEvent.clear(input);
+    userEvent.type(input, 'New Name');
+    input.blur();
+
+    // While the same-field save is in flight, the input is disabled AND
+    // aria-busy so screen readers announce it as "busy" rather than just
+    // "unavailable."
+    await waitFor(() => expect(input).toHaveAttribute('aria-busy', 'true'));
+    await waitFor(() => expect(input).not.toHaveAttribute('aria-busy', 'true'));
+  });
+
+  it('does not mark aria-busy when disabled because calculation is missing', () => {
+    const { getByRole } = render(
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={undefined}
+        onCall={mutationSpy}
+      >
+        <AutosaveTextField
+          label="Test Field"
+          fieldName="name"
+          schema={schema}
+        />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    const input = getByRole('textbox', { name: 'Test Field' });
+    expect(input).toBeDisabled();
+    expect(input).not.toHaveAttribute('aria-busy', 'true');
+  });
+
   it('shows props helperText when there is no validation error', async () => {
     const { findByRole } = render(
       <PdsGoalCalculatorTestWrapper

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/AutosaveTextField.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/AutosaveTextField.tsx
@@ -18,7 +18,7 @@ export const AutosaveTextField: React.FC<AutosaveTextFieldProps> = ({
   schema,
   ...props
 }) => {
-  const fieldProps = usePdsGoalAutoSave({
+  const { busy, ...fieldProps } = usePdsGoalAutoSave({
     fieldName,
     schema,
     saveOnChange: props.select,
@@ -34,6 +34,14 @@ export const AutosaveTextField: React.FC<AutosaveTextFieldProps> = ({
       {...fieldProps}
       {...props}
       disabled={fieldProps.disabled || props.disabled}
+      // Signal in-flight saves as "busy" rather than "unavailable" — the
+      // disabled state above also covers !calculation and props.disabled,
+      // which are not saves. Goes on the inner <input> so it travels with
+      // the role=textbox/combobox/spinbutton element.
+      inputProps={{
+        ...props.inputProps,
+        'aria-busy': busy || undefined,
+      }}
       error={showValidationError || undefined}
       helperText={
         showValidationError ? fieldProps.helperText : props.helperText

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.test.tsx
@@ -162,9 +162,6 @@ describe('usePdsGoalAutoSave', () => {
       result.current.onBlur();
     });
 
-    // The mutation response echoes the full fragment, so a second save
-    // landing during the first would overwrite the in-flight value. The
-    // input must be locked until the same-field save resolves.
     await waitFor(() => expect(result.current.disabled).toBe(true));
     await waitFor(() => expect(result.current.disabled).toBe(false));
   });
@@ -185,7 +182,6 @@ describe('usePdsGoalAutoSave', () => {
     await waitFor(() => expect(result.current.name.value).toBe('Test Goal'));
     expect(result.current.formType.disabled).toBe(false);
 
-    // Kick off a save for the `name` field (blur-driven).
     act(() => {
       result.current.name.onChange({
         target: { value: 'Updated Goal' },
@@ -195,9 +191,6 @@ describe('usePdsGoalAutoSave', () => {
       result.current.name.onBlur();
     });
 
-    // Sample synchronously mid-save: savingFieldCounts.name === 1 here, but
-    // the mock mutation has not yet resolved. Pre-fix (gating on a broad
-    // isMutating), formType.disabled would have been true at this moment.
     expect(result.current.formType.disabled).toBe(false);
 
     await waitFor(() =>
@@ -207,11 +200,6 @@ describe('usePdsGoalAutoSave', () => {
   });
 
   it('locks the Pay Rate input while a multi-field save covering payRate is in flight', async () => {
-    // Pay Type writes { salaryOrHourly, payRate: null } atomically via
-    // useSaveField — that multi-field save marks payRate as saving even
-    // though the blur-driven Pay Rate input itself never fired. The input
-    // must be disabled while the atomic clear is in flight so a
-    // user-typed value cannot race the null.
     const { result } = renderHook(
       () => ({
         payRate: usePdsGoalAutoSave({ fieldName: 'payRate', schema }),

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.test.tsx
@@ -167,4 +167,38 @@ describe('usePdsGoalAutoSave', () => {
       expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation'),
     );
   });
+
+  it('does not disable a saveOnChange field while an unrelated field is saving', async () => {
+    const { result } = renderHook(
+      () => ({
+        formType: usePdsGoalAutoSave({
+          fieldName: 'formType',
+          schema,
+          saveOnChange: true,
+        }),
+        name: usePdsGoalAutoSave({ fieldName: 'name', schema }),
+      }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => expect(result.current.name.value).toBe('Test Goal'));
+    expect(result.current.formType.disabled).toBe(false);
+
+    // Kick off a save for the `name` field (blur-driven).
+    act(() => {
+      result.current.name.onChange({
+        target: { value: 'Updated Goal' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+    act(() => {
+      result.current.name.onBlur();
+    });
+
+    // The unrelated formType select must NOT flicker disabled while `name`
+    // is saving — only same-field saves should disable a select.
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation'),
+    );
+    expect(result.current.formType.disabled).toBe(false);
+  });
 });

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.test.tsx
@@ -141,7 +141,7 @@ describe('usePdsGoalAutoSave', () => {
       } as React.ChangeEvent<HTMLInputElement>);
     });
 
-    await waitFor(() => expect(result.current.disabled).toBe(true));
+    expect(result.current.disabled).toBe(true);
     await waitFor(() => expect(result.current.disabled).toBe(false));
   });
 
@@ -162,8 +162,51 @@ describe('usePdsGoalAutoSave', () => {
       result.current.onBlur();
     });
 
-    await waitFor(() => expect(result.current.disabled).toBe(true));
+    expect(result.current.disabled).toBe(true);
     await waitFor(() => expect(result.current.disabled).toBe(false));
+  });
+
+  it('exposes busy=true only while a same-field save is in flight', async () => {
+    const { result } = renderHook(
+      () => usePdsGoalAutoSave({ fieldName: 'name', schema }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => expect(result.current.value).toBe('Test Goal'));
+    expect(result.current.busy).toBe(false);
+
+    act(() => {
+      result.current.onChange({
+        target: { value: 'Updated Goal' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+    act(() => {
+      result.current.onBlur();
+    });
+
+    expect(result.current.busy).toBe(true);
+    await waitFor(() => expect(result.current.busy).toBe(false));
+  });
+
+  it('reports busy=false when disabled solely because calculation is missing', () => {
+    const NoCalcWrapper: React.FC<{ children: React.ReactNode }> = ({
+      children,
+    }) => (
+      <PdsGoalCalculatorTestWrapper
+        calculationMock={undefined}
+        onCall={mutationSpy}
+      >
+        {children}
+      </PdsGoalCalculatorTestWrapper>
+    );
+
+    const { result } = renderHook(
+      () => usePdsGoalAutoSave({ fieldName: 'name', schema }),
+      { wrapper: NoCalcWrapper },
+    );
+
+    expect(result.current.disabled).toBe(true);
+    expect(result.current.busy).toBe(false);
   });
 
   it('does not disable a saveOnChange field while an unrelated field is saving', async () => {
@@ -218,7 +261,7 @@ describe('usePdsGoalAutoSave', () => {
       });
     });
 
-    await waitFor(() => expect(result.current.payRate.disabled).toBe(true));
+    expect(result.current.payRate.disabled).toBe(true);
     await waitFor(() => expect(result.current.payRate.disabled).toBe(false));
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.test.tsx
@@ -7,6 +7,7 @@ import {
 } from 'src/graphql/types.generated';
 import { PdsGoalCalculatorTestWrapper } from '../../PdsGoalCalculatorTestWrapper';
 import { usePdsGoalAutoSave } from './usePdsGoalAutoSave';
+import { useSaveField } from './useSaveField';
 
 const schema = yup.object({
   name: yup.string().required('Goal Name is required'),
@@ -144,7 +145,7 @@ describe('usePdsGoalAutoSave', () => {
     await waitFor(() => expect(result.current.disabled).toBe(false));
   });
 
-  it('does not disable blur-driven fields while a save is in flight', async () => {
+  it('disables blur-driven fields while a save for the same field is in flight', async () => {
     const { result } = renderHook(
       () => usePdsGoalAutoSave({ fieldName: 'name', schema }),
       { wrapper: Wrapper },
@@ -161,11 +162,11 @@ describe('usePdsGoalAutoSave', () => {
       result.current.onBlur();
     });
 
-    expect(result.current.disabled).toBe(false);
-
-    await waitFor(() =>
-      expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation'),
-    );
+    // The mutation response echoes the full fragment, so a second save
+    // landing during the first would overwrite the in-flight value. The
+    // input must be locked until the same-field save resolves.
+    await waitFor(() => expect(result.current.disabled).toBe(true));
+    await waitFor(() => expect(result.current.disabled).toBe(false));
   });
 
   it('does not disable a saveOnChange field while an unrelated field is saving', async () => {
@@ -194,11 +195,42 @@ describe('usePdsGoalAutoSave', () => {
       result.current.name.onBlur();
     });
 
-    // The unrelated formType select must NOT flicker disabled while `name`
-    // is saving — only same-field saves should disable a select.
+    // Sample synchronously mid-save: savingFieldCounts.name === 1 here, but
+    // the mock mutation has not yet resolved. Pre-fix (gating on a broad
+    // isMutating), formType.disabled would have been true at this moment.
+    expect(result.current.formType.disabled).toBe(false);
+
     await waitFor(() =>
       expect(mutationSpy).toHaveGraphqlOperation('UpdatePdsGoalCalculation'),
     );
     expect(result.current.formType.disabled).toBe(false);
+  });
+
+  it('locks the Pay Rate input while a multi-field save covering payRate is in flight', async () => {
+    // Pay Type writes { salaryOrHourly, payRate: null } atomically via
+    // useSaveField — that multi-field save marks payRate as saving even
+    // though the blur-driven Pay Rate input itself never fired. The input
+    // must be disabled while the atomic clear is in flight so a
+    // user-typed value cannot race the null.
+    const { result } = renderHook(
+      () => ({
+        payRate: usePdsGoalAutoSave({ fieldName: 'payRate', schema }),
+        saveField: useSaveField(),
+      }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => expect(result.current.payRate.value).toBe('50000'));
+    expect(result.current.payRate.disabled).toBe(false);
+
+    act(() => {
+      result.current.saveField({
+        salaryOrHourly: DesignationSupportSalaryType.Hourly,
+        payRate: null,
+      });
+    });
+
+    await waitFor(() => expect(result.current.payRate.disabled).toBe(true));
+    await waitFor(() => expect(result.current.payRate.disabled).toBe(false));
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.ts
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.ts
@@ -22,17 +22,10 @@ export const usePdsGoalAutoSave = ({
     saveValue: (value) => saveField({ [fieldName]: value }),
     fieldName,
     ...options,
-    // Block edits while a save for this same field is in flight. The
-    // UpdatePdsGoalCalculation response echoes the full fragment, so a
-    // second save landing during the first can overwrite the in-flight
-    // value in the Apollo cache with a stale server echo. Also covers the
-    // atomic Pay Type write of { salaryOrHourly, payRate: null }, which
-    // marks payRate as saving — disabling the blur-driven Pay Rate input
-    // while the clear is in flight. We scope to this field only;
-    // a *different* field's save in flight can still briefly stamp our
-    // optimistic write when its response echoes the full fragment, and
-    // that trade-off is accepted to avoid freezing every input on every
-    // save. The Pay Type write guards itself separately via isMutating.
+    // Block change-driven (select) autosaves while a save is in flight: rapid
+    // back-and-forth toggles can otherwise land out of order in the Apollo
+    // cache. formType is the load-bearing case — its value reshapes the goal
+    // calculation, so a stale final value silently understates the total.
     disabled: !calculation || isFieldSaving(fieldName),
   });
 };

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.ts
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.ts
@@ -16,16 +16,24 @@ export const usePdsGoalAutoSave = ({
 }: UsePdsAutoSaveOptions) => {
   const saveField = useSaveField();
   const { calculation, isFieldSaving } = usePdsGoalCalculator();
+  const busy = isFieldSaving(fieldName);
 
-  return useAutoSave({
+  const autoSaveProps = useAutoSave({
     value: calculation?.[fieldName] as string | number | null | undefined,
     saveValue: (value) => saveField({ [fieldName]: value }),
     fieldName,
     ...options,
-    // Block change-driven (select) autosaves while a save is in flight: rapid
-    // back-and-forth toggles can otherwise land out of order in the Apollo
-    // cache. formType is the load-bearing case — its value reshapes the goal
-    // calculation, so a stale final value silently understates the total.
-    disabled: !calculation || isFieldSaving(fieldName),
+    // Disable a field while its own save is in flight (including multi-field
+    // atomic saves like salaryOrHourly + payRate). Prevents rapid back-and-forth
+    // writes from landing out of order in the Apollo cache while leaving
+    // unrelated fields interactive. formType is the load-bearing case — its
+    // value reshapes the goal calculation, so a stale final value silently
+    // understates the total.
+    disabled: !calculation || busy,
   });
+
+  // Distinguish the "saving in flight" disable from the "calculation not
+  // loaded" / externally-disabled cases. Callers signal the former with
+  // aria-busy so the field reads as "busy" rather than "unavailable."
+  return { ...autoSaveProps, busy };
 };

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.ts
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.ts
@@ -22,13 +22,17 @@ export const usePdsGoalAutoSave = ({
     saveValue: (value) => saveField({ [fieldName]: value }),
     fieldName,
     ...options,
-    // Block change-driven (select) autosaves while a save for this same field
-    // is in flight: rapid back-and-forth toggles can otherwise land out of
-    // order in the Apollo cache. formType is the load-bearing case — its
-    // value reshapes the goal calculation, so a stale final value silently
-    // understates the total. Other fields' saves do not affect this one.
-    disabled:
-      !calculation ||
-      (options.saveOnChange === true && isFieldSaving(fieldName)),
+    // Block edits while a save for this same field is in flight. The
+    // UpdatePdsGoalCalculation response echoes the full fragment, so a
+    // second save landing during the first can overwrite the in-flight
+    // value in the Apollo cache with a stale server echo. Also covers the
+    // atomic Pay Type write of { salaryOrHourly, payRate: null }, which
+    // marks payRate as saving — disabling the blur-driven Pay Rate input
+    // while the clear is in flight. We scope to this field only;
+    // a *different* field's save in flight can still briefly stamp our
+    // optimistic write when its response echoes the full fragment, and
+    // that trade-off is accepted to avoid freezing every input on every
+    // save. The Pay Type write guards itself separately via isMutating.
+    disabled: !calculation || isFieldSaving(fieldName),
   });
 };

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.ts
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/usePdsGoalAutoSave.ts
@@ -15,17 +15,20 @@ export const usePdsGoalAutoSave = ({
   ...options
 }: UsePdsAutoSaveOptions) => {
   const saveField = useSaveField();
-  const { calculation, isMutating } = usePdsGoalCalculator();
+  const { calculation, isFieldSaving } = usePdsGoalCalculator();
 
   return useAutoSave({
     value: calculation?.[fieldName] as string | number | null | undefined,
     saveValue: (value) => saveField({ [fieldName]: value }),
     fieldName,
     ...options,
-    // Block change-driven (select) autosaves while a save is in flight: rapid
-    // back-and-forth toggles can otherwise land out of order in the Apollo
-    // cache. formType is the load-bearing case — its value reshapes the goal
-    // calculation, so a stale final value silently understates the total.
-    disabled: !calculation || (options.saveOnChange === true && isMutating),
+    // Block change-driven (select) autosaves while a save for this same field
+    // is in flight: rapid back-and-forth toggles can otherwise land out of
+    // order in the Apollo cache. formType is the load-bearing case — its
+    // value reshapes the goal calculation, so a stale final value silently
+    // understates the total. Other fields' saves do not affect this one.
+    disabled:
+      !calculation ||
+      (options.saveOnChange === true && isFieldSaving(fieldName)),
   });
 };

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/useSaveField.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/useSaveField.test.tsx
@@ -1,18 +1,45 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
-import { PdsGoalCalculatorTestWrapper } from '../../PdsGoalCalculatorTestWrapper';
+import { UpdatePdsGoalCalculationMutation } from '../../GoalsList/PdsGoalCalculations.generated';
+import {
+  PdsGoalCalculatorTestWrapper,
+  PdsGoalCalculatorTestWrapperProps,
+} from '../../PdsGoalCalculatorTestWrapper';
 import { useSaveField } from './useSaveField';
 
-const mutationSpy = jest.fn();
+type WrapperExtraMocks = {
+  UpdatePdsGoalCalculation: UpdatePdsGoalCalculationMutation;
+};
 
-const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <PdsGoalCalculatorTestWrapper
+const mutationSpy = jest.fn();
+const mockEnqueue = jest.fn();
+
+jest.mock('notistack', () => ({
+  ...jest.requireActual('notistack'),
+  useSnackbar: () => ({
+    enqueueSnackbar: mockEnqueue,
+  }),
+}));
+
+beforeEach(() => {
+  mutationSpy.mockClear();
+  mockEnqueue.mockClear();
+});
+
+interface WrapperProps {
+  children: React.ReactNode;
+  extraMocks?: PdsGoalCalculatorTestWrapperProps<WrapperExtraMocks>['extraMocks'];
+}
+
+const Wrapper: React.FC<WrapperProps> = ({ children, extraMocks }) => (
+  <PdsGoalCalculatorTestWrapper<WrapperExtraMocks>
     calculationMock={{
       id: 'goal-1',
       name: 'Test Goal',
       payRate: 50000,
     }}
     onCall={mutationSpy}
+    extraMocks={extraMocks}
   >
     {children}
   </PdsGoalCalculatorTestWrapper>
@@ -35,6 +62,35 @@ describe('useSaveField', () => {
           name: 'New Name',
         },
       }),
+    );
+  });
+
+  it('shows an error snackbar when the mutation fails', async () => {
+    const { result } = renderHook(useSaveField, {
+      wrapper: ({ children }) => (
+        <Wrapper
+          extraMocks={{
+            UpdatePdsGoalCalculation: () => {
+              throw new Error('Server Error');
+            },
+          }}
+        >
+          {children}
+        </Wrapper>
+      ),
+    });
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('PdsGoalCalculation'),
+    );
+
+    await result.current({ name: 'New Name' });
+
+    await waitFor(() =>
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        'Failed to save changes. Please try again.',
+        { variant: 'error' },
+      ),
     );
   });
 });

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/useSaveField.ts
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/useSaveField.ts
@@ -6,7 +6,7 @@ import { useUpdatePdsGoalCalculationMutation } from '../../GoalsList/PdsGoalCalc
 import { usePdsGoalCalculator } from '../PdsGoalCalculatorContext';
 
 export const useSaveField = () => {
-  const { calculation, trackMutation } = usePdsGoalCalculator();
+  const { calculation, trackFieldMutation } = usePdsGoalCalculator();
   const [updatePdsGoalCalculation] = useUpdatePdsGoalCalculationMutation();
   const { enqueueSnackbar } = useSnackbar();
   const { t } = useTranslation();
@@ -25,7 +25,7 @@ export const useSaveField = () => {
       }
 
       try {
-        return await trackMutation(
+        return await trackFieldMutation(
           updatePdsGoalCalculation({
             variables: {
               attributes: {
@@ -45,6 +45,7 @@ export const useSaveField = () => {
               },
             },
           }),
+          Object.keys(attributes),
         );
       } catch {
         enqueueSnackbar(t('Failed to save changes. Please try again.'), {
@@ -52,7 +53,13 @@ export const useSaveField = () => {
         });
       }
     },
-    [calculation, trackMutation, updatePdsGoalCalculation, enqueueSnackbar, t],
+    [
+      calculation,
+      trackFieldMutation,
+      updatePdsGoalCalculation,
+      enqueueSnackbar,
+      t,
+    ],
   );
 
   return saveField;

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/useSaveField.ts
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/useSaveField.ts
@@ -45,7 +45,9 @@ export const useSaveField = () => {
               },
             },
           }),
-          Object.keys(attributes),
+          Object.keys(attributes) as Array<
+            keyof DesignationSupportCalculationUpdateInput
+          >,
         );
       } catch {
         enqueueSnackbar(t('Failed to save changes. Please try again.'), {

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
@@ -157,12 +157,9 @@ describe('PdsGoalCalculatorContext', () => {
     it('marks every listed field as saving for the lifetime of a multi-field write', async () => {
       const { result } = renderUsePdsGoalCalculator();
 
-      // Sanity: no fields are saving before the mutation starts.
       expect(result.current.isFieldSaving('salaryOrHourly')).toBe(false);
       expect(result.current.isFieldSaving('payRate')).toBe(false);
 
-      // Hand-rolled deferred so the in-flight window is observable — a real
-      // mutation would resolve in a microtask and race the assertions.
       let resolveMutation!: (value: unknown) => void;
       const pendingMutation = new Promise((resolve) => {
         resolveMutation = resolve;
@@ -176,14 +173,8 @@ describe('PdsGoalCalculatorContext', () => {
         ]);
       });
 
-      // Both fields must be marked saving simultaneously — this is the whole
-      // reason `fields` is an array. The Pay Type path writes
-      // { salaryOrHourly, payRate: null } atomically, so the per-field
-      // disable for payRate must trigger even though only salaryOrHourly was
-      // user-edited.
       expect(result.current.isFieldSaving('salaryOrHourly')).toBe(true);
       expect(result.current.isFieldSaving('payRate')).toBe(true);
-      // An unrelated field is unaffected.
       expect(result.current.isFieldSaving('name')).toBe(false);
 
       await act(async () => {
@@ -195,10 +186,6 @@ describe('PdsGoalCalculatorContext', () => {
       expect(result.current.isFieldSaving('payRate')).toBe(false);
     });
 
-    // Regression guard: the decrement must run via `.finally(...)`, not
-    // `.then(...)`. If a future refactor moves the decrement into `.then`,
-    // a rejected mutation would leave the count stuck above zero and the
-    // field would stay disabled forever.
     it('clears saving fields when the mutation rejects', async () => {
       const { result } = renderUsePdsGoalCalculator();
 

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
@@ -153,6 +153,81 @@ describe('PdsGoalCalculatorContext', () => {
     expect(result.current.percentComplete).toBe(100);
   });
 
+  describe('trackFieldMutation', () => {
+    it('marks every listed field as saving for the lifetime of a multi-field write', async () => {
+      const { result } = renderUsePdsGoalCalculator();
+
+      // Sanity: no fields are saving before the mutation starts.
+      expect(result.current.isFieldSaving('salaryOrHourly')).toBe(false);
+      expect(result.current.isFieldSaving('payRate')).toBe(false);
+
+      // Hand-rolled deferred so the in-flight window is observable — a real
+      // mutation would resolve in a microtask and race the assertions.
+      let resolveMutation!: (value: unknown) => void;
+      const pendingMutation = new Promise((resolve) => {
+        resolveMutation = resolve;
+      });
+
+      let tracked!: Promise<unknown>;
+      act(() => {
+        tracked = result.current.trackFieldMutation(pendingMutation, [
+          'salaryOrHourly',
+          'payRate',
+        ]);
+      });
+
+      // Both fields must be marked saving simultaneously — this is the whole
+      // reason `fields` is an array. The Pay Type path writes
+      // { salaryOrHourly, payRate: null } atomically, so the per-field
+      // disable for payRate must trigger even though only salaryOrHourly was
+      // user-edited.
+      expect(result.current.isFieldSaving('salaryOrHourly')).toBe(true);
+      expect(result.current.isFieldSaving('payRate')).toBe(true);
+      // An unrelated field is unaffected.
+      expect(result.current.isFieldSaving('name')).toBe(false);
+
+      await act(async () => {
+        resolveMutation(undefined);
+        await tracked;
+      });
+
+      expect(result.current.isFieldSaving('salaryOrHourly')).toBe(false);
+      expect(result.current.isFieldSaving('payRate')).toBe(false);
+    });
+
+    // Regression guard: the decrement must run via `.finally(...)`, not
+    // `.then(...)`. If a future refactor moves the decrement into `.then`,
+    // a rejected mutation would leave the count stuck above zero and the
+    // field would stay disabled forever.
+    it('clears saving fields when the mutation rejects', async () => {
+      const { result } = renderUsePdsGoalCalculator();
+
+      let rejectMutation!: (reason: unknown) => void;
+      const pendingMutation = new Promise((_, reject) => {
+        rejectMutation = reject;
+      });
+
+      let tracked!: Promise<unknown>;
+      act(() => {
+        tracked = result.current.trackFieldMutation(pendingMutation, [
+          'salaryOrHourly',
+          'payRate',
+        ]);
+      });
+
+      expect(result.current.isFieldSaving('salaryOrHourly')).toBe(true);
+      expect(result.current.isFieldSaving('payRate')).toBe(true);
+
+      await act(async () => {
+        rejectMutation(new Error('mutation failed'));
+        await tracked.catch(() => undefined);
+      });
+
+      expect(result.current.isFieldSaving('salaryOrHourly')).toBe(false);
+      expect(result.current.isFieldSaving('payRate')).toBe(false);
+    });
+  });
+
   it('rounds percentComplete to 33/67/100 for the 3-step Simple form', async () => {
     const { result } = renderHook(() => usePdsGoalCalculator(), {
       wrapper: ({ children }) => (

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.test.tsx
@@ -213,6 +213,48 @@ describe('PdsGoalCalculatorContext', () => {
       expect(result.current.isFieldSaving('salaryOrHourly')).toBe(false);
       expect(result.current.isFieldSaving('payRate')).toBe(false);
     });
+
+    it('keeps a field saving while a second concurrent save on the same field is in flight', async () => {
+      const { result } = renderUsePdsGoalCalculator();
+
+      let resolveFirst!: (value: unknown) => void;
+      let resolveSecond!: (value: unknown) => void;
+      const firstMutation = new Promise((resolve) => {
+        resolveFirst = resolve;
+      });
+      const secondMutation = new Promise((resolve) => {
+        resolveSecond = resolve;
+      });
+
+      let trackedFirst!: Promise<unknown>;
+      let trackedSecond!: Promise<unknown>;
+      act(() => {
+        trackedFirst = result.current.trackFieldMutation(firstMutation, [
+          'payRate',
+        ]);
+        trackedSecond = result.current.trackFieldMutation(secondMutation, [
+          'payRate',
+        ]);
+      });
+
+      expect(result.current.isFieldSaving('payRate')).toBe(true);
+
+      await act(async () => {
+        resolveFirst(undefined);
+        await trackedFirst;
+      });
+
+      // Second save is still pending — payRate must remain saving so the UI
+      // doesn't flicker between the two overlapping mutations.
+      expect(result.current.isFieldSaving('payRate')).toBe(true);
+
+      await act(async () => {
+        resolveSecond(undefined);
+        await trackedSecond;
+      });
+
+      expect(result.current.isFieldSaving('payRate')).toBe(false);
+    });
   });
 
   it('rounds percentComplete to 33/67/100 for the 3-step Simple form', async () => {

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -39,8 +39,19 @@ export type PdsGoalCalculatorType = {
 
   /** Whether any mutations are currently in progress */
   isMutating: boolean;
+  /** Whether a save mutation tagged with the given field name is in flight */
+  isFieldSaving: (fieldName: string) => boolean;
   /** Call with the mutation promise to track the start and end of mutations */
   trackMutation: <T>(mutation: Promise<T>) => Promise<T>;
+  /**
+   * Like trackMutation, but also marks the listed fields as saving while the
+   * mutation is in flight so per-field disable checks can scope to the field
+   * being saved instead of any save in the calculator.
+   */
+  trackFieldMutation: <T>(
+    mutation: Promise<T>,
+    fields: string[],
+  ) => Promise<T>;
 
   rightPanelContent: React.ReactNode;
   setRightPanelContent: (content: React.ReactNode) => void;
@@ -108,6 +119,44 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(true);
   const { trackMutation, isMutating } = useTrackMutation();
 
+  const [savingFieldCounts, setSavingFieldCounts] = useState<
+    Record<string, number>
+  >({});
+
+  const isFieldSaving = useCallback(
+    (fieldName: string) => (savingFieldCounts[fieldName] ?? 0) > 0,
+    [savingFieldCounts],
+  );
+
+  const trackFieldMutation = useCallback(
+    <T,>(mutation: Promise<T>, fields: string[]): Promise<T> => {
+      setSavingFieldCounts((prev) => {
+        const next = { ...prev };
+        for (const field of fields) {
+          next[field] = (next[field] ?? 0) + 1;
+        }
+        return next;
+      });
+      return trackMutation(
+        mutation.finally(() => {
+          setSavingFieldCounts((prev) => {
+            const next = { ...prev };
+            for (const field of fields) {
+              const remaining = (next[field] ?? 0) - 1;
+              if (remaining <= 0) {
+                delete next[field];
+              } else {
+                next[field] = remaining;
+              }
+            }
+            return next;
+          });
+        }),
+      );
+    },
+    [trackMutation],
+  );
+
   useEffect(() => {
     if (steps.some((s) => s.step === activeStep)) {
       return;
@@ -173,7 +222,9 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
       summaryData,
       percentComplete,
       isMutating,
+      isFieldSaving,
       trackMutation,
+      trackFieldMutation,
       hcmUser,
       rightPanelContent,
       isDrawerOpen,
@@ -194,7 +245,9 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
       summaryData,
       percentComplete,
       isMutating,
+      isFieldSaving,
       trackMutation,
+      trackFieldMutation,
       hcmUser,
       rightPanelContent,
       isDrawerOpen,

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -42,17 +42,13 @@ export type PdsGoalCalculatorType = {
 
   /** Whether any mutations are currently in progress */
   isMutating: boolean;
-  /** Whether a save mutation tagged with the given field name is in flight */
+  /** Whether a save for the given field is in flight */
   isFieldSaving: (
     fieldName: keyof DesignationSupportCalculationUpdateInput,
   ) => boolean;
   /** Call with the mutation promise to track the start and end of mutations */
   trackMutation: <T>(mutation: Promise<T>) => Promise<T>;
-  /**
-   * Like trackMutation, but also marks the listed fields as saving while the
-   * mutation is in flight so per-field disable checks can scope to the field
-   * being saved instead of any save in the calculator.
-   */
+  /** Like trackMutation, but also marks the listed fields as saving. */
   trackFieldMutation: <T>(
     mutation: Promise<T>,
     fields: Array<keyof DesignationSupportCalculationUpdateInput>,

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -121,7 +121,7 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
   const { trackMutation, isMutating } = useTrackMutation();
 
   const [savingFieldCounts, setSavingFieldCounts] = useState<
-    Record<string, number>
+    Partial<Record<keyof DesignationSupportCalculationUpdateInput, number>>
   >({});
 
   const isFieldSaving = useCallback(
@@ -135,9 +135,10 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
       mutation: Promise<T>,
       fields: Array<keyof DesignationSupportCalculationUpdateInput>,
     ): Promise<T> => {
+      const uniqueFields = Array.from(new Set(fields));
       setSavingFieldCounts((prev) => {
         const next = { ...prev };
-        for (const field of fields) {
+        for (const field of uniqueFields) {
           next[field] = (next[field] ?? 0) + 1;
         }
         return next;
@@ -146,7 +147,7 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
         mutation.finally(() => {
           setSavingFieldCounts((prev) => {
             const next = { ...prev };
-            for (const field of fields) {
+            for (const field of uniqueFields) {
               const remaining = (next[field] ?? 0) - 1;
               if (remaining <= 0) {
                 delete next[field];

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -8,7 +8,10 @@ import React, {
 } from 'react';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
-import { DesignationSupportFormType } from 'src/graphql/types.generated';
+import {
+  DesignationSupportCalculationUpdateInput,
+  DesignationSupportFormType,
+} from 'src/graphql/types.generated';
 import { useTrackMutation } from 'src/hooks/useTrackMutation';
 import { safeProgressRatio } from '../../GoalCalculator/Shared/safeProgressRatio';
 import {
@@ -40,7 +43,9 @@ export type PdsGoalCalculatorType = {
   /** Whether any mutations are currently in progress */
   isMutating: boolean;
   /** Whether a save mutation tagged with the given field name is in flight */
-  isFieldSaving: (fieldName: string) => boolean;
+  isFieldSaving: (
+    fieldName: keyof DesignationSupportCalculationUpdateInput,
+  ) => boolean;
   /** Call with the mutation promise to track the start and end of mutations */
   trackMutation: <T>(mutation: Promise<T>) => Promise<T>;
   /**
@@ -50,7 +55,7 @@ export type PdsGoalCalculatorType = {
    */
   trackFieldMutation: <T>(
     mutation: Promise<T>,
-    fields: string[],
+    fields: Array<keyof DesignationSupportCalculationUpdateInput>,
   ) => Promise<T>;
 
   rightPanelContent: React.ReactNode;
@@ -124,12 +129,16 @@ export const PdsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
   >({});
 
   const isFieldSaving = useCallback(
-    (fieldName: string) => (savingFieldCounts[fieldName] ?? 0) > 0,
+    (fieldName: keyof DesignationSupportCalculationUpdateInput) =>
+      (savingFieldCounts[fieldName] ?? 0) > 0,
     [savingFieldCounts],
   );
 
   const trackFieldMutation = useCallback(
-    <T,>(mutation: Promise<T>, fields: string[]): Promise<T> => {
+    <T,>(
+      mutation: Promise<T>,
+      fields: Array<keyof DesignationSupportCalculationUpdateInput>,
+    ): Promise<T> => {
       setSavingFieldCounts((prev) => {
         const next = { ...prev };
         for (const field of fields) {


### PR DESCRIPTION
## Description

- The Form Type, Employment Status, and Pay Type selects in the PDS Goal Calculator Setup step briefly rendered disabled whenever an unrelated field (e.g. Benefits) was being saved, because they were gated on the global `isMutating` flag from the calculator context.
- Added per-field saving state to `PdsGoalCalculatorContext`: a new `isFieldSaving(fieldName)` selector and a `trackFieldMutation(promise, fields)` wrapper that tags the fields being written for the duration of the mutation.
- `useSaveField` now uses `trackFieldMutation` and passes `Object.keys(attributes)`, so each in-flight save tags only the fields it actually writes.
- `usePdsGoalAutoSave` and the manual Pay Type select in `SetupStep` now check `isFieldSaving(fieldName)` instead of `isMutating`. Same-field race protection on `formType` (and friends) is preserved — only the cross-field flicker is gone.
- Added a regression test that saving an unrelated field does not disable a `saveOnChange` select.
- Jira: [MPDX-9611](https://jira.cru.org/browse/MPDX-9611)

## Testing

- Open the PDS Goal Calculator Setup step for a Full-time Salaried goal so all of Form Type, Employment Status, Pay Type, Pay Rate, and Benefits are visible.
- Edit the Benefits field, then tab/click away to trigger the autosave.
- Watch Form Type, Employment Status, and Pay Type while the Benefits save is in flight — they should remain interactive (no flicker to a disabled state).
- Toggle Form Type (Default ↔ Simple) rapidly and confirm the Form Type select itself is briefly disabled while its own save is in flight — same-field race protection still applies.
- Toggle Pay Type (Salaried ↔ Hourly) and confirm the Pay Type select disables only during its own save, and the atomic `salaryOrHourly + payRate: null` write still happens.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)