### PR TITLE
MPDX-9705 - Staff expense aggregates as default

### DIFF
--- a/src/components/Reports/StaffExpenseReport/Helpers/filterTransactions.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/Helpers/filterTransactions.test.tsx
@@ -5,6 +5,7 @@ import {
   StaffExpensesSubCategoryEnum,
 } from 'src/graphql/types.generated';
 import i18n from 'src/lib/i18n';
+import { Filters } from '../SettingsDialog/SettingsDialog';
 import { DateRange, ReportType } from './StaffReportEnum';
 import {
   GroupedTransaction,
@@ -91,38 +92,40 @@ const mockFund: Fund = {
   ],
 };
 
+const baseFilters: Filters = {
+  selectedDateRange: null,
+  startDate: null,
+  endDate: null,
+  categories: [],
+};
+
+const baseParams = {
+  fund: mockFund,
+  targetTime: DateTime.fromISO('2025-01-15'),
+  t: i18n.t,
+  filters: baseFilters,
+  tableType: ReportType.Expense,
+};
+
 describe('filterTransactions', () => {
   it('filters transactions for the target month by default', () => {
-    const targetTime = DateTime.fromISO('2025-01-15');
     const result = filterTransactions({
-      fund: mockFund,
-      t: i18n.t,
-      filters: {
-        selectedDateRange: null,
-        startDate: null,
-        endDate: null,
-        categories: [],
-      },
+      ...baseParams,
       tableType: ReportType.Income,
-      targetTime,
     });
     // 1 income transaction, 3 expense transactions
     expect(result).toHaveLength(1);
   });
 
   it('filters transactions by custom date range', () => {
-    const targetTime = DateTime.fromISO('2024-06-15');
     const result = filterTransactions({
-      fund: mockFund,
-      targetTime,
-      t: i18n.t,
+      ...baseParams,
+      targetTime: DateTime.fromISO('2024-06-15'),
       filters: {
-        selectedDateRange: null,
+        ...baseFilters,
         startDate: DateTime.fromISO('2025-01-01'),
         endDate: DateTime.fromISO('2025-02-03'),
-        categories: [],
       },
-      tableType: ReportType.Expense,
     });
     // 3 expense transactions, 1 income transaction
     expect(result).toHaveLength(3);
@@ -130,50 +133,36 @@ describe('filterTransactions', () => {
 
   it('returns empty array if no main categories', () => {
     const emptyFund = { ...mockFund, categories: null };
-    const targetTime = DateTime.fromISO('2024-06-01');
     const result = filterTransactions({
+      ...baseParams,
       fund: emptyFund,
-      targetTime,
-      t: i18n.t,
+      targetTime: DateTime.fromISO('2024-06-01'),
       filters: {
-        selectedDateRange: null,
+        ...baseFilters,
         startDate: DateTime.fromISO('2025-01-01'),
         endDate: DateTime.fromISO('2025-02-03'),
-        categories: [],
       },
-      tableType: ReportType.Expense,
     });
     expect(result).toEqual([]);
   });
 
   it('returns empty array if no transactions in range and custom date range not selected', () => {
-    const targetTime = DateTime.fromISO('2023-01-01');
     const result = filterTransactions({
-      fund: mockFund,
-      targetTime,
-      t: i18n.t,
-      filters: {
-        selectedDateRange: null,
-        startDate: null,
-        endDate: null,
-        categories: [],
-      },
-      tableType: ReportType.Expense,
+      ...baseParams,
+      targetTime: DateTime.fromISO('2023-01-01'),
     });
     expect(result).toEqual([]);
   });
 
   it('returns empty array if no transactions in range with custom date range', () => {
-    const targetTime = DateTime.fromISO('2024-06-01');
     const result = filterTransactions({
-      fund: mockFund,
-      targetTime,
-      t: i18n.t,
+      ...baseParams,
+      targetTime: DateTime.fromISO('2024-06-01'),
       filters: {
+        ...baseFilters,
         selectedDateRange: DateRange.YearToDate,
         startDate: DateTime.fromISO('2025-04-01'),
         endDate: DateTime.fromISO('2025-06-03'),
-        categories: [],
       },
       tableType: ReportType.Income,
     });
@@ -181,18 +170,12 @@ describe('filterTransactions', () => {
   });
 
   it('groups transactions when category is selected in filters', () => {
-    const targetTime = DateTime.fromISO('2025-01-15');
     const result = filterTransactions({
-      fund: mockFund,
-      targetTime,
-      t: i18n.t,
+      ...baseParams,
       filters: {
-        selectedDateRange: null,
-        startDate: null,
-        endDate: null,
+        ...baseFilters,
         categories: [StaffExpenseCategoryEnum.AdditionalSalary],
       },
-      tableType: ReportType.Expense,
     });
 
     // One grouped, one ungrouped
@@ -206,52 +189,38 @@ describe('filterTransactions', () => {
   });
 
   it('does not group transactions when category is not selected in filters', () => {
-    const targetTime = DateTime.fromISO('2025-01-15');
-    const result = filterTransactions({
-      fund: mockFund,
-      targetTime,
-      t: i18n.t,
-      filters: {
-        selectedDateRange: null,
-        startDate: null,
-        endDate: null,
-        categories: [],
-      },
-      tableType: ReportType.Expense,
-    });
+    const result = filterTransactions({ ...baseParams });
 
     // 3 expense transactions, 1 income transaction
     expect(result).toHaveLength(3);
     expect(result.every((r) => !('groupedTransactions' in r))).toBe(true);
   });
 
+  it('groups every category by default when no categories are selected', () => {
+    const result = filterTransactions({ ...baseParams, filters: undefined });
+
+    expect(
+      result.every(
+        (groupedTransaction) => 'groupedTransactions' in groupedTransaction,
+      ),
+    ).toBe(true);
+  });
+
   it('maintains income/expense separation when grouping', () => {
-    const targetTime = DateTime.fromISO('2025-01-15');
+    const filters = {
+      ...baseFilters,
+      categories: [StaffExpenseCategoryEnum.AdditionalSalary],
+    };
 
     const incomeResult = filterTransactions({
-      fund: mockFund,
-      targetTime,
-      t: i18n.t,
-      filters: {
-        selectedDateRange: null,
-        startDate: null,
-        endDate: null,
-        categories: [StaffExpenseCategoryEnum.AdditionalSalary],
-      },
+      ...baseParams,
+      filters,
       tableType: ReportType.Income,
     });
 
     const expenseResult = filterTransactions({
-      fund: mockFund,
-      targetTime,
-      t: i18n.t,
-      filters: {
-        selectedDateRange: null,
-        startDate: null,
-        endDate: null,
-        categories: [StaffExpenseCategoryEnum.AdditionalSalary],
-      },
-      tableType: ReportType.Expense,
+      ...baseParams,
+      filters,
     });
 
     expect(incomeResult).toHaveLength(1);
@@ -272,18 +241,12 @@ describe('filterTransactions', () => {
   });
 
   it('places grouped transactions at the top of the result array', () => {
-    const targetTime = DateTime.fromISO('2025-01-15');
     const result = filterTransactions({
-      fund: mockFund,
-      targetTime,
-      t: i18n.t,
+      ...baseParams,
       filters: {
-        selectedDateRange: null,
-        startDate: null,
-        endDate: null,
+        ...baseFilters,
         categories: [StaffExpenseCategoryEnum.AdditionalSalary],
       },
-      tableType: ReportType.Expense,
     });
 
     // First item should be the grouped transaction
@@ -299,21 +262,15 @@ describe('filterTransactions', () => {
   });
 
   it('groups multiple categories when multiple are selected', () => {
-    const targetTime = DateTime.fromISO('2025-01-15');
     const result = filterTransactions({
-      fund: mockFund,
-      targetTime,
-      t: i18n.t,
+      ...baseParams,
       filters: {
-        selectedDateRange: null,
-        startDate: null,
-        endDate: null,
+        ...baseFilters,
         categories: [
           StaffExpenseCategoryEnum.AdditionalSalary,
           StaffExpenseCategoryEnum.Benefits,
         ],
       },
-      tableType: ReportType.Expense,
     });
 
     // Both categories should be grouped
@@ -330,18 +287,12 @@ describe('filterTransactions', () => {
   });
 
   it('calculates correct total amount for grouped transactions', () => {
-    const targetTime = DateTime.fromISO('2025-01-15');
     const result = filterTransactions({
-      fund: mockFund,
-      targetTime,
-      t: i18n.t,
+      ...baseParams,
       filters: {
-        selectedDateRange: null,
-        startDate: null,
-        endDate: null,
+        ...baseFilters,
         categories: [StaffExpenseCategoryEnum.AdditionalSalary],
       },
-      tableType: ReportType.Expense,
     });
 
     const grouped = result[0] as GroupedTransaction;
@@ -351,18 +302,12 @@ describe('filterTransactions', () => {
   });
 
   it('uses earliest transaction date for grouped transaction', () => {
-    const targetTime = DateTime.fromISO('2025-01-15');
     const result = filterTransactions({
-      fund: mockFund,
-      targetTime,
-      t: i18n.t,
+      ...baseParams,
       filters: {
-        selectedDateRange: null,
-        startDate: null,
-        endDate: null,
+        ...baseFilters,
         categories: [StaffExpenseCategoryEnum.AdditionalSalary],
       },
-      tableType: ReportType.Expense,
     });
 
     const grouped = result[0] as GroupedTransaction;
@@ -371,18 +316,12 @@ describe('filterTransactions', () => {
   });
 
   it('sets displayCategory to localized category name for grouped transactions', () => {
-    const targetTime = DateTime.fromISO('2025-01-15');
     const result = filterTransactions({
-      fund: mockFund,
-      targetTime,
-      t: i18n.t,
+      ...baseParams,
       filters: {
-        selectedDateRange: null,
-        startDate: null,
-        endDate: null,
+        ...baseFilters,
         categories: [StaffExpenseCategoryEnum.AdditionalSalary],
       },
-      tableType: ReportType.Expense,
     });
 
     const grouped = result[0] as GroupedTransaction;
@@ -392,18 +331,12 @@ describe('filterTransactions', () => {
   });
 
   it('handles empty result when no transactions match grouping criteria', () => {
-    const targetTime = DateTime.fromISO('2025-01-15');
     const result = filterTransactions({
-      fund: mockFund,
-      targetTime,
-      t: i18n.t,
+      ...baseParams,
       filters: {
-        selectedDateRange: null,
-        startDate: null,
-        endDate: null,
+        ...baseFilters,
         categories: [StaffExpenseCategoryEnum.Transfer],
       },
-      tableType: ReportType.Expense,
     });
 
     // No Transfer transactions in the data, so we should only get ungrouped transactions
@@ -412,16 +345,9 @@ describe('filterTransactions', () => {
     expect(result.every((r) => !('groupedTransactions' in r))).toBe(true);
   });
 
-  describe('No filters applied', () => {
+  describe('Ungrouped transactions (categories explicitly deselected)', () => {
     it('should set displayCategory correctly for individual transactions when category equals subcategory', () => {
-      const targetTime = DateTime.fromISO('2025-01-15');
-      const result = filterTransactions({
-        fund: mockFund,
-        targetTime,
-        t: i18n.t,
-        filters: null,
-        tableType: ReportType.Expense,
-      });
+      const result = filterTransactions({ ...baseParams });
 
       const same = result.find(
         (r) => r.category === StaffExpenseCategoryEnum.AdditionalSalary,
@@ -431,14 +357,7 @@ describe('filterTransactions', () => {
     });
 
     it('should set displayCategory correctly for individual transactions when category differs from subcategory', () => {
-      const targetTime = DateTime.fromISO('2025-01-15');
-      const result = filterTransactions({
-        fund: mockFund,
-        targetTime,
-        t: i18n.t,
-        filters: null,
-        tableType: ReportType.Expense,
-      });
+      const result = filterTransactions({ ...baseParams });
 
       const different = result.find(
         (r) => r.category === StaffExpenseCategoryEnum.Benefits,

--- a/src/components/Reports/StaffExpenseReport/Helpers/filterTransactions.tsx
+++ b/src/components/Reports/StaffExpenseReport/Helpers/filterTransactions.tsx
@@ -41,16 +41,20 @@ interface FilterTransactionsParams {
  */
 const groupTransactionsByCategory = (
   transactions: Transaction[],
-  groupedCategories: string[],
+  groupedCategories: string[] | null,
   fundType: string,
   t: TFunction,
 ): (Transaction | GroupedTransaction)[] => {
-  // Group transactions by category if the category is in groupedCategories
+  // Group a transaction when its category is selected. `null` means no explicit
+  // selection, so every category is consolidated.
   const grouped: Map<string, Transaction[]> = new Map();
   const ungrouped: Transaction[] = [];
 
   transactions.forEach((transaction) => {
-    if (groupedCategories.includes(transaction.category)) {
+    if (
+      groupedCategories === null ||
+      groupedCategories.includes(transaction.category)
+    ) {
       const key = transaction.category;
       if (!grouped.has(key)) {
         grouped.set(key, []);
@@ -108,7 +112,6 @@ export const filterTransactions = ({
   tableType,
 }: FilterTransactionsParams): (Transaction | GroupedTransaction)[] => {
   const isInDateRange = createDateRangeFilter(filters, targetTime);
-  const selectedCategories = filters?.categories ?? [];
 
   const filteredTransactions =
     fund.categories?.flatMap((category) =>
@@ -152,9 +155,11 @@ export const filterTransactions = ({
       ),
     ) ?? [];
 
+  const groupedCategories = filters?.categories ?? null;
+
   return groupTransactionsByCategory(
     filteredTransactions,
-    selectedCategories,
+    groupedCategories,
     fund.fundType,
     t,
   );

--- a/src/components/Reports/StaffExpenseReport/SettingsDialog/SettingsDialog.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/SettingsDialog/SettingsDialog.test.tsx
@@ -93,10 +93,17 @@ const TestComponent: React.FC<
   </TestRouter>
 );
 
+const baseFilters: Filters = {
+  selectedDateRange: null,
+  startDate: null,
+  endDate: null,
+  categories: [],
+};
+
 describe('SettingsDialog', () => {
   const defaultProps = {
     isOpen: true,
-    onClose: jest.fn(),
+    onClose: mutationSpy,
     selectedFundType: 'Primary',
   };
 
@@ -152,9 +159,8 @@ describe('SettingsDialog', () => {
 
   it('should populate form with selectedFilters when provided', async () => {
     const selectedFilters: Filters = {
+      ...baseFilters,
       selectedDateRange: DateRange.MonthToDate,
-      startDate: null,
-      endDate: null,
       categories: [
         StaffExpenseCategoryEnum.Benefits,
         StaffExpenseCategoryEnum.Salary,
@@ -181,10 +187,9 @@ describe('SettingsDialog', () => {
 
   it('should preserve custom dates when no selectedDateRange is set', () => {
     const selectedFilters: Filters = {
-      selectedDateRange: null,
+      ...baseFilters,
       startDate: DateTime.fromISO('2025-01-01'),
       endDate: DateTime.fromISO('2025-01-31'),
-      categories: [],
     };
 
     const { getByLabelText } = render(
@@ -248,6 +253,16 @@ describe('SettingsDialog', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('checks all available categories by default when no selection exists', async () => {
+    const { findByLabelText, getByLabelText } = render(
+      <TestComponent {...defaultProps} />,
+    );
+
+    expect(await findByLabelText('Benefits')).toBeChecked();
+    expect(getByLabelText('Salary')).toBeChecked();
+    expect(getByLabelText('Donation')).toBeChecked();
+  });
+
   it('should toggle category selection', async () => {
     const { getByLabelText, findByLabelText } = render(
       <TestComponent {...defaultProps} />,
@@ -256,49 +271,80 @@ describe('SettingsDialog', () => {
     expect(await findByLabelText('Benefits')).toBeInTheDocument();
 
     const benefitsCheckbox = getByLabelText('Benefits');
-    const salaryCheckbox = getByLabelText('Salary');
-
-    expect(benefitsCheckbox).not.toBeChecked();
-    expect(salaryCheckbox).not.toBeChecked();
-
-    userEvent.click(benefitsCheckbox);
-    userEvent.click(salaryCheckbox);
-
     expect(benefitsCheckbox).toBeChecked();
-    expect(salaryCheckbox).toBeChecked();
-
     userEvent.click(benefitsCheckbox);
     expect(benefitsCheckbox).not.toBeChecked();
   });
 
-  it('should call onClose with form values when Apply Filters is clicked', async () => {
-    const onClose = jest.fn();
-
+  it('should call onClose with the remaining categories when one is deselected', async () => {
     const { findByLabelText, getByLabelText, getByRole } = render(
-      <TestComponent {...defaultProps} onClose={onClose} />,
+      <TestComponent {...defaultProps} />,
     );
 
-    expect(await findByLabelText('Benefits')).toBeInTheDocument();
+    expect(await findByLabelText('Benefits')).toBeChecked();
 
     userEvent.click(getByLabelText('Benefits'));
 
     userEvent.click(getByRole('button', { name: 'Apply Filters' }));
 
     await waitFor(() => {
-      expect(onClose).toHaveBeenCalledWith({
-        selectedDateRange: null,
-        startDate: null,
-        endDate: null,
-        categories: [StaffExpenseCategoryEnum.Benefits],
+      expect(mutationSpy).toHaveBeenCalledWith({
+        ...baseFilters,
+        categories: [
+          StaffExpenseCategoryEnum.Donation,
+          StaffExpenseCategoryEnum.Salary,
+        ],
       });
     });
   });
 
-  it('should calculate dates for predefined ranges on submission', async () => {
-    const onClose = jest.fn();
+  it('should submit an empty categories array when all are deselected', async () => {
+    const { findByLabelText, getByLabelText, getByRole } = render(
+      <TestComponent {...defaultProps} />,
+    );
 
+    expect(await findByLabelText('Benefits')).toBeChecked();
+
+    userEvent.click(getByLabelText('Benefits'));
+    userEvent.click(getByLabelText('Donation'));
+    userEvent.click(getByLabelText('Salary'));
+
+    userEvent.click(getByRole('button', { name: 'Apply Filters' }));
+
+    await waitFor(() => {
+      expect(mutationSpy).toHaveBeenCalledWith({
+        ...baseFilters,
+        categories: [],
+      });
+    });
+  });
+
+  it('should preserve default when only the date range changes', async () => {
+    const { findByLabelText, getByLabelText, getByRole } = render(
+      <TestComponent {...defaultProps} />,
+    );
+
+    expect(await findByLabelText('Benefits')).toBeChecked();
+
+    const dropdown = getByLabelText('Select Date Range');
+    userEvent.click(dropdown);
+    userEvent.click(getByRole('option', { name: 'Month to Date' }));
+
+    userEvent.click(getByRole('button', { name: 'Apply Filters' }));
+
+    await waitFor(() => {
+      expect(mutationSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selectedDateRange: DateRange.MonthToDate,
+          categories: null,
+        }),
+      );
+    });
+  });
+
+  it('should calculate dates for predefined ranges on submission', async () => {
     const { getByLabelText, getByRole } = render(
-      <TestComponent {...defaultProps} onClose={onClose} />,
+      <TestComponent {...defaultProps} />,
     );
 
     // Select predefined range
@@ -309,7 +355,7 @@ describe('SettingsDialog', () => {
     userEvent.click(getByRole('button', { name: 'Apply Filters' }));
 
     await waitFor(() => {
-      expect(onClose).toHaveBeenCalledWith(
+      expect(mutationSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           selectedDateRange: DateRange.MonthToDate,
           startDate: expect.any(Object),
@@ -320,20 +366,14 @@ describe('SettingsDialog', () => {
   });
 
   it('should call onClose with original filters when Cancel is clicked', async () => {
-    const onClose = jest.fn();
     const originalFilters: Filters = {
+      ...baseFilters,
       selectedDateRange: DateRange.WeekToDate,
-      startDate: null,
-      endDate: null,
       categories: [StaffExpenseCategoryEnum.Salary],
     };
 
     const { findByLabelText, getByRole, getByLabelText } = render(
-      <TestComponent
-        {...defaultProps}
-        onClose={onClose}
-        selectedFilters={originalFilters}
-      />,
+      <TestComponent {...defaultProps} selectedFilters={originalFilters} />,
     );
 
     expect(await findByLabelText('Benefits')).toBeInTheDocument();
@@ -341,24 +381,7 @@ describe('SettingsDialog', () => {
     userEvent.click(getByLabelText('Benefits'));
     userEvent.click(getByRole('button', { name: 'Cancel' }));
 
-    expect(onClose).toHaveBeenCalledWith(originalFilters);
-  });
-
-  it('should reset form when Cancel is clicked', async () => {
-    const onClose = jest.fn();
-
-    const { findByLabelText, getByLabelText, getByRole } = render(
-      <TestComponent {...defaultProps} onClose={onClose} />,
-    );
-
-    expect(await findByLabelText('Benefits')).toBeInTheDocument();
-
-    userEvent.click(getByLabelText('Benefits'));
-    expect(getByLabelText('Benefits')).toBeChecked();
-
-    userEvent.click(getByRole('button', { name: 'Cancel' }));
-
-    expect(onClose).toHaveBeenCalled();
+    expect(mutationSpy).toHaveBeenCalledWith(originalFilters);
   });
 
   it('should disable Apply Filters button when form is not dirty and enable when dirty', async () => {
@@ -379,47 +402,36 @@ describe('SettingsDialog', () => {
   });
 
   it('should call onClose with original filters when dialog backdrop is clicked', () => {
-    const onClose = jest.fn();
-    const originalFilters: Filters = {
-      selectedDateRange: null,
-      startDate: null,
-      endDate: null,
-      categories: [],
-    };
-
     const { getByRole } = render(
       <TestComponent
         {...defaultProps}
-        onClose={onClose}
-        selectedFilters={originalFilters}
+        onClose={mutationSpy}
+        selectedFilters={baseFilters}
       />,
     );
     const dialog = getByRole('dialog');
     userEvent.click(dialog.parentElement!);
 
-    expect(onClose).toHaveBeenCalledWith(originalFilters);
+    expect(mutationSpy).toHaveBeenCalledWith(baseFilters);
   });
 
-  it('should handle undefined selectedFilters and undefined categories', async () => {
+  it('checks all categories when selectedFilters or its categories are null', async () => {
     const { findByLabelText, rerender } = render(
       <TestComponent {...defaultProps} selectedFilters={undefined} />,
     );
 
-    expect(await findByLabelText('Benefits')).not.toBeChecked();
+    expect(await findByLabelText('Benefits')).toBeChecked();
 
-    // Also test with defined filters but undefined categories
     const selectedFilters: Filters = {
-      selectedDateRange: null,
-      startDate: null,
-      endDate: null,
-      categories: undefined,
+      ...baseFilters,
+      categories: null,
     };
 
     rerender(
       <TestComponent {...defaultProps} selectedFilters={selectedFilters} />,
     );
 
-    expect(await findByLabelText('Benefits')).not.toBeChecked();
+    expect(await findByLabelText('Benefits')).toBeChecked();
   });
 
   it('should query using the time prop month when no date filter is set', async () => {

--- a/src/components/Reports/StaffExpenseReport/SettingsDialog/SettingsDialog.tsx
+++ b/src/components/Reports/StaffExpenseReport/SettingsDialog/SettingsDialog.tsx
@@ -40,7 +40,11 @@ export interface Filters {
   selectedDateRange: DateRange | null;
   startDate?: DateTime | null;
   endDate?: DateTime | null;
-  categories?: string[];
+  /**
+   * `null` means no explicit selection: every available category is shown as
+   * checked and the report aggregates all of them.
+   */
+  categories: string[] | null;
 }
 
 const validationSchema = yup.object({
@@ -75,7 +79,7 @@ const validationSchema = yup.object({
         return startDate <= value;
       },
     ),
-  categories: yup.array().of(yup.string()),
+  categories: yup.array().of(yup.string()).nullable(),
 });
 
 const calculateDateRange = (
@@ -174,7 +178,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
     }, 0);
   };
 
-  const initialValues = {
+  const initialValues: Filters = {
     selectedDateRange: selectedFilters?.selectedDateRange ?? null,
     startDate:
       selectedFilters?.selectedDateRange === null
@@ -184,7 +188,7 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
       selectedFilters?.selectedDateRange === null
         ? selectedFilters?.endDate
         : null,
-    categories: selectedFilters?.categories ?? [],
+    categories: selectedFilters?.categories ?? null,
   };
 
   const handleSubmit = (values: Filters) => {
@@ -213,6 +217,16 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
           validateForm,
           setTouched,
         }) => {
+          const handleCategoryToggle = (category: string, checked: boolean) => {
+            const selectedCategories = values.categories ?? availableCategories;
+            const newCategories = checked
+              ? [...selectedCategories, category]
+              : selectedCategories.filter(
+                  (selectedCategory) => selectedCategory !== category,
+                );
+            setFieldValue('categories', newCategories);
+          };
+
           return (
             <Form>
               <DialogContent>
@@ -310,8 +324,8 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
 
                 <Typography sx={{ mt: 2, whiteSpace: 'pre-line' }}>
                   {t(
-                    `You can combine certain categories of data into single rows. This may be useful for long date ranges (e.g., "Year to Date").
-                    Select which categories to consolidate. Each category remains separate.`,
+                    `Income and expenses are combined by categories by default. This may be useful for long date ranges (e.g., "Year to Date").
+                    Select which categories to keep consolidated.`,
                   )}
                 </Typography>
 
@@ -347,15 +361,13 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
                           key={category}
                           control={
                             <Checkbox
-                              checked={values.categories.includes(category)}
-                              onChange={(e) => {
-                                const newCategories = e.target.checked
-                                  ? [...values.categories, category]
-                                  : values.categories.filter(
-                                      (c) => c !== category,
-                                    );
-                                setFieldValue('categories', newCategories);
-                              }}
+                              checked={
+                                !values.categories ||
+                                values.categories.includes(category)
+                              }
+                              onChange={(e) =>
+                                handleCategoryToggle(category, e.target.checked)
+                              }
                             />
                           }
                           label={localizedCategory}

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
@@ -247,33 +247,24 @@ describe('StaffExpenseReport', () => {
   it('correctly displays totals for income and expenses', async () => {
     const { getAllByRole, queryByRole } = render(<TestComponent />);
 
-    // Header row and 2 expense transaction rows
+    // Header row and 1 grouped expense row
     await waitFor(() => {
-      expect(getAllByRole('row')).toHaveLength(3);
+      expect(getAllByRole('row')).toHaveLength(2);
     });
 
     expect(queryByRole('heading', { name: 'Income' })).not.toBeInTheDocument();
   });
 
   it('switches fund display when clicking View Account button', async () => {
-    const { findByRole, findByText, getAllByRole } = render(<TestComponent />);
+    const { findByRole, queryByText } = render(<TestComponent />);
 
     await findByRole('heading', { name: 'Primary' });
-    expect(await findByText('Currently Viewing')).toBeInTheDocument();
 
-    waitFor(() => {
-      expect(getAllByRole('row')).toHaveLength(3);
-    });
+    expect(queryByText('-$100')).not.toBeInTheDocument();
 
-    userEvent.click(
-      await findByRole('button', {
-        name: 'View Account',
-      }),
-    );
+    userEvent.click(await findByRole('button', { name: 'View Account' }));
 
-    waitFor(() => {
-      expect(getAllByRole('row')).toHaveLength(2);
-    });
+    expect(queryByText('-$200')).not.toBeInTheDocument();
   });
 
   it('shows month title and navigation when only category filters are applied', async () => {


### PR DESCRIPTION
## Description

Scott would like categories to be aggregated by default in the staff expense report. This begs the question of whether we want to keep this filtering logic at all. The codebase would benefit from removing it, but after my meeting with Scott earlier he hinted that some users may still like the option to remove this aggregate behavior and that he would follow up with @rguinee

This PR also has some needed test file refactors to DRY things up.

https://jira.cru.org/browse/MPDX-9705

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to Staff Expense Report
- Test that all transaction and income rows are already pre-aggregated into their base categories.
- Test that going to the filter settings allows a user to be able to deselect aggregation on whichever categories they choose, and that this behavior works as expected.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
