### PR TITLE
HS-1639514 - Fix Google Import, MailChimp, Organization, and PrayerLetters redirects

### DIFF
--- a/src/components/Settings/integrations/useOauthUrl.test.tsx
+++ b/src/components/Settings/integrations/useOauthUrl.test.tsx
@@ -1,0 +1,79 @@
+import React, { PropsWithChildren } from 'react';
+import { renderHook } from '@testing-library/react';
+import { Session } from 'next-auth';
+import { useSession } from 'next-auth/react';
+import { renderToString } from 'react-dom/server';
+import TestRouter from '__tests__/util/TestRouter';
+import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
+import { useOauthUrl } from './useOauthUrl';
+
+jest.mock('next-auth/react');
+
+const accountListId = 'account-list-1';
+const apiToken = 'apiToken';
+
+const Wrapper = ({ children }: PropsWithChildren) => (
+  <TestRouter router={{ query: { accountListId } }}>{children}</TestRouter>
+);
+
+const renderUseOauthUrl = () =>
+  renderHook(() => useOauthUrl(), { wrapper: Wrapper });
+
+beforeEach(() => {
+  process.env.OAUTH_URL = 'https://auth.mpdx.org';
+  (useSession as jest.Mock).mockReturnValue({
+    data: { user: { apiToken } } as Session,
+  });
+});
+
+describe('useOauthUrl', () => {
+  it('builds the Google OAuth url with the redirect back to integrations', () => {
+    const { result } = renderUseOauthUrl();
+
+    expect(result.current.getGoogleOauthUrl()).toBe(
+      `https://auth.mpdx.org/auth/user/google?account_list_id=${accountListId}&redirect_to=${encodeURIComponent(
+        `http://localhost/accountLists/${accountListId}/settings/integrations?selectedTab=${IntegrationAccordion.Google}`,
+      )}&access_token=${apiToken}`,
+    );
+  });
+
+  it('includes the organization id in the DonorHub OAuth url', () => {
+    const { result } = renderUseOauthUrl();
+
+    expect(result.current.getOrganizationOauthUrl('org-1')).toBe(
+      `https://auth.mpdx.org/auth/user/donorhub?account_list_id=${accountListId}&redirect_to=${encodeURIComponent(
+        `http://localhost/accountLists/${accountListId}/settings/integrations?selectedTab=${IntegrationAccordion.Organization}`,
+      )}&access_token=${apiToken}&organization_id=org-1`,
+    );
+  });
+
+  it('renders on the server when window is undefined', () => {
+    const Probe = () => {
+      const { getGoogleOauthUrl } = useOauthUrl();
+      return <a href={getGoogleOauthUrl()}>{'link'}</a>;
+    };
+
+    const originalWindow = global.window;
+    // @ts-expect-error simulating a server environment with no window
+    delete global.window;
+
+    try {
+      let html = '';
+      expect(() => {
+        html = renderToString(
+          <Wrapper>
+            <Probe />
+          </Wrapper>,
+        );
+      }).not.toThrow();
+
+      expect(html).toContain(
+        `redirect_to=${encodeURIComponent(
+          `/accountLists/${accountListId}/settings/integrations?selectedTab=${IntegrationAccordion.Google}`,
+        )}`,
+      );
+    } finally {
+      global.window = originalWindow;
+    }
+  });
+});

--- a/src/components/Settings/integrations/useOauthUrl.ts
+++ b/src/components/Settings/integrations/useOauthUrl.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useRequiredSession } from 'src/hooks/useRequiredSession';
@@ -6,12 +7,15 @@ export const useOauthUrl = () => {
   const { apiToken } = useRequiredSession();
   const accountListId = useAccountListId();
 
-  const getRedirectUrl = (accordion: IntegrationAccordion) => {
-    const domain = window.location.origin;
-    return encodeURIComponent(
-      `${domain}/accountLists/${accountListId}/settings/integrations?selectedTab=${accordion}`,
+  const [origin, setOrigin] = useState('');
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
+
+  const getRedirectUrl = (accordion: IntegrationAccordion) =>
+    encodeURIComponent(
+      `${origin}/accountLists/${accountListId}/settings/integrations?selectedTab=${accordion}`,
     );
-  };
 
   return {
     getGoogleOauthUrl: () =>


### PR DESCRIPTION
## Description

Caused by a minor regression from https://github.com/CruGlobal/mpdx-react/pull/1781
- https://secure.helpscout.net/conversation/3341814677/1639514?viewId=8745276

#### Issue:

useOauthUrl.ts built the OAuth button URLs by reading window.location.origin directly inside getRedirectUrl. The integration accordions call these getters during render to set each button's href, and render also runs on the server. 

On a full page load (the OAuth redirect landing, a direct URL, or a refresh), window is undefined on the server, so the read threw ReferenceError: window is not defined and crashed the page render. This was introduced by PR #1781 (Remove SITE_URL), which deleted the env var that had been the SSR-safe branch of `process.env.SITE_URL || window.location.origin`, leaving only the window read.

Fix: Resolve the origin in a client side only useEffect and hold it in state that starts
as an empty string. 

SSR and the first hydration render use the empty value, so no window access happens during render and the server/client markup matches. After mount, the effect sets the real window.location.origin and rerenders,
patching the button hrefs with the user's host. This keeps the redirect correct across all domains without depending on a build-time env var. Fixes all four OAuth flows (Google, MailChimp, DonorHub/Organization, prayerletters.com),
which share getRedirectUrl.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to MPDX Tools > Import from Google > Select 'Connect Google Account'
    - In production this will cause a server side error, in the preview environment this will resolve correctly. 
- You can test also that refreshes in the Settings work when the PrayerLetters and MailChimp accordions are open as well.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
