### PR TITLE
[SAA-645] - Require description on savings fund transfer form

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1961,7 +1961,7 @@
     "Not taxed now": "Not taxed now",
     "Not Yet Enrolled": "Not Yet Enrolled",
     "Note": "Note",
-    "Note is required": "Note is required",
+    "Note (Optional)": "Note (Optional)",
     "Note: Italy staff must complete a paper MHI form.": "Note: Italy staff must complete a paper MHI form.",
     "Note: You may be enrolled in our automatic annual 1% increase to your 403(b). To verify this or update it, you can go to <2>your Principal account</2>. Your gross salary will not be affected, so your net pay will decrease by 1%. If you would like to receive the same net pay after this 1% increase, you will need to calculate a new salary here.": "Note: You may be enrolled in our automatic annual 1% increase to your 403(b). To verify this or update it, you can go to <2>your Principal account</2>. Your gross salary will not be affected, so your net pay will decrease by 1%. If you would like to receive the same net pay after this 1% increase, you will need to calculate a new salary here.",
     "Notes": "Notes",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1961,7 +1961,7 @@
     "Not taxed now": "Not taxed now",
     "Not Yet Enrolled": "Not Yet Enrolled",
     "Note": "Note",
-    "Note (Optional)": "Note (Optional)",
+    "Note is required": "Note is required",
     "Note: Italy staff must complete a paper MHI form.": "Note: Italy staff must complete a paper MHI form.",
     "Note: You may be enrolled in our automatic annual 1% increase to your 403(b). To verify this or update it, you can go to <2>your Principal account</2>. Your gross salary will not be affected, so your net pay will decrease by 1%. If you would like to receive the same net pay after this 1% increase, you will need to calculate a new salary here.": "Note: You may be enrolled in our automatic annual 1% increase to your 403(b). To verify this or update it, you can go to <2>your Principal account</2>. Your gross salary will not be affected, so your net pay will decrease by 1%. If you would like to receive the same net pay after this 1% increase, you will need to calculate a new salary here.",
     "Notes": "Notes",

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -259,12 +259,15 @@ describe('TransferModal', () => {
 
       const toAccount = getByRole('combobox', { name: /to account/i });
       const amountField = getByRole('spinbutton', { name: /amount/i });
+      const noteField = getByRole('textbox', { name: /note/i });
 
       userEvent.click(toAccount);
       userEvent.click(getByRole('option', { name: /staff savings/i }));
 
       userEvent.clear(amountField);
       userEvent.type(amountField, '100');
+
+      userEvent.type(noteField, 'Test note');
 
       userEvent.click(getByRole('button', { name: /submit/i }));
 
@@ -283,6 +286,7 @@ describe('TransferModal', () => {
 
       const toAccount = getByRole('combobox', { name: /to account/i });
       const amountField = getByRole('spinbutton', { name: /amount/i });
+      const noteField = getByRole('textbox', { name: /note/i });
       const submitButton = getByRole('button', { name: /submit/i });
 
       userEvent.click(toAccount);
@@ -290,6 +294,8 @@ describe('TransferModal', () => {
 
       userEvent.clear(amountField);
       userEvent.type(amountField, '100');
+
+      userEvent.type(noteField, 'Test note');
 
       userEvent.click(submitButton);
 
@@ -301,6 +307,58 @@ describe('TransferModal', () => {
           },
         );
       });
+    });
+
+    it('should require a note for one-time transfers', async () => {
+      const { getByRole, findByText } = render(<Components />);
+
+      const toAccount = getByRole('combobox', { name: /to account/i });
+      const amountField = getByRole('spinbutton', { name: /amount/i });
+
+      userEvent.click(toAccount);
+      userEvent.click(getByRole('option', { name: /staff savings/i }));
+
+      userEvent.clear(amountField);
+      userEvent.type(amountField, '100');
+
+      userEvent.click(getByRole('button', { name: /submit/i }));
+
+      expect(await findByText('Note is required')).toBeInTheDocument();
+      expect(mutationSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: expect.objectContaining({
+            operationName: 'CreateTransfer',
+          }),
+        }),
+      );
+    });
+
+    it('should reject a whitespace-only note for one-time transfers', async () => {
+      const { getByRole, findByText } = render(<Components />);
+
+      const toAccount = getByRole('combobox', { name: /to account/i });
+      const amountField = getByRole('spinbutton', { name: /amount/i });
+      const noteField = getByRole('textbox', { name: /note/i });
+
+      userEvent.click(toAccount);
+      userEvent.click(getByRole('option', { name: /staff savings/i }));
+
+      userEvent.clear(amountField);
+      userEvent.type(amountField, '100');
+
+      userEvent.type(noteField, '   ');
+      userEvent.tab();
+
+      userEvent.click(getByRole('button', { name: /submit/i }));
+
+      expect(await findByText('Note is required')).toBeInTheDocument();
+      expect(mutationSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: expect.objectContaining({
+            operationName: 'CreateTransfer',
+          }),
+        }),
+      );
     });
   });
 
