### PR TITLE
[MPDX-9524] Add New Staff Goal Calculator page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -86,6 +86,7 @@ const config: NextConfig = {
     DONATION_SERVICES_EMAIL:
       process.env.DONATION_SERVICES_EMAIL ?? 'donation.services@cru.org',
     DISABLE_NEW_REPORTS: process.env.DISABLE_NEW_REPORTS,
+    DISABLE_NS_GOAL_CALCULATOR: process.env.DISABLE_NS_GOAL_CALCULATOR,
   },
   // Force .page prefix on page files (ex. index.page.tsx) so generated files can be included in /pages directory without Next.js throwing build errors
   pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],

--- a/pages/accountLists/[accountListId]/hrTools/nsGoalCalculator/index.page.test.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/nsGoalCalculator/index.page.test.tsx
@@ -1,0 +1,57 @@
+import { ThemeProvider } from '@mui/material/styles';
+import TestRouter from '__tests__/util/TestRouter';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { render } from '__tests__/util/testingLibraryReactMock';
+import { blockImpersonatingNonDevelopers } from 'pages/api/utils/pagePropsHelpers';
+import { GetUserQuery } from 'src/components/User/GetUser.generated';
+import { UsStaffGroupEnum, UserTypeEnum } from 'src/graphql/types.generated';
+import theme from 'src/theme';
+import { NsGoalCalculatorPage, getServerSideProps } from './index.page';
+
+interface TestComponentProps {
+  userType?: UserTypeEnum;
+  usStaffGroup?: UsStaffGroupEnum;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({
+  userType = UserTypeEnum.UsStaff,
+  usStaffGroup = UsStaffGroupEnum.NewStaff,
+}) => (
+  <TestRouter>
+    <ThemeProvider theme={theme}>
+      <GqlMockedProvider<{
+        GetUser: GetUserQuery;
+      }>
+        mocks={{
+          GetUser: { user: { userType, usStaffGroup } },
+        }}
+      >
+        <NsGoalCalculatorPage />
+      </GqlMockedProvider>
+    </ThemeProvider>
+  </TestRouter>
+);
+
+describe('NsGoalCalculator page', () => {
+  it('uses blockImpersonatingNonDevelopers for server-side props', () => {
+    expect(getServerSideProps).toBe(blockImpersonatingNonDevelopers);
+  });
+
+  it('renders the calculator when the user is eligible (New Staff)', async () => {
+    const { findByRole } = render(<TestComponent />);
+
+    expect(
+      await findByRole('heading', { name: 'Review Your Calculation' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows limited access when the user is ineligible', async () => {
+    const { findByText } = render(
+      <TestComponent usStaffGroup={UsStaffGroupEnum.PaidWithDesignation} />,
+    );
+
+    expect(
+      await findByText('Access to this feature is limited.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/pages/accountLists/[accountListId]/hrTools/nsGoalCalculator/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/nsGoalCalculator/index.page.tsx
@@ -1,0 +1,103 @@
+import Head from 'next/head';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { blockImpersonatingNonDevelopers } from 'pages/api/utils/pagePropsHelpers';
+import { NsGoalCalculator } from 'src/components/HrTools/NsGoalCalculator/NsGoalCalculator';
+import { NsGoalCalculatorProvider } from 'src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorContext';
+import { SidePanelsLayout } from 'src/components/Layouts/SidePanelsLayout';
+import Loading from 'src/components/Loading';
+import {
+  HeaderTypeEnum,
+  MultiPageHeader,
+  multiPageHeaderHeight,
+} from 'src/components/Shared/MultiPageLayout/MultiPageHeader';
+import {
+  MultiPageMenu,
+  NavTypeEnum,
+} from 'src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu';
+import {
+  RequiredUserGroupEnum,
+  UserTypeAccess,
+} from 'src/components/Shared/UserTypeAccess/UserTypeAccess';
+import { ReportPageWrapper } from 'src/components/Shared/styledComponents/ReportPageWrapper';
+import { useAccountListId } from 'src/hooks/useAccountListId';
+import { getAppName } from 'src/lib/getAppName';
+
+interface NsGoalCalculatorContentProps {
+  isNavListOpen: boolean;
+  onNavListToggle: () => void;
+}
+
+const NsGoalCalculatorContent: React.FC<NsGoalCalculatorContentProps> = ({
+  isNavListOpen,
+  onNavListToggle,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <SidePanelsLayout
+      isScrollBox={false}
+      leftPanel={
+        <MultiPageMenu
+          isOpen={isNavListOpen}
+          selectedId="nsGoalCalculator"
+          onClose={onNavListToggle}
+          navType={NavTypeEnum.HrTools}
+        />
+      }
+      leftOpen={isNavListOpen}
+      leftWidth="290px"
+      headerHeight={multiPageHeaderHeight}
+      mainContent={
+        <>
+          <MultiPageHeader
+            isNavListOpen={isNavListOpen}
+            onNavListToggle={onNavListToggle}
+            title={t('New Staff Goal Calculator')}
+            headerType={HeaderTypeEnum.HrTools}
+          />
+          <NsGoalCalculator />
+        </>
+      }
+    />
+  );
+};
+
+export const NsGoalCalculatorPage: React.FC = () => {
+  const { t } = useTranslation();
+  const appName = getAppName();
+  const accountListId = useAccountListId();
+  const [isNavListOpen, setNavListOpen] = useState(false);
+
+  const handleNavListToggle = () => {
+    setNavListOpen(!isNavListOpen);
+  };
+
+  return (
+    <>
+      <Head>
+        <title>{`${appName} | ${t(
+          'HR Tools | New Staff Goal Calculator',
+        )}`}</title>
+      </Head>
+      {accountListId ? (
+        <UserTypeAccess requireUserGroups={RequiredUserGroupEnum.NsGoalCalc}>
+          <ReportPageWrapper>
+            <NsGoalCalculatorProvider>
+              <NsGoalCalculatorContent
+                isNavListOpen={isNavListOpen}
+                onNavListToggle={handleNavListToggle}
+              />
+            </NsGoalCalculatorProvider>
+          </ReportPageWrapper>
+        </UserTypeAccess>
+      ) : (
+        <Loading loading />
+      )}
+    </>
+  );
+};
+
+export const getServerSideProps = blockImpersonatingNonDevelopers;
+
+export default NsGoalCalculatorPage;

--- a/src/components/HrTools/GoalCalculator/Shared/GoalCalculatorContext.tsx
+++ b/src/components/HrTools/GoalCalculator/Shared/GoalCalculatorContext.tsx
@@ -40,7 +40,7 @@ export type GoalCalculatorType = {
   closeRightPanel: () => void;
 
   isDrawerOpen: boolean;
-  handleStepChange: (stepId: GoalCalculatorStepEnum) => void;
+  handleStepChange: (step: GoalCalculatorStepEnum) => void;
   handleContinue: () => void;
   toggleDrawer: () => void;
   setDrawerOpen: (open: boolean) => void;

--- a/src/components/HrTools/NsGoalCalculator/NextSteps/NextStepsStep.tsx
+++ b/src/components/HrTools/NsGoalCalculator/NextSteps/NextStepsStep.tsx
@@ -1,0 +1,20 @@
+import { Box, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { NsGoalCalculatorLayout } from '../Shared/NsGoalCalculatorLayout';
+
+export const NextStepsStep: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <NsGoalCalculatorLayout
+      mainContent={
+        <Box mx={4} my={2}>
+          <Typography variant="h6">{t('Next Steps')}</Typography>
+          <Typography variant="body1" color="textSecondary">
+            {t('This step is coming soon.')}
+          </Typography>
+        </Box>
+      }
+    />
+  );
+};

--- a/src/components/HrTools/NsGoalCalculator/NsGoalCalculator.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/NsGoalCalculator.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NsGoalCalculator } from './NsGoalCalculator';
+import { NsGoalCalculatorTestWrapper } from './NsGoalCalculatorTestWrapper';
+
+const TestComponent: React.FC = () => (
+  <NsGoalCalculatorTestWrapper>
+    <NsGoalCalculator />
+  </NsGoalCalculatorTestWrapper>
+);
+
+describe('NsGoalCalculator', () => {
+  it('renders the first step by default', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(
+      getByRole('heading', { name: 'Review Your Calculation' }),
+    ).toBeInTheDocument();
+  });
+
+  it('navigates between steps via the step list', async () => {
+    const { getByRole } = render(<TestComponent />);
+
+    userEvent.click(getByRole('button', { name: '2. Presenting Your Goal' }));
+    expect(
+      getByRole('heading', { name: 'Presenting Your Goal' }),
+    ).toBeInTheDocument();
+
+    userEvent.click(getByRole('button', { name: '3. Next Steps' }));
+    expect(getByRole('heading', { name: 'Next Steps' })).toBeInTheDocument();
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/NsGoalCalculator.tsx
+++ b/src/components/HrTools/NsGoalCalculator/NsGoalCalculator.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { NextStepsStep } from './NextSteps/NextStepsStep';
+import { NsGoalCalculatorStepEnum } from './NsGoalCalculatorHelper';
+import { PresentingYourGoalStep } from './PresentingYourGoal/PresentingYourGoalStep';
+import { ReviewYourCalculationStep } from './ReviewYourCalculation/ReviewYourCalculationStep';
+import { useNsGoalCalculator } from './Shared/NsGoalCalculatorContext';
+
+export const NsGoalCalculator: React.FC = () => {
+  const { currentStep } = useNsGoalCalculator();
+
+  switch (currentStep.step) {
+    case NsGoalCalculatorStepEnum.ReviewYourCalculation:
+      return <ReviewYourCalculationStep />;
+    case NsGoalCalculatorStepEnum.PresentingYourGoal:
+      return <PresentingYourGoalStep />;
+    case NsGoalCalculatorStepEnum.NextSteps:
+      return <NextStepsStep />;
+  }
+};

--- a/src/components/HrTools/NsGoalCalculator/NsGoalCalculatorHelper.ts
+++ b/src/components/HrTools/NsGoalCalculator/NsGoalCalculatorHelper.ts
@@ -1,0 +1,5 @@
+export enum NsGoalCalculatorStepEnum {
+  ReviewYourCalculation = 'review-your-calculation',
+  PresentingYourGoal = 'presenting-your-goal',
+  NextSteps = 'next-steps',
+}

--- a/src/components/HrTools/NsGoalCalculator/NsGoalCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/NsGoalCalculator/NsGoalCalculatorTestWrapper.tsx
@@ -1,0 +1,27 @@
+import { ThemeProvider } from '@mui/material/styles';
+import { SnackbarProvider } from 'notistack';
+import TestRouter from '__tests__/util/TestRouter';
+import theme from 'src/theme';
+import { NsGoalCalculatorProvider } from './Shared/NsGoalCalculatorContext';
+
+interface NsGoalCalculatorTestWrapperProps {
+  children?: React.ReactNode;
+}
+
+export const NsGoalCalculatorTestWrapper: React.FC<
+  NsGoalCalculatorTestWrapperProps
+> = ({ children }) => (
+  <ThemeProvider theme={theme}>
+    <TestRouter
+      router={{
+        query: {
+          accountListId: 'account-list-1',
+        },
+      }}
+    >
+      <SnackbarProvider>
+        <NsGoalCalculatorProvider>{children}</NsGoalCalculatorProvider>
+      </SnackbarProvider>
+    </TestRouter>
+  </ThemeProvider>
+);

--- a/src/components/HrTools/NsGoalCalculator/PresentingYourGoal/PresentingYourGoalStep.tsx
+++ b/src/components/HrTools/NsGoalCalculator/PresentingYourGoal/PresentingYourGoalStep.tsx
@@ -1,0 +1,20 @@
+import { Box, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { NsGoalCalculatorLayout } from '../Shared/NsGoalCalculatorLayout';
+
+export const PresentingYourGoalStep: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <NsGoalCalculatorLayout
+      mainContent={
+        <Box mx={4} my={2}>
+          <Typography variant="h6">{t('Presenting Your Goal')}</Typography>
+          <Typography variant="body1" color="textSecondary">
+            {t('This step is coming soon.')}
+          </Typography>
+        </Box>
+      }
+    />
+  );
+};

--- a/src/components/HrTools/NsGoalCalculator/ReviewYourCalculation/ReviewYourCalculationStep.tsx
+++ b/src/components/HrTools/NsGoalCalculator/ReviewYourCalculation/ReviewYourCalculationStep.tsx
@@ -1,0 +1,20 @@
+import { Box, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { NsGoalCalculatorLayout } from '../Shared/NsGoalCalculatorLayout';
+
+export const ReviewYourCalculationStep: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <NsGoalCalculatorLayout
+      mainContent={
+        <Box mx={4} my={2}>
+          <Typography variant="h6">{t('Review Your Calculation')}</Typography>
+          <Typography variant="body1" color="textSecondary">
+            {t('This step is coming soon.')}
+          </Typography>
+        </Box>
+      }
+    />
+  );
+};

--- a/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorContext.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorContext.test.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect } from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NsGoalCalculatorStepEnum } from '../NsGoalCalculatorHelper';
+import { NsGoalCalculatorTestWrapper } from '../NsGoalCalculatorTestWrapper';
+import { useNsGoalCalculator } from './NsGoalCalculatorContext';
+
+interface InnerComponentProps {
+  initialStep?: NsGoalCalculatorStepEnum;
+}
+
+const InnerComponent: React.FC<InnerComponentProps> = ({ initialStep }) => {
+  const {
+    currentStep,
+    isDrawerOpen,
+    handleStepChange,
+    handleContinue,
+    toggleDrawer,
+  } = useNsGoalCalculator();
+
+  useEffect(() => {
+    if (initialStep) {
+      handleStepChange(initialStep);
+    }
+  }, [initialStep, handleStepChange]);
+
+  return (
+    <div>
+      <h2>{currentStep.title}</h2>
+      <div aria-label="drawer state" data-open={isDrawerOpen}>
+        Drawer: {isDrawerOpen ? 'open' : 'closed'}
+      </div>
+      <button
+        onClick={() =>
+          handleStepChange(NsGoalCalculatorStepEnum.PresentingYourGoal)
+        }
+      >
+        Change Step
+      </button>
+      <button onClick={handleContinue}>Continue</button>
+      <button onClick={toggleDrawer}>Toggle Drawer</button>
+    </div>
+  );
+};
+
+const TestComponent: React.FC<InnerComponentProps> = (props) => (
+  <NsGoalCalculatorTestWrapper>
+    <InnerComponent {...props} />
+  </NsGoalCalculatorTestWrapper>
+);
+
+describe('NsGoalCalculatorContext', () => {
+  it('provides the first step as the initial state', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(getByRole('heading')).toHaveTextContent('Review Your Calculation');
+  });
+
+  it('changes to the requested step', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    userEvent.click(getByRole('button', { name: 'Change Step' }));
+    expect(getByRole('heading')).toHaveTextContent('Presenting Your Goal');
+  });
+
+  it('continues to the next step', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    userEvent.click(getByRole('button', { name: 'Continue' }));
+    expect(getByRole('heading')).toHaveTextContent('Presenting Your Goal');
+  });
+
+  it('ignores a change to an unknown step', () => {
+    const { getByRole } = render(
+      <TestComponent
+        initialStep={'not-a-real-step' as NsGoalCalculatorStepEnum}
+      />,
+    );
+
+    expect(getByRole('heading')).toHaveTextContent('Review Your Calculation');
+  });
+
+  it('does not continue past the last step', () => {
+    const { getByRole } = render(
+      <TestComponent initialStep={NsGoalCalculatorStepEnum.NextSteps} />,
+    );
+    expect(getByRole('heading')).toHaveTextContent('Next Steps');
+
+    userEvent.click(getByRole('button', { name: 'Continue' }));
+    expect(getByRole('heading')).toHaveTextContent('Next Steps');
+  });
+
+  it('toggles the drawer state', () => {
+    const { getByRole, getByLabelText } = render(<TestComponent />);
+
+    const drawerState = getByLabelText('drawer state');
+    expect(drawerState).toHaveAttribute('data-open', 'true');
+
+    userEvent.click(getByRole('button', { name: 'Toggle Drawer' }));
+    expect(drawerState).toHaveAttribute('data-open', 'false');
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorContext.tsx
+++ b/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorContext.tsx
@@ -1,0 +1,86 @@
+import React, { createContext, useCallback, useMemo, useState } from 'react';
+import { NsGoalCalculatorStepEnum } from '../NsGoalCalculatorHelper';
+import { NsGoalCalculatorStep, useSteps } from './useSteps';
+
+export type NsGoalCalculatorType = {
+  steps: NsGoalCalculatorStep[];
+  currentStep: NsGoalCalculatorStep;
+  currentIndex: number;
+  isDrawerOpen: boolean;
+  handleStepChange: (step: NsGoalCalculatorStepEnum) => void;
+  handleContinue: () => void;
+  toggleDrawer: () => void;
+};
+
+const NsGoalCalculatorContext = createContext<NsGoalCalculatorType | null>(
+  null,
+);
+
+export const useNsGoalCalculator = (): NsGoalCalculatorType => {
+  const context = React.useContext(NsGoalCalculatorContext);
+  if (context === null) {
+    throw new Error(
+      'Could not find NsGoalCalculatorContext. Make sure that your component is inside <NsGoalCalculatorProvider>.',
+    );
+  }
+  return context;
+};
+
+interface Props {
+  children?: React.ReactNode;
+}
+
+export const NsGoalCalculatorProvider: React.FC<Props> = ({ children }) => {
+  const steps = useSteps();
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(true);
+
+  const currentStep = steps[currentIndex];
+
+  const toggleDrawer = useCallback(() => {
+    setIsDrawerOpen((prev) => !prev);
+  }, []);
+
+  const handleStepChange = useCallback(
+    (newStep: NsGoalCalculatorStepEnum) => {
+      const newIndex = steps.findIndex((step) => step.step === newStep);
+      if (newIndex !== -1) {
+        setCurrentIndex(newIndex);
+      }
+    },
+    [steps],
+  );
+
+  const handleContinue = useCallback(() => {
+    if (currentIndex < steps.length - 1) {
+      setCurrentIndex(currentIndex + 1);
+    }
+  }, [steps, currentIndex]);
+
+  const contextValue = useMemo(
+    (): NsGoalCalculatorType => ({
+      steps,
+      currentStep,
+      currentIndex,
+      isDrawerOpen,
+      handleStepChange,
+      handleContinue,
+      toggleDrawer,
+    }),
+    [
+      steps,
+      currentStep,
+      currentIndex,
+      isDrawerOpen,
+      handleStepChange,
+      handleContinue,
+      toggleDrawer,
+    ],
+  );
+
+  return (
+    <NsGoalCalculatorContext.Provider value={contextValue}>
+      {children}
+    </NsGoalCalculatorContext.Provider>
+  );
+};

--- a/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorLayout.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorLayout.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NsGoalCalculatorTestWrapper } from '../NsGoalCalculatorTestWrapper';
+import { NsGoalCalculatorLayout } from './NsGoalCalculatorLayout';
+
+const TestComponent: React.FC = () => (
+  <NsGoalCalculatorTestWrapper>
+    <NsGoalCalculatorLayout mainContent={<div>Main panel content</div>} />
+  </NsGoalCalculatorTestWrapper>
+);
+
+describe('NsGoalCalculatorLayout', () => {
+  it('renders the sidebar title', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(getByRole('heading', { name: 'Your MPD Goal' })).toBeInTheDocument();
+  });
+
+  it('labels the steps sidebar', () => {
+    const { getByLabelText } = render(<TestComponent />);
+
+    expect(getByLabelText('Steps')).toBeInTheDocument();
+  });
+
+  it('renders the step list', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(
+      getByRole('button', { name: '1. Review Your Calculation' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the main content slot', () => {
+    const { getByText } = render(<TestComponent />);
+
+    expect(getByText('Main panel content')).toBeInTheDocument();
+  });
+
+  it('collapses and expands the sidebar with the toggle button', () => {
+    const { getByLabelText } = render(<TestComponent />);
+
+    const sidebar = getByLabelText('Steps');
+    expect(sidebar).toHaveAttribute('aria-expanded', 'true');
+
+    userEvent.click(getByLabelText('Toggle Menu'));
+    expect(sidebar).toHaveAttribute('aria-expanded', 'false');
+
+    userEvent.click(getByLabelText('Toggle Menu'));
+    expect(sidebar).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('keeps steps clickable while the sidebar is open', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    const step = getByRole('button', { name: '2. Presenting Your Goal' });
+    userEvent.click(step);
+
+    expect(step).toHaveAttribute('aria-current', 'step');
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorLayout.tsx
+++ b/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorLayout.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { PanelLayout } from '../../Shared/CalculationReports/PanelLayout/PanelLayout';
+import { useIconPanelItems } from '../../Shared/CalculationReports/PanelLayout/useIconPanelItems';
+import { PanelTypeEnum } from '../../Shared/CalculationReports/Shared/sharedTypes';
+import { useNsGoalCalculator } from './NsGoalCalculatorContext';
+import { NsGoalCalculatorStepsList } from './NsGoalCalculatorStepsList';
+
+interface NsGoalCalculatorLayoutProps {
+  mainContent: React.ReactNode;
+}
+
+/**
+ * This is the layout shared by all new staff goal calculator pages. It renders the collapsible
+ * step list sidebar and a slot for the main content.
+ */
+export const NsGoalCalculatorLayout: React.FC<NsGoalCalculatorLayoutProps> = ({
+  mainContent,
+}) => {
+  const { t } = useTranslation();
+  const { currentIndex, isDrawerOpen, toggleDrawer } = useNsGoalCalculator();
+
+  const iconPanelItems = useIconPanelItems(isDrawerOpen, toggleDrawer);
+
+  return (
+    <PanelLayout
+      panelType={PanelTypeEnum.Other}
+      percentComplete={0}
+      showPercentage={false}
+      icons={iconPanelItems}
+      currentIndex={currentIndex}
+      sidebarTitle={t('Your MPD Goal')}
+      sidebarContent={<NsGoalCalculatorStepsList />}
+      isSidebarOpen={isDrawerOpen}
+      sidebarAriaLabel={t('Steps')}
+      mainContent={mainContent}
+    />
+  );
+};

--- a/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorStepsList.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorStepsList.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NsGoalCalculatorTestWrapper } from '../NsGoalCalculatorTestWrapper';
+import { NsGoalCalculatorStepsList } from './NsGoalCalculatorStepsList';
+
+const TestComponent: React.FC = () => (
+  <NsGoalCalculatorTestWrapper>
+    <NsGoalCalculatorStepsList />
+  </NsGoalCalculatorTestWrapper>
+);
+
+describe('NsGoalCalculatorStepsList', () => {
+  it('renders each step with a number prefix', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(
+      getByRole('button', { name: '1. Review Your Calculation' }),
+    ).toBeInTheDocument();
+    expect(
+      getByRole('button', { name: '2. Presenting Your Goal' }),
+    ).toBeInTheDocument();
+    expect(getByRole('button', { name: '3. Next Steps' })).toBeInTheDocument();
+  });
+
+  it('marks the first step as current by default', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(
+      getByRole('button', { name: '1. Review Your Calculation' }),
+    ).toHaveAttribute('aria-current', 'step');
+    expect(
+      getByRole('button', { name: '2. Presenting Your Goal' }),
+    ).not.toHaveAttribute('aria-current');
+  });
+
+  it('moves the current marker when a step is clicked', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    userEvent.click(getByRole('button', { name: '2. Presenting Your Goal' }));
+
+    expect(
+      getByRole('button', { name: '2. Presenting Your Goal' }),
+    ).toHaveAttribute('aria-current', 'step');
+    expect(
+      getByRole('button', { name: '1. Review Your Calculation' }),
+    ).not.toHaveAttribute('aria-current');
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorStepsList.tsx
+++ b/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorStepsList.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { List, ListItemButton } from '@mui/material';
+import { CategoryListItemStyles } from 'src/components/HrTools/Shared/CalculationReports/Shared/styledComponents/StepsListStyles';
+import { ListItemContent } from 'src/components/HrTools/Shared/CalculationReports/StepsList/ListItemContent';
+import { useNsGoalCalculator } from './NsGoalCalculatorContext';
+
+export const NsGoalCalculatorStepsList: React.FC = () => {
+  const { steps, currentStep, handleStepChange } = useNsGoalCalculator();
+
+  const currentIndex = steps.findIndex(
+    (step) => step.step === currentStep.step,
+  );
+
+  return (
+    <List disablePadding>
+      {steps.map((step, index) => {
+        const current = step.step === currentStep.step;
+        return (
+          <ListItemButton
+            key={step.step}
+            sx={CategoryListItemStyles}
+            aria-current={current ? 'step' : undefined}
+            onClick={() => handleStepChange(step.step)}
+          >
+            <ListItemContent
+              title={`${index + 1}. ${step.title}`}
+              complete={index < currentIndex}
+              current={current}
+            />
+          </ListItemButton>
+        );
+      })}
+    </List>
+  );
+};

--- a/src/components/HrTools/NsGoalCalculator/Shared/useSteps.tsx
+++ b/src/components/HrTools/NsGoalCalculator/Shared/useSteps.tsx
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { NsGoalCalculatorStepEnum } from '../NsGoalCalculatorHelper';
+
+export interface NsGoalCalculatorStep {
+  step: NsGoalCalculatorStepEnum;
+  title: string;
+}
+
+export const useSteps = (): NsGoalCalculatorStep[] => {
+  const { t } = useTranslation();
+
+  const steps = useMemo(
+    () => [
+      {
+        step: NsGoalCalculatorStepEnum.ReviewYourCalculation,
+        title: t('Review Your Calculation'),
+      },
+      {
+        step: NsGoalCalculatorStepEnum.PresentingYourGoal,
+        title: t('Presenting Your Goal'),
+      },
+      {
+        step: NsGoalCalculatorStepEnum.NextSteps,
+        title: t('Next Steps'),
+      },
+    ],
+    [t],
+  );
+
+  return steps;
+};

--- a/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/PdsGoalCalculatorContext.tsx
@@ -60,7 +60,7 @@ export type PdsGoalCalculatorType = {
 
   stepIndex: number;
   isDrawerOpen: boolean;
-  handleStepChange: (stepId: PdsGoalCalculatorStepEnum) => void;
+  handleStepChange: (step: PdsGoalCalculatorStepEnum) => void;
   handleContinue: () => void;
   handlePreviousStep: () => void;
   toggleDrawer: () => void;

--- a/src/components/HrTools/Shared/CalculationReports/Shared/styledComponents/StepsListStyles.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/Shared/styledComponents/StepsListStyles.tsx
@@ -9,7 +9,7 @@ export const CategoryListItemStyles: SxProps<Theme> = (theme) => ({
     fontSize: '1rem',
   },
   padding: 0,
-  paddingLeft: theme.spacing(3),
+  paddingLeft: theme.spacing(2),
 });
 
 export const CategoryListItemIcon = styled(ListItemIcon)(({ theme }) => ({

--- a/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
@@ -530,6 +530,7 @@ describe('MultiPageMenu', () => {
       expect(
         queryByText('Paid with Designation Support Goal Calculator'),
       ).not.toBeInTheDocument();
+      expect(queryByText('New Staff Goal Calculator')).not.toBeInTheDocument();
       expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
     });
 
@@ -564,6 +565,7 @@ describe('MultiPageMenu', () => {
       expect(await findByText('Additional Salary Request')).toBeInTheDocument();
       expect(queryByText('Salary Calculation Form')).not.toBeInTheDocument();
       expect(getByText('Savings Fund Transfer')).toBeInTheDocument();
+      expect(getByText('New Staff Goal Calculator')).toBeInTheDocument();
       expect(queryByText('MPD Goal Calculator')).not.toBeInTheDocument();
       expect(queryByText('MHA Calculation Tool')).not.toBeInTheDocument();
       expect(
@@ -608,6 +610,7 @@ describe('MultiPageMenu', () => {
       expect(
         queryByText('Paid with Designation Support Goal Calculator'),
       ).not.toBeInTheDocument();
+      expect(queryByText('New Staff Goal Calculator')).not.toBeInTheDocument();
       expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
     });
 
@@ -647,6 +650,7 @@ describe('MultiPageMenu', () => {
       expect(queryByText('Savings Fund Transfer')).not.toBeInTheDocument();
       expect(queryByText('MPD Goal Calculator')).not.toBeInTheDocument();
       expect(queryByText('MHA Calculation Tool')).not.toBeInTheDocument();
+      expect(queryByText('New Staff Goal Calculator')).not.toBeInTheDocument();
       expect(queryByText('Ministry Partner Reminders')).not.toBeInTheDocument();
     });
 
@@ -687,6 +691,7 @@ describe('MultiPageMenu', () => {
       expect(queryByText('Additional Salary Request')).not.toBeInTheDocument();
       expect(queryByText('MPD Goal Calculator')).not.toBeInTheDocument();
       expect(queryByText('MHA Calculation Tool')).not.toBeInTheDocument();
+      expect(queryByText('New Staff Goal Calculator')).not.toBeInTheDocument();
     });
 
     it('shows hr tools for interns', async () => {
@@ -726,6 +731,7 @@ describe('MultiPageMenu', () => {
       expect(queryByText('Additional Salary Request')).not.toBeInTheDocument();
       expect(queryByText('MPD Goal Calculator')).not.toBeInTheDocument();
       expect(queryByText('MHA Calculation Tool')).not.toBeInTheDocument();
+      expect(queryByText('New Staff Goal Calculator')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/Shared/UserTypeAccess/UserTypeAccess.test.tsx
+++ b/src/components/Shared/UserTypeAccess/UserTypeAccess.test.tsx
@@ -123,6 +123,30 @@ describe('UserTypeAccess', () => {
     ).toBeInTheDocument();
   });
 
+  it('should render LimitedAccess when user type is allowed but user is ineligible for the NS goal calculator', async () => {
+    const { findByRole } = render(
+      <TestComponent
+        requireUserGroups={RequiredUserGroupEnum.NsGoalCalc}
+        usStaffGroup={UsStaffGroupEnum.PartTimeFieldStaff}
+      />,
+    );
+    expect(
+      await findByRole('heading', {
+        name: 'Access to this feature is limited.',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should render child component when user is eligible for the NS goal calculator', async () => {
+    const { findByText } = render(
+      <TestComponent
+        requireUserGroups={RequiredUserGroupEnum.NsGoalCalc}
+        usStaffGroup={UsStaffGroupEnum.NewStaff}
+      />,
+    );
+    expect(await findByText('Test Content')).toBeInTheDocument();
+  });
+
   it('should render LimitedAccess when user type is allowed but user is ineligible for the PDS goal calculator', async () => {
     const { findByRole } = render(
       <TestComponent

--- a/src/components/Shared/UserTypeAccess/UserTypeAccess.tsx
+++ b/src/components/Shared/UserTypeAccess/UserTypeAccess.tsx
@@ -8,6 +8,7 @@ export enum RequiredUserGroupEnum {
   SalaryCalc = 'salaryCalc',
   Mha = 'mha',
   MpdGoalCalc = 'mpdGoalCalc',
+  NsGoalCalc = 'nsGoalCalc',
   PdsGoalCalc = 'pdsGoalCalc',
 }
 
@@ -31,6 +32,7 @@ export const UserTypeAccess: React.FC<UserTypeAccessProps> = ({
     inSalaryCalcIneligibleGroup,
     inMhaIneligibleGroup,
     inMpdGoalCalcIneligibleGroup,
+    inNsGoalCalcIneligibleGroup,
     inPdsGoalCalcIneligibleGroup,
     userType,
     hasNoStaffAccount,
@@ -43,6 +45,7 @@ export const UserTypeAccess: React.FC<UserTypeAccessProps> = ({
     [RequiredUserGroupEnum.SalaryCalc]: inSalaryCalcIneligibleGroup,
     [RequiredUserGroupEnum.Mha]: inMhaIneligibleGroup,
     [RequiredUserGroupEnum.MpdGoalCalc]: inMpdGoalCalcIneligibleGroup,
+    [RequiredUserGroupEnum.NsGoalCalc]: inNsGoalCalcIneligibleGroup,
     [RequiredUserGroupEnum.PdsGoalCalc]: inPdsGoalCalcIneligibleGroup,
   };
 

--- a/src/hooks/useHrToolsNavItems.ts
+++ b/src/hooks/useHrToolsNavItems.ts
@@ -13,6 +13,7 @@ export function useHrToolsNavItems(): {
     inSalaryCalcIneligibleGroup,
     inMhaIneligibleGroup,
     inMpdGoalCalcIneligibleGroup,
+    inNsGoalCalcIneligibleGroup,
     inPdsGoalCalcIneligibleGroup,
     hasNoStaffAccount,
     userLoading,
@@ -33,6 +34,13 @@ export function useHrToolsNavItems(): {
         id: 'staffSavingFund',
         title: t('Savings Fund Transfer'),
         hideItem: hasNoStaffAccount,
+      },
+      {
+        id: 'nsGoalCalculator',
+        title: t('New Staff Goal Calculator'),
+        hideItem:
+          process.env.DISABLE_NS_GOAL_CALCULATOR === 'true' ||
+          inNsGoalCalcIneligibleGroup,
       },
       {
         id: 'goalCalculator',
@@ -66,6 +74,7 @@ export function useHrToolsNavItems(): {
     inSalaryCalcIneligibleGroup,
     inMhaIneligibleGroup,
     inMpdGoalCalcIneligibleGroup,
+    inNsGoalCalcIneligibleGroup,
     inPdsGoalCalcIneligibleGroup,
     userLoading,
     hasNoStaffAccount,

--- a/src/hooks/useIneligibleByGroup.test.tsx
+++ b/src/hooks/useIneligibleByGroup.test.tsx
@@ -80,11 +80,14 @@ describe('useIneligibleByGroup', () => {
       });
 
       await waitFor(() => expect(result.current.userLoading).toBe(false));
-      expect(result.current.inAsrIneligibleGroup).toBe(false);
-      expect(result.current.inSalaryCalcIneligibleGroup).toBe(false);
-      expect(result.current.inMhaIneligibleGroup).toBe(false);
-      expect(result.current.inMpdGoalCalcIneligibleGroup).toBe(false);
-      expect(result.current.inPdsGoalCalcIneligibleGroup).toBe(true);
+      expect(result.current).toMatchObject({
+        inAsrIneligibleGroup: false,
+        inSalaryCalcIneligibleGroup: false,
+        inMhaIneligibleGroup: false,
+        inMpdGoalCalcIneligibleGroup: false,
+        inNsGoalCalcIneligibleGroup: true,
+        inPdsGoalCalcIneligibleGroup: true,
+      });
     });
 
     it('new staff eligibility', async () => {
@@ -94,11 +97,14 @@ describe('useIneligibleByGroup', () => {
       });
 
       await waitFor(() => expect(result.current.userLoading).toBe(false));
-      expect(result.current.inAsrIneligibleGroup).toBe(false);
-      expect(result.current.inSalaryCalcIneligibleGroup).toBe(true);
-      expect(result.current.inMhaIneligibleGroup).toBe(true);
-      expect(result.current.inMpdGoalCalcIneligibleGroup).toBe(true);
-      expect(result.current.inPdsGoalCalcIneligibleGroup).toBe(true);
+      expect(result.current).toMatchObject({
+        inAsrIneligibleGroup: false,
+        inSalaryCalcIneligibleGroup: true,
+        inMhaIneligibleGroup: true,
+        inMpdGoalCalcIneligibleGroup: true,
+        inNsGoalCalcIneligibleGroup: false,
+        inPdsGoalCalcIneligibleGroup: true,
+      });
     });
 
     it('part time field staff eligibility', async () => {
@@ -108,11 +114,14 @@ describe('useIneligibleByGroup', () => {
       });
 
       await waitFor(() => expect(result.current.userLoading).toBe(false));
-      expect(result.current.inAsrIneligibleGroup).toBe(true);
-      expect(result.current.inSalaryCalcIneligibleGroup).toBe(true);
-      expect(result.current.inMhaIneligibleGroup).toBe(true);
-      expect(result.current.inMpdGoalCalcIneligibleGroup).toBe(true);
-      expect(result.current.inPdsGoalCalcIneligibleGroup).toBe(true);
+      expect(result.current).toMatchObject({
+        inAsrIneligibleGroup: true,
+        inSalaryCalcIneligibleGroup: true,
+        inMhaIneligibleGroup: true,
+        inMpdGoalCalcIneligibleGroup: true,
+        inNsGoalCalcIneligibleGroup: true,
+        inPdsGoalCalcIneligibleGroup: true,
+      });
     });
 
     it('paid with designation eligibility', async () => {
@@ -122,11 +131,14 @@ describe('useIneligibleByGroup', () => {
       });
 
       await waitFor(() => expect(result.current.userLoading).toBe(false));
-      expect(result.current.inAsrIneligibleGroup).toBe(true);
-      expect(result.current.inSalaryCalcIneligibleGroup).toBe(true);
-      expect(result.current.inMhaIneligibleGroup).toBe(true);
-      expect(result.current.inMpdGoalCalcIneligibleGroup).toBe(true);
-      expect(result.current.inPdsGoalCalcIneligibleGroup).toBe(false);
+      expect(result.current).toMatchObject({
+        inAsrIneligibleGroup: true,
+        inSalaryCalcIneligibleGroup: true,
+        inMhaIneligibleGroup: true,
+        inMpdGoalCalcIneligibleGroup: true,
+        inNsGoalCalcIneligibleGroup: true,
+        inPdsGoalCalcIneligibleGroup: false,
+      });
     });
 
     it('intern eligibility', async () => {
@@ -136,11 +148,14 @@ describe('useIneligibleByGroup', () => {
       });
 
       await waitFor(() => expect(result.current.userLoading).toBe(false));
-      expect(result.current.inAsrIneligibleGroup).toBe(true);
-      expect(result.current.inSalaryCalcIneligibleGroup).toBe(true);
-      expect(result.current.inMhaIneligibleGroup).toBe(true);
-      expect(result.current.inMpdGoalCalcIneligibleGroup).toBe(true);
-      expect(result.current.inPdsGoalCalcIneligibleGroup).toBe(true);
+      expect(result.current).toMatchObject({
+        inAsrIneligibleGroup: true,
+        inSalaryCalcIneligibleGroup: true,
+        inMhaIneligibleGroup: true,
+        inMpdGoalCalcIneligibleGroup: true,
+        inNsGoalCalcIneligibleGroup: true,
+        inPdsGoalCalcIneligibleGroup: true,
+      });
     });
 
     it('national expat eligibility', async () => {
@@ -150,11 +165,14 @@ describe('useIneligibleByGroup', () => {
       });
 
       await waitFor(() => expect(result.current.userLoading).toBe(false));
-      expect(result.current.inAsrIneligibleGroup).toBe(false);
-      expect(result.current.inSalaryCalcIneligibleGroup).toBe(false);
-      expect(result.current.inMhaIneligibleGroup).toBe(false);
-      expect(result.current.inMpdGoalCalcIneligibleGroup).toBe(true);
-      expect(result.current.inPdsGoalCalcIneligibleGroup).toBe(true);
+      expect(result.current).toMatchObject({
+        inAsrIneligibleGroup: false,
+        inSalaryCalcIneligibleGroup: false,
+        inMhaIneligibleGroup: false,
+        inMpdGoalCalcIneligibleGroup: true,
+        inNsGoalCalcIneligibleGroup: true,
+        inPdsGoalCalcIneligibleGroup: true,
+      });
     });
 
     describe('spouse us staff group', () => {
@@ -165,11 +183,14 @@ describe('useIneligibleByGroup', () => {
         });
 
         await waitFor(() => expect(result.current.userLoading).toBe(false));
-        expect(result.current.inAsrIneligibleGroup).toBe(false);
-        expect(result.current.inSalaryCalcIneligibleGroup).toBe(true);
-        expect(result.current.inMhaIneligibleGroup).toBe(false);
-        expect(result.current.inMpdGoalCalcIneligibleGroup).toBe(true);
-        expect(result.current.inPdsGoalCalcIneligibleGroup).toBe(true);
+        expect(result.current).toMatchObject({
+          inAsrIneligibleGroup: false,
+          inSalaryCalcIneligibleGroup: true,
+          inMhaIneligibleGroup: false,
+          inMpdGoalCalcIneligibleGroup: true,
+          inNsGoalCalcIneligibleGroup: true,
+          inPdsGoalCalcIneligibleGroup: true,
+        });
       });
     });
 
@@ -180,11 +201,14 @@ describe('useIneligibleByGroup', () => {
       });
 
       await waitFor(() => expect(result.current.userLoading).toBe(false));
-      expect(result.current.inAsrIneligibleGroup).toBe(true);
-      expect(result.current.inSalaryCalcIneligibleGroup).toBe(true);
-      expect(result.current.inMhaIneligibleGroup).toBe(true);
-      expect(result.current.inMpdGoalCalcIneligibleGroup).toBe(true);
-      expect(result.current.inPdsGoalCalcIneligibleGroup).toBe(true);
+      expect(result.current).toMatchObject({
+        inAsrIneligibleGroup: true,
+        inSalaryCalcIneligibleGroup: true,
+        inMhaIneligibleGroup: true,
+        inMpdGoalCalcIneligibleGroup: true,
+        inNsGoalCalcIneligibleGroup: true,
+        inPdsGoalCalcIneligibleGroup: true,
+      });
     });
   });
 });

--- a/src/hooks/useIneligibleByGroup.ts
+++ b/src/hooks/useIneligibleByGroup.ts
@@ -39,6 +39,9 @@ export function useIneligibleByGroup() {
   const inMpdGoalCalcIneligibleGroup = !isInEligibleGroup(usStaffGroup, [
     SeniorStaff,
   ]);
+  const inNsGoalCalcIneligibleGroup = !isInEligibleGroup(usStaffGroup, [
+    NewStaff,
+  ]);
   const inPdsGoalCalcIneligibleGroup = !isInEligibleGroup(usStaffGroup, [
     PaidWithDesignation,
   ]);
@@ -49,6 +52,7 @@ export function useIneligibleByGroup() {
       inSalaryCalcIneligibleGroup,
       inMhaIneligibleGroup,
       inMpdGoalCalcIneligibleGroup,
+      inNsGoalCalcIneligibleGroup,
       inPdsGoalCalcIneligibleGroup,
       userType,
       hasNoStaffAccount,
@@ -60,6 +64,7 @@ export function useIneligibleByGroup() {
       inSalaryCalcIneligibleGroup,
       inMhaIneligibleGroup,
       inMpdGoalCalcIneligibleGroup,
+      inNsGoalCalcIneligibleGroup,
       inPdsGoalCalcIneligibleGroup,
       userType,
       hasNoStaffAccount,


### PR DESCRIPTION
## Description

Sets up page and basic context, step list, and placeholder components. The menu item is gated by an environment variable (I set `DISABLE_NS_GOAL_CALCULATOR=true` for production).

MPDX-9524

## Testing

- Impersonate timothy.ethington@cru.org (new staff role)
- Go to `/hrTools/nsGoalCalculator`
- Check that the page renders

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
