### PR TITLE
MPDX-9629, MPDX-9630 Salary Calc UAT

### DIFF
--- a/pages/accountLists/[accountListId]/hrTools/salaryCalculator/[calculationId]/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/salaryCalculator/[calculationId]/index.page.tsx
@@ -55,7 +55,7 @@ const SalaryCalculatorEditInnerPage: React.FC = () => {
   return (
     <>
       <Head>
-        <title>{`${appName} | ${t('Salary Calculator')}`}</title>
+        <title>{`${appName} | ${t('HR Tools | Salary Calculation Form')}`}</title>
       </Head>
       <UserTypeAccess
         requireStaffAccount
@@ -68,7 +68,7 @@ const SalaryCalculatorEditInnerPage: React.FC = () => {
               isOpen={isNavListOpen}
               selectedId="salaryCalculator"
               onClose={handleNavListToggle}
-              navType={NavTypeEnum.Reports}
+              navType={NavTypeEnum.HrTools}
             />
           }
           leftOpen={isNavListOpen}
@@ -78,8 +78,8 @@ const SalaryCalculatorEditInnerPage: React.FC = () => {
               <MultiPageHeader
                 isNavListOpen={isNavListOpen}
                 onNavListToggle={handleNavListToggle}
-                title={t('Salary Calculator')}
-                headerType={HeaderTypeEnum.Report}
+                title={t('Salary Calculation Form')}
+                headerType={HeaderTypeEnum.HrTools}
                 rightExtra={<SalaryCalculatorSavingStatus />}
               />
               <SalaryCalculator />

--- a/pages/accountLists/[accountListId]/hrTools/salaryCalculator/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/salaryCalculator/index.page.tsx
@@ -56,7 +56,7 @@ const SalaryCalculatorPage: React.FC = () => {
               <MultiPageHeader
                 isNavListOpen={isNavListOpen}
                 onNavListToggle={handleNavListToggle}
-                title={t('Salary Calculator')}
+                title={t('Salary Calculation Form')}
                 headerType={HeaderTypeEnum.HrTools}
               />
 

--- a/pages/accountLists/[accountListId]/hrTools/salaryCalculator/salaryCalculator.page.test.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/salaryCalculator/salaryCalculator.page.test.tsx
@@ -20,10 +20,10 @@ const TestComponent: React.FC<TestComponentProps> = ({
 
 describe('SalaryCalculatorPage', () => {
   it('renders the Salary Calculator header', async () => {
-    const { findByRole } = render(<TestComponent />);
+    const { findAllByRole } = render(<TestComponent />);
     expect(
-      await findByRole('heading', { name: /Salary Calculator/i }),
-    ).toBeInTheDocument();
+      await findAllByRole('heading', { name: /Salary Calculation Form/i }),
+    ).toHaveLength(2);
   });
 
   it('uses blockImpersonatingNonDevelopers for server-side props', () => {
@@ -44,15 +44,15 @@ describe('SalaryCalculatorPage', () => {
     });
 
     it('renders NewSalaryCalculatorLanding when shouldShowPending is false', async () => {
-      const { findByRole } = render(
+      const { findAllByRole } = render(
         <LandingTestWrapper>
           <SalaryCalculatorPage />
         </LandingTestWrapper>,
       );
 
       expect(
-        await findByRole('heading', { name: 'Salary Calculator' }),
-      ).toBeInTheDocument();
+        await findAllByRole('heading', { name: 'Salary Calculation Form' }),
+      ).toHaveLength(2);
     });
   });
 


### PR DESCRIPTION
## Description
1. Need to fix the wrong page title from "Salary Calculator" to "Salary Calculation Form"
2. On the effective date step, the wrong hamburger menu options were showing (Reports vs. HR Tools)

Jira tickets:
- [MPDX-9629](https://jira.cru.org/browse/MPDX-9629)
- [MPDX-9630](https://jira.cru.org/browse/MPDX-9630)

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `/hrTools/salaryCalculator`
- Click "Continue Salary Calculation"
- Check that the title now reads "Salary Calculation Form"
- Click the hamburger icon
- Ensure "HR Tools" is present and NOT "Reports"

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
