### PR TITLE
MPDX-9657 Frontend - Add localized labels for missing staff expense categories and subcategories

### DIFF
--- a/src/components/Reports/Shared/Helpers/transformStaffExpenseEnums.ts
+++ b/src/components/Reports/Shared/Helpers/transformStaffExpenseEnums.ts
@@ -12,6 +12,8 @@ export const getLocalizedCategory = (
   const categoryLabels: Record<StaffExpenseCategoryEnum, string> = {
     [StaffExpenseCategoryEnum.Donation]: t('Donation'),
     [StaffExpenseCategoryEnum.Transfer]: t('Transfer'),
+    [StaffExpenseCategoryEnum.AccountTransfer]: t('Account Transfer'),
+    [StaffExpenseCategoryEnum.StaffExpense]: t('Staff Expense'),
     [StaffExpenseCategoryEnum.MinistryReimbursement]: t(
       'Ministry Reimbursement',
     ),
@@ -132,6 +134,12 @@ export const getLocalizedSubCategory = (
     [StaffExpensesSubCategoryEnum.StaffAssessment]: t('Staff Assessment'),
     [StaffExpensesSubCategoryEnum.OtherAssessment]: t('Other Assessment'),
     [StaffExpensesSubCategoryEnum.CreditCardFee]: t('Credit Card Fee'),
+    [StaffExpensesSubCategoryEnum.AccountTransfer]: t('Account Transfer'),
+    [StaffExpensesSubCategoryEnum.Registration]: t('Registration'),
+    [StaffExpensesSubCategoryEnum.Purchase]: t('Purchase'),
+    [StaffExpensesSubCategoryEnum.SummerMission]: t('Summer Mission'),
+    [StaffExpensesSubCategoryEnum.Staffcard]: t('StaffCard'),
+    [StaffExpensesSubCategoryEnum.PaCard]: t('PA Card'),
   };
 
   return subcategoryLabels[value] ?? t('Unknown Subcategory');


### PR DESCRIPTION
## Description

- These cateories and sub categories were being sent from SAA but were missing in MPDX.
Backend PR: https://github.com/CruGlobal/mpdx_api/pull/3348

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to Staff Expense Report with account Neil_9.New_Married_Staff@cru.org
- Select May Income and Expenses
- Check that the income and expenses correctly load

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
