### PR TITLE
MPDX-9374 - Display effective approved salary instead of current salary

### DIFF
--- a/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.test.tsx
@@ -8,8 +8,11 @@ import {
 } from 'src/graphql/types.generated';
 import { SalaryCalculationQuery } from '../../SalaryCalculatorContext/SalaryCalculation.generated';
 import {
+  EffectiveSalaryRequestMock,
   SalaryCalculatorTestWrapper,
   SalaryCalculatorTestWrapperProps,
+  hcmSpouseMock,
+  hcmUserMock,
 } from '../../SalaryCalculatorTestWrapper';
 import { RequestedSalaryCard } from './RequestedSalaryCard';
 
@@ -27,9 +30,19 @@ const defaultSalaryMock: DeepPartial<SalaryCalculationQuery['salaryRequest']> =
     },
   };
 
-const TestComponent: React.FC<SalaryCalculatorTestWrapperProps> = (props) => (
+const approvedSalaryMock: EffectiveSalaryRequestMock = {
+  personNumber: hcmUserMock.staffInfo.personNumber,
+  salary: 11111,
+  spouseSalary: 22222,
+};
+
+const TestComponent: React.FC<SalaryCalculatorTestWrapperProps> = ({
+  effectiveSalaryRequestMock = approvedSalaryMock,
+  ...props
+}) => (
   <SalaryCalculatorTestWrapper
     salaryRequestMock={defaultSalaryMock}
+    effectiveSalaryRequestMock={effectiveSalaryRequestMock}
     hcmUser={{
       currentSalary: { grossSalaryAmount: 10001 },
     }}
@@ -74,7 +87,7 @@ As you set your salary level, the amount you receive should reflect the amount o
         expect(
           getAllByRole('rowheader').map((cell) => cell.textContent),
         ).toEqual([
-          'Current Salary',
+          'Current Requested Salary',
           'Minimum Salary',
           'Maximum Allowable Salary (CAP)',
           'Requested Salary',
@@ -86,7 +99,27 @@ As you set your salary level, the amount you receive should reflect the amount o
       const { getAllByRole } = render(<TestComponent />);
 
       const expectedCells = [
-        ['$10,001.00', '$20,001.00'],
+        ['$11,111.00', '$22,222.00'],
+        ['$10,003.00', '$20,003.00'],
+        ['$10,004.00', '$20,004.00'],
+      ].flat();
+
+      await waitFor(() =>
+        expect(
+          getAllByRole('cell')
+            .slice(0, -2)
+            .map((cell) => cell.textContent),
+        ).toEqual(expectedCells),
+      );
+    });
+
+    it('should render a dash when there is no approved salary request', async () => {
+      const { getAllByRole } = render(
+        <TestComponent effectiveSalaryRequestMock={null} />,
+      );
+
+      const expectedCells = [
+        ['–', '–'],
         ['$10,003.00', '$20,003.00'],
         ['$10,004.00', '$20,004.00'],
       ].flat();
@@ -98,6 +131,31 @@ As you set your salary level, the amount you receive should reflect the amount o
             .slice(0, -2)
             .map((cell) => cell.textContent),
         ).toEqual(expectedCells),
+      );
+    });
+
+    it('swaps the requested salary when the spouse created the request', async () => {
+      const { getAllByRole } = render(
+        <TestComponent
+          effectiveSalaryRequestMock={{
+            ...approvedSalaryMock,
+            personNumber: hcmSpouseMock.staffInfo.personNumber,
+          }}
+        />,
+      );
+
+      await waitFor(() =>
+        expect(
+          getAllByRole('cell')
+            .slice(0, -2)
+            .map((cell) => cell.textContent),
+        ).toEqual(
+          [
+            ['$22,222.00', '$11,111.00'],
+            ['$10,003.00', '$20,003.00'],
+            ['$10,004.00', '$20,004.00'],
+          ].flat(),
+        ),
       );
     });
 
