### PR TITLE
[MPDX-9567] - Add Person Number label to MHA, SC, ASR

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2104,6 +2104,8 @@
     "person": "person",
     "Person created successfully": "Person created successfully",
     "Person deleted successfully": "Person deleted successfully",
+    "Person Number: {{personNumbers}}_one": "Person Number: {{personNumbers}}",
+    "Person Number: {{personNumbers}}_other": "Person Numbers: {{personNumbers}}",
     "Person updated successfully": "Person updated successfully",
     "Personal": "Personal",
     "Personal Contact Information": "Personal Contact Information",

--- a/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
@@ -104,7 +104,7 @@ describe('AboutForm', () => {
     const { findByText, getByText } = render(<TestWrapper />);
 
     expect(await findByText('Doc, John')).toBeInTheDocument();
-    expect(getByText('00123456')).toBeInTheDocument();
+    expect(getByText('Person Number: 00123456')).toBeInTheDocument();
   });
 
   it('should display financial data when a request exists', async () => {

--- a/src/components/HrTools/AdditionalSalaryRequest/FormVersions/Edit/EditForm.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/FormVersions/Edit/EditForm.test.tsx
@@ -28,7 +28,7 @@ describe('EditForm', () => {
 
     expect(getByText('Edit Your Request')).toBeInTheDocument();
     expect(getByText('Doe, John')).toBeInTheDocument();
-    expect(getByText('00123456')).toBeInTheDocument();
+    expect(getByText('Person Number: 00123456')).toBeInTheDocument();
   });
 
   it('displays financial balances from context', () => {

--- a/src/components/HrTools/AdditionalSalaryRequest/FormVersions/New/NewForm.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/FormVersions/New/NewForm.test.tsx
@@ -32,7 +32,7 @@ describe('NewForm', () => {
       const { getByText } = renderComponent();
 
       expect(getByText('Doe, John')).toBeInTheDocument();
-      expect(getByText('00123456')).toBeInTheDocument();
+      expect(getByText('Person Number: 00123456')).toBeInTheDocument();
     });
 
     it('renders instructional text and notes', () => {

--- a/src/components/HrTools/AdditionalSalaryRequest/FormVersions/View/ViewForm.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/FormVersions/View/ViewForm.test.tsx
@@ -28,7 +28,7 @@ describe('ViewForm', () => {
 
     expect(getByText('View Your Request')).toBeInTheDocument();
     expect(getByText('Doe, John')).toBeInTheDocument();
-    expect(getByText('00123456')).toBeInTheDocument();
+    expect(getByText('Person Number: 00123456')).toBeInTheDocument();
 
     expect(
       getByRole('button', { name: /back to status/i }),

--- a/src/components/HrTools/MinisterHousingAllowance/MinisterHousingAllowance.tsx
+++ b/src/components/HrTools/MinisterHousingAllowance/MinisterHousingAllowance.tsx
@@ -155,7 +155,11 @@ export const MinisterHousingAllowanceReport = () => {
                   <Typography variant="h5">{t('Your MHA')}</Typography>
                 </Box>
 
-                <NameDisplay names={names} personNumbers={personNumbers} />
+                <NameDisplay
+                  names={names}
+                  personNumbers={personNumbers}
+                  personNumberCount={isMarried ? 2 : 1}
+                />
 
                 {hasNoRequests ? (
                   <>

--- a/src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay.test.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay.test.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider } from '@mui/material/styles';
-import { render } from '@testing-library/react';
+import { render } from '__tests__/util/testingLibraryReactMock';
 import {
   ContextType,
   HcmData,
@@ -14,6 +14,7 @@ const titleTwo = 'Title Two';
 interface TestComponentProps {
   names: string;
   personNumbers: string;
+  personNumberCount?: number;
   showContent?: boolean;
   contextValue?: Partial<ContextType>;
   spouseComponent?: React.ReactNode;
@@ -22,6 +23,7 @@ interface TestComponentProps {
 const TestComponent: React.FC<TestComponentProps> = ({
   names,
   personNumbers,
+  personNumberCount,
   showContent,
   contextValue,
   spouseComponent,
@@ -34,6 +36,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
         <NameDisplay
           names={names}
           personNumbers={personNumbers}
+          personNumberCount={personNumberCount}
           showContent={showContent}
           titleOne={titleOne}
           titleTwo={titleTwo}
@@ -71,10 +74,11 @@ describe('NameDisplay', () => {
   });
 
   it('renders correctly for a married person', () => {
-    const { getByText } = render(
+    const { getByText, getByTestId } = render(
       <TestComponent
         names="Doe, John and Jane"
         personNumbers="000123456 and 100123456"
+        personNumberCount={2}
         contextValue={{
           isMarried: true,
           preferredName: 'John',
@@ -94,9 +98,9 @@ describe('NameDisplay', () => {
     );
 
     expect(getByText('Doe, John and Jane')).toBeInTheDocument();
-    expect(
-      getByText('Person Number: 000123456 and 100123456'),
-    ).toBeInTheDocument();
+    expect(getByTestId('person-numbers')).toHaveTextContent(
+      'Person Numbers: 000123456 and 100123456',
+    );
   });
 
   it('renders content when showContent is true', () => {

--- a/src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay.test.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay.test.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider } from '@mui/material/styles';
-import { render } from '__tests__/util/testingLibraryReactMock';
+import { render } from '@testing-library/react';
 import {
   ContextType,
   HcmData,

--- a/src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay.test.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay.test.tsx
@@ -67,7 +67,7 @@ describe('NameDisplay', () => {
     );
 
     expect(getByText('Doe, John')).toBeInTheDocument();
-    expect(getByText('000123456')).toBeInTheDocument();
+    expect(getByText('Person Number: 000123456')).toBeInTheDocument();
   });
 
   it('renders correctly for a married person', () => {
@@ -94,7 +94,9 @@ describe('NameDisplay', () => {
     );
 
     expect(getByText('Doe, John and Jane')).toBeInTheDocument();
-    expect(getByText('000123456 and 100123456')).toBeInTheDocument();
+    expect(
+      getByText('Person Number: 000123456 and 100123456'),
+    ).toBeInTheDocument();
   });
 
   it('renders content when showContent is true', () => {

--- a/src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay.tsx
@@ -14,6 +14,7 @@ import { currencyFormat } from 'src/lib/intlFormat';
 interface NameDisplayProps {
   names: string;
   personNumbers: string;
+  personNumberCount?: number;
   showContent?: boolean;
   titleOne?: string;
   titleTwo?: string;
@@ -25,6 +26,7 @@ interface NameDisplayProps {
 export const NameDisplay: React.FC<NameDisplayProps> = ({
   names,
   personNumbers,
+  personNumberCount = 1,
   showContent,
   titleOne,
   titleTwo,
@@ -45,7 +47,10 @@ export const NameDisplay: React.FC<NameDisplayProps> = ({
           sx={{ color: 'text.secondary' }}
           data-testid="person-numbers"
         >
-          {t('Person Number: {{personNumbers}}', { personNumbers })}
+          {t('Person Number: {{personNumbers}}', {
+            personNumbers,
+            count: personNumberCount,
+          })}
         </Typography>
       </Box>
       {spouseComponent}

--- a/src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay.tsx
@@ -47,10 +47,9 @@ export const NameDisplay: React.FC<NameDisplayProps> = ({
           sx={{ color: 'text.secondary' }}
           data-testid="person-numbers"
         >
-          {t('Person Number: {{personNumbers}}', {
-            personNumbers,
-            count: personNumberCount,
-          })}
+          {personNumberCount > 1
+            ? t('Person Numbers: {{personNumbers}}', { personNumbers })
+            : t('Person Number: {{personNumbers}}', { personNumbers })}
         </Typography>
       </Box>
       {spouseComponent}

--- a/src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay.tsx
@@ -7,6 +7,7 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat } from 'src/lib/intlFormat';
 
@@ -31,6 +32,7 @@ export const NameDisplay: React.FC<NameDisplayProps> = ({
   amountTwo,
   spouseComponent,
 }) => {
+  const { t } = useTranslation();
   const locale = useLocale();
   const theme = useTheme();
   const currency = 'USD';
@@ -43,7 +45,7 @@ export const NameDisplay: React.FC<NameDisplayProps> = ({
           sx={{ color: 'text.secondary' }}
           data-testid="person-numbers"
         >
-          {personNumbers}
+          {t('Person Number: {{personNumbers}}', { personNumbers })}
         </Typography>
       </Box>
       {spouseComponent}


### PR DESCRIPTION
## Description

- Adds a `Person Number:` label before the staff ID displayed on the Minister Housing Allowance (MHA), Salary Calculator (SC), and Additional Salary Request (ASR) forms.
- Without the label, the bare number can be confused with a staff account number or other identifiers; the label removes that ambiguity.
- Change is made once in the shared `NameDisplay` component, which all three forms render through, so all three pick up the label automatically.
- Related Jira ticket: MPDX-9567

## Testing

- Go to the Salary Calculator landing page for an account list and verify the user's name card shows `Person Number: <id>` (single user) or `Person Number: <id> and <spouse id>` (married couple).
- Go to the Minister Housing Allowance landing page and confirm the same label appears above the user info card.
- Open an Additional Salary Request (any of New, Edit, View, or About variants) and confirm the same label appears above the user info card.
- Run `yarn test NameDisplay AboutForm NewForm EditForm ViewForm NewSalaryCalculatorLanding PendingSalaryCalculationLanding MinisterHousingAllowance` and verify all tests pass.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history