### PR TITLE
MPDX-9650 - Improve validation in Savings Fund Transfer

### DIFF
--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -192,8 +192,69 @@ describe('TransferModal', () => {
       userEvent.tab();
 
       expect(
-        await findByText('End date must be after transfer date'),
+        await findByText(
+          'End date must be at least one day after the transfer date',
+        ),
       ).toBeInTheDocument();
+    });
+
+    it('should reject an end date equal to the transfer date for recurring transfers', async () => {
+      const { getByRole, findByLabelText, getByLabelText, findByText } = render(
+        <Components />,
+      );
+
+      userEvent.click(getByRole('radio', { name: /monthly/i }));
+      expect(getByRole('radio', { name: /monthly/i })).toBeChecked();
+
+      const transferDate = await findByLabelText(/transfer date/i);
+      const endDate = getByLabelText(/end date/i);
+
+      userEvent.clear(transferDate);
+      userEvent.type(transferDate, '12/01/2024');
+      userEvent.tab();
+
+      userEvent.clear(endDate);
+      userEvent.type(endDate, '12/01/2024');
+
+      userEvent.tab();
+
+      expect(
+        await findByText(
+          'End date must be at least one day after the transfer date',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should accept an end date one day after the transfer date for recurring transfers', async () => {
+      const { getByRole, findByLabelText, getByLabelText, queryByText } =
+        render(<Components />);
+
+      userEvent.click(getByRole('radio', { name: /monthly/i }));
+      expect(getByRole('radio', { name: /monthly/i })).toBeChecked();
+
+      expect(await findByLabelText(/end date/i)).toBeInTheDocument();
+
+      const transferDate = getByLabelText(/transfer date/i);
+      const endDate = getByLabelText(/end date/i);
+
+      userEvent.clear(transferDate);
+      userEvent.type(transferDate, '12/01/2024');
+      expect(transferDate).toHaveValue('12/01/2024');
+      userEvent.tab();
+
+      userEvent.clear(endDate);
+      userEvent.type(endDate, '12/02/2024');
+      expect(endDate).toHaveValue('12/02/2024');
+
+      userEvent.tab();
+
+      await waitFor(() =>
+        expect(
+          queryByText(
+            'End date must be at least one day after the transfer date',
+          ),
+        ).not.toBeInTheDocument(),
+      );
     });
 
     it('should submit form with valid data', async () => {
@@ -345,6 +406,18 @@ describe('TransferModal', () => {
           queryByRole('textbox', { name: /end date/i }),
         ).not.toBeInTheDocument(),
       );
+    });
+
+    it('should show descriptive helper text for the end date field', async () => {
+      const { getByRole, findByText } = render(<Components />);
+
+      userEvent.click(getByRole('radio', { name: /monthly/i }));
+
+      expect(
+        await findByText(
+          'The transfer will no longer recur after this date. If left blank, the transfer will recur indefinitely until manually stopped.',
+        ),
+      ).toBeInTheDocument();
     });
 
     it('should show error message when monthly schedule is selected', async () => {

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -119,14 +119,14 @@ const transferSchema = (locale: string) =>
         is: (schedule: ScheduleEnum) => schedule !== ScheduleEnum.OneTime,
         then: (schema) =>
           schema.test(
-            'end>=start',
-            i18n.t('End date must be after transfer date'),
+            'end>start',
+            i18n.t('End date must be at least one day after the transfer date'),
             function (end) {
               const start = this.parent.transferDate as DateTime | null;
               if (!end || !start) {
                 return true;
               }
-              return end.toMillis() >= start.toMillis();
+              return end.startOf('day') > start.startOf('day');
             },
           ),
         otherwise: (schema) => schema.notRequired(),
@@ -491,7 +491,11 @@ export const TransferModal: React.FC<TransferModalProps> = ({
                             }}
                             error={touched.endDate && Boolean(errors.endDate)}
                             helperText={
-                              touched.endDate && (errors.endDate as string)
+                              touched.endDate && errors.endDate
+                                ? errors.endDate
+                                : t(
+                                    'The transfer will no longer recur after this date. If left blank, the transfer will recur indefinitely until manually stopped.',
+                                  )
                             }
                           />
                         </Grid>


### PR DESCRIPTION
## Description

- Ensures the start and end date can't be the same date, since SAA has validation that raises in error for this case.
- Adds information text for the recurring end date
https://jira.cru.org/browse/MPDX-9580

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to SavingsFundTransfer
- Ensure that the user cannot set the start date and the end date to be the same date.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
