### PR TITLE
MPDX-9618 Link Ministry Expenses step to MPDX MPGA report

### DIFF
--- a/src/components/HrTools/GoalCalculator/MinistryExpenses/MinistryExpensesStep.tsx
+++ b/src/components/HrTools/GoalCalculator/MinistryExpenses/MinistryExpensesStep.tsx
@@ -26,7 +26,7 @@ const Instructions: React.FC = () => {
             component={NextLink}
             href={`/accountLists/${accountListId}/reports/mpgaIncomeExpenses`}
           >
-            MPGA tool
+            Ministry Partner Giving Analysis tool
           </Link>{' '}
           can show you your averages in some of these categories. If you did not
           take full reimbursements for the entire year, or if your

--- a/src/components/HrTools/GoalCalculator/MinistryExpenses/MinistryExpensesStep.tsx
+++ b/src/components/HrTools/GoalCalculator/MinistryExpenses/MinistryExpensesStep.tsx
@@ -26,14 +26,14 @@ const Instructions: React.FC = () => {
             component={NextLink}
             href={`/accountLists/${accountListId}/reports/mpgaIncomeExpenses`}
           >
-            MPGA report
+            MPGA tool
           </Link>{' '}
           can show you your averages in some of these categories. If you did not
           take full reimbursements for the entire year, or if your
           reimbursements were abnormally high (e.g. you had a surgery or bought
           a new computer), or low (e.g. no summer mission), you will want to
           adjust the averages from the MPGA to reflect an average year. Click
-          the link above and look under the Ministry Expenses section.
+          the link above and look at the Ministry rows in the Expenses table.
         </Trans>
       </Typography>
     </InstructionsWrapper>

--- a/src/components/HrTools/GoalCalculator/MinistryExpenses/MinistryExpensesStep.tsx
+++ b/src/components/HrTools/GoalCalculator/MinistryExpenses/MinistryExpensesStep.tsx
@@ -1,6 +1,8 @@
+import NextLink from 'next/link';
 import React from 'react';
 import { Link, Typography, styled } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
+import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useGoalCalculator } from '../Shared/GoalCalculatorContext';
 import { ExpensesStep } from '../SharedComponents/ExpensesStep/ExpensesStep';
 
@@ -12,6 +14,7 @@ const InstructionsWrapper = styled('div')(({ theme }) => ({
 
 const Instructions: React.FC = () => {
   const { t } = useTranslation();
+  const accountListId = useAccountListId() ?? '';
 
   return (
     <InstructionsWrapper>
@@ -19,16 +22,18 @@ const Instructions: React.FC = () => {
         <Trans t={t}>
           Enter amounts for the following categories of reimbursable and
           ministry expenses. The{' '}
-          <Link href="https://staffweb.cru.org/mpd-donations/my-donations/mpga.html">
-            MPGA tool on StaffWeb
+          <Link
+            component={NextLink}
+            href={`/accountLists/${accountListId}/reports/mpgaIncomeExpenses`}
+          >
+            MPGA report
           </Link>{' '}
           can show you your averages in some of these categories. If you did not
           take full reimbursements for the entire year, or if your
           reimbursements were abnormally high (e.g. you had a surgery or bought
           a new computer), or low (e.g. no summer mission), you will want to
           adjust the averages from the MPGA to reflect an average year. Click
-          the link above, go to the Income/Expenses tab, and look under the
-          Ministry Expenses section.
+          the link above and look under the Ministry Expenses section.
         </Trans>
       </Typography>
     </InstructionsWrapper>


### PR DESCRIPTION
## Description

- Replace the external StaffWeb MPGA link in the (MPD) Goal Calculator's Ministry Expenses step with an in-app link to the MPDX MPGA report (`/accountLists/{id}/reports/mpgaIncomeExpenses`).
- Use `Link component={NextLink}` for client-side routing and `useAccountListId()` to build the path, consistent with `SummaryReport.tsx`.
- Drop the "go to the Income/Expenses tab" guidance since the MPDX MPGA page already opens directly to the Income/Expense view.

Jira: [MPDX-9618](https://jira.cru.org/browse/MPDX-9618)

## Testing

- Open an account list and go to **HR Tools → Goal Calculator** and open a goal
- Navigate to the **Ministry Expenses** step
- Confirm the instructions paragraph at the top contains a link reading **"MPGA report"** (not "MPGA tool on StaffWeb")
- Click the link and verify it routes in-app to **Reports → Ministry Partner Giving Analysis** for the same account list (no StaffWeb redirect, no full page reload)
- Confirm the link is keyboard-focusable and activates with Enter

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history