### PR TITLE
[no-Jira] Open newly-created contacts

### DIFF
--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateMultipleContacts/CreateMultipleContacts.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateMultipleContacts/CreateMultipleContacts.test.tsx
@@ -176,6 +176,14 @@ describe('CreateMultipleContacts', () => {
         contactId: 'contact-1',
         primaryAddressId: 'address-1',
       });
+
+      expect(router.push).toHaveBeenCalledWith({
+        pathname: '/accountLists/[accountListId]/contacts',
+        query: {
+          accountListId,
+          filters: JSON.stringify({ ids: ['contact-1'] }),
+        },
+      });
     }, 20000);
 
     it('creates one referral', async () => {
@@ -373,13 +381,15 @@ describe('CreateMultipleContacts', () => {
       const { getAllByRole, getByRole } = render(
         <SnackbarProvider>
           <ThemeProvider theme={theme}>
-            <GqlMockedProvider onCall={mutationSpy}>
-              <CreateMultipleContacts
-                accountListId={accountListId}
-                handleClose={handleClose}
-                rows={3}
-              />
-            </GqlMockedProvider>
+            <TestRouter router={router}>
+              <GqlMockedProvider onCall={mutationSpy}>
+                <CreateMultipleContacts
+                  accountListId={accountListId}
+                  handleClose={handleClose}
+                  rows={3}
+                />
+              </GqlMockedProvider>
+            </TestRouter>
           </ThemeProvider>
         </SnackbarProvider>,
       );

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateMultipleContacts/CreateMultipleContacts.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/Items/CreateMultipleContacts/CreateMultipleContacts.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import React, { ReactElement } from 'react';
 import {
   CircularProgress,
@@ -131,6 +132,7 @@ export const CreateMultipleContacts = ({
 }: Props): ReactElement<Props> => {
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
+  const { push } = useRouter();
   const initialContacts: ContactTable = {
     contacts: new Array(rows).fill(defaultContact),
   };
@@ -254,6 +256,17 @@ export const CreateMultipleContacts = ({
           variant: 'success',
         },
       );
+
+      const ids = createdContacts.filter((id) => typeof id === 'string');
+      if (ids.length > 0) {
+        push({
+          pathname: '/accountLists/[accountListId]/contacts',
+          query: {
+            accountListId,
+            filters: JSON.stringify({ ids }),
+          },
+        });
+      }
     }
 
     handleClose();


### PR DESCRIPTION
## Description

After creating multiple contacts with the Add Multiple Contacts modal, open those contacts in the contacts list with an `ids` filter. The old AngularJS MPDX used to do this. This change will make it much easier to create several contacts and then mass-create an initial task for them at the same time (like "Text for support appointment"), like I'm doing this week 🙂

## Testing

- Open the Add Multiple Contacts modal from the navbar
- Create more than one contact
- Verify that just those contacts are shown in the contacts list

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
