### PR TITLE
HS-1623061 - Refactor commitment warning in EditPartnershipInfoModal component to only show when moving away from Partner - Financial

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.test.tsx
@@ -306,6 +306,20 @@ describe('EditPartnershipInfoModal', () => {
     expect(handleClose).toHaveBeenCalled();
   });
 
+  it('should not show remove commitment warning when switching to Partner - Financial', async () => {
+    const { getByLabelText, getByText, getByRole, findByText, queryByTestId } =
+      render(<Components />);
+    const statusInput = getByLabelText('Status');
+
+    userEvent.click(statusInput);
+    userEvent.click(await findByText('Ask in Future'));
+    userEvent.click(getByRole('button', { name: 'No' }));
+
+    userEvent.click(statusInput);
+    userEvent.click(getByText('Partner - Financial'));
+    expect(queryByTestId('removeCommitmentMessage')).not.toBeInTheDocument();
+  });
+
   it('should handle editing status | Financial', async () => {
     const { getByLabelText, getByText } = render(<Components />);
     const statusInput = getByLabelText('Status');

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
@@ -180,13 +180,12 @@ export const EditPartnershipInfoModal: React.FC<
       pledgeAmount,
       locale,
     );
-    if (
-      (newStatus !== StatusEnum.PartnerFinancial &&
-        oldStatus === StatusEnum.PartnerFinancial &&
-        normalizedPledgeAmount &&
-        normalizedPledgeAmount > 0) ||
-      pledgeFrequency
-    ) {
+    const leavingPartnerFinancial =
+      oldStatus === StatusEnum.PartnerFinancial &&
+      newStatus !== StatusEnum.PartnerFinancial;
+    const hasCommitmentDetails =
+      (normalizedPledgeAmount && normalizedPledgeAmount > 0) || pledgeFrequency;
+    if (leavingPartnerFinancial && hasCommitmentDetails) {
       setShowRemoveCommitmentWarning(true);
     }
   };


### PR DESCRIPTION
## Description

[HS ticket](https://secure.helpscout.net/conversation/3327590916/1623061?viewId=320670)
[Jira ticket](https://jira.cru.org/browse/MPDX-9633)
- This is working off of the assumption that the  display for removing a commitment should only be triggered when moving away from `Partner - Financial`, indicating a flaw in the initial if statement. It's ideal to ensure that this is really the case, or if we want some version of this display to also show for other types of status transitions.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to a contact in the contact list and select the edit icon
- Set the contact's status to 'Partner - Financial' if not already set
- Check that there is display information asking if you would like to remove the commitment.
- Check that this display information only displays when moving away from 'Partner - Financial'

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
