### PR TITLE
[No Jira] - Refactor PDS Goal Calculator part-time fees to be amount rather than percent

### DIFF
--- a/src/components/HrTools/PdsGoalCalculator/SupportItem/otherBreakdown.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SupportItem/otherBreakdown.test.tsx
@@ -20,7 +20,7 @@ const constants: OtherExpensesConstants = {
   salarySubtotal: 5000,
   fourOThreeBPercentage: 0.08,
   grossMonthlyPay: 5000,
-  workCompPercentage: 0.02,
+  workCompAmount: 100,
   attritionRate: 0.05,
   creditCardFeeRate: 0.03,
   adminRate: 0.1,

--- a/src/components/HrTools/PdsGoalCalculator/calculations/OtherExpenses.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/OtherExpenses.test.ts
@@ -10,7 +10,7 @@ const defaultConstants: OtherExpensesConstants = {
   salarySubtotal: 5000,
   fourOThreeBPercentage: 0.1,
   grossMonthlyPay: 4000,
-  workCompPercentage: 0.17,
+  workCompAmount: 680,
   attritionRate: 0.06,
   creditCardFeeRate: 0.06,
   adminRate: 0.12,
@@ -57,9 +57,9 @@ describe('calculateOtherExpenses', () => {
   });
 
   describe('work comp', () => {
-    it('calculates as grossMonthlyPay × workCompPercentage for part-time', () => {
+    it('uses the fixed workCompAmount for part-time', () => {
       const result = calculateOtherExpenses(partTime(), defaultConstants);
-      // 4000 * 0.17
+      // fixed amount
       expect(result.workComp).toBeCloseTo(680);
     });
 
@@ -183,7 +183,7 @@ describe('calculateOtherExpenses', () => {
 
     it('produces correct totals for a part-time employee', () => {
       const result = calculateOtherExpenses(partTime(), defaultConstants);
-      // reimbursable=500, 403b=400, workComp=4000*0.17=680, benefits=0
+      // reimbursable=500, 403b=400, workComp=680 (fixed), benefits=0
       // subtotal=5000+500+400+680+0=6580
       // attrition=6580*0.06=394.80
       // creditCardFees=(6580+394.80)/(1-0.06)-(6580+394.80)≈445.20

--- a/src/components/HrTools/PdsGoalCalculator/calculations/OtherExpenses.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/OtherExpenses.ts
@@ -14,7 +14,7 @@ export interface OtherExpensesConstants {
   salarySubtotal: number;
   fourOThreeBPercentage: number;
   grossMonthlyPay: number;
-  workCompPercentage: number;
+  workCompAmount: number;
   attritionRate: number;
   creditCardFeeRate: number;
   adminRate: number;
@@ -41,9 +41,7 @@ export const calculateOtherExpenses = (
   const reimbursableExpenses = constants.reimbursableTotal;
   const fourOThreeBContributions =
     constants.grossMonthlyPay * constants.fourOThreeBPercentage;
-  const workComp = isPartTime
-    ? constants.grossMonthlyPay * constants.workCompPercentage
-    : 0;
+  const workComp = isPartTime ? constants.workCompAmount : 0;
   const benefits = isFullTime ? (calculation.benefits ?? 0) : 0;
 
   const subtotal =

--- a/src/components/HrTools/PdsGoalCalculator/calculations/buildPdsGoalConstants.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/buildPdsGoalConstants.test.ts
@@ -28,7 +28,7 @@ const buildMiscConstants = (
       : { EMPLOYER_FICA_RATE: makeConstant(0.08) }),
     ...(overrides.workComp !== undefined
       ? { PART_TIME_WORK_COMPENSATION: makeConstant(overrides.workComp) }
-      : { PART_TIME_WORK_COMPENSATION: makeConstant(0.17) }),
+      : { PART_TIME_WORK_COMPENSATION: makeConstant(20.35) }),
     ...(overrides.creditCardFeeRate !== undefined
       ? { CREDIT_CARD_FEE_RATE: makeConstant(overrides.creditCardFeeRate) }
       : { CREDIT_CARD_FEE_RATE: makeConstant(0.06) }),
@@ -59,7 +59,7 @@ describe('buildPdsGoalConstants', () => {
 
     expect(result).toEqual({
       employerFicaRate: 0.08,
-      workCompPercentage: 0.17,
+      workCompAmount: 20.35,
       attritionRate: 0.06,
       creditCardFeeRate: 0.06,
       adminRate: 0.12,

--- a/src/components/HrTools/PdsGoalCalculator/calculations/pdsGoalConstants.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/pdsGoalConstants.ts
@@ -9,7 +9,7 @@ import { SalaryTotals } from './salaryCalculation';
 
 export interface PdsGoalTotalConstants {
   employerFicaRate: number;
-  workCompPercentage: number;
+  workCompAmount: number;
   attritionRate: number;
   creditCardFeeRate: number;
   adminRate: number;
@@ -29,14 +29,14 @@ export const buildPdsGoalConstants = (
   const rates = goalMiscConstants.RATES;
 
   const employerFicaRate = additionalRates?.EMPLOYER_FICA_RATE?.fee;
-  const workCompPercentage = additionalRates?.PART_TIME_WORK_COMPENSATION?.fee;
+  const workCompAmount = additionalRates?.PART_TIME_WORK_COMPENSATION?.fee;
   const attritionRate = rates?.ATTRITION_RATE?.fee;
   const creditCardFeeRate = additionalRates?.CREDIT_CARD_FEE_RATE?.fee;
   const adminRate = rates?.ADMIN_RATE?.fee;
 
   if (
     employerFicaRate === undefined ||
-    workCompPercentage === undefined ||
+    workCompAmount === undefined ||
     attritionRate === undefined ||
     creditCardFeeRate === undefined ||
     adminRate === undefined
@@ -52,7 +52,7 @@ export const buildPdsGoalConstants = (
 
   return {
     employerFicaRate,
-    workCompPercentage,
+    workCompAmount,
     attritionRate,
     creditCardFeeRate,
     adminRate,
@@ -73,7 +73,7 @@ export const buildOtherExpensesConstants = (
     salarySubtotal: salaryTotals.subtotal,
     fourOThreeBPercentage: isSimple ? 0 : constants.fourOThreeBPercentage,
     grossMonthlyPay: salaryTotals.grossMonthlyPay,
-    workCompPercentage: constants.workCompPercentage,
+    workCompAmount: constants.workCompAmount,
     attritionRate: constants.attritionRate,
     creditCardFeeRate: constants.creditCardFeeRate,
     adminRate: constants.adminRate,

--- a/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.test.ts
+++ b/src/components/HrTools/PdsGoalCalculator/calculations/usePdsSummaryData.test.ts
@@ -31,7 +31,7 @@ const mockUseGoalCalculatorConstants =
   >;
 
 const EMPLOYER_FICA_RATE = 0.08;
-const WORK_COMP_PERCENTAGE = 0.17;
+const WORK_COMP_AMOUNT = 400;
 const ATTRITION_RATE = 0.06;
 const CREDIT_CARD_FEE_RATE = 0.06;
 const ADMIN_RATE = 0.12;
@@ -51,7 +51,7 @@ const constantsMock = gqlMock<GoalCalculatorConstantsQuery>(
           {
             category: MpdGoalMiscConstantCategoryEnum.AdditionalRates,
             label: MpdGoalMiscConstantLabelEnum.PartTimeWorkCompensation,
-            fee: WORK_COMP_PERCENTAGE,
+            fee: WORK_COMP_AMOUNT,
           },
           {
             category: MpdGoalMiscConstantCategoryEnum.AdditionalRates,
@@ -151,7 +151,7 @@ describe('usePdsSummaryData', () => {
         },
       ],
       [
-        'workCompPercentage',
+        'workCompAmount',
         {
           ADDITIONAL_RATES: {
             ...defaultConstants.goalMiscConstants.ADDITIONAL_RATES,
@@ -329,14 +329,14 @@ describe('usePdsSummaryData', () => {
       // Reimbursable: monthly = 400, annual = 1200, raw = 500, above floor
       //
       // 403b = 2166.667 * 0.08 = 173.333
-      // workComp = 2166.667 * 0.17 = 368.333 (part-time)
+      // workComp = 400 (fixed amount, part-time)
       // benefits = 0 (part-time, ignores calculation.benefits)
-      // subtotal = 2340 + 500 + 173.333 + 368.333 + 0 = 3381.667
-      // attrition = 3381.667 * 0.06 = 202.9
-      // creditCardFees = (3381.667 + 202.9) / (1 - 0.06) - (3381.667 + 202.9) ≈ 228.80
-      // adminBase ≈ 3813.37
-      // assessment = adminBase / (1 - 0.12) - adminBase ≈ 520.00
-      // overallTotal ≈ 3381.667 + 202.9 + 228.80 + 520.00 ≈ 4333.37
+      // subtotal = 2340 + 500 + 173.333 + 400 + 0 = 3413.333
+      // attrition = 3413.333 * 0.06 = 204.8
+      // creditCardFees = (3413.333 + 204.8) / (1 - 0.06) - (3413.333 + 204.8) ≈ 230.94
+      // adminBase ≈ 3849.08
+      // assessment = adminBase / (1 - 0.12) - adminBase ≈ 524.87
+      // overallTotal ≈ 3413.333 + 204.8 + 230.94 + 524.87 ≈ 4373.95
       const calc = {
         ...defaultCalculation,
         salaryOrHourly: DesignationSupportSalaryType.Hourly,
@@ -348,8 +348,8 @@ describe('usePdsSummaryData', () => {
       const { result } = renderHook(() =>
         usePdsSummaryData(calc, defaultHcmUser),
       );
-      expect(result.current.data?.overallTotal).toBeCloseTo(4333.37, 0);
-      expect(result.current.data?.otherTotals.workComp).toBeCloseTo(368.33, 2);
+      expect(result.current.data?.overallTotal).toBeCloseTo(4373.95, 0);
+      expect(result.current.data?.otherTotals.workComp).toBeCloseTo(400, 2);
       expect(result.current.data?.otherTotals.benefits).toBe(0);
     });
 


### PR DESCRIPTION
## Description

- Changes the PDS Goal Calculator's part-time work compensation fee from a percentage applied to gross monthly pay to a flat dollar amount pulled directly from the `PART_TIME_WORK_COMPENSATION` rate.
- Renames `workCompPercentage` to `workCompAmount` across `pdsGoalConstants`, `OtherExpenses`, and their tests to reflect the new semantics.
- Updates `calculateOtherExpenses` so the part-time `workComp` value is the constant amount instead of `grossMonthlyPay * workCompPercentage`.
- Updates `usePdsSummaryData`, `buildPdsGoalConstants`, and `otherBreakdown` tests to use the new amount-based value and expected outputs.

Backend work done in this [PR](https://github.com/CruGlobal/mpdx_api/pull/3341)

## Testing

- Go to the PDS Goal Calculator for a part-time staff member.
- Open the Other Expenses / breakdown section and verify the work compensation line shows the flat `PART_TIME_WORK_COMPENSATION` amount, not a percentage of gross monthly pay.
- Switch the calculation to full-time and confirm work compensation is `0`.
- Run `yarn test src/components/HrTools/PdsGoalCalculator/calculations` and confirm `OtherExpenses`, `buildPdsGoalConstants`, and `usePdsSummaryData` suites all pass.
- Check the PDS goal subtotal/total updates correctly when toggling part-time vs full-time.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history