### PR TITLE
[no-Jira] Combine percentComplete and showPercentage props

### DIFF
--- a/src/components/HrTools/AdditionalSalaryRequest/AdditionalSalaryRequest.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/AdditionalSalaryRequest.tsx
@@ -53,8 +53,7 @@ export const AdditionalSalaryRequest: React.FC = () => {
   return (
     <PanelLayout
       panelType={PanelTypeEnum.Other}
-      percentComplete={0}
-      showPercentage={false}
+      percentComplete={null}
       steps={steps}
       currentIndex={currentIndex}
       icons={iconPanelItems}

--- a/src/components/HrTools/AdditionalSalaryRequest/MainPages/InProgress/InProgressDisplay.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/MainPages/InProgress/InProgressDisplay.tsx
@@ -72,8 +72,7 @@ export const InProgressDisplay: React.FC = () => {
   return (
     <PanelLayout
       panelType={PanelTypeEnum.Other}
-      percentComplete={0}
-      showPercentage={false}
+      percentComplete={null}
       backHref={''}
       sidebarTitle={t('Additional Salary Request')}
       icons={iconPanelItems}

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/RequestPage.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/RequestPage.tsx
@@ -206,8 +206,7 @@ export const RequestPage: React.FC = () => {
   return (
     <PanelLayout
       panelType={PanelTypeEnum.Other}
-      showPercentage={pageType !== PageEnum.View}
-      percentComplete={percentComplete}
+      percentComplete={pageType !== PageEnum.View ? percentComplete : null}
       steps={steps}
       currentIndex={currentIndex}
       icons={iconPanelItems}

--- a/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorLayout.tsx
+++ b/src/components/HrTools/NsGoalCalculator/Shared/NsGoalCalculatorLayout.tsx
@@ -25,8 +25,7 @@ export const NsGoalCalculatorLayout: React.FC<NsGoalCalculatorLayoutProps> = ({
   return (
     <PanelLayout
       panelType={PanelTypeEnum.Other}
-      percentComplete={0}
-      showPercentage={false}
+      percentComplete={null}
       icons={iconPanelItems}
       currentIndex={currentIndex}
       sidebarTitle={t('Your MPD Goal')}

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculator.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculator.tsx
@@ -41,8 +41,7 @@ export const SalaryCalculator: React.FC = () => {
   return (
     <PanelLayout
       panelType={PanelTypeEnum.Other}
-      percentComplete={percentComplete}
-      showPercentage={editing}
+      percentComplete={editing ? percentComplete : null}
       steps={steps}
       currentIndex={currentIndex}
       icons={editing ? iconPanelItems : []}

--- a/src/components/HrTools/Shared/CalculationReports/PanelLayout/PanelLayout.test.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/PanelLayout/PanelLayout.test.tsx
@@ -204,9 +204,9 @@ describe('PanelLayout', () => {
     expect(queryByText('42%')).not.toBeInTheDocument();
   });
 
-  it('hides the progress indicator when showPercentage is false', () => {
+  it('hides the progress indicator when percentComplete is null', () => {
     const { queryByRole } = render(
-      <TestComponent panelType={PanelTypeEnum.Other} showPercentage={false} />,
+      <TestComponent panelType={PanelTypeEnum.Other} percentComplete={null} />,
     );
 
     expect(queryByRole('progressbar')).not.toBeInTheDocument();

--- a/src/components/HrTools/Shared/CalculationReports/PanelLayout/PanelLayout.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/PanelLayout/PanelLayout.tsx
@@ -26,8 +26,7 @@ export interface IconPanelItem {
 
 export interface PanelLayoutProps {
   panelType: PanelTypeEnum;
-  percentComplete: number;
-  showPercentage?: boolean;
+  percentComplete: number | null;
   progressLoading?: boolean;
   icons?: IconPanelItem[];
   sidebarContent?: React.ReactNode;
@@ -46,7 +45,6 @@ export interface PanelLayoutProps {
 export const PanelLayout: React.FC<PanelLayoutProps> = ({
   panelType,
   percentComplete,
-  showPercentage = true,
   progressLoading = false,
   icons,
   sidebarContent,
@@ -131,7 +129,7 @@ export const PanelLayout: React.FC<PanelLayoutProps> = ({
               </Box>
             ) : (
               <>
-                {showPercentage && (
+                {percentComplete !== null && (
                   <StyledBox>
                     <CircularProgressWithLabel
                       progress={percentComplete}


### PR DESCRIPTION
## Description

Combine `percentComplete` and `showPercentage` props in the shared `PanelLayout`.

## Testing

- Go to the new staff goal calculator
- Check that the percentage doesn't render

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
