### PR TITLE
[no-Jira] Add custom `toHaveTableStructure` jest matcher

### DIFF
--- a/.claude/rules/code-review.md
+++ b/.claude/rules/code-review.md
@@ -278,6 +278,7 @@ Project-specific testing conventions added to the Testing agent's universal chec
 
 - **`GqlMockedProvider` is the only GraphQL mock pattern.** All component tests that hit GraphQL must wrap in `<GqlMockedProvider<{ OperationName: OperationNameQuery }> mocks={...}>` with typed generics so mock shapes are type-checked at compile time
 - **`mutationSpy` + `toHaveGraphqlOperation(...)` pattern** is preferred over brittle snapshot-based assertions for verifying mutations
+- **`toHaveTableStructure(...)` for full table contents** — when asserting more than a couple table cells, use `expect(getByRole('table')).toHaveTableStructure({ columnHeaders, rowHeaders, cells })` instead of ad-hoc `getByRole('cell')`
 - **`findBy*` for async assertions** — prefer `await findByText(...)` over `await waitFor(() => getByText(...))`
 - **No `fetch` mocking** — never mock `global.fetch` or `window.fetch`; use Apollo operation-level mocks
 - **No `any` in test types** — mock shapes use generated operation types (`ContactDetailsQuery`, etc.) from `.generated.ts` files

