### PR TITLE
MPDX-9672 Frontend - Remove unused approvedOverallAmount, spouseSpecific and staffSpecific GQL fields

### DIFF
--- a/src/components/HrTools/MinisterHousingAllowance/MinisterHousingAllowance.graphql
+++ b/src/components/HrTools/MinisterHousingAllowance/MinisterHousingAllowance.graphql
@@ -13,12 +13,9 @@ fragment RequestAttributes on MhaRequestAttributes {
   emailAddress
   iUnderstandMhaPolicy
   hrApprovedAt
-  approvedOverallAmount
   availableDate
   boardApprovedAt
   deadlineDate
-  spouseSpecific
-  staffSpecific
   submittedAt
   changesRequestedAt
 }

--- a/src/components/HrTools/MinisterHousingAllowance/MinisterHousingAllowance.test.tsx
+++ b/src/components/HrTools/MinisterHousingAllowance/MinisterHousingAllowance.test.tsx
@@ -106,11 +106,6 @@ describe('MinisterHousingAllowanceReport', () => {
           {
             ...mockMHARequest,
             status: MhaStatusEnum.BoardApproved,
-            requestAttributes: {
-              ...mockMHARequest.requestAttributes,
-              spouseSpecific: 5000,
-              staffSpecific: 10000,
-            },
           },
         ]}
       />,
@@ -200,11 +195,6 @@ describe('MinisterHousingAllowanceReport', () => {
           {
             ...mockMHARequest,
             status: MhaStatusEnum.BoardApproved,
-            requestAttributes: {
-              ...mockMHARequest.requestAttributes,
-              spouseSpecific: 5000,
-              staffSpecific: 10000,
-            },
           },
         ]}
       />,
@@ -242,11 +232,6 @@ describe('MinisterHousingAllowanceReport', () => {
           {
             ...mockMHARequest,
             status: MhaStatusEnum.BoardApproved,
-            requestAttributes: {
-              ...mockMHARequest.requestAttributes,
-              spouseSpecific: 5000,
-              staffSpecific: 10000,
-            },
           },
         ]}
       />,
@@ -265,11 +250,6 @@ describe('MinisterHousingAllowanceReport', () => {
         mhaRequestsMock={[
           {
             ...mockMHARequest,
-            requestAttributes: {
-              ...mockMHARequest.requestAttributes,
-              spouseSpecific: 5000,
-              staffSpecific: 10000,
-            },
           },
         ]}
       />,

--- a/src/components/HrTools/MinisterHousingAllowance/mockData.ts
+++ b/src/components/HrTools/MinisterHousingAllowance/mockData.ts
@@ -8,7 +8,6 @@ export const mockMHARequest: MHARequest = {
   status: MhaStatusEnum.Pending,
   feedback: null,
   requestAttributes: {
-    approvedOverallAmount: 15000,
     submittedAt: '2019-10-01T15:30:45.123Z',
     deadlineDate: '2019-10-23T15:30:45.123Z',
     boardApprovedAt: '2019-10-30T15:30:45.123Z',
@@ -27,8 +26,6 @@ export const mockMHARequest: MHARequest = {
     emailAddress: null,
     iUnderstandMhaPolicy: true,
     hrApprovedAt: '2019-11-01T15:30:45.123Z',
-    spouseSpecific: null,
-    staffSpecific: 15000,
     changesRequestedAt: null,
   },
 };


### PR DESCRIPTION
## Description

- These values aren't needed and aren't being used in the frontend. They are essentially dead/vestigial and so needed to be removed the GraphQL files, mocks, and tests. 
https://github.com/CruGlobal/mpdx_api/pull/3356

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to MHA Calculator
- Check that the Calculator correctly renders without any API side errors

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
