### PR TITLE
MPDX-9655 Frontend - Add transfer date validation and editing functionality in TransferModal for One Time transfer start date

### DIFF
--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -379,6 +379,30 @@ describe('TransferModal', () => {
       ).toBeInTheDocument();
     });
 
+    it('should allow editing the transfer date for one-time transfers', async () => {
+      const { getByLabelText } = render(<Components />);
+
+      const transferDate = getByLabelText(/transfer date/i);
+      expect(transferDate).toBeEnabled();
+
+      userEvent.clear(transferDate);
+      userEvent.type(transferDate, '12/01/2099');
+      expect(transferDate).toHaveValue('12/01/2099');
+    });
+
+    it('should reject a past transfer date for one-time transfers', async () => {
+      const { getByLabelText, findByText } = render(<Components />);
+
+      const transferDate = getByLabelText(/transfer date/i);
+      userEvent.clear(transferDate);
+      userEvent.type(transferDate, '12/31/2019');
+      userEvent.tab();
+
+      expect(
+        await findByText('Transfer start date cannot be in the past'),
+      ).toBeInTheDocument();
+    });
+
     it('should show error message when monthly schedule is selected', async () => {
       const { getByRole, getByLabelText, findByText } = render(<Components />);
 
@@ -464,8 +488,8 @@ describe('TransferModal', () => {
   });
 
   describe('Mutations', () => {
-    it('should create a one-time transfer', async () => {
-      const { getByRole } = render(<Components />);
+    it('should create a one-time transfer with the selected transfer date', async () => {
+      const { getByRole, getByLabelText } = render(<Components />);
 
       const amountField = getByRole('spinbutton', { name: /amount/i });
 
@@ -474,6 +498,12 @@ describe('TransferModal', () => {
 
       userEvent.clear(amountField);
       userEvent.type(amountField, '100');
+
+      const transferDate = getByLabelText(/transfer date/i);
+      userEvent.clear(transferDate);
+      userEvent.type(transferDate, '12/01/2099');
+      expect(transferDate).toHaveValue('12/01/2099');
+      userEvent.tab();
 
       userEvent.click(getByRole('button', { name: /submit/i }));
 
@@ -487,6 +517,7 @@ describe('TransferModal', () => {
                 sourceFundTypeName: 'Staff Account',
                 destinationFundTypeName: 'Staff Savings',
                 description: '',
+                transactedAt: '2099-12-01T00:00:00.000+00:00',
               }),
             }),
           }),

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -104,9 +104,12 @@ const transferSchema = (locale: string) =>
         }
 
         return this.createError({
-          message: i18n.t(
-            'Recurring transfers must start at least one day in the future',
-          ),
+          message:
+            schedule === ScheduleEnum.OneTime
+              ? i18n.t('Transfer start date cannot be in the past')
+              : i18n.t(
+                  'Recurring transfers must start at least one day in the future',
+                ),
         });
       }),
     endDate: yup
@@ -216,6 +219,7 @@ export const TransferModal: React.FC<TransferModalProps> = ({
             sourceFundTypeName: transferFrom,
             destinationFundTypeName: transferTo,
             description: note,
+            transactedAt: convertedTransferDate,
           },
         });
       } else {
@@ -429,11 +433,21 @@ export const TransferModal: React.FC<TransferModalProps> = ({
                   <Grid container spacing={2}>
                     {schedule === ScheduleEnum.OneTime ? (
                       <Grid item xs={12}>
-                        <TextField
-                          fullWidth
+                        <CustomDateField
                           label={t('Transfer Date')}
-                          value={transferDate.toFormat('MM/dd/yyyy')}
-                          disabled={true}
+                          value={transferDate}
+                          onChange={(date) => {
+                            setFieldValue('transferDate', date);
+                            setFieldTouched('transferDate', true, false);
+                          }}
+                          error={
+                            touched.transferDate && Boolean(errors.transferDate)
+                          }
+                          helperText={
+                            touched.transferDate &&
+                            (errors.transferDate as string)
+                          }
+                          required
                         />
                       </Grid>
                     ) : (

--- a/src/components/HrTools/SavingsFundTransfer/TransferMutations.graphql
+++ b/src/components/HrTools/SavingsFundTransfer/TransferMutations.graphql
@@ -47,7 +47,7 @@ mutation CreateTransfer(
   $destinationFundTypeName: String!
   $description: String!
   $amount: Float!
-  $transactedAt: ISO8601DateTime
+  $transactedAt: ISO8601DateTime!
 ) {
   createTransfer(
     input: {

--- a/src/components/HrTools/SavingsFundTransfer/TransferMutations.graphql
+++ b/src/components/HrTools/SavingsFundTransfer/TransferMutations.graphql
@@ -47,6 +47,7 @@ mutation CreateTransfer(
   $destinationFundTypeName: String!
   $description: String!
   $amount: Float!
+  $transactedAt: ISO8601DateTime
 ) {
   createTransfer(
     input: {
@@ -54,6 +55,7 @@ mutation CreateTransfer(
       destinationFundTypeName: $destinationFundTypeName
       description: $description
       amount: $amount
+      transactedAt: $transactedAt
     }
   ) {
     message


### PR DESCRIPTION
## Description

Scott would like users to choose when to have a one time transfer fulfilled (i.e. future dateable)
- Jira ticket: https://jira.cru.org/browse/MPDX-9655
- Backend PR: https://github.com/CruGlobal/mpdx_api/pull/3342
- SAA backend PR (by Ethan Tison): https://github.com/CruGlobal/staff_accounting_app/pull/573

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to Savings Fund Transfer
- Attempt a one time transfer and ensure that the user can select future dates, and that validation is correctly managed for past dates.
- Check that the transaction goes through.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
