### PR TITLE
[no-Jira] Run prettier on changed files in pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
     "@mui/base@5.0.0-beta.40": "patch:@mui/base@npm%3A5.0.0-beta.40#./.yarn/patches/@mui-base-npm-5.0.0-beta.40-248417914d.patch"
   },
   "lint-staged": {
-    "*.{js,ts,tsx}": "eslint --cache --fix"
+    "*.{js,ts,tsx}": "eslint --cache --fix",
+    "*": "prettier --write --ignore-unknown"
   },
   "packageManager": "yarn@4.14.1"
 }


### PR DESCRIPTION
## Description

- Add `prettier --write --ignore-unknown` to the lint-staged config in `package.json` so Prettier formats all staged files during the Husky pre-commit hook
- Previously only ESLint ran on staged `.js`/`.ts`/`.tsx` files; now Prettier also formats other file types (JSON, GraphQL, Markdown, CSS, etc.)
- `--ignore-unknown` skips files Prettier can't parse, and `.prettierignore` is respected automatically
- No changes needed to `.husky/pre-commit` — it already runs `yarn lint-staged`

## Testing

- Make a formatting-violating change to a file (e.g. add extra spaces or inconsistent indentation to a `.json` or `.ts` file)
- Stage the file with `git add` and run `git commit`
- Check that the pre-commit hook reformats the file and the committed version is properly formatted

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)