### PR TITLE
MPDX-9653 - Simplify From Account -> To Account behavior in Savings Fund Transfer

### DIFF
--- a/src/components/HrTools/SavingsFundTransfer/BalanceCard/BalanceCard.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/BalanceCard/BalanceCard.test.tsx
@@ -62,7 +62,6 @@ describe('BalanceCard', () => {
     expect(getByText('Current Balance')).toBeInTheDocument();
     expect(getByText('$15,000.00')).toBeInTheDocument();
     expect(getByRole('button', { name: /transfer from/i })).toBeInTheDocument();
-    expect(getByRole('button', { name: /transfer to/i })).toBeInTheDocument();
   });
 
   it('should display title correctly', () => {
@@ -186,21 +185,6 @@ describe('BalanceCard', () => {
     expect(mockHandleOpenTransferModal).toHaveBeenCalledWith({
       transfer: {
         transferFrom: expect.any(String),
-      },
-    });
-  });
-
-  it('should call handleOpenTransferModal with correct parameters when Transfer To is clicked', async () => {
-    const { findByRole } = render(<Components />);
-
-    const transferToButton = await findByRole('button', {
-      name: /transfer to/i,
-    });
-    userEvent.click(transferToButton);
-
-    expect(mockHandleOpenTransferModal).toHaveBeenCalledWith({
-      transfer: {
-        transferTo: expect.any(String),
       },
     });
   });

--- a/src/components/HrTools/SavingsFundTransfer/BalanceCard/BalanceCard.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/BalanceCard/BalanceCard.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  Groups,
-  MoveToInbox,
-  Outbox,
-  Savings,
-  Wallet,
-} from '@mui/icons-material';
+import { Groups, Outbox, Savings, Wallet } from '@mui/icons-material';
 import { Box, Button, Card, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { SimpleScreenOnly } from 'src/components/Reports/styledComponents';
@@ -51,14 +45,6 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
     });
   };
 
-  const handleTransferTo = () => {
-    handleOpenTransferModal({
-      transfer: {
-        transferTo: fund.fundType,
-      },
-    });
-  };
-
   return (
     <Card
       variant="outlined"
@@ -70,6 +56,8 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
         fontSize: '1.25rem',
         boxShadow: isSelected ? 3 : 1,
         transition: 'box-shadow 0.3s ease-in-out',
+        display: 'flex',
+        flexDirection: 'column',
       }}
     >
       <Box display={'flex'} flexDirection="row" alignItems="center" gap={1}>
@@ -99,6 +87,9 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
               '@media print': { fontSize: '12pt' },
               fontWeight: 500,
               fontSize: '13pt',
+              minHeight: '3em',
+              display: 'flex',
+              alignItems: 'center',
             }}
           >
             {title}
@@ -107,7 +98,7 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
       </Box>
       <Box
         sx={{
-          mt: 5,
+          mt: 3,
           '@media print': { mt: 2 },
         }}
       >
@@ -135,20 +126,16 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
       <SimpleScreenOnly
         sx={{
           alignItems: 'left',
-          mt: 2,
-          ml: 0,
+          mt: 'auto',
         }}
       >
         <Button
           onClick={handleTransferFrom}
           disabled={fund.endBalance <= fund.deficitLimit}
+          fullWidth
         >
           <Outbox fontSize="small" sx={{ mr: 0.5 }} />
           {t('TRANSFER FROM')}
