### PR TITLE
MPDX-9666 Add PDFs to ASR

### DIFF
--- a/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
@@ -139,15 +139,23 @@ describe('AboutForm', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should have Progressive Approvals link', () => {
-    const { getByText } = render(<TestWrapper />);
+  it('should link to the Progressive Approvals document', () => {
+    const { getByRole } = render(<TestWrapper />);
 
-    expect(getByText('Progressive Approvals')).toBeInTheDocument();
+    expect(
+      getByRole('link', { name: 'Progressive Approvals' }),
+    ).toHaveAttribute(
+      'href',
+      'https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link',
+    );
   });
 
-  it('should have paper version download link', () => {
-    const { getByText } = render(<TestWrapper />);
+  it('should link to the paper version document', () => {
+    const { getByRole } = render(<TestWrapper />);
 
-    expect(getByText('paper version')).toBeInTheDocument();
+    expect(getByRole('link', { name: 'paper version' })).toHaveAttribute(
+      'href',
+      'https://drive.google.com/file/d/17Xe-OTtC8em41PASIWR_ew8mZ9pUYqYF/view?usp=sharing',
+    );
   });
 });

--- a/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.test.tsx
@@ -155,7 +155,7 @@ describe('AboutForm', () => {
 
     expect(getByRole('link', { name: 'paper version' })).toHaveAttribute(
       'href',
-      'https://drive.google.com/file/d/17Xe-OTtC8em41PASIWR_ew8mZ9pUYqYF/view?usp=sharing',
+      'https://drive.google.com/file/d/1BXoJGnr9Gc3_KAek8jI8RsKAOo_We0JV/view?usp=drive_link',
     );
   });
 });