@@ -468,12 +526,15 @@ describe('TransferModal', () => {
       const { getByRole } = render(<Components />);
 
       const amountField = getByRole('spinbutton', { name: /amount/i });
+      const noteField = getByRole('textbox', { name: /note/i });
 
       userEvent.click(getByRole('combobox', { name: /to account/i }));
       userEvent.click(getByRole('option', { name: /staff savings/i }));
 
       userEvent.clear(amountField);
       userEvent.type(amountField, '100');
+
+      userEvent.type(noteField, '  Test note  ');
 
       userEvent.click(getByRole('button', { name: /submit/i }));
 
@@ -486,7 +547,7 @@ describe('TransferModal', () => {
                 amount: 100,
                 sourceFundTypeName: 'Staff Account',
                 destinationFundTypeName: 'Staff Savings',
-                description: '',
+                description: 'Test note',
               }),
             }),
           }),

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -314,6 +314,7 @@ describe('TransferModal', () => {
 
       const toAccount = getByRole('combobox', { name: /to account/i });
       const amountField = getByRole('spinbutton', { name: /amount/i });
+      const noteField = getByRole('textbox', { name: /note/i });
 
       userEvent.click(toAccount);
       userEvent.click(getByRole('option', { name: /staff savings/i }));
@@ -321,16 +322,14 @@ describe('TransferModal', () => {
       userEvent.clear(amountField);
       userEvent.type(amountField, '100');
 
-      userEvent.click(getByRole('button', { name: /submit/i }));
+      await waitFor(() =>
+        expect(getByRole('button', { name: /submit/i })).toBeDisabled(),
+      );
+
+      userEvent.click(noteField);
+      userEvent.tab();
 
       expect(await findByText('Note is required')).toBeInTheDocument();
-      expect(mutationSpy).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          operation: expect.objectContaining({
-            operationName: 'CreateTransfer',
-          }),
-        }),
-      );
     });
 
     it('should reject a whitespace-only note for one-time transfers', async () => {
@@ -349,16 +348,11 @@ describe('TransferModal', () => {
       userEvent.type(noteField, '   ');
       userEvent.tab();
 
-      userEvent.click(getByRole('button', { name: /submit/i }));
+      await waitFor(() =>
+        expect(getByRole('button', { name: /submit/i })).toBeDisabled(),
+      );
 
       expect(await findByText('Note is required')).toBeInTheDocument();
-      expect(mutationSpy).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          operation: expect.objectContaining({
-            operationName: 'CreateTransfer',
-          }),
-        }),
-      );
     });
   });
 

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -133,9 +133,8 @@ const transferSchema = (locale: string) =>
       .required(i18n.t('Amount is required'))
       .min(0.01, i18n.t('Amount must be at least $0.01')),
     note: yup.string().when('schedule', {
-      is: (schedule: ScheduleEnum) => schedule === ScheduleEnum.OneTime,
+      is: ScheduleEnum.OneTime,
       then: (schema) => schema.trim().required(i18n.t('Note is required')),
-      otherwise: (schema) => schema.notRequired(),
     }),
   });
 interface TransferModalProps {

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -132,7 +132,11 @@ const transferSchema = (locale: string) =>
       .number()
       .required(i18n.t('Amount is required'))
       .min(0.01, i18n.t('Amount must be at least $0.01')),
-    note: yup.string().nullable(),
+    note: yup.string().when('schedule', {
+      is: (schedule: ScheduleEnum) => schedule === ScheduleEnum.OneTime,
+      then: (schema) => schema.trim().required(i18n.t('Note is required')),
+      otherwise: (schema) => schema.notRequired(),
+    }),
   });
 interface TransferModalProps {
   data: TransferModalData;
@@ -215,7 +219,7 @@ export const TransferModal: React.FC<TransferModalProps> = ({
             amount: amount,
             sourceFundTypeName: transferFrom,
             destinationFundTypeName: transferTo,
-            description: note,
+            description: note.trim(),
           },
         });
       } else {
@@ -506,10 +510,16 @@ export const TransferModal: React.FC<TransferModalProps> = ({
                     <FormControl fullWidth>
                       <TextField
                         id="transfer-note"
-                        label={t('Note (Optional)')}
+                        label={t('Note')}
                         name="note"
                         value={note}
                         onChange={handleChange}
+                        onBlur={handleBlur}
+                        error={touched.note && Boolean(errors.note)}
+                        helperText={
+                          touched.note && errors.note ? errors.note : ''
+                        }
+                        required
                         fullWidth
                       />
                     </FormControl>


### PR DESCRIPTION
Mark the Note field required on one-time savings fund transfers with a real validator that trims and rejects whitespace-only input, so a blank description is blocked in the form instead of failing at SAA with a confusing 422. Recurring transfers are unaffected. Description is trimmed before submit.

## Description

Please explain a bullet-point summary of the changes.
List any PRs that this PR is dependent on and any Jira tickets that this PR is related to.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to ...
- Do ...
- Check that ...

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
