### PR TITLE
MPDX-9604 Hide save button when no changes present

### DIFF
--- a/src/components/HrTools/MinistryPartnerReminders/PartnerRemindersReport.test.tsx
+++ b/src/components/HrTools/MinistryPartnerReminders/PartnerRemindersReport.test.tsx
@@ -125,17 +125,10 @@ describe('PartnerRemindersReport', () => {
     await waitFor(() => expect(onNavListToggle).toHaveBeenCalled());
   });
 
-  it('should show saved snackbar when save is clicked with no changes', async () => {
-    mockEnqueue.mockClear();
-    const { getByRole } = render(<TestComponent />);
+  it('should hide save button when no changes are made', async () => {
+    const { queryByRole } = render(<TestComponent />);
 
-    userEvent.click(getByRole('button', { name: 'Save' }));
-
-    await waitFor(() =>
-      expect(mockEnqueue).toHaveBeenCalledWith('No changes have been made', {
-        variant: 'info',
-      }),
-    );
+    expect(queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
   });
 
   it('should render reminder data in table', async () => {

--- a/src/components/HrTools/MinistryPartnerReminders/PartnerRemindersReport.tsx
+++ b/src/components/HrTools/MinistryPartnerReminders/PartnerRemindersReport.tsx
@@ -89,38 +89,6 @@ export const PartnerRemindersReport: React.FC<MPRemindersReportProps> = ({
     window.print();
   };
 
-  const handleSave = async (values: RowValues) => {
-    const updates = Object.entries(values.status)
-      .filter(([id, statusCd]) => initialValues.status[id] !== statusCd)
-      .map(([id, statusCd]) => {
-        return {
-          rowId: id,
-          statusCd,
-        };
-      });
-
-    if (updates.length === 0) {
-      enqueueSnackbar(t('No changes have been made'), { variant: 'info' });
-      return;
-    }
-
-    await updateMutation({
-      variables: {
-        input: {
-          accountListId: accountListId ?? '',
-          designationNumber,
-          updates,
-        },
-      },
-      onCompleted: () => {
-        enqueueSnackbar(t('Changes saved'), { variant: 'success' });
-      },
-      onError: () => {
-        enqueueSnackbar(t('Error saving changes'), { variant: 'error' });
-      },
-    });
-  };
-
   const transformedData: ReminderData[] = useMemo(
     () =>
       reminders
@@ -157,13 +125,39 @@ export const PartnerRemindersReport: React.FC<MPRemindersReportProps> = ({
     [transformedData],
   );
 
+  const getUpdates = (values: RowValues) => {
+    return Object.entries(values.status)
+      .filter(([id, statusCd]) => initialValues.status[id] !== statusCd)
+      .map(([id, statusCd]) => {
+        return {
+          rowId: id,
+          statusCd,
+        };
+      });
+  };
+
+  const handleSave = async (values: RowValues) => {
+    await updateMutation({
+      variables: {
+        input: {
+          accountListId: accountListId ?? '',
+          designationNumber,
+          updates: getUpdates(values),
+        },
+      },
+      onCompleted: () => {
+        enqueueSnackbar(t('Changes saved'), { variant: 'success' });
+      },
+    });
+  };
+
   return (
     <Formik<RowValues>
       initialValues={initialValues}
       onSubmit={handleSave}
       enableReinitialize
     >
-      {({ submitForm }) => (
+      {({ submitForm, values }) => (
         <Box>
           <SimpleScreenOnly>
             <MultiPageHeader
@@ -216,10 +210,10 @@ export const PartnerRemindersReport: React.FC<MPRemindersReportProps> = ({
                     </Typography>
 
                     <Typography sx={{ marginTop: 3, lineHeight: 1.5 }}>
-                      When you&apos;re done, click the &quot;Save&quot; button
-                      at the bottom of the page. Wondering how the{' '}
-                      <i>Reminder System</i> works and how it differs from the
-                      Receipting System? Check out{' '}
+                      When you&apos;re done, a &quot;Save&quot; button will
+                      appear at the top of the page. Click it to save your
+                      changes. Wondering how the <i>Reminder System</i> works
+                      and how it differs from the Receipting System? Check out{' '}
                       <Link
                         sx={{
                           color: theme.palette.primary.main,
@@ -238,9 +232,11 @@ export const PartnerRemindersReport: React.FC<MPRemindersReportProps> = ({
                 <Box mb={2}>
                   <Box mb={2}>
                     <SimpleScreenOnly>
-                      <Button variant="contained" onClick={submitForm}>
-                        {t('Save')}
-                      </Button>
+                      {getUpdates(values).length > 0 && (
+                        <Button variant="contained" onClick={submitForm}>
+                          {t('Save')}
+                        </Button>
+                      )}
                     </SimpleScreenOnly>
                   </Box>
                   <Typography>


### PR DESCRIPTION
## Description

Currently, Ministry Partner Reminders shows the "Save" button regardless of changes present or not. When there are no changes and the user clicks "Save", there is an information snackbar that says "No changes have been made". Instead, we want to hide the "Save" button until there are changes present.

Jira ticket: [MPDX-9604](https://jira.cru.org/browse/MPDX-9604)

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

Impersonate: caleb.cox@cru.org
- Go to `/hrTools/partnerReminders`
- Verify "Save" button not present
- Select a different reminder status
- Check that "Save" button appears
- Click & ensure status was changed

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
