### PR TITLE
MPDX-9632 Hide ASR balance and CAP when no request exists yet

### DIFF
--- a/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
@@ -70,9 +70,7 @@ const TestWrapper: React.FC<TestWrapperProps> = ({ asrMocks }) => (
   <ThemeProvider theme={theme}>
     <TestRouter router={router}>
       <SnackbarProvider>
-        <GqlMockedProvider<AboutFormMocks>
-          mocks={{ ...hcmMocks, ...asrMocks }}
-        >
+        <GqlMockedProvider<AboutFormMocks> mocks={{ ...hcmMocks, ...asrMocks }}>
           <AdditionalSalaryRequestProvider>
             <AboutForm />
           </AdditionalSalaryRequestProvider>

--- a/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
@@ -64,13 +64,17 @@ type AboutFormMocks = {
 
 interface TestWrapperProps {
   asrMocks?: Partial<AboutFormMocks>;
+  onCall?: jest.Mock;
 }
 
-const TestWrapper: React.FC<TestWrapperProps> = ({ asrMocks }) => (
+const TestWrapper: React.FC<TestWrapperProps> = ({ asrMocks, onCall }) => (
   <ThemeProvider theme={theme}>
     <TestRouter router={router}>
       <SnackbarProvider>
-        <GqlMockedProvider<AboutFormMocks> mocks={{ ...hcmMocks, ...asrMocks }}>
+        <GqlMockedProvider<AboutFormMocks>
+          mocks={{ ...hcmMocks, ...asrMocks }}
+          onCall={onCall}
+        >
           <AdditionalSalaryRequestProvider>
             <AboutForm />
           </AdditionalSalaryRequestProvider>
@@ -113,16 +117,22 @@ describe('AboutForm', () => {
   });
 
   it('should hide financial data when no request has been created yet', async () => {
+    const mutationSpy = jest.fn();
     const { findByText, queryByText } = render(
       <TestWrapper
         asrMocks={{
           AdditionalSalaryRequest: { latestAdditionalSalaryRequest: null },
         }}
+        onCall={mutationSpy}
       />,
     );
 
-    // Wait for the query to resolve before asserting absence.
+    // The CardHeader name proves the form rendered; absence assertions below
+    // document that only the financial portion is hidden when no ASR exists.
     expect(await findByText('Doc, John')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('AdditionalSalaryRequest'),
+    );
     expect(queryByText(/Primary Account Balance/i)).not.toBeInTheDocument();
     expect(
       queryByText(/Your Maximum Allowable Salary \(CAP\)/i),

--- a/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
@@ -6,6 +6,7 @@ import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from 'src/theme';
 import { HcmQuery } from '../../Shared/HcmData/Hcm.generated';
+import { AdditionalSalaryRequestQuery } from '../AdditionalSalaryRequest.generated';
 import { AdditionalSalaryRequestProvider } from '../Shared/AdditionalSalaryRequestContext';
 import { AboutForm } from './AboutForm';
 
@@ -29,7 +30,7 @@ const router = {
   isReady: true,
 };
 
-const mocks = {
+const hcmMocks = {
   Hcm: {
     hcm: [
       {
@@ -56,11 +57,22 @@ const mocks = {
   },
 };
 
-const TestWrapper: React.FC = () => (
+type AboutFormMocks = {
+  Hcm: HcmQuery;
+  AdditionalSalaryRequest: AdditionalSalaryRequestQuery;
+};
+
+interface TestWrapperProps {
+  asrMocks?: Partial<AboutFormMocks>;
+}
+
+const TestWrapper: React.FC<TestWrapperProps> = ({ asrMocks }) => (
   <ThemeProvider theme={theme}>
     <TestRouter router={router}>
       <SnackbarProvider>
-        <GqlMockedProvider<{ Hcm: HcmQuery }> mocks={mocks}>
+        <GqlMockedProvider<AboutFormMocks>
+          mocks={{ ...hcmMocks, ...asrMocks }}
+        >
           <AdditionalSalaryRequestProvider>
             <AboutForm />
           </AdditionalSalaryRequestProvider>
@@ -86,15 +98,37 @@ describe('AboutForm', () => {
     ).toBeInTheDocument();
   });
 
-  it('should display user information and financial data', async () => {
+  it('should display user information', async () => {
     const { findByText, getByText } = render(<TestWrapper />);
 
     expect(await findByText('Doc, John')).toBeInTheDocument();
     expect(getByText('00123456')).toBeInTheDocument();
-    expect(getByText(/Primary Account Balance/i)).toBeInTheDocument();
+  });
+
+  it('should display financial data when a request exists', async () => {
+    const { findByText } = render(<TestWrapper />);
+
+    expect(await findByText(/Primary Account Balance/i)).toBeInTheDocument();
     expect(
-      getByText(/Your Maximum Allowable Salary \(CAP\)/i),
+      await findByText(/Your Maximum Allowable Salary \(CAP\)/i),
     ).toBeInTheDocument();
+  });
+
+  it('should hide financial data when no request has been created yet', async () => {
+    const { findByText, queryByText } = render(
+      <TestWrapper
+        asrMocks={{
+          AdditionalSalaryRequest: { latestAdditionalSalaryRequest: null },
+        }}
+      />,
+    );
+
+    // Wait for the query to resolve before asserting absence.
+    expect(await findByText('Doc, John')).toBeInTheDocument();
+    expect(queryByText(/Primary Account Balance/i)).not.toBeInTheDocument();
+    expect(
+      queryByText(/Your Maximum Allowable Salary \(CAP\)/i),
+    ).not.toBeInTheDocument();
   });
 
   it('should have Progressive Approvals link', () => {

--- a/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.tsx
@@ -15,9 +15,8 @@ export const AboutForm: React.FC = () => {
   const theme = useTheme();
 
   const { name, accountNumber, primaryAccountBalance } = useFormUserInfo();
-  const individualCap =
-    requestData?.latestAdditionalSalaryRequest?.calculations.currentSalaryCap ??
-    0;
+  const latestRequest = requestData?.latestAdditionalSalaryRequest;
+  const individualCap = latestRequest?.calculations.currentSalaryCap ?? 0;
 
   return (
     <AdditionalSalaryRequestSection title={getHeader(currentIndex)}>
@@ -96,7 +95,7 @@ export const AboutForm: React.FC = () => {
         titleTwo={t('Your Maximum Allowable Salary (CAP)')}
         amountTwo={individualCap}
         spouseComponent={<SpouseComponent />}
-        showContent
+        showContent={!!latestRequest}
       />
     </AdditionalSalaryRequestSection>
   );


### PR DESCRIPTION
## Description

- Hide the **Primary Account Balance** and **Your Maximum Allowable Salary (CAP)** amounts on the ASR About form when no `latestAdditionalSalaryRequest` exists yet. These values are sourced from the latest request's `calculations`, so before any ASR has been submitted they would render as a meaningless `$0.00`.
- The name + person-number header still renders; only the balance/CAP row is hidden via the existing `showContent` prop on `NameDisplay`.
- This change is scoped to `AboutForm` — `NewForm`, `EditForm`, and `ViewForm` always render with a populated ASR because `RequestPage.handleContinue()` creates one before transitioning to those screens.
- Jira: [MPDX-9632](https://jira.cru.org/browse/MPDX-9632)

## Testing

- Go to **HR Tools → Additional Salary Request** as a user who has never submitted an ASR (or whose only ASR is in a status outside `IN_PROGRESS / ACTION_REQUIRED / PENDING / APPROVED_NOT_PAID / APPROVED_AND_PAID`).
- On the **About this Form** step, confirm the name card still shows your preferred name and person number, and that the **Primary Account Balance** and **Your Maximum Allowable Salary (CAP)** row is no longer shown.
- As a user who *does* have a current ASR (any of the statuses above), confirm the same About step still shows the balance and CAP amounts as before.
- Continue past the About step to verify NewForm/EditForm/ViewForm are unaffected — balance and CAP continue to display there.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)