-        </Button>
-        <Button onClick={handleTransferTo}>
-          <MoveToInbox fontSize="small" sx={{ mr: 0.5 }} />
-          {t('TRANSFER TO')}
         </Button>
       </SimpleScreenOnly>
     </Card>

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -53,7 +53,7 @@ jest.mock('@mui/material', () => {
 });
 
 const transferDefaultData: TransferModalData['transfer'] = {
-  transferFrom: 'transferFrom',
+  transferFrom: 'Staff Account',
   transferTo: '',
   amount: 0,
   schedule: ScheduleEnum.OneTime,
@@ -152,11 +152,8 @@ describe('TransferModal', () => {
       userEvent.type(amountField, '-100');
       userEvent.tab();
 
-      const fromAccount = getByRole('combobox', { name: /from account/i });
       const toAccount = getByRole('combobox', { name: /to account/i });
 
-      userEvent.click(fromAccount);
-      userEvent.click(getByRole('option', { name: /staff account/i }));
       userEvent.click(toAccount);
       userEvent.click(getByRole('option', { name: /staff savings/i }));
 
@@ -199,12 +196,8 @@ describe('TransferModal', () => {
     it('should submit form with valid data', async () => {
       const { getByRole } = render(<Components />);
 
-      const fromAccount = getByRole('combobox', { name: /from account/i });
       const toAccount = getByRole('combobox', { name: /to account/i });
       const amountField = getByRole('spinbutton', { name: /amount/i });
-
-      userEvent.click(fromAccount);
-      userEvent.click(getByRole('option', { name: /staff account/i }));
 
       userEvent.click(toAccount);
       userEvent.click(getByRole('option', { name: /staff savings/i }));
@@ -227,13 +220,9 @@ describe('TransferModal', () => {
     it('should handle form submission successfully', async () => {
       const { getByRole } = render(<Components />);
 
-      const fromAccount = getByRole('combobox', { name: /from account/i });
       const toAccount = getByRole('combobox', { name: /to account/i });
       const amountField = getByRole('spinbutton', { name: /amount/i });
       const submitButton = getByRole('button', { name: /submit/i });
-
-      userEvent.click(fromAccount);
-      userEvent.click(getByRole('option', { name: /staff account/i }));
 
       userEvent.click(toAccount);
       userEvent.click(getByRole('option', { name: /staff savings/i }));
@@ -274,55 +263,25 @@ describe('TransferModal', () => {
       expect(getByLabelText(/end date/i)).toHaveValue('');
     });
 
-    it('should validate that from and to accounts are different', async () => {
-      const { getByRole, queryByRole, getAllByRole } = render(<Components />);
+    it('locks the From Account to the launching card and excludes it from To Account options', async () => {
+      const { getByRole, queryByRole } = render(<Components />);
 
-      const [fromAccount, toAccount] = getAllByRole('combobox');
+      const fromAccount = getByRole('combobox', { name: /from account/i });
+      expect(fromAccount).toHaveTextContent('Staff Account');
 
       userEvent.click(fromAccount);
-      expect(
-        getByRole('option', { name: /staff account/i }),
-      ).toBeInTheDocument();
-      userEvent.click(getByRole('option', { name: /staff account/i }));
+      expect(queryByRole('listbox')).not.toBeInTheDocument();
 
-      userEvent.click(toAccount);
+      userEvent.click(getByRole('combobox', { name: /to account/i }));
+
       await waitFor(() =>
         expect(
           queryByRole('option', { name: /staff account/i }),
         ).not.toBeInTheDocument(),
       );
-
-      userEvent.click(getByRole('option', { name: /staff savings/i }));
-      userEvent.click(getByRole('button', { name: /submit/i }));
-    });
-
-    it('should swap accounts when swap button is clicked', async () => {
-      const { getByRole, getByTestId } = render(<Components />);
-
-      const icon = getByTestId('SwapHorizIcon');
-      const swapButton = icon.closest('button');
-
-      expect(swapButton).toBeDisabled();
-
-      const fromAccount = getByRole('combobox', { name: /from account/i });
-      const toAccount = getByRole('combobox', { name: /to account/i });
-
-      userEvent.click(fromAccount);
-      userEvent.click(getByRole('option', { name: /staff account/i }));
-
-      userEvent.click(toAccount);
-      userEvent.click(getByRole('option', { name: /staff savings/i }));
-
-      await waitFor(() => {
-        expect(swapButton).not.toBeDisabled();
-      });
-
-      userEvent.click(swapButton as HTMLButtonElement);
-
-      await waitFor(() => {
-        expect(fromAccount).toHaveTextContent('Staff Savings');
-        expect(toAccount).toHaveTextContent('Staff Account');
-      });
+      expect(
+        getByRole('option', { name: /staff savings/i }),
+      ).toBeInTheDocument();
     });
 
     it('should show/hide end date based on schedule selection', async () => {
@@ -393,11 +352,7 @@ describe('TransferModal', () => {
     it('should show information box when amount exceeds limit', async () => {
       const { getByRole, findByRole } = render(<Components />);
 
-      const fromAccount = getByRole('combobox', { name: /from account/i });
       const toAccount = getByRole('combobox', { name: /to account/i });
-
-      userEvent.click(fromAccount);
-      userEvent.click(getByRole('option', { name: /staff account/i }));
 
       userEvent.click(toAccount);
       userEvent.click(getByRole('option', { name: /staff savings/i }));
@@ -441,9 +396,6 @@ describe('TransferModal', () => {
 
       const amountField = getByRole('spinbutton', { name: /amount/i });
 
-      userEvent.click(getByRole('combobox', { name: /from account/i }));
-      userEvent.click(getByRole('option', { name: /staff account/i }));
-
       userEvent.click(getByRole('combobox', { name: /to account/i }));
       userEvent.click(getByRole('option', { name: /staff savings/i }));
 
@@ -473,9 +425,6 @@ describe('TransferModal', () => {
       const { getByRole, getByLabelText } = render(<Components />);
 
       const amountField = getByRole('spinbutton', { name: /amount/i });
-
-      userEvent.click(getByRole('combobox', { name: /from account/i }));
-      userEvent.click(getByRole('option', { name: /staff account/i }));
 
       userEvent.click(getByRole('combobox', { name: /to account/i }));
       userEvent.click(getByRole('option', { name: /staff savings/i }));

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import East from '@mui/icons-material/East';
-import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
+import { ArrowRightAlt } from '@mui/icons-material';
 import {
   Alert,
   Box,
@@ -11,12 +10,10 @@ import {
   FormHelperText,
   FormLabel,
   Grid,
-  IconButton,
   InputLabel,
   Radio,
   RadioGroup,
   TextField,
-  Tooltip,
   Typography,
 } from '@mui/material';
 import { Formik } from 'formik';
@@ -309,26 +306,17 @@ export const TransferModal: React.FC<TransferModalProps> = ({
                             {t('From Account')}
                           </InputLabel>
                           <TransferModalSelect
-                            notSelected={transferTo}
-                            funds={funds}
+                            funds={funds.filter(
+                              (fund) => fund.fundType === transferFrom,
+                            )}
                             label={t('From Account')}
                             labelId="transferFrom"
                             name="transferFrom"
                             value={transferFrom}
-                            disabled={!isNew}
-                            onChange={handleChange}
-                            onBlur={handleBlur}
-                            error={
-                              touched.transferFrom &&
-                              Boolean(errors.transferFrom)
-                            }
+                            readOnly
+                            IconComponent={() => null}
                             required
                           />
-                          {touched.transferFrom && errors.transferFrom && (
-                            <FormHelperText error={true}>
-                              {errors.transferFrom}
-                            </FormHelperText>
-                          )}
                         </FormControl>
                       </Grid>
 
@@ -342,18 +330,7 @@ export const TransferModal: React.FC<TransferModalProps> = ({
                           alignItems: 'center',
                         }}
                       >
-                        <IconButton
-                          onClick={() => {
-                            setFieldValue('transferFrom', transferTo);
-                            setFieldValue('transferTo', transferFrom);
-                          }}
-                          color="primary"
-                          disabled={!transferFrom || !transferTo}
-                        >
-                          <Tooltip title={t('Swap')}>
-                            <SwapHorizIcon />
-                          </Tooltip>
-                        </IconButton>
+                        <ArrowRightAlt />
                       </Grid>
 
                       <Grid item xs={12} sm={5.5}>
@@ -398,7 +375,7 @@ export const TransferModal: React.FC<TransferModalProps> = ({
                         <FundInfoDisplay fund={fund} />
                       </Grid>
                       <Grid item xs={12} sm={1} sx={{ textAlign: 'center' }}>
-                        <East />
+                        <ArrowRightAlt />
                       </Grid>
                       <Grid item xs={12} sm={5.5}>
                         <FundInfoDisplay
@@ -527,7 +504,6 @@ export const TransferModal: React.FC<TransferModalProps> = ({
                         id="transfer-note"
                         label={t('Note (Optional)')}
                         name="note"
-                        disabled={!isNew}
                         value={note}
                         onChange={handleChange}
                         fullWidth

--- a/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
@@ -247,9 +247,6 @@ describe('TransfersPage', () => {
     expect(
       await findAllByRole('button', { name: 'TRANSFER FROM' }),
     ).toHaveLength(2);
-    expect(await findAllByRole('button', { name: 'TRANSFER TO' })).toHaveLength(
-      2,
-    );
 
     const tables = await findAllByRole('grid');
     expect(tables.length).toBe(2);


### PR DESCRIPTION
## Description

- Ensures that the 'From' account is disabled, and that the 'Transfer to' button is removed to fulfill ticket requirements. 
    - This heavily implies the ability to swap From and To accounts in the selects should be removed as well.
- https://jira.cru.org/browse/MPDX-9653

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to Savings Fund Transfer on any test account
- Test the behavior of selecting the From button, ensuring that a user cannot change the From account.
- Ensure that the To button is removed from every card.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