@@ -148,7 +206,7 @@ As you set your salary level, the amount you receive should reflect the amount o
         expect(
           getAllByRole('rowheader').map((cell) => cell.textContent),
         ).toEqual([
-          'Current Salary',
+          'Current Requested Salary',
           'Minimum Salary',
           'Maximum Allowable Salary (CAP)',
           'Requested Salary',
@@ -159,7 +217,23 @@ As you set your salary level, the amount you receive should reflect the amount o
     it('should render table cells with formatted currency', async () => {
       const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
 
-      const expectedCells = ['$10,001.00', '$10,003.00', '$10,004.00'];
+      const expectedCells = ['$11,111.00', '$10,003.00', '$10,004.00'];
+
+      await waitFor(() =>
+        expect(
+          getAllByRole('cell')
+            .slice(0, -1)
+            .map((cell) => cell.textContent),
+        ).toEqual(expectedCells),
+      );
+    });
+
+    it('should render a dash when there is no approved salary request', async () => {
+      const { getAllByRole } = render(
+        <TestComponent hasSpouse={false} effectiveSalaryRequestMock={null} />,
+      );
+
+      const expectedCells = ['–', '$10,003.00', '$10,004.00'];
 
       await waitFor(() =>
         expect(

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.tsx
@@ -15,10 +15,14 @@ import * as yup from 'yup';
 import { useAutosaveForm } from 'src/components/Shared/Autosave/AutosaveForm';
 import { amount } from 'src/lib/yupHelpers';
 import { AutosaveTextField } from '../../Autosave/AutosaveTextField';
-import { CalculationFieldsFragment } from '../../SalaryCalculatorContext/SalaryCalculation.generated';
+import {
+  CalculationFieldsFragment,
+  useEffectiveSalaryCalculationQuery,
+} from '../../SalaryCalculatorContext/SalaryCalculation.generated';
 import { useSalaryCalculator } from '../../SalaryCalculatorContext/SalaryCalculatorContext';
 import { EffectiveDateNote } from '../../Shared/EffectiveDateNote';
 import { StepCard, StepTableHead } from '../../Shared/StepCard';
+import { orientSalaryRequest } from '../../Shared/orientSalaryRequest';
 import { useFormatters } from '../../Shared/useFormatters';
 import { useCaps } from '../useCaps';
 import { useSosaBlockOverCap } from '../useSosaBlockOverCap';
@@ -34,6 +38,13 @@ export const RequestedSalaryCard: React.FC = () => {
   const { overCapPerson } = useCaps();
   const { isUserSosa, blockOnCap } = useSosaBlockOverCap();
   const { markValid, markInvalid } = useAutosaveForm();
+
+  const { data: effectiveData } = useEffectiveSalaryCalculationQuery();
+  const { salary, spouseSalary } =
+    orientSalaryRequest(
+      effectiveData?.salaryRequest,
+      hcmUser?.staffInfo.personNumber,
+    ) ?? {};
 
   // Disable the Continue button while the saved gross exceeds the SOSA cap.
   useEffect(() => {
@@ -128,14 +139,12 @@ export const RequestedSalaryCard: React.FC = () => {
           <TableBody>
             <TableRow>
               <TableCell component="th" scope="row">
-                {t('Current Salary')}
+                {t('Current Requested Salary')}
               </TableCell>
-              <TableCell>
-                {formatCurrency(hcmUser?.currentSalary.grossSalaryAmount)}
-              </TableCell>
+              <TableCell>{salary ? formatCurrency(salary) : '–'}</TableCell>
               {hcmSpouse && (
                 <TableCell>
-                  {formatCurrency(hcmSpouse.currentSalary.grossSalaryAmount)}
+                  {spouseSalary ? formatCurrency(spouseSalary) : '–'}
                 </TableCell>
               )}
             </TableRow>

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculatorTestWrapper.tsx
@@ -18,7 +18,10 @@ import {
   HcmQueryVariables,
 } from '../Shared/HcmData/Hcm.generated';
 import { PayrollDatesQuery } from './EffectiveDateStep/PayrollDates.generated';
-import { SalaryCalculationQuery } from './SalaryCalculatorContext/SalaryCalculation.generated';
+import {
+  EffectiveSalaryCalculationQuery,
+  SalaryCalculationQuery,
+} from './SalaryCalculatorContext/SalaryCalculation.generated';
 import { SalaryCalculatorProvider } from './SalaryCalculatorContext/SalaryCalculatorContext';
 
 const hcmMock = gqlMock<HcmQuery, HcmQueryVariables>(HcmDocument, {
@@ -91,8 +94,13 @@ export type SalaryRequestMock = DeepPartial<
   SalaryCalculationQuery['salaryRequest']
 >;
 
+export type EffectiveSalaryRequestMock = DeepPartial<
+  EffectiveSalaryCalculationQuery['salaryRequest']
+>;
+
 export interface SalaryCalculatorTestWrapperProps {
   salaryRequestMock?: SalaryRequestMock;
+  effectiveSalaryRequestMock?: EffectiveSalaryRequestMock;
   hcmUser?: DeepPartial<HcmQuery['hcm'][number]>;
   hcmSpouse?: DeepPartial<HcmQuery['hcm'][number]>;
   onCall?: MockLinkCallHandler;
@@ -107,6 +115,7 @@ export const SalaryCalculatorTestWrapper: React.FC<
   SalaryCalculatorTestWrapperProps
 > = ({
   salaryRequestMock,
+  effectiveSalaryRequestMock = null,
   hcmUser,
   hcmSpouse,
   onCall,
@@ -133,6 +142,7 @@ export const SalaryCalculatorTestWrapper: React.FC<
           Hcm: HcmQuery;
           PayrollDates: PayrollDatesQuery;
           SalaryCalculation: SalaryCalculationQuery;
+          EffectiveSalaryCalculation: EffectiveSalaryCalculationQuery;
           GoalCalculatorConstants: GoalCalculatorConstantsQuery;
           StaffAccount: StaffAccountQuery;
           GetUser: GetUserQuery;
@@ -151,6 +161,9 @@ export const SalaryCalculatorTestWrapper: React.FC<
             },
             PayrollDates: {
               payrollDates,
+            },
+            EffectiveSalaryCalculation: {
+              salaryRequest: effectiveSalaryRequestMock,
             },
             GoalCalculatorConstants: {
               constant: {


### PR DESCRIPTION
## Description

This ticket slipped through the cracks: https://jira.cru.org/browse/MPDX-9374

Sorry about that!

This displays the user and user spouse's current requested salary from their latest approved request.
I took the ticket description to mean we want to remove the current gross salary from the display and replace it with this value. Do we instead want to display _both_?


## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to SalaryCalculator
- Continue to Step 3
- Check that the effective request's salary and spouse salary amount display as expected.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
