### PR TITLE
MPDX-9647 - Make transfers filter searchable by account/fund type name

### DIFF
--- a/src/components/HrTools/SavingsFundTransfer/Helper/getFundLabel.test.ts
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/getFundLabel.test.ts
@@ -1,0 +1,27 @@
+import i18n from 'src/lib/i18n';
+import { FundTypeEnum } from '../mockData';
+import { getFundLabel } from './getFundLabel';
+
+describe('getFundLabel', () => {
+  it('returns the Primary Account label', () => {
+    expect(getFundLabel(FundTypeEnum.Primary, i18n.t)).toBe('Primary Account');
+  });
+
+  it('returns the Savings Account label', () => {
+    expect(getFundLabel(FundTypeEnum.Savings, i18n.t)).toBe('Savings Account');
+  });
+
+  it('returns the Conference Savings Account label', () => {
+    expect(getFundLabel(FundTypeEnum.ConferenceSavings, i18n.t)).toBe(
+      'Staff Conference Savings Account',
+    );
+  });
+
+  it('returns an empty string for an unknown fund', () => {
+    expect(getFundLabel('staffAccount', i18n.t)).toBe('N/A');
+  });
+
+  it('returns an empty string when the fund is undefined', () => {
+    expect(getFundLabel(undefined, i18n.t)).toBe('N/A');
+  });
+});

--- a/src/components/HrTools/SavingsFundTransfer/Helper/getFundLabel.ts
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/getFundLabel.ts
@@ -1,0 +1,15 @@
+import { TFunction } from 'i18next';
+import { FundTypeEnum } from '../mockData';
+
+export const getFundLabel = (fund: string | undefined, t: TFunction) => {
+  if (fund === FundTypeEnum.Primary) {
+    return t('Primary Account');
+  }
+  if (fund === FundTypeEnum.Savings) {
+    return t('Savings Account');
+  }
+  if (fund === FundTypeEnum.ConferenceSavings) {
+    return t('Staff Conference Savings Account');
+  }
+  return t('N/A');
+};

--- a/src/components/HrTools/SavingsFundTransfer/Table/PrintTable.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/Table/PrintTable.test.tsx
@@ -93,7 +93,7 @@ describe('PrintTable', () => {
     );
 
     expect(
-      await findByRole('cell', { name: 'Conference Savings Account' }),
+      await findByRole('cell', { name: 'Staff Conference Savings Account' }),
     ).toBeInTheDocument();
   });
 

--- a/src/components/HrTools/SavingsFundTransfer/Table/PrintTable.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/Table/PrintTable.test.tsx
@@ -6,7 +6,7 @@ import { render } from '@testing-library/react';
 import { DateTime } from 'luxon';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from 'src/theme';
-import { StatusEnum, TableTypeEnum, mockData } from '../mockData';
+import { FundTypeEnum, StatusEnum, TableTypeEnum, mockData } from '../mockData';
 import { PrintTable } from './PrintTable';
 
 const mutationSpy = jest.fn();