--- a/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.tsx
@@ -60,12 +60,10 @@ export const AboutForm: React.FC = () => {
           In special cases where requests exceed the remaining allowable salary,
           we require additional review through our{' '}
           <Link
-            href="#"
+            href="https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link"
+            target="_blank"
+            rel="noopener noreferrer"
             underline="always"
-            onClick={(e) => {
-              e.preventDefault();
-              // TODO: Implement Progressive Approvals navigation/modal
-            }}
           >
             Progressive Approvals
           </Link>{' '}
@@ -75,12 +73,10 @@ export const AboutForm: React.FC = () => {
         <Typography variant="body1" paragraph>
           Alternatively, you may download and submit the{' '}
           <Link
-            href="#"
+            href="https://drive.google.com/file/d/17Xe-OTtC8em41PASIWR_ew8mZ9pUYqYF/view?usp=sharing"
+            target="_blank"
+            rel="noopener noreferrer"
             underline="always"
-            onClick={(e) => {
-              e.preventDefault();
-              // TODO: Implement paper version download
-            }}
           >
             paper version
           </Link>{' '}

--- a/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/AboutForm/AboutForm.tsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { NameDisplay } from '../../Shared/CalculationReports/NameDisplay/NameDisplay';
 import { useAdditionalSalaryRequest } from '../Shared/AdditionalSalaryRequestContext';
 import { getHeader } from '../Shared/Helper/getHeader';
+import { paperVersionLink, progressiveApprovalsLink } from '../Shared/pdfLinks';
 import { useFormUserInfo } from '../Shared/useFormUserInfo';
 import { AdditionalSalaryRequestSection } from '../SharedComponents/AdditionalSalaryRequestSection';
 import { SpouseComponent } from '../SharedComponents/SpouseComponent';
@@ -60,7 +61,7 @@ export const AboutForm: React.FC = () => {
           In special cases where requests exceed the remaining allowable salary,
           we require additional review through our{' '}
           <Link
-            href="https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link"
+            href={progressiveApprovalsLink}
             target="_blank"
             rel="noopener noreferrer"
             underline="always"
@@ -73,7 +74,7 @@ export const AboutForm: React.FC = () => {
         <Typography variant="body1" paragraph>
           Alternatively, you may download and submit the{' '}
           <Link
-            href="https://drive.google.com/file/d/17Xe-OTtC8em41PASIWR_ew8mZ9pUYqYF/view?usp=sharing"
+            href={paperVersionLink}
             target="_blank"
             rel="noopener noreferrer"
             underline="always"

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.test.tsx
@@ -71,6 +71,17 @@ describe('CapSubContent', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('should link to the Progressive Approvals document', () => {
+    const { getByRole } = renderCapSubContent();
+
+    expect(
+      getByRole('link', { name: 'Progressive Approvals' }),
+    ).toHaveAttribute(
+      'href',
+      'https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link',
+    );
+  });
+
   it('renders nothing when reason is board cap exception (message is carried by getCapOverrides)', () => {
     mockUseAdditionalSalaryRequest.mockReturnValue({
       requestData: {

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.tsx
@@ -35,7 +35,9 @@ export const CapSubContent: React.FC = () => {
         Please complete the Approval Process section below and we will review
         your request through our{' '}
         <Link
-          href="/"
+          href="https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link"
+          target="_blank"
+          rel="noopener noreferrer"
           style={{ display: 'inline', color: theme.palette.primary.main }}
         >
           Progressive Approvals

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/CapSubContent.tsx
@@ -11,6 +11,7 @@ import theme from 'src/theme';
 import { CompleteFormValues } from '../../AdditionalSalaryRequest';
 import { useAdditionalSalaryRequest } from '../../Shared/AdditionalSalaryRequestContext';
 import { getTotal } from '../../Shared/Helper/getTotal';
+import { progressiveApprovalsLink } from '../../Shared/pdfLinks';
 
 export const CapSubContent: React.FC = () => {
   const { t } = useTranslation();
@@ -35,7 +36,7 @@ export const CapSubContent: React.FC = () => {
         Please complete the Approval Process section below and we will review
         your request through our{' '}
         <Link
-          href="https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link"
+          href={progressiveApprovalsLink}
           target="_blank"
           rel="noopener noreferrer"
           style={{ display: 'inline', color: theme.palette.primary.main }}

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.test.tsx
@@ -75,15 +75,21 @@ describe('SplitCapSubContent', () => {
 
     const { getByText, getByRole } = renderSplitCapSubContent('Jane');
 
+    const progressiveApprovalsLink = getByRole('link', {
+      name: 'Progressive Approvals',
+    });
+
     expect(
       getByText(/Please make adjustments to your request/),
     ).toBeInTheDocument();
     expect(
       getByText(/separate request up to Jane's maximum allowable salary/),
     ).toBeInTheDocument();
-    expect(
-      getByRole('link', { name: 'Progressive Approvals' }),
-    ).toBeInTheDocument();
+    expect(progressiveApprovalsLink).toBeInTheDocument();
+    expect(progressiveApprovalsLink).toHaveAttribute(
+      'href',
+      'https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link',
+    );
   });
 
   it('renders status bar header with spouse salary and cap amounts', () => {

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.tsx
@@ -58,7 +58,9 @@ export const SplitCapSubContent: React.FC<SplitCapSubContentProps> = ({
         salary, any additional requests can be submitted online but will require
         approval through our{' '}
         <Link
-          href="/"
+          href="https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link"
+          target="_blank"
+          rel="noopener noreferrer"
           style={{ display: 'inline', color: theme.palette.primary.main }}
         >
           Progressive Approvals

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/SplitCapSubContent.tsx
@@ -6,6 +6,7 @@ import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat } from 'src/lib/intlFormat';
 import theme from 'src/theme';
 import { CompleteFormValues } from '../../AdditionalSalaryRequest';
+import { progressiveApprovalsLink } from '../../Shared/pdfLinks';
 import { useSalaryCalculations } from '../../Shared/useSalaryCalculations';
 
 interface SplitCapSubContentProps {
@@ -58,7 +59,7 @@ export const SplitCapSubContent: React.FC<SplitCapSubContentProps> = ({
         salary, any additional requests can be submitted online but will require
         approval through our{' '}
         <Link
-          href="https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link"
+          href={progressiveApprovalsLink}
           target="_blank"
           rel="noopener noreferrer"
           style={{ display: 'inline', color: theme.palette.primary.main }}

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/SpouseOverCapSubContent.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/SpouseOverCapSubContent.test.tsx
@@ -13,6 +13,9 @@ describe('SpouseOverCapSubContent', () => {
     expect(getByText(/Jane/)).toBeInTheDocument();
 
     const link = getByRole('link', { name: 'Progressive Approvals' });
-    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      'href',
+      'https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link',
+    );
   });
 });

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/SpouseOverCapSubContent.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/SpouseOverCapSubContent.tsx
@@ -17,7 +17,9 @@ export const SpouseOverCapSubContent: React.FC<
       to reduce the amount on {spouseName}&apos;s request, which may avoid
       requiring approval through our{' '}
       <Link
-        href="/"
+        href="https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link"
+        target="_blank"
+        rel="noopener noreferrer"
         style={{ display: 'inline', color: theme.palette.primary.main }}
       >
         Progressive Approvals

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/SpouseOverCapSubContent.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/Helper/SpouseOverCapSubContent.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { Trans, useTranslation } from 'react-i18next';
 import theme from 'src/theme';
+import { progressiveApprovalsLink } from '../../Shared/pdfLinks';
 
 interface SpouseOverCapSubContentProps {
   spouseName: string;
@@ -17,7 +18,7 @@ export const SpouseOverCapSubContent: React.FC<
       to reduce the amount on {spouseName}&apos;s request, which may avoid
       requiring approval through our{' '}
       <Link
-        href="https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link"
+        href={progressiveApprovalsLink}
         target="_blank"
         rel="noopener noreferrer"
         style={{ display: 'inline', color: theme.palette.primary.main }}

--- a/src/components/HrTools/AdditionalSalaryRequest/Shared/pdfLinks.ts
+++ b/src/components/HrTools/AdditionalSalaryRequest/Shared/pdfLinks.ts
@@ -1,0 +1,4 @@
+export const progressiveApprovalsLink =
+  'https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link';
+export const paperVersionLink =
+  'https://drive.google.com/file/d/1BXoJGnr9Gc3_KAek8jI8RsKAOo_We0JV/view?usp=drive_link';

--- a/src/components/HrTools/AdditionalSalaryRequest/SharedComponents/ReceiptAlertText.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/SharedComponents/ReceiptAlertText.tsx
@@ -5,7 +5,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import { StyledListItem } from 'src/components/HrTools/SavingsFundTransfer/styledComponents/StyledListItem';
 import theme from 'src/theme';
 
-//TODO [MPDX-9303]: Add link for Progressive Approvals
 //TODO [MPDX-9303]: Get number of days for approval time frame
 
 interface BulletListProps {
@@ -38,7 +37,9 @@ export const ExceedsCapAlertText: React.FC = () => {
       Because your request exceeds your remaining allowable salary it requires
       additional review. We will review your request through{' '}
       <Link
-        href="/"
+        href="https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link"
+        target="_blank"
+        rel="noopener noreferrer"
         style={{ display: 'inline', color: theme.palette.primary.main }}
       >
         Progressive Approvals

--- a/src/components/HrTools/AdditionalSalaryRequest/SharedComponents/ReceiptAlertText.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/SharedComponents/ReceiptAlertText.tsx
@@ -4,6 +4,7 @@ import { Box, List, ListItemText } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
 import { StyledListItem } from 'src/components/HrTools/SavingsFundTransfer/styledComponents/StyledListItem';
 import theme from 'src/theme';
+import { progressiveApprovalsLink } from '../Shared/pdfLinks';
 
 //TODO [MPDX-9303]: Get number of days for approval time frame
 
@@ -37,7 +38,7 @@ export const ExceedsCapAlertText: React.FC = () => {
       Because your request exceeds your remaining allowable salary it requires
       additional review. We will review your request through{' '}
       <Link
-        href="https://drive.google.com/file/d/1Z1WuiIUMrmfrUUV0V-ACCdhyuSd1Cgzg/view?usp=drive_link"
+        href={progressiveApprovalsLink}
         target="_blank"
         rel="noopener noreferrer"
         style={{ display: 'inline', color: theme.palette.primary.main }}

--- a/src/components/HrTools/SalaryCalculator/Receipt/Receipt.tsx
+++ b/src/components/HrTools/SalaryCalculator/Receipt/Receipt.tsx
@@ -12,6 +12,8 @@ import {
 import { Trans, useTranslation } from 'react-i18next';
 import { ProgressiveApprovalTierReasonEnum } from 'src/graphql/types.generated';
 import { useAccountListId } from 'src/hooks/useAccountListId';
+import theme from 'src/theme';
+import { progressiveApprovalsLink } from '../../AdditionalSalaryRequest/Shared/pdfLinks';
 import { useCaps } from '../SalaryCalculation/useCaps';
 import { useSalaryCalculator } from '../SalaryCalculatorContext/SalaryCalculatorContext';
 import { useFormatters } from '../Shared/useFormatters';
@@ -76,8 +78,17 @@ export const ReceiptStep: React.FC = () => {
               needs to be signed off by the{' '}
               {{ approver: progressiveApprovalTier.approver }}. This may affect
               your selected effective date. We will review your request through
-              our Progressive Approvals process and notify you of any changes to
-              the status of this request.
+              our{' '}
+              <NextLink
+                href={progressiveApprovalsLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ display: 'inline', color: theme.palette.primary.main }}
+              >
+                Progressive Approvals
+              </NextLink>{' '}
+              process and notify you of any changes to the status of this
+              request.
             </Trans>
           )}
         </Typography>

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestSummaryCard/RequestSummaryCard.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestSummaryCard/RequestSummaryCard.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import React, { useId } from 'react';
 import InfoIcon from '@mui/icons-material/Info';
 import {
@@ -18,6 +19,7 @@ import {
   ProgressiveApprovalTierEnum,
   ProgressiveApprovalTierReasonEnum,
 } from 'src/graphql/types.generated';
+import { progressiveApprovalsLink } from '../../../AdditionalSalaryRequest/Shared/pdfLinks';
 import { useSalaryCalculator } from '../../SalaryCalculatorContext/SalaryCalculatorContext';
 import { StepCard } from '../../Shared/StepCard';
 import { useFormatters } from '../../Shared/useFormatters';
@@ -118,7 +120,15 @@ export const RequestSummaryCard: React.FC = () => {
       Your {{ combined: combinedModifier }} Gross Requested Salary exceeds your{' '}
       {{ combined: combinedModifier }} Maximum Allowable Salary. Please make
       adjustments to your Salary Request above or fill out the Approval Process
-      Section below to request a higher amount through our Progressive Approvals
+      Section below to request a higher amount through our{' '}
+      <Link
+        href={progressiveApprovalsLink}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ display: 'inline', color: theme.palette.primary.main }}
+      >
+        Progressive Approvals
+      </Link>{' '}
       process. This will take{' '}
       {{ timeframe: progressiveApprovalTier.approvalTimeframe }} as it needs to
       be signed off by the {{ approver: progressiveApprovalTier.approver }}.

--- a/src/components/HrTools/SalaryCalculator/StepNavigation/useSubmitDialogContent.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/StepNavigation/useSubmitDialogContent.test.tsx
@@ -1,8 +1,9 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { render, renderHook, waitFor } from '@testing-library/react';
 import {
   ProgressiveApprovalTierEnum,
   ProgressiveApprovalTierReasonEnum,
 } from 'src/graphql/types.generated';
+import { progressiveApprovalsLink } from '../../AdditionalSalaryRequest/Shared/pdfLinks';
 import { SalaryCalculatorTestWrapper } from '../SalaryCalculatorTestWrapper';
 import { useSubmitDialogContent } from './useSubmitDialogContent';
 
@@ -86,9 +87,16 @@ describe('useSubmitDialogContent', () => {
       );
     });
 
-    expect(result.current.subContent).toContain('$80,000.00');
-    expect(result.current.subContent).toContain('2-3 weeks');
-    expect(result.current.subContent).toContain('Vice President');
+    const { container, getByRole } = render(
+      <div>{result.current.subContent}</div>,
+    );
+
+    expect(container).toHaveTextContent('$80,000.00');
+    expect(container).toHaveTextContent('2-3 weeks');
+    expect(container).toHaveTextContent('Vice President');
+    expect(
+      getByRole('link', { name: 'Progressive Approvals' }),
+    ).toHaveAttribute('href', progressiveApprovalsLink);
   });
 
   it('returns board cap exception content when the reason is BoardCapException', async () => {

--- a/src/components/HrTools/SalaryCalculator/StepNavigation/useSubmitDialogContent.tsx
+++ b/src/components/HrTools/SalaryCalculator/StepNavigation/useSubmitDialogContent.tsx
@@ -1,8 +1,13 @@
-import { useTranslation } from 'react-i18next';
+import Link from 'next/link';
+import React from 'react';
+import { Box } from '@mui/material';
+import { Trans, useTranslation } from 'react-i18next';
 import {
   ProgressiveApprovalTierEnum,
   ProgressiveApprovalTierReasonEnum,
 } from 'src/graphql/types.generated';
+import theme from 'src/theme';
+import { progressiveApprovalsLink } from '../../AdditionalSalaryRequest/Shared/pdfLinks';
 import { useCaps } from '../SalaryCalculation/useCaps';
 import { useSalaryCalculator } from '../SalaryCalculatorContext/SalaryCalculatorContext';
 import { useFormatters } from '../Shared/useFormatters';
@@ -10,7 +15,7 @@ import { useFormatters } from '../Shared/useFormatters';
 interface DialogContent {
   title: string;
   content: string;
-  subContent: string;
+  subContent: React.ReactNode;
 }
 
 export const useSubmitDialogContent = (): DialogContent => {
@@ -36,7 +41,7 @@ export const useSubmitDialogContent = (): DialogContent => {
   let title = t(
     'Your request requires additional approval because your Gross Salary exceeds your Maximum Allowable Salary. Do you want to continue?',
   );
-  let subContent: string;
+  let subContent: React.ReactNode;
   if (reason === ProgressiveApprovalTierReasonEnum.BoardCapException) {
     subContent = t(
       "You have a Board approved Maximum Allowable Salary (CAP) and your salary request exceeds that amount. As a result we need to get their approval for this request. We'll forward your request to them and get back to you with their decision.",
@@ -53,13 +58,26 @@ export const useSubmitDialogContent = (): DialogContent => {
       },
     );
   } else {
-    subContent = t(
-      'We will review your request through our Progressive Approvals process. For the {{amount}} you are requesting, this will take {{timeframe}} as it needs to be signed off by {{approvers}}. This may affect your selected effective date.',
-      {
-        amount: formatCurrency(combinedGross),
-        timeframe: progressiveApprovalTier?.approvalTimeframe,
-        approvers: progressiveApprovalTier?.approver,
-      },
+    subContent = (
+      <Box>
+        <Trans t={t}>
+          We will review your request through our{' '}
+          <Link
+            href={progressiveApprovalsLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ display: 'inline', color: theme.palette.primary.main }}
+          >
+            Progressive Approvals
+          </Link>{' '}
+          process. For the {{ amount: formatCurrency(combinedGross) }} you are
+          requesting, this will take{' '}
+          {{ timeframe: progressiveApprovalTier?.approvalTimeframe }} as it
+          needs to be signed off by{' '}
+          {{ approvers: progressiveApprovalTier?.approver }}. This may affect
+          your selected effective date.
+        </Trans>
+      </Box>
     );
   }
 


### PR DESCRIPTION
## Description

Currently, there are two links on ASR's About Form page that are doing nothing when clicked. We want to add this functionality:
- "Progressive Approvals" = links to a PDF of the progressive approvals table that Staff Services will maintain 
- "paper version" = links to a PDF of ASR's paper version

Google drive: https://drive.google.com/drive/folders/1o_hFNSdgWiH-xe3Dg4SsKEYpmqGN9b03 

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `/hrTools/additionalSalaryRequest`
- Click "Progressive Approvals" and "paper version" links
- Check that both PDFs have downloaded successfully

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
