### PR TITLE
MPDX-9365 - PDS Goal Calculator: Make Pay Rate required and fix validation

### DIFF
--- a/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/PdsGoalCalculator.test.tsx
@@ -50,6 +50,16 @@ describe('PdsGoalCalculator', () => {
     expect(await findByRole('button', { name: /continue/i })).toBeDisabled();
   });
 
+  it('disables the Continue button when Pay Type is not selected', async () => {
+    const { findByRole } = render(
+      <PdsGoalCalculatorTestWrapper calculationMock={{ salaryOrHourly: null }}>
+        <PdsGoalCalculator />
+      </PdsGoalCalculatorTestWrapper>,
+    );
+
+    expect(await findByRole('button', { name: /continue/i })).toBeDisabled();
+  });
+
   it('re-enables the Continue button after the user fills in the missing field', async () => {
     const { findByRole } = render(
       <PdsGoalCalculatorTestWrapper calculationMock={{ name: '' }}>

--- a/src/components/HrTools/PdsGoalCalculator/Setup/PayTypeField.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/PayTypeField.tsx
@@ -1,0 +1,58 @@
+import React, { useMemo } from 'react';
+import { MenuItem, TextField } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import * as yup from 'yup';
+import { DesignationSupportSalaryType } from 'src/graphql/types.generated';
+import { usePdsGoalAutoSave } from '../Shared/Autosave/usePdsGoalAutoSave';
+import { useSaveField } from '../Shared/Autosave/useSaveField';
+
+// Uses usePdsGoalAutoSave directly (not AutosaveTextField) so the onChange can
+// atomically clear payRate alongside salaryOrHourly in a single mutation.
+export const PayTypeField: React.FC = () => {
+  const { t } = useTranslation();
+  const saveField = useSaveField();
+  const schema = useMemo(
+    () =>
+      yup.object({
+        salaryOrHourly: yup
+          .string()
+          .required(t('Pay Type is a required field')),
+      }),
+    [t],
+  );
+  const {
+    value,
+    onChange: updateValidation,
+    disabled,
+    error,
+    helperText: errorMessage,
+  } = usePdsGoalAutoSave({ fieldName: 'salaryOrHourly', schema });
+
+  return (
+    <TextField
+      fullWidth
+      size="small"
+      variant="outlined"
+      select
+      label={t('Pay Type')}
+      error={error}
+      helperText={error ? errorMessage : t('Changing this clears Pay Rate.')}
+      value={value}
+      disabled={disabled}
+      onChange={(event) => {
+        updateValidation(event as React.ChangeEvent<HTMLInputElement>);
+        const newValue = event.target.value as DesignationSupportSalaryType;
+        if (newValue !== value) {
+          saveField({ salaryOrHourly: newValue, payRate: null });
+        }
+      }}
+    >
+      <MenuItem value={DesignationSupportSalaryType.Salaried}>
+        {t('Salaried')}
+      </MenuItem>
+      <MenuItem value={DesignationSupportSalaryType.Hourly}>
+        {t('Hourly')}
+      </MenuItem>
+    </TextField>
+  );
+};

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.tsx
@@ -34,12 +34,12 @@ import { AutosaveTextField } from '../Shared/Autosave/AutosaveTextField';
 import { useSaveField } from '../Shared/Autosave/useSaveField';
 import { usePdsGoalCalculator } from '../Shared/PdsGoalCalculatorContext';
 import { HoursPerWeekGrid } from './HoursPerWeekGrid/HoursPerWeekGrid';
+import { PayTypeField } from './PayTypeField';
 
 export const SetupStep: React.FC = () => {
   const { t } = useTranslation();
   const theme = useTheme();
-  const { calculation, hcmUser, isMutating, setRightPanelContent } =
-    usePdsGoalCalculator();
+  const { calculation, hcmUser, setRightPanelContent } = usePdsGoalCalculator();
   const { data: userData } = useGetUserQuery();
   const schema = useMemo(
     () =>
@@ -203,33 +203,7 @@ export const SetupStep: React.FC = () => {
           </Grid>
 
           <Grid item xs={12}>
-            {/* Manual TextField (not AutosaveTextField) because changing Pay
-                Type must atomically clear payRate as well; AutosaveTextField
-                only writes the single bound fieldName. */}
-            <TextField
-              fullWidth
-              size="small"
-              variant="outlined"
-              select
-              label={t('Pay Type')}
-              helperText={t('Changing this clears Pay Rate.')}
-              value={calculation?.salaryOrHourly ?? ''}
-              disabled={!calculation || isMutating}
-              onChange={(event) => {
-                const newValue = event.target
-                  .value as DesignationSupportSalaryType;
-                if (newValue !== calculation?.salaryOrHourly) {
-                  saveField({ salaryOrHourly: newValue, payRate: null });
-                }
-              }}
-            >
-              <MenuItem value={DesignationSupportSalaryType.Salaried}>
-                {t('Salaried')}
-              </MenuItem>
-              <MenuItem value={DesignationSupportSalaryType.Hourly}>
-                {t('Hourly')}
-              </MenuItem>
-            </TextField>
+            <PayTypeField />
           </Grid>
 
           {payType && (


### PR DESCRIPTION
## Description

[Jira ticket](https://jira.cru.org/browse/MPDX-9635)

Pay Type (salaryOrHourly) was declared required in the Yup schema but rendered as a plain MUI <TextField>, so it never registered with AutosaveForm. The Continue button stayed enabled even with Pay Type empty.

This PR extracts PayTypeField into its own component that calls usePdsGoalAutoSave directly, giving it full Yup validation and AutosaveForm registration while keeping the custom onChange that atomically clears payRate alongside salaryOrHourly in a single mutation.

## Testing

- Go to PDS Goal Calculator
- Check that validation works as expected on Pay Type

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