@@ -14,8 +14,8 @@ const mutationSpy = jest.fn();
 const mockTransfers = [
   {
     ...mockData[0],
-    transferFrom: 'Savings',
-    transferTo: 'Primary',
+    transferFrom: FundTypeEnum.Savings,
+    transferTo: FundTypeEnum.Primary,
     amount: 2500,
     status: StatusEnum.Complete,
     transferDate: DateTime.fromISO('2023-01-01'),
@@ -27,8 +27,8 @@ const mockTransfers = [
 const mockDefault = [
   {
     ...mockData[1],
-    transferFrom: 'Conference',
-    transferTo: 'Primary',
+    transferFrom: FundTypeEnum.ConferenceSavings,
+    transferTo: FundTypeEnum.Primary,
   },
 ];
 
@@ -81,7 +81,7 @@ describe('PrintTable', () => {
     expect(getByRole('cell', { name: 'Test transfer' })).toBeInTheDocument();
   });
 
-  it('renders default fund when no transfer provided', async () => {
+  it('renders the Conference Savings Account label', async () => {
     const { findByRole } = render(
       <ThemeProvider theme={theme}>
         <LocalizationProvider dateAdapter={AdapterLuxon}>

--- a/src/components/HrTools/SavingsFundTransfer/Table/PrintTable.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/Table/PrintTable.tsx
@@ -11,12 +11,8 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useLocale } from 'src/hooks/useLocale';
 import { StyledTableRow } from '../../../Reports/styledComponents';
-import {
-  FundTypeEnum,
-  ScheduleEnum,
-  TableTypeEnum,
-  Transfers,
-} from '../mockData';
+import { getFundLabel } from '../Helper/getFundLabel';
+import { ScheduleEnum, TableTypeEnum, Transfers } from '../mockData';
 
 interface PrintTableProps {
   transfers: Transfers[];
@@ -53,19 +49,9 @@ export const PrintTable: React.FC<PrintTableProps> = ({ transfers, type }) => {
               transfers.map((transfer) => (
                 <StyledTableRow key={transfer.id}>
                   <TableCell>
-                    {transfer.transferFrom === FundTypeEnum.Primary
-                      ? t('Primary Account')
-                      : transfer.transferFrom === FundTypeEnum.Savings
-                        ? t('Savings Account')
-                        : t('Conference Savings Account')}
+                    {getFundLabel(transfer.transferFrom, t)}
                   </TableCell>
-                  <TableCell>
-                    {transfer.transferTo === FundTypeEnum.Primary
-                      ? t('Primary Account')
-                      : transfer.transferTo === FundTypeEnum.Savings
-                        ? t('Savings Account')
-                        : t('Conference Savings Account')}
-                  </TableCell>
+                  <TableCell>{getFundLabel(transfer.transferTo, t)}</TableCell>
                   <TableCell>
                     {transfer.amount?.toLocaleString(locale, {
                       style: 'currency',

--- a/src/components/HrTools/SavingsFundTransfer/Table/TransfersTable.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/Table/TransfersTable.test.tsx
@@ -163,6 +163,20 @@ describe('TransferHistoryTable', () => {
     expect(descCells[1]).toHaveTextContent('$2,500.00');
   });
 
+  it('sorts the Transfers column by the derived fund-pair label', async () => {
+    const { getAllByRole, findByRole } = render(<TestComponent />);
+
+    userEvent.click(await findByRole('columnheader', { name: 'Transfers' }));
+    const descCells = getAllByRole('gridcell', { name: /\$\d+/ });
+    expect(descCells[0]).toHaveTextContent('$2,500.00');
+    expect(descCells[1]).toHaveTextContent('$1,200.00');
+
+    userEvent.click(await findByRole('columnheader', { name: 'Transfers' }));
+    const ascCells = getAllByRole('gridcell', { name: /\$\d+/ });
+    expect(ascCells[0]).toHaveTextContent('$1,200.00');
+    expect(ascCells[1]).toHaveTextContent('$2,500.00');
+  });
+
   describe('Calendar', () => {
     it('opens the calendar when Add Stop Date is clicked', async () => {
       const { getByRole, findByRole } = render(<TestComponent />);

--- a/src/components/HrTools/SavingsFundTransfer/Table/TransfersTable.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/Table/TransfersTable.tsx
@@ -16,6 +16,7 @@ import { useLocale } from 'src/hooks/useLocale';
 import { CustomEditCalendar } from '../CustomEditCalendar/CustomEditCalendar';
 import { DynamicDeleteTransferModal } from '../DeleteTransferModal/DynamicDeleteTransferModal';
 import { DynamicFailedTransferModal } from '../FailedTransferModal/DynamicFailedTransferModal';
+import { getFundLabel } from '../Helper/getFundLabel';
 import { useUpdateRecurringTransferMutation } from '../TransferMutations.generated';
 import {
   ActionTypeEnum,
@@ -195,6 +196,11 @@ export const TransfersTable: React.FC<TransfersTableProps> = ({
       headerName: t('Transfers'),
       width: 150,
       renderCell: transfers,
+      valueGetter: (_value, row) =>
+        t('{{from}} to {{to}}', {
+          from: getFundLabel(row.transferFrom, t),
+          to: getFundLabel(row.transferTo, t),
+        }),
     },
     {
       field: 'amount',


### PR DESCRIPTION
## Description

- The Transfers filter didn't work, which is completely fair since it displays icons. However, it may be nice for the transfers filter to match against the names of the accounts.

- https://jira.cru.org/browse/MPDX-9647

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to Savings Fund Transfer
- Select the filter button 
- Check that you are able to search Transfers using regular text

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
