### PR TITLE
MPDX-9646 - MPD Goal: Change line item numbering in MpdGoalTable for consistency

### DIFF
--- a/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoal/MpdGoalTable.tsx
+++ b/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoal/MpdGoalTable.tsx
@@ -242,18 +242,18 @@ export const MpdGoalTable: React.FC<MpdGoalTableProps> = ({
       },
       ...ministryExpenseRows,
       {
-        line: '4',
+        line: '3',
         category: t('Ministry Expenses Subtotal'),
         value: (goalTotals) =>
           goalTotals.ministryExpensesTotal + goalTotals.benefitsCharge,
       },
       {
-        line: '5',
+        line: '4',
         category: t('Subtotal'),
         value: (goalTotals) => goalTotals.overallSubtotal,
       },
       {
-        line: '6',
+        line: '5',
         category: t('Subtotal with {{admin}} admin charge', {
           admin: percentageFormat(
             goalMiscConstants.RATES?.ADMIN_RATE?.fee ?? 0,
@@ -263,8 +263,8 @@ export const MpdGoalTable: React.FC<MpdGoalTableProps> = ({
         value: (goalTotals) => goalTotals.overallSubtotalWithAdmin,
       },
       {
-        line: '7',
-        category: t('Total Goal (line 6 with {{attrition}} attrition)', {
+        line: '6',
+        category: t('Total Goal (line 5 with {{attrition}} attrition)', {
           attrition: percentageFormat(
             goalMiscConstants.RATES?.ATTRITION_RATE?.fee ?? 0,
             locale,
@@ -273,17 +273,17 @@ export const MpdGoalTable: React.FC<MpdGoalTableProps> = ({
         value: (goalTotals) => goalTotals.overallTotal,
       },
       {
-        line: '8',
+        line: '7',
         category: t('Solid Monthly Support Developed'),
         value: () => supportRaised,
       },
       {
-        line: '9',
+        line: '8',
         category: t('Monthly Support to be Developed'),
         value: (goalTotals) => goalTotals.overallTotal - supportRaised,
       },
       {
-        line: '10',
+        line: '9',
         category: t('Support Goal Percentage Progress'),
         value: (goalTotals) =>
           safeProgressRatio(supportRaised, goalTotals.overallTotal),
@@ -366,14 +366,14 @@ export const MpdGoalTable: React.FC<MpdGoalTableProps> = ({
           // Bold subtotal and total lines
           if (
             params.row.line === '1J' ||
-            params.row.line === '7' ||
-            params.row.line === '9'
+            params.row.line === '6' ||
+            params.row.line === '8'
           ) {
             classes.push('bold');
           }
 
           // Add a top border to some lines
-          if (params.row.line === '1' || params.row.line === '7') {
+          if (params.row.line === '1' || params.row.line === '6') {
             classes.push('top-border');
           }
 

--- a/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoalStep/MpdGoalStepRightPanel/MpdGoalStepRightPanelAccordions/MpdGoalStepRightPanelAccordions.test.tsx
+++ b/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoalStep/MpdGoalStepRightPanel/MpdGoalStepRightPanelAccordions/MpdGoalStepRightPanelAccordions.test.tsx
@@ -16,10 +16,10 @@ describe('MpdGoalStepRightPanelAccordion', () => {
     ).toBeInTheDocument();
     expect(getByRole('button', { name: '2 Benefits' })).toBeInTheDocument();
     expect(
-      getByRole('button', { name: '3 Ministry Expenses' }),
+      getByRole('button', { name: '3A-J Ministry Expenses' }),
     ).toBeInTheDocument();
     expect(
-      getByRole('button', { name: '10 Support Goal Percentage Progress' }),
+      getByRole('button', { name: '9 Support Goal Percentage Progress' }),
     ).toBeInTheDocument();
   });
 

--- a/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoalStep/MpdGoalStepRightPanel/MpdGoalStepRightPanelAccordions/MpdGoalStepRightPanelAccordions.tsx
+++ b/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoalStep/MpdGoalStepRightPanel/MpdGoalStepRightPanelAccordions/MpdGoalStepRightPanelAccordions.tsx
@@ -107,47 +107,47 @@ export const MpdGoalStepRightPanelAccordions: React.FC = () => {
       ),
     },
     {
-      line: '3',
+      line: '3A-J',
       title: t('Ministry Expenses'),
       content: t(
         'Various ministry-related expenses including miles, travel, meetings, meals, MPD, supplies, summer assignments, medical expenses, account transfers, and other costs.',
       ),
     },
     {
-      line: '4',
+      line: '3',
       title: t('Ministry Expenses Subtotal'),
       content: t('Sum of all ministry expenses plus benefits.'),
     },
     {
-      line: '5',
+      line: '4',
       title: t('Subtotal'),
       content: t('Overall subtotal before admin charge and attrition.'),
     },
     {
-      line: '6',
+      line: '5',
       title: t('Subtotal with admin charge'),
       content: t('Subtotal including the administrative charge percentage.'),
       hasSpace: true,
     },
     {
-      line: '7',
+      line: '6',
       title: t('Total Goal (with attrition)'),
       content: t(
-        'Final total goal including attrition rate applied to line 6.',
+        'Final total goal including attrition rate applied to line 5.',
       ),
     },
     {
-      line: '8',
+      line: '7',
       title: t('Solid Monthly Support Developed'),
       content: t('Amount of monthly support already raised and committed.'),
     },
     {
-      line: '9',
+      line: '8',
       title: t('Monthly Support to be Developed'),
       content: t('Remaining monthly support needed to reach the total goal.'),
     },
     {
-      line: '10',
+      line: '9',
       title: t('Support Goal Percentage Progress'),
       content: t(
         'Percentage of the total goal that has been achieved through developed support.',


### PR DESCRIPTION
## Description

I changed the numbering slightly so the ministry subtotal would have the same number as the ministry expense sub items, which matches the same pattern as the above Gross Monthly Salary and its sub items.
- https://jira.cru.org/browse/MPDX-9646

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to MPD Goal > Summary
- Check the numbering of the MpdGoalTable line items and that it makes sense and aligns with design expectations.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