--- a/__tests__/extensions/toHaveTableStructure.test.tsx
+++ b/__tests__/extensions/toHaveTableStructure.test.tsx
@@ -59,6 +59,8 @@ describe('toHaveTableStructure', () => {
     const { getByRole } = render(<TestTable />);
 
     expect(getByRole('table')).toHaveTableStructure({
+      columnHeaders: ['Category', expect.stringContaining('Jo'), 'Jane'],
+      rowHeaders: [expect.stringContaining('Sal'), 'MHA'],
       cells: [
         [expect.stringContaining('10,001'), '$20,001.00'],
         ['$10,002.00', '$20,002.00'],
@@ -86,6 +88,51 @@ describe('toHaveTableStructure', () => {
     expect(getByRole('table')).not.toHaveTableStructure({
       rowHeaders: ['Salary', 'MHA', 'Total'],
     });
+  });
+
+  it('matches an empty table', () => {
+    const { getByRole } = render(
+      <table>
+        <tbody></tbody>
+      </table>,
+    );
+
+    expect(getByRole('table')).toHaveTableStructure({
+      cells: [],
+      columnHeaders: [],
+      rowHeaders: [],
+    });
+  });
+
+  it('throws when no structure properties are provided', () => {
+    const { getByRole } = render(<TestTable />);
+
+    expect(() => expect(getByRole('table')).toHaveTableStructure({})).toThrow(
+      'toHaveTableStructure requires at least one of cells, columnHeaders, or rowHeaders',
+    );
+  });
+
+  it('describes the mismatched properties in the failure message', () => {
+    const { getByRole } = render(<TestTable />);
+
+    expect(() =>
+      expect(getByRole('table')).toHaveTableStructure({
+        columnHeaders: ['Category', 'John'],
+        rowHeaders: ['Salary', 'MHA'],
+      }),
+    ).toThrow(
+      /Expected table to match the expected structure[\s\S]*columnHeaders:[\s\S]*Expected columnHeaders[\s\S]*Received columnHeaders/,
+    );
+  });
+
+  it('explains the failure when the table unexpectedly matches', () => {
+    const { getByRole } = render(<TestTable />);
+
+    expect(() =>
+      expect(getByRole('table')).not.toHaveTableStructure({
+        rowHeaders: ['Salary', 'MHA'],
+      }),
+    ).toThrow('Expected table not to match the expected structure');
   });
 
   it('only inspects the received table', () => {

--- a/__tests__/extensions/toHaveTableStructure.test.tsx
+++ b/__tests__/extensions/toHaveTableStructure.test.tsx
@@ -1,0 +1,112 @@
+import { render } from '@testing-library/react';
+
+const TestTable: React.FC = () => (
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">Category</th>
+        <th scope="col">John</th>
+        <th scope="col">Jane</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">Salary</th>
+        <td>$10,001.00</td>
+        <td>$20,001.00</td>
+      </tr>
+      <tr>
+        <th scope="row">MHA</th>
+        <td>$10,002.00</td>
+        <td>$20,002.00</td>
+      </tr>
+    </tbody>
+  </table>
+);
+
+describe('toHaveTableStructure', () => {
+  it('matches the full table structure', () => {
+    const { getByRole } = render(<TestTable />);
+
+    expect(getByRole('table')).toHaveTableStructure({
+      columnHeaders: ['Category', 'John', 'Jane'],
+      rowHeaders: ['Salary', 'MHA'],
+      cells: ['$10,001.00', '$20,001.00', '$10,002.00', '$20,002.00'],
+    });
+  });
+
+  it('matches 2-dimensional arrays of cells', () => {
+    const { getByRole } = render(<TestTable />);
+
+    expect(getByRole('table')).toHaveTableStructure({
+      columnHeaders: [['Category'], ['John', 'Jane']],
+      cells: [
+        ['$10,001.00', '$20,001.00'],
+        ['$10,002.00', '$20,002.00'],
+      ],
+    });
+  });
+
+  it('matches when only some structure properties are provided', () => {
+    const { getByRole } = render(<TestTable />);
+
+    expect(getByRole('table')).toHaveTableStructure({
+      rowHeaders: ['Salary', 'MHA'],
+    });
+  });
+
+  it('supports asymmetric matchers', () => {
+    const { getByRole } = render(<TestTable />);
+
+    expect(getByRole('table')).toHaveTableStructure({
+      cells: [
+        [expect.stringContaining('10,001'), '$20,001.00'],
+        ['$10,002.00', '$20,002.00'],
+      ],
+    });
+  });
+
+  it('does not match cells in a different order', () => {
+    const { getByRole } = render(<TestTable />);
+
+    expect(getByRole('table')).not.toHaveTableStructure({
+      cells: [
+        ['$20,001.00', '$10,001.00'],
+        ['$20,002.00', '$10,002.00'],
+      ],
+    });
+  });
+
+  it('does not match missing or extra structure', () => {
+    const { getByRole } = render(<TestTable />);
+
+    expect(getByRole('table')).not.toHaveTableStructure({
+      columnHeaders: ['Category', 'John'],
+    });
+    expect(getByRole('table')).not.toHaveTableStructure({
+      rowHeaders: ['Salary', 'MHA', 'Total'],
+    });
+  });
+
+  it('only inspects the received table', () => {
+    const { getAllByRole } = render(
+      <>
+        <TestTable />
+        <table>
+          <tbody>
+            <tr>
+              <td>Other table</td>
+            </tr>
+          </tbody>
+        </table>
+      </>,
+    );
+
+    const [, otherTable] = getAllByRole('table');
+    expect(otherTable).toHaveTableStructure({
+      cells: ['Other table'],
+      columnHeaders: [],
+      rowHeaders: [],
+    });
+  });
+});

--- a/__tests__/extensions/toHaveTableStructure.ts
+++ b/__tests__/extensions/toHaveTableStructure.ts
@@ -28,6 +28,12 @@ export const toHaveTableStructure: TableStructureMatcher = function (
   received,
   expected,
 ) {
+  if (!expected.cells && !expected.columnHeaders && !expected.rowHeaders) {
+    throw new Error(
+      'toHaveTableStructure requires at least one of cells, columnHeaders, or rowHeaders',
+    );
+  }
+
   const mismatches: string[] = [];
   structureRoles.forEach(([property, role]) => {
     const expectedContents = expected[property];
@@ -35,6 +41,9 @@ export const toHaveTableStructure: TableStructureMatcher = function (
       return;
     }
 
+    // Nested arrays are flattened, so row grouping is for readability only.
+    // Contents are compared as one flat list in DOM order, and row boundaries
+    // are not verified.
     const expectedFlattened = expectedContents.flat();
     const actualContents = within(received)
       .queryAllByRole(role)

--- a/__tests__/extensions/toHaveTableStructure.ts
+++ b/__tests__/extensions/toHaveTableStructure.ts
@@ -1,0 +1,64 @@
+import { within } from '@testing-library/dom';
+
+interface AsymmetricMatcher {
+  asymmetricMatch: (actual: unknown) => boolean;
+}
+
+type ExpectedContent = string | AsymmetricMatcher;
+
+export interface ExpectedTableStructure {
+  cells?: Array<ExpectedContent | ExpectedContent[]>;
+  columnHeaders?: Array<ExpectedContent | ExpectedContent[]>;
+  rowHeaders?: Array<ExpectedContent | ExpectedContent[]>;
+}
+
+export type TableStructureMatcher = (
+  this: jest.MatcherContext,
+  received: HTMLElement,
+  expected: ExpectedTableStructure,
+) => jest.CustomMatcherResult;
+
+const structureRoles = [
+  ['cells', 'cell'],
+  ['columnHeaders', 'columnheader'],
+  ['rowHeaders', 'rowheader'],
+] as const;
+
+export const toHaveTableStructure: TableStructureMatcher = function (
+  received,
+  expected,
+) {
+  const mismatches: string[] = [];
+  structureRoles.forEach(([property, role]) => {
+    const expectedContents = expected[property];
+    if (!expectedContents) {
+      return;
+    }
+
+    const expectedFlattened = expectedContents.flat();
+    const actualContents = within(received)
+      .queryAllByRole(role)
+      .map((element) => element.textContent);
+    if (!this.equals(actualContents, expectedFlattened)) {
+      mismatches.push(
+        `${property}:\n${this.utils.printDiffOrStringify(
+          expectedFlattened,
+          actualContents,
+          `Expected ${property}`,
+          `Received ${property}`,
+          this.expand !== false,
+        )}`,
+      );
+    }
+  });
+
+  return {
+    pass: mismatches.length === 0,
+    message: () =>
+      mismatches.length
+        ? `Expected table to match the expected structure\n\n${mismatches.join(
+            '\n\n',
+          )}`
+        : 'Expected table not to match the expected structure',
+  };
+};

--- a/__tests__/jest.d.ts
+++ b/__tests__/jest.d.ts
@@ -12,6 +12,25 @@ declare global {
         variables?: Record<string, unknown>,
       ) => jest.CustomMatcherResult;
 
+      /**
+       * Asserts that a table contains exactly the provided column headers,
+       * row headers, and cells. Omitted properties are not checked. Cell
+       * contents may be strings or asymmetric matchers like `expect.stringContaining(...)`.
+       *
+       * Nested arrays are flattened before comparison, so grouping cells into
+       * rows is for readability only. Contents are compared as one flat list
+       * in DOM order, and row boundaries are NOT verified.
+       *
+       * @example
+       * expect(getByRole('table')).toHaveTableStructure({
+       *   columnHeaders: ['Category', 'John'],
+       *   rowHeaders: ['Salary', 'MHA'],
+       *   cells: [
+       *     ['$10,001.00', '$20,001.00'],
+       *     ['$10,002.00', '$20,002.00'],
+       *   ],
+       * });
+       */
       toHaveTableStructure: (
         structure: ExpectedTableStructure,
       ) => jest.CustomMatcherResult;

--- a/__tests__/jest.d.ts
+++ b/__tests__/jest.d.ts
@@ -1,4 +1,8 @@
 import { type GraphqlOperationMatcher } from './extensions/toHaveGraphqlOperation';
+import {
+  type ExpectedTableStructure,
+  type TableStructureMatcher,
+} from './extensions/toHaveTableStructure';
 
 declare global {
   namespace jest {
@@ -7,10 +11,15 @@ declare global {
         operationName: string,
         variables?: Record<string, unknown>,
       ) => jest.CustomMatcherResult;
+
+      toHaveTableStructure: (
+        structure: ExpectedTableStructure,
+      ) => jest.CustomMatcherResult;
     }
 
     interface ExpectExtendMap {
       toHaveGraphqlOperation: GraphqlOperationMatcher;
+      toHaveTableStructure: TableStructureMatcher;
     }
   }
 }

--- a/__tests__/util/setup.ts
+++ b/__tests__/util/setup.ts
@@ -8,6 +8,7 @@ import { session } from '__tests__/fixtures/session';
 import { loadConstantsMockData } from 'src/components/Constants/LoadConstantsMock';
 import { useApiConstants } from 'src/components/Constants/UseApiConstants';
 import { toHaveGraphqlOperation } from '../extensions/toHaveGraphqlOperation';
+import { toHaveTableStructure } from '../extensions/toHaveTableStructure';
 import matchMediaMock from './matchMediaMock';
 // Configure i18next in tests
 import 'src/lib/i18n';
@@ -34,6 +35,7 @@ jest.mock('next-auth/react', () => {
 
 expect.extend({
   toHaveGraphqlOperation,
+  toHaveTableStructure,
 });
 
 Object.defineProperty(window, 'crypto', {

--- a/jest.config.js
+++ b/jest.config.js
@@ -35,7 +35,7 @@ const customJestConfig = {
   moduleDirectories: ['node_modules', '<rootDir>/'],
   collectCoverageFrom: [
     '{src,pages}/**/*.{js,jsx,ts,tsx}',
-    '__tests__/util/extensions/**/*.{js,jsx,ts,tsx}',
+    '__tests__/extensions/**/*.{js,jsx,ts,tsx}',
     'lighthouse/**/*.mjs',
     '!pages/api/**',
     '!**/*.generated.ts',

--- a/src/components/HrTools/SalaryCalculator/403bSection/403bSection.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/403bSection/403bSection.test.tsx
@@ -21,39 +21,23 @@ const TestComponent: React.FC<SalaryCalculatorTestWrapperProps> = (props) => (
 
 describe('403bSection', () => {
   describe('married', () => {
-    it('should render table headers', async () => {
-      const { getAllByRole } = render(<TestComponent />);
+    it('should render table headers and formatted cell values', async () => {
+      const { getByRole } = render(<TestComponent />);
 
       await waitFor(() =>
-        expect(
-          getAllByRole('columnheader').map((cell) => cell.textContent),
-        ).toEqual(['Category', 'John', 'Jane']),
-      );
-
-      await waitFor(() =>
-        expect(
-          getAllByRole('rowheader').map((cell) => cell.textContent),
-        ).toEqual([
-          'Current Tax-Deferred Contribution Percent',
-          'Current Roth 403(b) Contribution Percent',
-          'Maximum Contribution Limit',
-        ]),
-      );
-    });
-
-    it('should render table cells with formatted values', async () => {
-      const { getAllByRole } = render(<TestComponent />);
-
-      const expectedCells = [
-        ['5.00%', '8.00%'],
-        ['12.00%', '10.00%'],
-        ['$10,001.00', '$20,001.00'],
-      ].flat();
-
-      await waitFor(() =>
-        expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-          expectedCells,
-        ),
+        expect(getByRole('table')).toHaveTableStructure({
+          columnHeaders: ['Category', 'John', 'Jane'],
+          rowHeaders: [
+            'Current Tax-Deferred Contribution Percent',
+            'Current Roth 403(b) Contribution Percent',
+            'Maximum Contribution Limit',
+          ],
+          cells: [
+            ['5.00%', '8.00%'],
+            ['12.00%', '10.00%'],
+            ['$10,001.00', '$20,001.00'],
+          ],
+        }),
       );
     });
 
@@ -74,35 +58,19 @@ describe('403bSection', () => {
   });
 
   describe('single', () => {
-    it('should render table headers', async () => {
-      const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
+    it('should render table headers and formatted cell values', async () => {
+      const { getByRole } = render(<TestComponent hasSpouse={false} />);
 
       await waitFor(() =>
-        expect(
-          getAllByRole('columnheader').map((cell) => cell.textContent),
-        ).toEqual(['Category', 'John']),
-      );
-
-      await waitFor(() =>
-        expect(
-          getAllByRole('rowheader').map((cell) => cell.textContent),
-        ).toEqual([
-          'Current Tax-Deferred Contribution Percent',
-          'Current Roth 403(b) Contribution Percent',
-          'Maximum Contribution Limit',
-        ]),
-      );
-    });
-
-    it('should render table cells with formatted values', async () => {
-      const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
-
-      const expectedCells = ['5.00%', '12.00%', '$10,001.00'];
-
-      await waitFor(() =>
-        expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-          expectedCells,
-        ),
+        expect(getByRole('table')).toHaveTableStructure({
+          columnHeaders: ['Category', 'John'],
+          rowHeaders: [
+            'Current Tax-Deferred Contribution Percent',
+            'Current Roth 403(b) Contribution Percent',
+            'Maximum Contribution Limit',
+          ],
+          cells: ['5.00%', '12.00%', '$10,001.00'],
+        }),
       );
     });
   });

--- a/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/NewSalaryCalculatorLanding.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/NewSalaryCalculatorLanding.test.tsx
@@ -34,52 +34,48 @@ describe('NewSalaryCalculatorLanding', () => {
   });
 
   it('renders table with correct cell data', async () => {
-    const { getAllByRole } = render(<TestComponent hasApprovedCalculation />);
-
-    const expectedCells = [
-      ['Maximum Allowable Salary', '$60,000.00', '$70,000.00'],
-      ['Requested Salary', '$50,000.00', '$60,000.00'],
-      ['Tax-deferred 403(b) Contribution', '5%', '6%'],
-      ['Roth 403(b) Contribution', '12%', '10%'],
-      ['Security (SECA/FICA) Status', 'Subject to SECA', 'Subject to SECA'],
-      ['Current Gross Salary', '$55,000.00', '$10,000.00'],
-      [
-        'Current MHA (Included in Current Gross Salary)',
-        '$10,000.00View MHA Form',
-        '$12,000.00',
-      ],
-    ].flat();
+    const { getByRole } = render(<TestComponent hasApprovedCalculation />);
 
     await waitFor(() =>
-      expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-        expectedCells,
-      ),
+      expect(getByRole('table')).toHaveTableStructure({
+        cells: [
+          ['Maximum Allowable Salary', '$60,000.00', '$70,000.00'],
+          ['Requested Salary', '$50,000.00', '$60,000.00'],
+          ['Tax-deferred 403(b) Contribution', '5%', '6%'],
+          ['Roth 403(b) Contribution', '12%', '10%'],
+          ['Security (SECA/FICA) Status', 'Subject to SECA', 'Subject to SECA'],
+          ['Current Gross Salary', '$55,000.00', '$10,000.00'],
+          [
+            'Current MHA (Included in Current Gross Salary)',
+            '$10,000.00View MHA Form',
+            '$12,000.00',
+          ],
+        ],
+      }),
     );
   });
 
   it('swaps effective request fields when the spouse created the request', async () => {
-    const { getAllByRole } = render(
+    const { getByRole } = render(
       <TestComponent hasApprovedCalculation hasSpouseApprovedCalculation />,
     );
 
-    const expectedCells = [
-      ['Maximum Allowable Salary', '$70,000.00', '$60,000.00'],
-      ['Requested Salary', '$60,000.00', '$50,000.00'],
-      ['Tax-deferred 403(b) Contribution', '5%', '6%'],
-      ['Roth 403(b) Contribution', '12%', '10%'],
-      ['Security (SECA/FICA) Status', 'Subject to SECA', 'Subject to SECA'],
-      ['Current Gross Salary', '$55,000.00', '$10,000.00'],
-      [
-        'Current MHA (Included in Current Gross Salary)',
-        '$10,000.00View MHA Form',
-        '$12,000.00',
-      ],
-    ].flat();
-
     await waitFor(() =>
-      expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-        expectedCells,
-      ),
+      expect(getByRole('table')).toHaveTableStructure({
+        cells: [
+          ['Maximum Allowable Salary', '$70,000.00', '$60,000.00'],
+          ['Requested Salary', '$60,000.00', '$50,000.00'],
+          ['Tax-deferred 403(b) Contribution', '5%', '6%'],
+          ['Roth 403(b) Contribution', '12%', '10%'],
+          ['Security (SECA/FICA) Status', 'Subject to SECA', 'Subject to SECA'],
+          ['Current Gross Salary', '$55,000.00', '$10,000.00'],
+          [
+            'Current MHA (Included in Current Gross Salary)',
+            '$10,000.00View MHA Form',
+            '$12,000.00',
+          ],
+        ],
+      }),
     );
   });
 

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestSummaryCard/RequestSummaryCard.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestSummaryCard/RequestSummaryCard.test.tsx
@@ -209,47 +209,27 @@ This may affect your selected effective date.',
   });
 
   describe('table', () => {
-    it('renders table headers', async () => {
-      const { getAllByRole } = render(<TestComponent />);
+    it('renders table headers, row headers, and cells', async () => {
+      const { getByRole } = render(<TestComponent />);
 
       await waitFor(() =>
-        expect(
-          getAllByRole('columnheader').map((cell) => cell.textContent),
-        ).toEqual(['Description', 'John', 'Jane']),
-      );
-    });
-
-    it('renders row headers', async () => {
-      const { getAllByRole } = render(<TestComponent />);
-
-      await waitFor(() =>
-        expect(
-          getAllByRole('rowheader').map((cell) => cell.textContent),
-        ).toEqual([
-          'Requested Salary (includes MHA)',
-          'SECA and Related Federal Taxes',
-          '403b Contribution',
-          'Gross Requested Salary',
-          'Maximum Allowable Salary',
-        ]),
-      );
-    });
-
-    it('renders table cells', async () => {
-      const { getAllByRole } = render(<TestComponent />);
-
-      const expectedCells = [
-        ['$10,001.00', '$20,001.00'],
-        ['$10,002.00', '$20,002.00'],
-        ['$10,003.00', '$20,003.00'],
-        ['$10,004.00', '$20,004.00'],
-        ['$10,005.00', '$20,005.00'],
-      ].flat();
-
-      await waitFor(() =>
-        expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-          expectedCells,
-        ),
+        expect(getByRole('table')).toHaveTableStructure({
+          columnHeaders: ['Description', 'John', 'Jane'],
+          rowHeaders: [
+            'Requested Salary (includes MHA)',
+            'SECA and Related Federal Taxes',
+            '403b Contribution',
+            'Gross Requested Salary',
+            'Maximum Allowable Salary',
+          ],
+          cells: [
+            ['$10,001.00', '$20,001.00'],
+            ['$10,002.00', '$20,002.00'],
+            ['$10,003.00', '$20,003.00'],
+            ['$10,004.00', '$20,004.00'],
+            ['$10,005.00', '$20,005.00'],
+          ],
+        }),
       );
     });
 
@@ -272,7 +252,7 @@ This may affect your selected effective date.',
 
   describe('single user', () => {
     it('modifies labels and hides table cells', async () => {
-      const { getByTestId, getAllByRole } = render(
+      const { getByTestId, getByRole } = render(
         <TestComponent hasSpouse={false} />,
       );
 
@@ -289,28 +269,24 @@ This may affect your selected effective date.',
       );
 
       await waitFor(() =>
-        expect(
-          getAllByRole('columnheader').map((cell) => cell.textContent),
-        ).toEqual(['Description', 'John']),
+        expect(getByRole('table')).toHaveTableStructure({
+          columnHeaders: ['Description', 'John'],
+          rowHeaders: [
+            'Requested Salary (includes MHA)',
+            'SECA and Related Federal Taxes',
+            '403b Contribution',
+            'Gross Requested Salary',
+            'Maximum Allowable Salary',
+          ],
+          cells: [
+            '$10,001.00',
+            '$10,002.00',
+            '$10,003.00',
+            '$10,004.00',
+            '$10,005.00',
+          ],
+        }),
       );
-
-      expect(getAllByRole('rowheader').map((cell) => cell.textContent)).toEqual(
-        [
-          'Requested Salary (includes MHA)',
-          'SECA and Related Federal Taxes',
-          '403b Contribution',
-          'Gross Requested Salary',
-          'Maximum Allowable Salary',
-        ],
-      );
-
-      expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual([
-        '$10,001.00',
-        '$10,002.00',
-        '$10,003.00',
-        '$10,004.00',
-        '$10,005.00',
-      ]);
     });
 
     describe('requires above division head approval', () => {

--- a/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/SalaryCalculation/RequestedSalaryCard/RequestedSalaryCard.test.tsx
@@ -74,68 +74,55 @@ As you set your salary level, the amount you receive should reflect the amount o
       );
     });
 
-    it('should render table headers', async () => {
-      const { getAllByRole } = render(<TestComponent />);
+    it('should render table headers and cells with formatted currency', async () => {
+      const { getByRole } = render(<TestComponent />);
 
       await waitFor(() =>
-        expect(
-          getAllByRole('columnheader').map((cell) => cell.textContent),
-        ).toEqual(['Category', 'John', 'Jane']),
-      );
-
-      await waitFor(() =>
-        expect(
-          getAllByRole('rowheader').map((cell) => cell.textContent),
-        ).toEqual([
-          'Current Requested Salary',
-          'Minimum Salary',
-          'Maximum Allowable Salary (CAP)',
-          'Requested Salary',
-        ]),
-      );
-    });
-
-    it('should render table cells with formatted currency', async () => {
-      const { getAllByRole } = render(<TestComponent />);
-
-      const expectedCells = [
-        ['$11,111.00', '$22,222.00'],
-        ['$10,003.00', '$20,003.00'],
-        ['$10,004.00', '$20,004.00'],
-      ].flat();
-
-      await waitFor(() =>
-        expect(
-          getAllByRole('cell')
-            .slice(0, -2)
-            .map((cell) => cell.textContent),
-        ).toEqual(expectedCells),
+        expect(getByRole('table')).toHaveTableStructure({
+          columnHeaders: ['Category', 'John', 'Jane'],
+          rowHeaders: [
+            'Current Requested Salary',
+            'Minimum Salary',
+            'Maximum Allowable Salary (CAP)',
+            'Requested Salary',
+          ],
+          cells: [
+            ['$11,111.00', '$22,222.00'],
+            ['$10,003.00', '$20,003.00'],
+            ['$10,004.00', '$20,004.00'],
+            // The requested salary inputs
+            [
+              expect.stringContaining('Requested salary'),
+              expect.stringContaining('Spouse requested salary'),
+            ],
+          ],
+        }),
       );
     });
 
     it('should render a dash when there is no approved salary request', async () => {
-      const { getAllByRole } = render(
+      const { getByRole } = render(
         <TestComponent effectiveSalaryRequestMock={null} />,
       );
 
-      const expectedCells = [
-        ['–', '–'],
-        ['$10,003.00', '$20,003.00'],
-        ['$10,004.00', '$20,004.00'],
-      ].flat();
-
       await waitFor(() =>
-        expect(
-          getAllByRole('cell')
-            // Skip the two inputs
-            .slice(0, -2)
-            .map((cell) => cell.textContent),
-        ).toEqual(expectedCells),
+        expect(getByRole('table')).toHaveTableStructure({
+          cells: [
+            ['–', '–'],
+            ['$10,003.00', '$20,003.00'],
+            ['$10,004.00', '$20,004.00'],
+            // The requested salary inputs
+            [
+              expect.stringContaining('Requested salary'),
+              expect.stringContaining('Spouse requested salary'),
+            ],
+          ],
+        }),
       );
     });
 
     it('swaps the requested salary when the spouse created the request', async () => {
-      const { getAllByRole } = render(
+      const { getByRole } = render(
         <TestComponent
           effectiveSalaryRequestMock={{
             ...approvedSalaryMock,
@@ -145,17 +132,18 @@ As you set your salary level, the amount you receive should reflect the amount o
       );
 
       await waitFor(() =>
-        expect(
-          getAllByRole('cell')
-            .slice(0, -2)
-            .map((cell) => cell.textContent),
-        ).toEqual(
-          [
+        expect(getByRole('table')).toHaveTableStructure({
+          cells: [
             ['$22,222.00', '$11,111.00'],
             ['$10,003.00', '$20,003.00'],
             ['$10,004.00', '$20,004.00'],
-          ].flat(),
-        ),
+            // The requested salary inputs
+            [
+              expect.stringContaining('Requested salary'),
+              expect.stringContaining('Spouse requested salary'),
+            ],
+          ],
+        }),
       );
     });
 
@@ -193,55 +181,44 @@ As you set your salary level, the amount you receive should reflect the amount o
       );
     });
 
-    it('should render table headers', async () => {
-      const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
+    it('should render table headers and cells with formatted currency', async () => {
+      const { getByRole } = render(<TestComponent hasSpouse={false} />);
 
       await waitFor(() =>
-        expect(
-          getAllByRole('columnheader').map((cell) => cell.textContent),
-        ).toEqual(['Category', 'John']),
-      );
-
-      await waitFor(() =>
-        expect(
-          getAllByRole('rowheader').map((cell) => cell.textContent),
-        ).toEqual([
-          'Current Requested Salary',
-          'Minimum Salary',
-          'Maximum Allowable Salary (CAP)',
-          'Requested Salary',
-        ]),
-      );
-    });
-
-    it('should render table cells with formatted currency', async () => {
-      const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
-
-      const expectedCells = ['$11,111.00', '$10,003.00', '$10,004.00'];
-
-      await waitFor(() =>
-        expect(
-          getAllByRole('cell')
-            .slice(0, -1)
-            .map((cell) => cell.textContent),
-        ).toEqual(expectedCells),
+        expect(getByRole('table')).toHaveTableStructure({
+          columnHeaders: ['Category', 'John'],
+          rowHeaders: [
+            'Current Requested Salary',
+            'Minimum Salary',
+            'Maximum Allowable Salary (CAP)',
+            'Requested Salary',
+          ],
+          cells: [
+            '$11,111.00',
+            '$10,003.00',
+            '$10,004.00',
+            // The requested salary input
+            expect.stringContaining('Requested salary'),
+          ],
+        }),
       );
     });
 
     it('should render a dash when there is no approved salary request', async () => {
-      const { getAllByRole } = render(
+      const { getByRole } = render(
         <TestComponent hasSpouse={false} effectiveSalaryRequestMock={null} />,
       );
 
-      const expectedCells = ['–', '$10,003.00', '$10,004.00'];
-
       await waitFor(() =>
-        expect(
-          getAllByRole('cell')
-            // Skip the one input
-            .slice(0, -1)
-            .map((cell) => cell.textContent),
-        ).toEqual(expectedCells),
+        expect(getByRole('table')).toHaveTableStructure({
+          cells: [
+            '–',
+            '$10,003.00',
+            '$10,004.00',
+            // The requested salary input
+            expect.stringContaining('Requested salary'),
+          ],
+        }),
       );
     });
   });

--- a/src/components/HrTools/SalaryCalculator/Shared/SalaryInformationCard.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/Shared/SalaryInformationCard.test.tsx
@@ -27,37 +27,26 @@ describe('SalaryInformationCard', () => {
     expect(await findByTestId('last-updated')).toBeInTheDocument();
   });
 
-  it('renders category column headers', async () => {
-    const { getAllByRole } = render(<TestComponent />);
+  it('renders category column headers and salary category names', async () => {
+    const { getByRole } = render(<TestComponent />);
 
     await waitFor(() =>
-      expect(
-        getAllByRole('columnheader').map((cell) => cell.textContent),
-      ).toEqual(['Category', 'John', 'Jane']),
-    );
-  });
-
-  it('renders salary category names', async () => {
-    const { getAllByRole } = render(<TestComponent />);
-
-    const expectedCells = [
-      ['Maximum Allowable Salary', '$60,000.00', '$70,000.00'],
-      ['Requested Salary', '$50,000.00', '$60,000.00'],
-      ['Tax-deferred 403(b) Contribution', '5%', '6%'],
-      ['Roth 403(b) Contribution', '12%', '10%'],
-      ['Security (SECA/FICA) Status', 'Subject to SECA', 'Subject to SECA'],
-      ['Current Gross Salary', '$55,000.00', '$10,000.00'],
-      [
-        'Current MHA (Included in Current Gross Salary)',
-        '$10,000.00View MHA Form',
-        '$12,000.00',
-      ],
-    ].flat();
-
-    await waitFor(() =>
-      expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-        expectedCells,
-      ),
+      expect(getByRole('table')).toHaveTableStructure({
+        columnHeaders: ['Category', 'John', 'Jane'],
+        cells: [
+          ['Maximum Allowable Salary', '$60,000.00', '$70,000.00'],
+          ['Requested Salary', '$50,000.00', '$60,000.00'],
+          ['Tax-deferred 403(b) Contribution', '5%', '6%'],
+          ['Roth 403(b) Contribution', '12%', '10%'],
+          ['Security (SECA/FICA) Status', 'Subject to SECA', 'Subject to SECA'],
+          ['Current Gross Salary', '$55,000.00', '$10,000.00'],
+          [
+            'Current MHA (Included in Current Gross Salary)',
+            '$10,000.00View MHA Form',
+            '$12,000.00',
+          ],
+        ],
+      }),
     );
   });
 

--- a/src/components/HrTools/SalaryCalculator/Summary/MhaCard.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/Summary/MhaCard.test.tsx
@@ -41,63 +41,54 @@ const TestComponent: React.FC<SalaryCalculatorTestWrapperProps> = (props) => (
 );
 
 describe('MhaCard', () => {
-  it('should render table headers', async () => {
-    const { getAllByRole } = render(<TestComponent />);
+  it('should render table headers and cells with formatted currency values', async () => {
+    const { getByRole } = render(<TestComponent />);
 
     await waitFor(() =>
-      expect(
-        getAllByRole('columnheader').map((cell) => cell.textContent),
-      ).toEqual(['Category', 'John', 'Jane']),
-    );
-  });
-
-  it('should render table cells with formatted currency values', async () => {
-    const { getAllByRole } = render(<TestComponent />);
-
-    const expectedCells = [
-      ['15. Minimum Required Salary', '$10,001.00', '$20,001.00'],
-      ['16. SubtotalLine 12 - Line 15', '$10,002.00', '$20,002.00'],
-      [
-        "17. Minister's Housing AllowanceUse the lesser of line 16 or your CCC Board approved amount.",
-        '$10,003.00',
-        '$20,003.00',
-      ],
-      [
-        '18. SubtotalLine 16 - Line 17Enter the greater of this amount or zero.',
-        '$10,004.00',
-        '$20,004.00',
-      ],
-      ['19. Minimum Required Salary', '$10,001.00', '$20,001.00'],
-      ['20. CompensationLine 18 + Line 19', '$10,005.00', '$20,005.00'],
-      ['21. 403(b) AmountLine 14 - Line 12', '$10,006.00', '$20,006.00'],
-      [
-        'a. Tax-deferred (before tax) AmountNot taxed now',
-        '$10,007.00',
-        '$20,007.00',
-      ],
-      ['b. Roth (after-tax) AmountTaxed now', '$10,008.00', '$20,008.00'],
-      ['c. Total AmountLine 21a + Line 21b', '$10,006.00', '$20,006.00'],
-      [
-        '22. Annual Compensation RateLine 20 + Line 21c',
-        '$10,009.00',
-        '$20,009.00',
-      ],
-    ].flat();
-
-    await waitFor(() =>
-      expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-        expectedCells,
-      ),
+      expect(getByRole('table')).toHaveTableStructure({
+        columnHeaders: ['Category', 'John', 'Jane'],
+        cells: [
+          ['15. Minimum Required Salary', '$10,001.00', '$20,001.00'],
+          ['16. SubtotalLine 12 - Line 15', '$10,002.00', '$20,002.00'],
+          [
+            "17. Minister's Housing AllowanceUse the lesser of line 16 or your CCC Board approved amount.",
+            '$10,003.00',
+            '$20,003.00',
+          ],
+          [
+            '18. SubtotalLine 16 - Line 17Enter the greater of this amount or zero.',
+            '$10,004.00',
+            '$20,004.00',
+          ],
+          ['19. Minimum Required Salary', '$10,001.00', '$20,001.00'],
+          ['20. CompensationLine 18 + Line 19', '$10,005.00', '$20,005.00'],
+          ['21. 403(b) AmountLine 14 - Line 12', '$10,006.00', '$20,006.00'],
+          [
+            'a. Tax-deferred (before tax) AmountNot taxed now',
+            '$10,007.00',
+            '$20,007.00',
+          ],
+          ['b. Roth (after-tax) AmountTaxed now', '$10,008.00', '$20,008.00'],
+          ['c. Total AmountLine 21a + Line 21b', '$10,006.00', '$20,006.00'],
+          [
+            '22. Annual Compensation RateLine 20 + Line 21c',
+            '$10,009.00',
+            '$20,009.00',
+          ],
+        ],
+      }),
     );
   });
 
   it('should render fewer table headers and cells when single', async () => {
-    const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
+    const { getAllByRole, getByRole } = render(
+      <TestComponent hasSpouse={false} />,
+    );
 
     await waitFor(() =>
-      expect(
-        getAllByRole('columnheader').map((cell) => cell.textContent),
-      ).toEqual(['Category', 'John']),
+      expect(getByRole('table')).toHaveTableStructure({
+        columnHeaders: ['Category', 'John'],
+      }),
     );
 
     // 11 rows with 2 cells each

--- a/src/components/HrTools/SalaryCalculator/Summary/SalaryCalculationCard.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/Summary/SalaryCalculationCard.test.tsx
@@ -39,63 +39,54 @@ const TestComponent: React.FC<SalaryCalculatorTestWrapperProps> = (props) => (
 );
 
 describe('SalaryCalculationCard', () => {
-  it('should render table headers', async () => {
-    const { getAllByRole } = render(<TestComponent />);
+  it('should render table headers and cells with formatted currency and percentage values', async () => {
+    const { getByRole } = render(<TestComponent />);
 
     await waitFor(() =>
-      expect(
-        getAllByRole('columnheader').map((cell) => cell.textContent),
-      ).toEqual(['Category', 'John', 'Jane']),
-    );
-  });
-
-  it('should render table cells with formatted currency and percentage values', async () => {
-    const { getAllByRole } = render(<TestComponent />);
-
-    const expectedCells = [
-      [
-        '10. Requested SalaryBefore SECA and 403(b)',
-        '$10,001.00',
-        '$20,001.00',
-      ],
-      ['11. Taxes', '$10,002.00', '$20,002.00'],
-      ['a. SECA(If applicable) Line 10 × 0.22', '$10,002.00', '$20,002.00'],
-      [
-        'b. State and Local(If selected in Step 6) Line 10 × 0.05',
-        'TBD',
-        'TBD',
-      ],
-      [
-        '12. SubtotalLine 10 + Line 11This amount must be at least $10,004.00',
-        '$10,003.00',
-        '$20,003.00',
-      ],
-      ['13. 403(b) Contribution'],
-      ['a. Tax-deferred (before tax) percentage', '5.00%', '8.00%'],
-      ['b. Roth (after-tax) percentage', '12.00%', '10.00%'],
-      ['c. Total ContributionLine 13a + 13b', '12.34%', '23.45%'],
-      ['d. 1.00 minus 403(b) percentage', '0.8766', '0.7655'],
-      [
-        '14. Gross SalaryLine 12 ÷ Line 13dIf this amount is greater than your CAP (the lesser of line 9a or 9b), it must be approved.',
-        '$10,005.00',
-        '$20,005.00',
-      ],
-    ].flat();
-
-    await waitFor(() =>
-      expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-        expectedCells,
-      ),
+      expect(getByRole('table')).toHaveTableStructure({
+        columnHeaders: ['Category', 'John', 'Jane'],
+        cells: [
+          [
+            '10. Requested SalaryBefore SECA and 403(b)',
+            '$10,001.00',
+            '$20,001.00',
+          ],
+          ['11. Taxes', '$10,002.00', '$20,002.00'],
+          ['a. SECA(If applicable) Line 10 × 0.22', '$10,002.00', '$20,002.00'],
+          [
+            'b. State and Local(If selected in Step 6) Line 10 × 0.05',
+            'TBD',
+            'TBD',
+          ],
+          [
+            '12. SubtotalLine 10 + Line 11This amount must be at least $10,004.00',
+            '$10,003.00',
+            '$20,003.00',
+          ],
+          ['13. 403(b) Contribution'],
+          ['a. Tax-deferred (before tax) percentage', '5.00%', '8.00%'],
+          ['b. Roth (after-tax) percentage', '12.00%', '10.00%'],
+          ['c. Total ContributionLine 13a + 13b', '12.34%', '23.45%'],
+          ['d. 1.00 minus 403(b) percentage', '0.8766', '0.7655'],
+          [
+            '14. Gross SalaryLine 12 ÷ Line 13dIf this amount is greater than your CAP (the lesser of line 9a or 9b), it must be approved.',
+            '$10,005.00',
+            '$20,005.00',
+          ],
+        ],
+      }),
     );
   });
 
   it('should render fewer table headers and cells when single', async () => {
-    const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
+    const { getAllByRole, getByRole } = render(
+      <TestComponent hasSpouse={false} />,
+    );
 
     await waitFor(() =>
-      expect(
-        getAllByRole('columnheader').map((cell) => cell.textContent),
-      ).toEqual(['Category', 'John']),
+      expect(getByRole('table')).toHaveTableStructure({
+        columnHeaders: ['Category', 'John'],
+      }),
     );
 
     // 10 rows with 2 cells each and 1 row (row 13) with one cell

--- a/src/components/HrTools/SalaryCalculator/Summary/SalaryCapCard.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/Summary/SalaryCapCard.test.tsx
@@ -50,59 +50,50 @@ const TestComponent: React.FC<SalaryCalculatorTestWrapperProps> = (props) => (
 );
 
 describe('SalaryCapCard', () => {
-  it('should render table headers', async () => {
-    const { getAllByRole } = render(<TestComponent />);
+  it('should render table headers and cells with formatted currency and percentage values', async () => {
+    const { getByRole } = render(<TestComponent />);
 
     await waitFor(() =>
-      expect(
-        getAllByRole('columnheader').map((cell) => cell.textContent),
-      ).toEqual(['Category', 'John', 'Jane']),
-    );
-  });
-
-  it('should render table cells with formatted currency and percentage values', async () => {
-    const { getAllByRole } = render(<TestComponent />);
-
-    const expectedCells = [
-      ['1. Annual Base', '$10,001.00', '$20,001.00'],
-      ['2. Additional Salary', '$10,002.00', '$20,002.00'],
-      [
-        '3. Geographic AdjustmentCity: New YorkLine 2 × Geographic Cost of Living Factor',
-        '$10,003.00',
-        '$20,003.00',
-      ],
-      ['4. Tenure', '$10,004.00', '$20,004.00'],
-      ['5. SubtotalLine 3 + Line 4', '$10,005.00', '$20,005.00'],
-      [
-        '6. SECA(If applicable) Line 5 × 0.22Includes tax on the social security',
-        '$10,006.00',
-        '$20,006.00',
-      ],
-      ['7. SubtotalLine 5 + Line 6', '$10,007.00', '$20,007.00'],
-      ['8. 403(b) Contribution', '-', '-'],
-      ['a. 403(b) Contribution Percentage', '12.34%', '23.45%'],
-      ['b. 1.00 Minus 403(b) Percentage', '0.8766', '0.7655'],
-      [
-        '9. Maximum Allowable Salary (CAP)Line 7 × Line 8bFor a couple, the combined CAPs cannot exceed $10,011.00, with neither individual exceeding $10,010.00.',
-      ],
-      ['a. Personal Factors Cap', '$10,008.00', '$20,008.00'],
-      ['b. Max Allowable Cap', '$10,009.00', '$20,009.00'],
-    ].flat();
-
-    await waitFor(() =>
-      expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-        expectedCells,
-      ),
+      expect(getByRole('table')).toHaveTableStructure({
+        columnHeaders: ['Category', 'John', 'Jane'],
+        cells: [
+          ['1. Annual Base', '$10,001.00', '$20,001.00'],
+          ['2. Additional Salary', '$10,002.00', '$20,002.00'],
+          [
+            '3. Geographic AdjustmentCity: New YorkLine 2 × Geographic Cost of Living Factor',
+            '$10,003.00',
+            '$20,003.00',
+          ],
+          ['4. Tenure', '$10,004.00', '$20,004.00'],
+          ['5. SubtotalLine 3 + Line 4', '$10,005.00', '$20,005.00'],
+          [
+            '6. SECA(If applicable) Line 5 × 0.22Includes tax on the social security',
+            '$10,006.00',
+            '$20,006.00',
+          ],
+          ['7. SubtotalLine 5 + Line 6', '$10,007.00', '$20,007.00'],
+          ['8. 403(b) Contribution', '-', '-'],
+          ['a. 403(b) Contribution Percentage', '12.34%', '23.45%'],
+          ['b. 1.00 Minus 403(b) Percentage', '0.8766', '0.7655'],
+          [
+            '9. Maximum Allowable Salary (CAP)Line 7 × Line 8bFor a couple, the combined CAPs cannot exceed $10,011.00, with neither individual exceeding $10,010.00.',
+          ],
+          ['a. Personal Factors Cap', '$10,008.00', '$20,008.00'],
+          ['b. Max Allowable Cap', '$10,009.00', '$20,009.00'],
+        ],
+      }),
     );
   });
 
   it('should render fewer table headers and cells when single', async () => {
-    const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
+    const { getAllByRole, getByRole } = render(
+      <TestComponent hasSpouse={false} />,
+    );
 
     await waitFor(() =>
-      expect(
-        getAllByRole('columnheader').map((cell) => cell.textContent),
-      ).toEqual(['Category', 'John']),
+      expect(getByRole('table')).toHaveTableStructure({
+        columnHeaders: ['Category', 'John'],
+      }),
     );
 
     // 12 rows with 2 cells each and 1 row (row 9) with one cell

--- a/src/components/HrTools/SalaryCalculator/Summary/SalarySummaryCard.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/Summary/SalarySummaryCard.test.tsx
@@ -95,40 +95,33 @@ const TestComponent: React.FC<TestComponentProps> = ({
 );
 
 describe('SalarySummaryCard', () => {
-  it('should render table headers', async () => {
+  it('should render table headers and cells', async () => {
     const { getAllByRole } = render(<TestComponent />);
 
-    const expectedHeaders = [
-      ['John', 'Old', 'New'],
-      ['Jane', 'Old', 'New'],
-    ].flat();
+    await waitFor(() => {
+      const tables = getAllByRole('table');
+      expect(tables).toHaveLength(2);
 
-    await waitFor(() =>
-      expect(
-        getAllByRole('columnheader').map((cell) => cell.textContent),
-      ).toEqual(expectedHeaders),
-    );
-  });
-
-  it('should render table cells', async () => {
-    const { getAllByRole } = render(<TestComponent />);
-
-    const expectedCells = [
-      ['Requested Salary', '$10,001.00', '$30,001.00'],
-      ['MHA', '$10,002.00', '$30,002.00'],
-      ['403(b) Contribution', '10.00%', '30.00%'],
-      ['Max Allowable Salary', '$10,003.00', '$30,003.00'],
-      ['Requested Salary', '$20,001.00', '$40,001.00'],
-      ['MHA', '$20,002.00', '$40,002.00'],
-      ['403(b) Contribution', '20.00%', '40.00%'],
-      ['Max Allowable Salary', '$20,003.00', '$40,003.00'],
-    ].flat();
-
-    await waitFor(() =>
-      expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-        expectedCells,
-      ),
-    );
+      const [userTable, spouseTable] = tables;
+      expect(userTable).toHaveTableStructure({
+        columnHeaders: ['John', 'Old', 'New'],
+        cells: [
+          ['Requested Salary', '$10,001.00', '$30,001.00'],
+          ['MHA', '$10,002.00', '$30,002.00'],
+          ['403(b) Contribution', '10.00%', '30.00%'],
+          ['Max Allowable Salary', '$10,003.00', '$30,003.00'],
+        ],
+      });
+      expect(spouseTable).toHaveTableStructure({
+        columnHeaders: ['Jane', 'Old', 'New'],
+        cells: [
+          ['Requested Salary', '$20,001.00', '$40,001.00'],
+          ['MHA', '$20,002.00', '$40,002.00'],
+          ['403(b) Contribution', '20.00%', '40.00%'],
+          ['Max Allowable Salary', '$20,003.00', '$40,003.00'],
+        ],
+      });
+    });
   });
 
   it('swaps fields when the spouse created the request', async () => {
@@ -136,91 +129,77 @@ describe('SalarySummaryCard', () => {
       <TestComponent hasSpouseApprovedCalculation />,
     );
 
-    const expectedCells = [
-      ['Requested Salary', '$20,001.00', '$30,001.00'],
-      ['MHA', '$20,002.00', '$30,002.00'],
-      ['403(b) Contribution', '20.00%', '30.00%'],
-      ['Max Allowable Salary', '$20,003.00', '$30,003.00'],
-      ['Requested Salary', '$10,001.00', '$40,001.00'],
-      ['MHA', '$10,002.00', '$40,002.00'],
-      ['403(b) Contribution', '10.00%', '40.00%'],
-      ['Max Allowable Salary', '$10,003.00', '$40,003.00'],
-    ].flat();
+    await waitFor(() => {
+      const tables = getAllByRole('table');
+      expect(tables).toHaveLength(2);
 
-    await waitFor(() =>
-      expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-        expectedCells,
-      ),
-    );
+      const [userTable, spouseTable] = tables;
+      expect(userTable).toHaveTableStructure({
+        cells: [
+          ['Requested Salary', '$20,001.00', '$30,001.00'],
+          ['MHA', '$20,002.00', '$30,002.00'],
+          ['403(b) Contribution', '20.00%', '30.00%'],
+          ['Max Allowable Salary', '$20,003.00', '$30,003.00'],
+        ],
+      });
+      expect(spouseTable).toHaveTableStructure({
+        cells: [
+          ['Requested Salary', '$10,001.00', '$40,001.00'],
+          ['MHA', '$10,002.00', '$40,002.00'],
+          ['403(b) Contribution', '10.00%', '40.00%'],
+          ['Max Allowable Salary', '$10,003.00', '$40,003.00'],
+        ],
+      });
+    });
   });
 
   describe('no approved calculation', () => {
-    it('should hide the Old column headers', async () => {
+    it('should hide the Old column headers and cells', async () => {
       const { getAllByRole } = render(
         <TestComponent hasApprovedCalculation={false} />,
       );
 
-      const expectedHeaders = [
-        ['John', 'New'],
-        ['Jane', 'New'],
-      ].flat();
+      await waitFor(() => {
+        const tables = getAllByRole('table');
+        expect(tables).toHaveLength(2);
 
-      await waitFor(() =>
-        expect(
-          getAllByRole('columnheader').map((cell) => cell.textContent),
-        ).toEqual(expectedHeaders),
-      );
-    });
-
-    it('should hide the Old column cells', async () => {
-      const { getAllByRole } = render(
-        <TestComponent hasApprovedCalculation={false} />,
-      );
-
-      const expectedCells = [
-        ['Requested Salary', '$30,001.00'],
-        ['MHA', '$30,002.00'],
-        ['403(b) Contribution', '30.00%'],
-        ['Max Allowable Salary', '$30,003.00'],
-        ['Requested Salary', '$40,001.00'],
-        ['MHA', '$40,002.00'],
-        ['403(b) Contribution', '40.00%'],
-        ['Max Allowable Salary', '$40,003.00'],
-      ].flat();
-
-      await waitFor(() =>
-        expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-          expectedCells,
-        ),
-      );
+        const [userTable, spouseTable] = tables;
+        expect(userTable).toHaveTableStructure({
+          columnHeaders: ['John', 'New'],
+          cells: [
+            ['Requested Salary', '$30,001.00'],
+            ['MHA', '$30,002.00'],
+            ['403(b) Contribution', '30.00%'],
+            ['Max Allowable Salary', '$30,003.00'],
+          ],
+        });
+        expect(spouseTable).toHaveTableStructure({
+          columnHeaders: ['Jane', 'New'],
+          cells: [
+            ['Requested Salary', '$40,001.00'],
+            ['MHA', '$40,002.00'],
+            ['403(b) Contribution', '40.00%'],
+            ['Max Allowable Salary', '$40,003.00'],
+          ],
+        });
+      });
     });
   });
 
   describe('single', () => {
-    it('should render table headers', async () => {
-      const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
+    it('should render table headers and cells', async () => {
+      const { getByRole } = render(<TestComponent hasSpouse={false} />);
 
       await waitFor(() =>
-        expect(
-          getAllByRole('columnheader').map((cell) => cell.textContent),
-        ).toEqual(['John', 'Old', 'New']),
-      );
-    });
-
-    it('should render table cells', async () => {
-      const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
-
-      const expectedCells = [
-        ['Requested Salary', '$10,001.00', '$30,001.00'],
-        ['MHA', '$10,002.00', '$30,002.00'],
-        ['403(b) Contribution', '10.00%', '30.00%'],
-        ['Max Allowable Salary', '$10,003.00', '$30,003.00'],
-      ].flat();
-
-      await waitFor(() =>
-        expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-          expectedCells,
-        ),
+        expect(getByRole('table')).toHaveTableStructure({
+          columnHeaders: ['John', 'Old', 'New'],
+          cells: [
+            ['Requested Salary', '$10,001.00', '$30,001.00'],
+            ['MHA', '$10,002.00', '$30,002.00'],
+            ['403(b) Contribution', '10.00%', '30.00%'],
+            ['Max Allowable Salary', '$10,003.00', '$30,003.00'],
+          ],
+        }),
       );
     });
   });

--- a/src/components/HrTools/SalaryCalculator/Summary/StaffInfoSummaryCard.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/Summary/StaffInfoSummaryCard.test.tsx
@@ -66,20 +66,18 @@ const TestComponent: React.FC<TestComponentProps> = ({
 
 describe('StaffInfoSummaryCard', () => {
   it('should render table cells', async () => {
-    const { getAllByRole } = render(<TestComponent />);
-
-    const expectedCells = [
-      ['Staff Account Number', '123456'],
-      ['Full Names', 'John Doe and Jane Doe'],
-      ['Phone Number', '555-0123'],
-      ['Email Address', 'john.doe@example.comjane.doe@example.com'],
-      ['Effective for Paycheck Dated', '1/15/2024'],
-    ].flat();
+    const { getByRole } = render(<TestComponent />);
 
     await waitFor(() =>
-      expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-        expectedCells,
-      ),
+      expect(getByRole('table')).toHaveTableStructure({
+        cells: [
+          ['Staff Account Number', '123456'],
+          ['Full Names', 'John Doe and Jane Doe'],
+          ['Phone Number', '555-0123'],
+          ['Email Address', 'john.doe@example.comjane.doe@example.com'],
+          ['Effective for Paycheck Dated', '1/15/2024'],
+        ],
+      }),
     );
   });
 
@@ -91,20 +89,18 @@ describe('StaffInfoSummaryCard', () => {
 
   describe('single', () => {
     it('should render table cells', async () => {
-      const { getAllByRole } = render(<TestComponent hasSpouse={false} />);
-
-      const expectedCells = [
-        ['Staff Account Number', '123456'],
-        ['Full Names', 'John Doe'],
-        ['Phone Number', '555-0123'],
-        ['Email Address', 'john.doe@example.com'],
-        ['Effective for Paycheck Dated', '1/15/2024'],
-      ].flat();
+      const { getByRole } = render(<TestComponent hasSpouse={false} />);
 
       await waitFor(() =>
-        expect(getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
-          expectedCells,
-        ),
+        expect(getByRole('table')).toHaveTableStructure({
+          cells: [
+            ['Staff Account Number', '123456'],
+            ['Full Names', 'John Doe'],
+            ['Phone Number', '555-0123'],
+            ['Email Address', 'john.doe@example.com'],
+            ['Effective for Paycheck Dated', '1/15/2024'],
+          ],
+        }),
       );
     });
   });

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
-import { render, waitFor } from '@testing-library/react';
+import {
+  render,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Settings } from 'luxon';
 import { SnackbarProvider } from 'notistack';
@@ -277,7 +281,7 @@ describe('StaffExpenseReport', () => {
   });
 
   it('shows month title and navigation when only category filters are applied', async () => {
-    const { getByRole, findByLabelText, findByRole } = render(
+    const { getByRole, findByLabelText, queryByRole } = render(
       <TestComponent />,
     );
 
@@ -288,9 +292,12 @@ describe('StaffExpenseReport', () => {
       expect(getByRole('button', { name: 'Apply Filters' })).not.toBeDisabled(),
     );
     userEvent.click(getByRole('button', { name: 'Apply Filters' }));
+    await waitForElementToBeRemoved(() => queryByRole('dialog'), {
+      timeout: 5000,
+    });
 
     expect(
-      await findByRole('heading', { name: 'January 2020', level: 6 }),
+      getByRole('heading', { name: 'January 2020', level: 6 }),
     ).toBeInTheDocument();
     expect(getByRole('button', { name: 'Previous Month' })).toBeInTheDocument();
     expect(getByRole('button', { name: 'Next Month' })).toBeInTheDocument();
@@ -310,6 +317,9 @@ describe('StaffExpenseReport', () => {
     userEvent.click(getByRole('option', { name: 'Month to Date' }));
 
     userEvent.click(await findByRole('button', { name: 'Apply Filters' }));
+    await waitForElementToBeRemoved(() => queryByRole('dialog'), {
+      timeout: 5000,
+    });
 
     expect(
       queryByRole('button', { name: 'Previous Month' }),


### PR DESCRIPTION
## Description

Create a custom `expect(table).toHaveTableStructure(...)` just matcher for verifying the headings and cells of a table in a single `expect`.

## Testing

- Verify that tests still pass

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
