### PR TITLE
[no-Jira] Show all pages to developers during development

### DIFF
--- a/__tests__/util/globalSetup.ts
+++ b/__tests__/util/globalSetup.ts
@@ -2,6 +2,8 @@ const globalSetup = (): void => {
   process.env.TZ = 'UTC';
   process.env.JWT_SECRET = 'test-environment-key';
   process.env.APP_NAME = 'MPDX';
+  // Ensure we don't bypass page visibility checks in tests
+  process.env.DEVELOPMENT_ENV = 'false';
 };
 
 export default globalSetup;

--- a/__tests__/util/mockSession.ts
+++ b/__tests__/util/mockSession.ts
@@ -3,7 +3,7 @@ import { useSession } from 'next-auth/react';
 import { session } from '__tests__/fixtures/session';
 
 // Override the globally-mocked useSession
-export const mockSession = (user: Partial<Session['user']> = {}): void => {
+export const mockSession = (user: Partial<Session['user']>): void => {
   (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
     data: { ...session, user: { ...session.user, ...user } },
     status: 'authenticated',

--- a/__tests__/util/mockSession.ts
+++ b/__tests__/util/mockSession.ts
@@ -1,0 +1,12 @@
+import { Session } from 'next-auth';
+import { useSession } from 'next-auth/react';
+import { session } from '__tests__/fixtures/session';
+
+// Override the globally-mocked useSession
+export const mockSession = (user: Partial<Session['user']> = {}): void => {
+  (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
+    data: { ...session, user: { ...session.user, ...user } },
+    status: 'authenticated',
+    update: () => Promise.resolve(null),
+  });
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -29,6 +29,7 @@ const withBundleAnalyzer = bundleAnalyzer({
 
 const config: NextConfig = {
   env: {
+    DEVELOPMENT_ENV: process.env.DEVELOPMENT_ENV ?? 'false',
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     JWT_SECRET: process.env.JWT_SECRET ?? 'development-key',
     API_URL: process.env.API_URL ?? 'https://api.stage.mpdx.org/graphql',

--- a/pages/api/utils/pagePropsHelpers.test.ts
+++ b/pages/api/utils/pagePropsHelpers.test.ts
@@ -12,7 +12,6 @@ import {
   makeGetServerSideProps,
 } from './pagePropsHelpers';
 
-jest.mock('next-auth/react');
 jest.mock('src/lib/apollo/ssrClient', () => jest.fn());
 
 const context = {

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonEmail/PersonEmail.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/People/Items/PersonModal/PersonEmail/PersonEmail.test.tsx
@@ -8,8 +8,6 @@ import theme from 'src/theme';
 import { getPersonSchema } from '../personModalHelper';
 import { PersonEmail } from './PersonEmail';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Contacts/MassActions/Exports/ExportsModal.test.tsx
+++ b/src/components/Contacts/MassActions/Exports/ExportsModal.test.tsx
@@ -10,7 +10,6 @@ import theme from 'src/theme';
 import { ExportsModal } from './ExportsModal';
 import { exportRest } from './exportRest';
 
-jest.mock('next-auth/react');
 jest.mock('./exportRest');
 
 const mockEnqueue = jest.fn();

--- a/src/components/Contacts/MassActions/Exports/MailMergedLabelModal/MailMergedLabelModal.test.tsx
+++ b/src/components/Contacts/MassActions/Exports/MailMergedLabelModal/MailMergedLabelModal.test.tsx
@@ -10,7 +10,6 @@ import theme from 'src/theme';
 import { exportRest } from '../exportRest';
 import { MailMergedLabelModal } from './MailMergedLabelModal';
 
-jest.mock('next-auth/react');
 jest.mock('../exportRest');
 
 const mockEnqueue = jest.fn();

--- a/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportPhysical/ExportPhysical.test.tsx
+++ b/src/components/Dashboard/ThisWeek/NewsletterMenu/MenuItems/ExportPhysical/ExportPhysical.test.tsx
@@ -14,7 +14,6 @@ import { CreateExportedContactsMutation } from './ExportPhysical.generated';
 
 const accountListId = '111';
 const handleClose = jest.fn();
-jest.mock('next-auth/react');
 
 describe('ExportPhysical', () => {
   const mocks = {

--- a/src/components/Helpjuice/Helpjuice.test.tsx
+++ b/src/components/Helpjuice/Helpjuice.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { useSession } from 'next-auth/react';
-import { session } from '__tests__/fixtures/session';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { mockSession } from '__tests__/util/mockSession';
 import { UserOptionQuery } from 'src/hooks/UserPreference.generated';
 import { Helpjuice } from './Helpjuice';
 import { widgetHTML } from './widget.mock';
@@ -92,18 +92,7 @@ describe('Helpjuice', () => {
     );
 
     // Update the session
-    (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
-      data: {
-        ...session,
-        user: {
-          ...session.user,
-          name: 'John Doe',
-          email: 'john.doe@cru.org',
-        },
-      },
-      status: 'authenticated',
-      update: () => Promise.resolve(null),
-    });
+    mockSession({ name: 'John Doe', email: 'john.doe@cru.org' });
     rerender(<Helpjuice />);
 
     expect(document.getElementById('helpjuice-contact-link')).toHaveProperty(

--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.test.tsx
@@ -4,10 +4,10 @@ import { MockedResponse } from '@apollo/client/testing';
 import { ThemeProvider } from '@mui/material/styles';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'jest-fetch-mock';
-import { signOut, useSession } from 'next-auth/react';
-import { session } from '__tests__/fixtures/session';
+import { signOut } from 'next-auth/react';
 import TestRouter from '__tests__/util/TestRouter';
 import TestWrapper from '__tests__/util/TestWrapper';
+import { mockSession } from '__tests__/util/mockSession';
 import { render, waitFor } from '__tests__/util/testingLibraryReactMock';
 import { TestSetupProvider } from 'src/components/Setup/SetupProvider';
 import theme from '../../../../../../theme';
@@ -231,14 +231,7 @@ describe('ProfileMenu while Impersonating', () => {
   beforeEach(() => {
     process.env.OAUTH_URL = 'https://auth.mpdx.org';
 
-    (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
-      data: {
-        ...session,
-        user: { ...session.user, impersonating: true },
-      },
-      status: 'authenticated',
-      update: () => Promise.resolve(null),
-    });
+    mockSession({ impersonating: true });
   });
 
   it('Should remove impersonating cookies and redirect user to Angular MPDX', async () => {

--- a/src/components/Settings/Accounts/InviteForm/InviteForm.test.tsx
+++ b/src/components/Settings/Accounts/InviteForm/InviteForm.test.tsx
@@ -9,8 +9,6 @@ import { InviteTypeEnum } from 'src/graphql/types.generated';
 import theme from '../../../../theme';
 import { InviteForm } from './InviteForm';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Accounts/ManageAccountAccess/ManageAccountAccessAccordion.test.tsx
+++ b/src/components/Settings/Accounts/ManageAccountAccess/ManageAccountAccessAccordion.test.tsx
@@ -10,8 +10,6 @@ import theme from '../../../../theme';
 import { GetAccountsSharingWithQuery } from './ManageAccountAccess.generated';
 import { ManageAccountAccessAccordion } from './ManageAccountAccessAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Accounts/ManageAccounts/ManageAccounts.test.tsx
+++ b/src/components/Settings/Accounts/ManageAccounts/ManageAccounts.test.tsx
@@ -14,8 +14,6 @@ import {
   GetUserIdQuery,
 } from './ManageAccounts.generated';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Accounts/MergeAccounts/MergeAccountsAccordion.test.tsx
+++ b/src/components/Settings/Accounts/MergeAccounts/MergeAccountsAccordion.test.tsx
@@ -8,8 +8,6 @@ import { AccountAccordion } from 'src/components/Shared/Forms/Accordions/Accordi
 import theme from '../../../../theme';
 import { MergeAccountsAccordion } from './MergeAccountsAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Accounts/MergeForm/MergeForm.test.tsx
+++ b/src/components/Settings/Accounts/MergeForm/MergeForm.test.tsx
@@ -12,8 +12,6 @@ import {
   GetAccountListsForMergingQuery,
 } from './MergeForm.generated';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Accounts/MergeSpouseAccounts/MergeSpouseAccountsAccordion.test.tsx
+++ b/src/components/Settings/Accounts/MergeSpouseAccounts/MergeSpouseAccountsAccordion.test.tsx
@@ -8,8 +8,6 @@ import { AccountAccordion } from 'src/components/Shared/Forms/Accordions/Accordi
 import theme from '../../../../theme';
 import { MergeSpouseAccountsAccordion } from './MergeSpouseAccountsAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Admin/ImpersonateUser/ImpersonateUserAccordion.test.tsx
+++ b/src/components/Settings/Admin/ImpersonateUser/ImpersonateUserAccordion.test.tsx
@@ -8,8 +8,6 @@ import { AdminAccordion } from 'src/components/Shared/Forms/Accordions/Accordion
 import theme from '../../../../theme';
 import { ImpersonateUserAccordion } from './ImpersonateUserAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Admin/ResetAccount/ResetAccountAccordion.test.tsx
+++ b/src/components/Settings/Admin/ResetAccount/ResetAccountAccordion.test.tsx
@@ -9,8 +9,6 @@ import { AdminAccordion } from 'src/components/Shared/Forms/Accordions/Accordion
 import theme from '../../../../theme';
 import { ResetAccountAccordion } from './ResetAccountAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion.test.tsx
+++ b/src/components/Settings/Coaches/ManageCoachesAccess/ManageCoachesAccessAccordion.test.tsx
@@ -10,8 +10,6 @@ import theme from '../../../../theme';
 import { GetAccountListCoachesQuery } from './ManageAccountAccess.generated';
 import { ManageCoachesAccessAccordion } from './ManageCoachesAccessAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Organization/AccountLists/AccountListRow/AccountListCoachesOrUsers/AccountListCoachesOrUsers.test.tsx
+++ b/src/components/Settings/Organization/AccountLists/AccountListRow/AccountListCoachesOrUsers/AccountListCoachesOrUsers.test.tsx
@@ -8,8 +8,6 @@ import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from '../../../../../../theme';
 import { AccountListCoachesOrUsers } from './AccountListCoachesOrUsers';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Organization/AccountLists/AccountListRow/AccountListInvites/AccountListInvites.test.tsx
+++ b/src/components/Settings/Organization/AccountLists/AccountListRow/AccountListInvites/AccountListInvites.test.tsx
@@ -9,8 +9,6 @@ import theme from '../../../../../../theme';
 import { AccountListsMocks } from '../../AccountLists.mock';
 import { AccountListInvites } from './AccountListInvites';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Organization/AccountLists/AccountListRow/AccountListRow.test.tsx
+++ b/src/components/Settings/Organization/AccountLists/AccountListRow/AccountListRow.test.tsx
@@ -10,8 +10,6 @@ import theme from '../../../../../theme';
 import { AccountListsMocks } from '../AccountLists.mock';
 import { AccountListRow } from './AccountListRow';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Organization/AccountLists/AccountLists.test.tsx
+++ b/src/components/Settings/Organization/AccountLists/AccountLists.test.tsx
@@ -12,8 +12,6 @@ import { AccountLists } from './AccountLists';
 import { SearchOrganizationsAccountListsQuery } from './AccountLists.generated';
 import { AccountListsMocks } from './AccountLists.mock';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Organization/Contacts/ContactRow/ContactRow.test.tsx
+++ b/src/components/Settings/Organization/Contacts/ContactRow/ContactRow.test.tsx
@@ -9,8 +9,6 @@ import theme from '../../../../../theme';
 import { ContactsMocks } from '../contactsMocks';
 import { ContactRow } from './ContactRow';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Organization/Contacts/Contacts.test.tsx
+++ b/src/components/Settings/Organization/Contacts/Contacts.test.tsx
@@ -11,8 +11,6 @@ import { SearchOrganizationsContactsQuery } from './Contact.generated';
 import { Contacts } from './Contacts';
 import { ContactsMocks } from './contactsMocks';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion.test.tsx
+++ b/src/components/Settings/Organization/ImpersonateUser/ImpersonateUserAccordion.test.tsx
@@ -10,8 +10,6 @@ import { OrganizationAccordion } from 'src/components/Shared/Forms/Accordions/Ac
 import theme from '../../../../theme';
 import { ImpersonateUserAccordion } from './ImpersonateUserAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion.test.tsx
+++ b/src/components/Settings/Organization/ManageOrganizationAccess/ManageOrganizationAccessAccordion.test.tsx
@@ -15,8 +15,6 @@ import {
 } from './ManageOrganizationAccess.generated';
 import { ManageOrganizationAccessAccordion } from './ManageOrganizationAccessAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/integrations/Chalkline/ChalklineAccordion.test.tsx
+++ b/src/components/Settings/integrations/Chalkline/ChalklineAccordion.test.tsx
@@ -9,8 +9,6 @@ import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/Acc
 import theme from '../../../../theme';
 import { ChalklineAccordion } from './ChalklineAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/integrations/Google/GoogleAccordion.test.tsx
+++ b/src/components/Settings/integrations/Google/GoogleAccordion.test.tsx
@@ -10,8 +10,6 @@ import theme from '../../../../theme';
 import { GoogleAccordion } from './GoogleAccordion';
 import { GoogleAccountsQuery } from './GoogleAccounts.generated';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/integrations/Google/Modals/DeleteGoogleAccountModal.test.tsx
+++ b/src/components/Settings/integrations/Google/Modals/DeleteGoogleAccountModal.test.tsx
@@ -8,8 +8,6 @@ import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from '../../../../../theme';
 import { DeleteGoogleAccountModal } from './DeleteGoogleAccountModal';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
@@ -15,8 +15,6 @@ import theme from '../../../../../theme';
 import { EditGoogleAccountModal } from './EditGoogleAccountModal';
 import { GoogleAccountIntegrationsQuery } from './googleIntegrations.generated';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.test.tsx
+++ b/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.test.tsx
@@ -10,8 +10,6 @@ import theme from '../../../../theme';
 import { MailchimpAccordion } from './MailchimpAccordion';
 import { MailchimpAccountQuery } from './MailchimpAccount.generated';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/integrations/Organization/ConnectOrganization.test.tsx
+++ b/src/components/Settings/integrations/Organization/ConnectOrganization.test.tsx
@@ -10,8 +10,6 @@ import theme from 'src/theme';
 import { ConnectOrganization } from './ConnectOrganization';
 import { GetOrganizationsQuery } from './Organizations.generated';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/integrations/Organization/Modals/OrganizationAddAccountModal.test.tsx
+++ b/src/components/Settings/integrations/Organization/Modals/OrganizationAddAccountModal.test.tsx
@@ -6,8 +6,6 @@ import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from 'src/theme';
 import { OrganizationAddAccountModal } from './OrganizationAddAccountModal';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Settings/integrations/Organization/Modals/OrganizationEditAccountModal.test.tsx
+++ b/src/components/Settings/integrations/Organization/Modals/OrganizationEditAccountModal.test.tsx
@@ -8,8 +8,6 @@ import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from '../../../../../theme';
 import { OrganizationEditAccountModal } from './OrganizationEditAccountModal';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const organizationId = 'organization-1';
 const contactId = 'contact-1';

--- a/src/components/Settings/integrations/Organization/Modals/OrganizationImportDataSyncModal.test.tsx
+++ b/src/components/Settings/integrations/Organization/Modals/OrganizationImportDataSyncModal.test.tsx
@@ -11,8 +11,6 @@ import {
   validateFile,
 } from './OrganizationImportDataSyncModal';
 
-jest.mock('next-auth/react');
-
 process.env.REST_API_URL = 'https://api.stage.mpdx.org/api/v2/';
 const accountListId = 'account-list-1';
 const organizationId = 'organizationId';

--- a/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
+++ b/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
@@ -15,8 +15,6 @@ import {
   GetUsersOrganizationsAccountsQuery,
 } from './Organizations.generated';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.test.tsx
+++ b/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.test.tsx
@@ -11,8 +11,6 @@ import theme from 'src/theme';
 import { PrayerlettersAccordion } from './PrayerlettersAccordion';
 import { PrayerlettersAccountQuery } from './PrayerlettersAccount.generated';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const contactId = 'contact-1';
 const router = {

--- a/src/components/Settings/integrations/useOauthUrl.test.tsx
+++ b/src/components/Settings/integrations/useOauthUrl.test.tsx
@@ -1,7 +1,5 @@
 import React, { PropsWithChildren } from 'react';
 import { renderHook } from '@testing-library/react';
-import { Session } from 'next-auth';
-import { useSession } from 'next-auth/react';
 import { renderToString } from 'react-dom/server';
 import TestRouter from '__tests__/util/TestRouter';
 import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
@@ -21,9 +19,6 @@ const renderUseOauthUrl = () =>
 
 beforeEach(() => {
   process.env.OAUTH_URL = 'https://auth.mpdx.org';
-  (useSession as jest.Mock).mockReturnValue({
-    data: { user: { apiToken } } as Session,
-  });
 });
 
 describe('useOauthUrl', () => {

--- a/src/components/Settings/integrations/useOauthUrl.test.tsx
+++ b/src/components/Settings/integrations/useOauthUrl.test.tsx
@@ -5,8 +5,6 @@ import TestRouter from '__tests__/util/TestRouter';
 import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
 import { useOauthUrl } from './useOauthUrl';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const apiToken = 'apiToken';
 

--- a/src/components/Settings/preferences/accordions/AccountNameAccordion/AccountNameAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/AccountNameAccordion/AccountNameAccordion.test.tsx
@@ -10,8 +10,6 @@ import theme from 'src/theme';
 import { UpdateAccountPreferencesDocument } from '../UpdateAccountPreferences.generated';
 import { AccountNameAccordion } from './AccountNameAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Settings/preferences/accordions/CurrencyAccordion/CurrencyAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/CurrencyAccordion/CurrencyAccordion.test.tsx
@@ -10,8 +10,6 @@ import theme from 'src/theme';
 import { UpdatePersonalPreferencesDocument } from '../UpdatePersonalPreferences.generated';
 import { CurrencyAccordion } from './CurrencyAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/DefaultAccountAccordion/DefaultAccountAccordion.test.tsx
@@ -8,8 +8,6 @@ import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/Acco
 import theme from 'src/theme';
 import { DefaultAccountAccordion } from './DefaultAccountAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Settings/preferences/accordions/EarlyAdopterAccordion/EarlyAdopterAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/EarlyAdopterAccordion/EarlyAdopterAccordion.test.tsx
@@ -9,8 +9,6 @@ import { UserPreferenceContext } from 'src/components/User/Preferences/UserPrefe
 import theme from 'src/theme';
 import { EarlyAdopterAccordion } from './EarlyAdopterAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.test.tsx
@@ -10,8 +10,6 @@ import theme from 'src/theme';
 import { ExportDataMutation } from '../../GetAccountPreferences.generated';
 import { ExportAllDataAccordion } from './ExportAllDataAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Settings/preferences/accordions/HomeCountryAccordion/HomeCountryAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/HomeCountryAccordion/HomeCountryAccordion.test.tsx
@@ -10,8 +10,6 @@ import theme from 'src/theme';
 import { UpdatePersonalPreferencesDocument } from '../UpdatePersonalPreferences.generated';
 import { HomeCountryAccordion } from './HomeCountryAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Settings/preferences/accordions/HourToSendNotificationsAccordion/HourToSendNotificationsAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/HourToSendNotificationsAccordion/HourToSendNotificationsAccordion.test.tsx
@@ -8,8 +8,6 @@ import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/Acco
 import theme from 'src/theme';
 import { HourToSendNotificationsAccordion } from './HourToSendNotificationsAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Settings/preferences/accordions/LanguageAccordion/LanguageAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/LanguageAccordion/LanguageAccordion.test.tsx
@@ -10,8 +10,6 @@ import theme from 'src/theme';
 import { UpdatePersonalPreferencesDocument } from '../UpdatePersonalPreferences.generated';
 import { LanguageAccordion } from './LanguageAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Settings/preferences/accordions/LocaleAccordion/LocaleAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/LocaleAccordion/LocaleAccordion.test.tsx
@@ -8,8 +8,6 @@ import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/Acco
 import theme from 'src/theme';
 import { LocaleAccordion } from './LocaleAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/MonthlyGoalAccordion/MonthlyGoalAccordion.test.tsx
@@ -8,8 +8,6 @@ import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/Acco
 import theme from 'src/theme';
 import { MonthlyGoalAccordion } from './MonthlyGoalAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Settings/preferences/accordions/MpdInfoAccordion/MpdInfoAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/MpdInfoAccordion/MpdInfoAccordion.test.tsx
@@ -10,8 +10,6 @@ import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/Acco
 import theme from 'src/theme';
 import { MpdInfoAccordion } from './MpdInfoAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Settings/preferences/accordions/PrimaryOrgAccordion/PrimaryOrgAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/PrimaryOrgAccordion/PrimaryOrgAccordion.test.tsx
@@ -8,8 +8,6 @@ import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/Acco
 import theme from 'src/theme';
 import { PrimaryOrgAccordion } from './PrimaryOrgAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Settings/preferences/accordions/TimeZoneAccordion/TimeZoneAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/TimeZoneAccordion/TimeZoneAccordion.test.tsx
@@ -8,8 +8,6 @@ import { PreferenceAccordion } from 'src/components/Shared/Forms/Accordions/Acco
 import theme from 'src/theme';
 import { TimeZoneAccordion } from './TimeZoneAccordion';
 
-jest.mock('next-auth/react');
-
 const accountListId = 'account-list-1';
 const router = {
   query: { accountListId },

--- a/src/components/Shared/MassActions/ContactsMassActionsDropdown.test.tsx
+++ b/src/components/Shared/MassActions/ContactsMassActionsDropdown.test.tsx
@@ -23,7 +23,7 @@ const openTaskModal = jest.fn();
 
 jest.mock('../../../hooks/useTaskModal');
 jest.mock('src/hooks/useAccountListId');
-jest.mock('next-auth/react');
+
 jest.mock('notistack', () => ({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore

--- a/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useSession } from 'next-auth/react';
-import { session } from '__tests__/fixtures/session';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { mockSession } from '__tests__/util/mockSession';
 import { GetDesignationAccountsQuery } from 'src/components/EditDonationModal/EditDonationModal.generated';
 import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import { UsStaffGroupEnum, UserTypeEnum } from 'src/graphql/types.generated';
@@ -316,14 +315,7 @@ describe('MultiPageMenu', () => {
   });
 
   it("hides the organizations links when user isn't admin and manages no organization", async () => {
-    (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
-      data: {
-        ...session,
-        user: { ...session.user, admin: false, developer: false },
-      },
-      status: 'authenticated',
-      update: () => Promise.resolve(null),
-    });
+    mockSession({ admin: false, developer: false });
 
     const mutationSpy = jest.fn();
     const { queryByText } = render(
@@ -358,14 +350,7 @@ describe('MultiPageMenu', () => {
   });
 
   it("shows the organizations links when user isn't admin but manages an organization", async () => {
-    (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
-      data: {
-        ...session,
-        user: { ...session.user, admin: false, developer: false },
-      },
-      status: 'authenticated',
-      update: () => Promise.resolve(null),
-    });
+    mockSession({ admin: false, developer: false });
 
     const mutationSpy = jest.fn();
     const { getByText } = render(
@@ -398,14 +383,7 @@ describe('MultiPageMenu', () => {
   });
 
   it('shows the developer tools', async () => {
-    (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
-      data: {
-        ...session,
-        user: { ...session.user, admin: false, developer: true },
-      },
-      status: 'authenticated',
-      update: () => Promise.resolve(null),
-    });
+    mockSession({ admin: false, developer: true });
 
     const mutationSpy = jest.fn();
     const { queryByText, getByText } = render(
@@ -446,14 +424,7 @@ describe('MultiPageMenu', () => {
   });
 
   it('shows the admin tools', async () => {
-    (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
-      data: {
-        ...session,
-        user: { ...session.user, admin: true, developer: false },
-      },
-      status: 'authenticated',
-      update: () => Promise.resolve(null),
-    });
+    mockSession({ admin: true, developer: false });
 
     const mutationSpy = jest.fn();
     const { queryByText, getByText } = render(

--- a/src/components/Shared/UserTypeAccess/UserTypeAccess.test.tsx
+++ b/src/components/Shared/UserTypeAccess/UserTypeAccess.test.tsx
@@ -1,22 +1,13 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
-import { useSession } from 'next-auth/react';
-import { session } from '__tests__/fixtures/session';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { mockSession } from '__tests__/util/mockSession';
 import { render } from '__tests__/util/testingLibraryReactMock';
 import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import { UsStaffGroupEnum, UserTypeEnum } from 'src/graphql/types.generated';
 import theme from 'src/theme';
 import { RequiredUserGroupEnum, UserTypeAccess } from './UserTypeAccess';
-
-const setDeveloper = (developer: boolean) => {
-  (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
-    data: { ...session, user: { ...session.user, developer } },
-    status: 'authenticated',
-    update: () => Promise.resolve(null),
-  });
-};
 
 const id = 'staff-1';
 
@@ -59,7 +50,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
 describe('UserTypeAccess', () => {
   afterEach(() => {
     process.env.DEVELOPMENT_ENV = 'false';
-    setDeveloper(false);
+    mockSession();
   });
 
   it('should render child component when user type is allowed', async () => {
@@ -239,7 +230,7 @@ describe('UserTypeAccess', () => {
 
   it('should render child component in a development env for a developer even when user is ineligible by group', async () => {
     process.env.DEVELOPMENT_ENV = 'true';
-    setDeveloper(true);
+    mockSession({ developer: true });
 
     const { findByText } = render(
       <TestComponent
@@ -253,7 +244,7 @@ describe('UserTypeAccess', () => {
 
   it('should render child component in a development env for a developer even when user type is not allowed', async () => {
     process.env.DEVELOPMENT_ENV = 'true';
-    setDeveloper(true);
+    mockSession({ developer: true });
 
     const { findByText } = render(
       <TestComponent userType={UserTypeEnum.NonCru} />,
@@ -264,7 +255,22 @@ describe('UserTypeAccess', () => {
 
   it('should not bypass eligibility gating in a development env for a non-developer', async () => {
     process.env.DEVELOPMENT_ENV = 'true';
-    setDeveloper(false);
+    mockSession({ developer: false });
+
+    const { findByRole } = render(
+      <TestComponent userType={UserTypeEnum.NonCru} />,
+    );
+
+    expect(
+      await findByRole('heading', {
+        name: 'Access to this feature is limited.',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should not bypass eligibility gating for a developer outside a development env', async () => {
+    process.env.DEVELOPMENT_ENV = 'false';
+    mockSession({ developer: true });
 
     const { findByRole } = render(
       <TestComponent userType={UserTypeEnum.NonCru} />,

--- a/src/components/Shared/UserTypeAccess/UserTypeAccess.test.tsx
+++ b/src/components/Shared/UserTypeAccess/UserTypeAccess.test.tsx
@@ -252,6 +252,21 @@ describe('UserTypeAccess', () => {
     expect(await findByText('Test Content')).toBeInTheDocument();
   });
 
+  it('should render LimitedAccess in a development env for a developer when staff account is required but not present', async () => {
+    process.env.DEVELOPMENT_ENV = 'true';
+    mockSession({ developer: true });
+
+    const { findByRole } = render(
+      <TestComponent requireStaffAccount staffAccountId={null} />,
+    );
+
+    expect(
+      await findByRole('heading', {
+        name: 'Access to this feature is limited.',
+      }),
+    ).toBeInTheDocument();
+  });
+
   it('should not bypass eligibility gating in a development env for a non-developer', async () => {
     process.env.DEVELOPMENT_ENV = 'true';
     mockSession({ developer: false });

--- a/src/components/Shared/UserTypeAccess/UserTypeAccess.test.tsx
+++ b/src/components/Shared/UserTypeAccess/UserTypeAccess.test.tsx
@@ -50,7 +50,6 @@ const TestComponent: React.FC<TestComponentProps> = ({
 describe('UserTypeAccess', () => {
   afterEach(() => {
     process.env.DEVELOPMENT_ENV = 'false';
-    mockSession();
   });
 
   it('should render child component when user type is allowed', async () => {

--- a/src/components/Shared/UserTypeAccess/UserTypeAccess.test.tsx
+++ b/src/components/Shared/UserTypeAccess/UserTypeAccess.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
+import { useSession } from 'next-auth/react';
+import { session } from '__tests__/fixtures/session';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { render } from '__tests__/util/testingLibraryReactMock';
@@ -7,6 +9,14 @@ import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import { UsStaffGroupEnum, UserTypeEnum } from 'src/graphql/types.generated';
 import theme from 'src/theme';
 import { RequiredUserGroupEnum, UserTypeAccess } from './UserTypeAccess';
+
+const setDeveloper = (developer: boolean) => {
+  (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
+    data: { ...session, user: { ...session.user, developer } },
+    status: 'authenticated',
+    update: () => Promise.resolve(null),
+  });
+};
 
 const id = 'staff-1';
 
@@ -47,6 +57,11 @@ const TestComponent: React.FC<TestComponentProps> = ({
 );
 
 describe('UserTypeAccess', () => {
+  afterEach(() => {
+    process.env.DEVELOPMENT_ENV = 'false';
+    setDeveloper(false);
+  });
+
   it('should render child component when user type is allowed', async () => {
     const { findByText } = render(<TestComponent />);
     expect(await findByText('Test Content')).toBeInTheDocument();
@@ -219,6 +234,46 @@ describe('UserTypeAccess', () => {
     ).toBeInTheDocument();
     expect(
       getByText(/something went wrong while loading your account information/i),
+    ).toBeInTheDocument();
+  });
+
+  it('should render child component in a development env for a developer even when user is ineligible by group', async () => {
+    process.env.DEVELOPMENT_ENV = 'true';
+    setDeveloper(true);
+
+    const { findByText } = render(
+      <TestComponent
+        requireUserGroups={RequiredUserGroupEnum.Asr}
+        usStaffGroup={UsStaffGroupEnum.PartTimeFieldStaff}
+      />,
+    );
+
+    expect(await findByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('should render child component in a development env for a developer even when user type is not allowed', async () => {
+    process.env.DEVELOPMENT_ENV = 'true';
+    setDeveloper(true);
+
+    const { findByText } = render(
+      <TestComponent userType={UserTypeEnum.NonCru} />,
+    );
+
+    expect(await findByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('should not bypass eligibility gating in a development env for a non-developer', async () => {
+    process.env.DEVELOPMENT_ENV = 'true';
+    setDeveloper(false);
+
+    const { findByRole } = render(
+      <TestComponent userType={UserTypeEnum.NonCru} />,
+    );
+
+    expect(
+      await findByRole('heading', {
+        name: 'Access to this feature is limited.',
+      }),
     ).toBeInTheDocument();
   });
 });

--- a/src/components/Shared/UserTypeAccess/UserTypeAccess.tsx
+++ b/src/components/Shared/UserTypeAccess/UserTypeAccess.tsx
@@ -1,6 +1,7 @@
 import Loading from 'src/components/Loading';
 import { UserTypeEnum } from 'src/graphql/types.generated';
 import { useIneligibleByGroup } from 'src/hooks/useIneligibleByGroup';
+import { useRequiredSession } from 'src/hooks/useRequiredSession';
 import { LimitedAccess } from '../LimitedAccess/LimitedAccess';
 
 export enum RequiredUserGroupEnum {
@@ -39,6 +40,7 @@ export const UserTypeAccess: React.FC<UserTypeAccessProps> = ({
     userLoading,
     userError,
   } = useIneligibleByGroup();
+  const { developer } = useRequiredSession();
 
   const ineligibleByGroup: Record<RequiredUserGroupEnum, boolean> = {
     [RequiredUserGroupEnum.Asr]: inAsrIneligibleGroup,
@@ -53,8 +55,9 @@ export const UserTypeAccess: React.FC<UserTypeAccessProps> = ({
     (userType && userType !== requiredUserType) ||
     (requireUserGroups && ineligibleByGroup[requireUserGroups]);
 
+  // When not in production, developers bypass all eligibility gating so they can reach all pages
   // Once HCM is ready to go live and DISABLE_NEW_REPORTS is removed, we can remove the alwaysAllow prop
-  if (alwaysAllow) {
+  if (alwaysAllow || (process.env.DEVELOPMENT_ENV === 'true' && developer)) {
     return children;
   }
 

--- a/src/components/Shared/UserTypeAccess/UserTypeAccess.tsx
+++ b/src/components/Shared/UserTypeAccess/UserTypeAccess.tsx
@@ -1,7 +1,7 @@
 import Loading from 'src/components/Loading';
 import { UserTypeEnum } from 'src/graphql/types.generated';
+import { useDeveloperBypass } from 'src/hooks/useDeveloperBypass';
 import { useIneligibleByGroup } from 'src/hooks/useIneligibleByGroup';
-import { useRequiredSession } from 'src/hooks/useRequiredSession';
 import { LimitedAccess } from '../LimitedAccess/LimitedAccess';
 
 export enum RequiredUserGroupEnum {
@@ -40,7 +40,7 @@ export const UserTypeAccess: React.FC<UserTypeAccessProps> = ({
     userLoading,
     userError,
   } = useIneligibleByGroup();
-  const { developer } = useRequiredSession();
+  const developerBypass = useDeveloperBypass();
 
   const ineligibleByGroup: Record<RequiredUserGroupEnum, boolean> = {
     [RequiredUserGroupEnum.Asr]: inAsrIneligibleGroup,
@@ -55,9 +55,8 @@ export const UserTypeAccess: React.FC<UserTypeAccessProps> = ({
     (userType && userType !== requiredUserType) ||
     (requireUserGroups && ineligibleByGroup[requireUserGroups]);
 
-  // When not in production, developers bypass all eligibility gating so they can reach all pages
   // Once HCM is ready to go live and DISABLE_NEW_REPORTS is removed, we can remove the alwaysAllow prop
-  if (alwaysAllow || (process.env.DEVELOPMENT_ENV === 'true' && developer)) {
+  if (alwaysAllow || developerBypass) {
     return children;
   }
 

--- a/src/components/Shared/UserTypeAccess/UserTypeAccess.tsx
+++ b/src/components/Shared/UserTypeAccess/UserTypeAccess.tsx
@@ -56,7 +56,7 @@ export const UserTypeAccess: React.FC<UserTypeAccessProps> = ({
     (requireUserGroups && ineligibleByGroup[requireUserGroups]);
 
   // Once HCM is ready to go live and DISABLE_NEW_REPORTS is removed, we can remove the alwaysAllow prop
-  if (alwaysAllow || developerBypass) {
+  if (alwaysAllow) {
     return children;
   }
 
@@ -68,7 +68,7 @@ export const UserTypeAccess: React.FC<UserTypeAccessProps> = ({
     return <Loading loading />;
   }
 
-  if (limitedAccess) {
+  if (limitedAccess && !developerBypass) {
     return <LimitedAccess />;
   }
 

--- a/src/components/Tool/FixMailingAddresses/FixMailingAddresses.test.tsx
+++ b/src/components/Tool/FixMailingAddresses/FixMailingAddresses.test.tsx
@@ -17,7 +17,6 @@ import {
 } from './FixMailingAddressesMock';
 import { InvalidAddressesQuery } from './GetInvalidAddresses.generated';
 
-jest.mock('next-auth/react');
 const accountListId = 'account-list-1';
 const contactId = 'contactId';
 const router = {

--- a/src/components/Tool/Import/Csv/uploadCsvFile.test.ts
+++ b/src/components/Tool/Import/Csv/uploadCsvFile.test.ts
@@ -13,7 +13,6 @@ import {
 } from './uploadCsvFile';
 
 jest.mock('src/lib/deserializeJsonApi');
-jest.mock('next-auth/react');
 
 const importId = 'import-id';
 

--- a/src/hooks/useDeveloperBypass.test.tsx
+++ b/src/hooks/useDeveloperBypass.test.tsx
@@ -5,7 +5,6 @@ import { useDeveloperBypass } from './useDeveloperBypass';
 describe('useDeveloperBypass', () => {
   afterEach(() => {
     process.env.DEVELOPMENT_ENV = 'false';
-    mockSession();
   });
 
   it('is true in a development env for a developer', () => {

--- a/src/hooks/useDeveloperBypass.test.tsx
+++ b/src/hooks/useDeveloperBypass.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { mockSession } from '__tests__/util/mockSession';
+import { useDeveloperBypass } from './useDeveloperBypass';
+
+describe('useDeveloperBypass', () => {
+  afterEach(() => {
+    process.env.DEVELOPMENT_ENV = 'false';
+    mockSession();
+  });
+
+  it('is true in a development env for a developer', () => {
+    process.env.DEVELOPMENT_ENV = 'true';
+    mockSession({ developer: true });
+
+    const { result } = renderHook(() => useDeveloperBypass());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('is false in a development env for a non-developer', () => {
+    process.env.DEVELOPMENT_ENV = 'true';
+    mockSession({ developer: false });
+
+    const { result } = renderHook(() => useDeveloperBypass());
+
+    expect(result.current).toBe(false);
+  });
+
+  // The production safety guarantee: a developer must never bypass gating
+  // outside a development env.
+  it('is false outside a development env for a developer', () => {
+    process.env.DEVELOPMENT_ENV = 'false';
+    mockSession({ developer: true });
+
+    const { result } = renderHook(() => useDeveloperBypass());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('is false outside a development env for a non-developer', () => {
+    process.env.DEVELOPMENT_ENV = 'false';
+    mockSession({ developer: false });
+
+    const { result } = renderHook(() => useDeveloperBypass());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/useDeveloperBypass.ts
+++ b/src/hooks/useDeveloperBypass.ts
@@ -1,0 +1,7 @@
+import { useRequiredSession } from './useRequiredSession';
+
+// When not in production, developers bypass all eligibility gating so they can reach all pages
+export function useDeveloperBypass(): boolean {
+  const { developer } = useRequiredSession();
+  return process.env.DEVELOPMENT_ENV === 'true' && developer;
+}

--- a/src/hooks/useHrToolsNavItems.test.tsx
+++ b/src/hooks/useHrToolsNavItems.test.tsx
@@ -25,7 +25,6 @@ const Wrapper = ({ children }: { children: ReactElement }) => (
 describe('useHrToolsNavItems', () => {
   afterEach(() => {
     process.env.DEVELOPMENT_ENV = 'false';
-    mockSession();
   });
 
   it('hides all items for an ineligible user when not in a development env', async () => {

--- a/src/hooks/useHrToolsNavItems.test.tsx
+++ b/src/hooks/useHrToolsNavItems.test.tsx
@@ -1,0 +1,86 @@
+import { ReactElement } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useSession } from 'next-auth/react';
+import { session } from '__tests__/fixtures/session';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { GetUserQuery } from 'src/components/User/GetUser.generated';
+import { UsStaffGroupEnum, UserTypeEnum } from 'src/graphql/types.generated';
+import { useHrToolsNavItems } from './useHrToolsNavItems';
+
+const setDeveloper = (developer: boolean) => {
+  (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
+    data: { ...session, user: { ...session.user, developer } },
+    status: 'authenticated',
+    update: () => Promise.resolve(null),
+  });
+};
+
+// A user in a group that is ineligible for every HR Tool and with no staff account
+const ineligibleUser = {
+  userType: UserTypeEnum.UsStaff,
+  usStaffGroup: UsStaffGroupEnum.PartTimeFieldStaff,
+  spouseUsStaffGroup: UsStaffGroupEnum.PartTimeFieldStaff,
+  staffAccountId: null,
+};
+
+const Wrapper = ({ children }: { children: ReactElement }) => (
+  <GqlMockedProvider<{ GetUser: GetUserQuery }>
+    mocks={{ GetUser: { user: ineligibleUser } }}
+  >
+    {children}
+  </GqlMockedProvider>
+);
+
+describe('useHrToolsNavItems', () => {
+  afterEach(() => {
+    process.env.DEVELOPMENT_ENV = 'false';
+    setDeveloper(false);
+  });
+
+  it('hides all items for an ineligible user when not in a development env', async () => {
+    process.env.DEVELOPMENT_ENV = 'false';
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useHrToolsNavItems(),
+      { wrapper: Wrapper },
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it('shows all items for an ineligible developer in a development env', async () => {
+    process.env.DEVELOPMENT_ENV = 'true';
+    setDeveloper(true);
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useHrToolsNavItems(),
+      { wrapper: Wrapper },
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.items.map((item) => item.id)).toEqual([
+      'salaryCalculator',
+      'staffSavingFund',
+      'nsGoalCalculator',
+      'goalCalculator',
+      'mhaCalculator',
+      'additionalSalaryRequest',
+      'pdsGoalCalculator',
+      'partnerReminders',
+    ]);
+  });
+
+  it('hides all items for an ineligible non-developer in a development env', async () => {
+    process.env.DEVELOPMENT_ENV = 'true';
+    setDeveloper(false);
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useHrToolsNavItems(),
+      { wrapper: Wrapper },
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.items).toHaveLength(0);
+  });
+});

--- a/src/hooks/useHrToolsNavItems.test.tsx
+++ b/src/hooks/useHrToolsNavItems.test.tsx
@@ -1,19 +1,10 @@
 import { ReactElement } from 'react';
 import { renderHook } from '@testing-library/react-hooks';
-import { useSession } from 'next-auth/react';
-import { session } from '__tests__/fixtures/session';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { mockSession } from '__tests__/util/mockSession';
 import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import { UsStaffGroupEnum, UserTypeEnum } from 'src/graphql/types.generated';
 import { useHrToolsNavItems } from './useHrToolsNavItems';
-
-const setDeveloper = (developer: boolean) => {
-  (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
-    data: { ...session, user: { ...session.user, developer } },
-    status: 'authenticated',
-    update: () => Promise.resolve(null),
-  });
-};
 
 // A user in a group that is ineligible for every HR Tool and with no staff account
 const ineligibleUser = {
@@ -34,12 +25,10 @@ const Wrapper = ({ children }: { children: ReactElement }) => (
 describe('useHrToolsNavItems', () => {
   afterEach(() => {
     process.env.DEVELOPMENT_ENV = 'false';
-    setDeveloper(false);
+    mockSession();
   });
 
   it('hides all items for an ineligible user when not in a development env', async () => {
-    process.env.DEVELOPMENT_ENV = 'false';
-
     const { result, waitForNextUpdate } = renderHook(
       () => useHrToolsNavItems(),
       { wrapper: Wrapper },
@@ -51,7 +40,7 @@ describe('useHrToolsNavItems', () => {
 
   it('shows all items for an ineligible developer in a development env', async () => {
     process.env.DEVELOPMENT_ENV = 'true';
-    setDeveloper(true);
+    mockSession({ developer: true });
 
     const { result, waitForNextUpdate } = renderHook(
       () => useHrToolsNavItems(),
@@ -73,7 +62,20 @@ describe('useHrToolsNavItems', () => {
 
   it('hides all items for an ineligible non-developer in a development env', async () => {
     process.env.DEVELOPMENT_ENV = 'true';
-    setDeveloper(false);
+    mockSession({ developer: false });
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useHrToolsNavItems(),
+      { wrapper: Wrapper },
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it('hides all items for an ineligible developer outside a development env', async () => {
+    process.env.DEVELOPMENT_ENV = 'false';
+    mockSession({ developer: true });
 
     const { result, waitForNextUpdate } = renderHook(
       () => useHrToolsNavItems(),

--- a/src/hooks/useHrToolsNavItems.ts
+++ b/src/hooks/useHrToolsNavItems.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useIneligibleByGroup } from './useIneligibleByGroup';
 import { NavItems } from './useReportNavItems';
+import { useRequiredSession } from './useRequiredSession';
 
 export function useHrToolsNavItems(): {
   items: NavItems[];
@@ -18,6 +19,7 @@ export function useHrToolsNavItems(): {
     hasNoStaffAccount,
     userLoading,
   } = useIneligibleByGroup();
+  const { developer } = useRequiredSession();
 
   const items = useMemo(() => {
     if (userLoading) {
@@ -67,7 +69,11 @@ export function useHrToolsNavItems(): {
         title: t('Ministry Partner Reminders'),
         hideItem: hasNoStaffAccount,
       },
-    ].filter((item) => !item.hideItem);
+      // When not in production, developers bypass all eligibility gating so they can reach all pages
+    ].filter(
+      (item) =>
+        (process.env.DEVELOPMENT_ENV === 'true' && developer) || !item.hideItem,
+    );
   }, [
     t,
     inAsrIneligibleGroup,
@@ -78,6 +84,7 @@ export function useHrToolsNavItems(): {
     inPdsGoalCalcIneligibleGroup,
     userLoading,
     hasNoStaffAccount,
+    developer,
   ]);
 
   return { items, loading: userLoading };

--- a/src/hooks/useHrToolsNavItems.ts
+++ b/src/hooks/useHrToolsNavItems.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDeveloperBypass } from './useDeveloperBypass';
 import { useIneligibleByGroup } from './useIneligibleByGroup';
 import { NavItems } from './useReportNavItems';
-import { useRequiredSession } from './useRequiredSession';
 
 export function useHrToolsNavItems(): {
   items: NavItems[];
@@ -19,7 +19,7 @@ export function useHrToolsNavItems(): {
     hasNoStaffAccount,
     userLoading,
   } = useIneligibleByGroup();
-  const { developer } = useRequiredSession();
+  const developerBypass = useDeveloperBypass();
 
   const items = useMemo(() => {
     if (userLoading) {
@@ -69,11 +69,7 @@ export function useHrToolsNavItems(): {
         title: t('Ministry Partner Reminders'),
         hideItem: hasNoStaffAccount,
       },
-      // When not in production, developers bypass all eligibility gating so they can reach all pages
-    ].filter(
-      (item) =>
-        (process.env.DEVELOPMENT_ENV === 'true' && developer) || !item.hideItem,
-    );
+    ].filter((item) => developerBypass || !item.hideItem);
   }, [
     t,
     inAsrIneligibleGroup,
@@ -84,7 +80,7 @@ export function useHrToolsNavItems(): {
     inPdsGoalCalcIneligibleGroup,
     userLoading,
     hasNoStaffAccount,
-    developer,
+    developerBypass,
   ]);
 
   return { items, loading: userLoading };

--- a/src/hooks/useReportNavItems.test.tsx
+++ b/src/hooks/useReportNavItems.test.tsx
@@ -1,0 +1,87 @@
+import { ReactElement } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useSession } from 'next-auth/react';
+import { session } from '__tests__/fixtures/session';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { GetUserQuery } from 'src/components/User/GetUser.generated';
+import { UserTypeEnum } from 'src/graphql/types.generated';
+import { UserOptionQuery } from './UserPreference.generated';
+import { useReportNavItems } from './useReportNavItems';
+
+const setDeveloper = (developer: boolean) => {
+  (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
+    data: { ...session, user: { ...session.user, developer } },
+    status: 'authenticated',
+    update: () => Promise.resolve(null),
+  });
+};
+
+// financialAccounts is gated to global staff, so it is hidden for this user unless a developer
+// bypasses gating
+const user = {
+  userType: UserTypeEnum.UsStaff,
+  staffAccountId: 'staff-1',
+};
+
+const Wrapper = ({ children }: { children: ReactElement }) => (
+  <GqlMockedProvider<{ GetUser: GetUserQuery; UserOption: UserOptionQuery }>
+    mocks={{
+      GetUser: { user },
+      // user_type_verified === 'true' keeps reports enabled
+      UserOption: { userOption: { key: 'user_type_verified', value: 'true' } },
+    }}
+  >
+    {children}
+  </GqlMockedProvider>
+);
+
+describe('useReportNavItems', () => {
+  afterEach(() => {
+    process.env.DEVELOPMENT_ENV = 'false';
+    setDeveloper(false);
+  });
+
+  it('hides gated items for a non-developer when not in a development env', async () => {
+    process.env.DEVELOPMENT_ENV = 'false';
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useReportNavItems(),
+      { wrapper: Wrapper },
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.map((item) => item.id)).not.toContain(
+      'financialAccounts',
+    );
+  });
+
+  it('does not bypass gating for a non-developer in a development env', async () => {
+    process.env.DEVELOPMENT_ENV = 'true';
+    setDeveloper(false);
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useReportNavItems(),
+      { wrapper: Wrapper },
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.map((item) => item.id)).not.toContain(
+      'financialAccounts',
+    );
+  });
+
+  it('shows gated items for a developer in a development env', async () => {
+    process.env.DEVELOPMENT_ENV = 'true';
+    setDeveloper(true);
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useReportNavItems(),
+      { wrapper: Wrapper },
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.map((item) => item.id)).toContain(
+      'financialAccounts',
+    );
+  });
+});

--- a/src/hooks/useReportNavItems.test.tsx
+++ b/src/hooks/useReportNavItems.test.tsx
@@ -29,7 +29,6 @@ const Wrapper = ({ children }: { children: ReactElement }) => (
 describe('useReportNavItems', () => {
   afterEach(() => {
     process.env.DEVELOPMENT_ENV = 'false';
-    mockSession();
   });
 
   it('hides gated items for a non-developer when not in a development env', async () => {

--- a/src/hooks/useReportNavItems.test.tsx
+++ b/src/hooks/useReportNavItems.test.tsx
@@ -1,20 +1,11 @@
 import { ReactElement } from 'react';
 import { renderHook } from '@testing-library/react-hooks';
-import { useSession } from 'next-auth/react';
-import { session } from '__tests__/fixtures/session';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { mockSession } from '__tests__/util/mockSession';
 import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import { UserTypeEnum } from 'src/graphql/types.generated';
 import { UserOptionQuery } from './UserPreference.generated';
 import { useReportNavItems } from './useReportNavItems';
-
-const setDeveloper = (developer: boolean) => {
-  (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
-    data: { ...session, user: { ...session.user, developer } },
-    status: 'authenticated',
-    update: () => Promise.resolve(null),
-  });
-};
 
 // financialAccounts is gated to global staff, so it is hidden for this user unless a developer
 // bypasses gating
@@ -38,12 +29,10 @@ const Wrapper = ({ children }: { children: ReactElement }) => (
 describe('useReportNavItems', () => {
   afterEach(() => {
     process.env.DEVELOPMENT_ENV = 'false';
-    setDeveloper(false);
+    mockSession();
   });
 
   it('hides gated items for a non-developer when not in a development env', async () => {
-    process.env.DEVELOPMENT_ENV = 'false';
-
     const { result, waitForNextUpdate } = renderHook(
       () => useReportNavItems(),
       { wrapper: Wrapper },
@@ -57,7 +46,7 @@ describe('useReportNavItems', () => {
 
   it('does not bypass gating for a non-developer in a development env', async () => {
     process.env.DEVELOPMENT_ENV = 'true';
-    setDeveloper(false);
+    mockSession({ developer: false });
 
     const { result, waitForNextUpdate } = renderHook(
       () => useReportNavItems(),
@@ -72,7 +61,7 @@ describe('useReportNavItems', () => {
 
   it('shows gated items for a developer in a development env', async () => {
     process.env.DEVELOPMENT_ENV = 'true';
-    setDeveloper(true);
+    mockSession({ developer: true });
 
     const { result, waitForNextUpdate } = renderHook(
       () => useReportNavItems(),
@@ -81,6 +70,21 @@ describe('useReportNavItems', () => {
     await waitForNextUpdate();
 
     expect(result.current.map((item) => item.id)).toContain(
+      'financialAccounts',
+    );
+  });
+
+  it('does not bypass gating for a developer outside a development env', async () => {
+    process.env.DEVELOPMENT_ENV = 'false';
+    mockSession({ developer: true });
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useReportNavItems(),
+      { wrapper: Wrapper },
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.map((item) => item.id)).not.toContain(
       'financialAccounts',
     );
   });

--- a/src/hooks/useReportNavItems.ts
+++ b/src/hooks/useReportNavItems.ts
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import { UserTypeEnum } from 'src/graphql/types.generated';
 import { useReportsDisabled } from './useReportsDisabled';
+import { useRequiredSession } from './useRequiredSession';
 
 export type NavItems = {
   id: string;
@@ -15,6 +16,7 @@ export function useReportNavItems(): NavItems[] {
   const { t } = useTranslation();
   const { data } = useGetUserQuery();
   const { reportsDisabled } = useReportsDisabled();
+  const { developer } = useRequiredSession();
 
   const userType = data?.user.userType;
   const usStaff = userType === UserTypeEnum.UsStaff;
@@ -76,7 +78,13 @@ export function useReportNavItems(): NavItems[] {
   ];
 
   return useMemo(
-    () => reportNavItems.filter((item) => !item.hideItem),
-    [t, usStaff, globalStaff, reportsDisabled, hasNoStaffAccount],
+    () =>
+      reportNavItems.filter(
+        // When not in production, developers bypass all eligibility gating so they can reach all pages
+        (item) =>
+          (process.env.DEVELOPMENT_ENV === 'true' && developer) ||
+          !item.hideItem,
+      ),
+    [t, usStaff, globalStaff, reportsDisabled, hasNoStaffAccount, developer],
   );
 }

--- a/src/hooks/useReportNavItems.ts
+++ b/src/hooks/useReportNavItems.ts
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import { UserTypeEnum } from 'src/graphql/types.generated';
+import { useDeveloperBypass } from './useDeveloperBypass';
 import { useReportsDisabled } from './useReportsDisabled';
-import { useRequiredSession } from './useRequiredSession';
 
 export type NavItems = {
   id: string;
@@ -16,7 +16,7 @@ export function useReportNavItems(): NavItems[] {
   const { t } = useTranslation();
   const { data } = useGetUserQuery();
   const { reportsDisabled } = useReportsDisabled();
-  const { developer } = useRequiredSession();
+  const developerBypass = useDeveloperBypass();
 
   const userType = data?.user.userType;
   const usStaff = userType === UserTypeEnum.UsStaff;
@@ -78,13 +78,14 @@ export function useReportNavItems(): NavItems[] {
   ];
 
   return useMemo(
-    () =>
-      reportNavItems.filter(
-        // When not in production, developers bypass all eligibility gating so they can reach all pages
-        (item) =>
-          (process.env.DEVELOPMENT_ENV === 'true' && developer) ||
-          !item.hideItem,
-      ),
-    [t, usStaff, globalStaff, reportsDisabled, hasNoStaffAccount, developer],
+    () => reportNavItems.filter((item) => developerBypass || !item.hideItem),
+    [
+      t,
+      usStaff,
+      globalStaff,
+      reportsDisabled,
+      hasNoStaffAccount,
+      developerBypass,
+    ],
   );
 }


### PR DESCRIPTION
## Description

When `DEVELOPMENT_ENV=true` is set, disable page visibility checks, except in production.

I set `DEVELOPMENT_ENV=true` in Amplify to all environments, and made a `DEVELOPMENT_ENV=false` override for `main`.

When impersonating someone, you will only see the pages they have access to. I think this is good.

Sorry for the opportunistic cleanup of session mocking code. I let Claude follow a rabbit trail 🐰

## Testing

- Login with the test account (senior staff)
- Check that the PDS goal calculator page shows up in the menu and via direct navigation

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
