### PR TITLE
[no-Jira] Add transform support to `useAutoSave`

### DIFF
--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/ContactInformation.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/ContactInformation.tsx
@@ -3,7 +3,7 @@ import Phone from '@mui/icons-material/Phone';
 import { InputAdornment, Stack, TextField, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
-import { phoneNumber, sanitizePhoneNumber } from 'src/lib/yupHelpers';
+import { phoneNumber } from 'src/lib/yupHelpers';
 import { useQuestionnaireAutoSave } from '../Shared/useQuestionnaireAutoSave';
 
 const placeholder = '000-000-0000';
@@ -41,10 +41,6 @@ export const ContactInformation: React.FC = () => {
           ),
         }}
         {...fieldProps}
-        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-          event.target.value = sanitizePhoneNumber(event.target.value);
-          fieldProps.onChange(event);
-        }}
         onBlur={() => {
           fieldProps.onBlur();
         }}

--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/ContactInformation.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/ContactInformation.tsx
@@ -41,9 +41,6 @@ export const ContactInformation: React.FC = () => {
           ),
         }}
         {...fieldProps}
-        onBlur={() => {
-          fieldProps.onBlur();
-        }}
       />
     </Stack>
   );

--- a/src/components/Shared/Autosave/useAutosave.test.tsx
+++ b/src/components/Shared/Autosave/useAutosave.test.tsx
@@ -55,6 +55,21 @@ const SelectTestComponent: React.FC = () => {
   );
 };
 
+const TransformTestComponent: React.FC = () => {
+  const schema = yup.object({
+    field: yup.string().transform((val) => val.replace(/\D/g, '')),
+  });
+
+  const props = useAutoSave({
+    value: '',
+    saveValue,
+    fieldName: 'field',
+    schema,
+  });
+
+  return <TextField label="Field" {...props} />;
+};
+
 describe('AutosaveTextField', () => {
   it('initializes with value and no errors', () => {
     const { getByRole } = render(<TestComponent />);
@@ -124,6 +139,15 @@ describe('AutosaveTextField', () => {
     userEvent.clear(input);
     userEvent.type(input, 'abc');
     expect(input).toHaveAccessibleDescription('Field must be a number');
+  });
+
+  it('transforms the input value', () => {
+    const { getByRole } = render(<TransformTestComponent />);
+
+    const input = getByRole('textbox', { name: 'Field' });
+    userEvent.type(input, 'a1b2c3');
+
+    expect(input).toHaveValue('123');
   });
 
   describe('select input', () => {

--- a/src/components/Shared/Autosave/useAutosave.ts
+++ b/src/components/Shared/Autosave/useAutosave.ts
@@ -50,15 +50,14 @@ export const useAutoSave = <Value extends string | number>({
 
   const transformValue = useCallback(
     (rawValue: string): string => {
-      try {
-        // Apply any schema transforms defined on the field
-        const transformed = yup
-          .reach(schema, fieldName)
-          .cast(rawValue, { assert: false });
-        return typeof transformed === 'string' ? transformed : rawValue;
-      } catch {
-        return rawValue;
-      }
+      // Apply any schema transforms defined on the field as the user types (e.g. stripping
+      // disallowed characters). Transforms must be idempotent.
+      const transformed = yup
+        .reach(schema, fieldName)
+        .cast(rawValue, { assert: false });
+      // Only apply string transforms. Number/select schemas cast to non-strings, so keep the raw
+      // keystrokes and let parseValue coerce them on save.
+      return typeof transformed === 'string' ? transformed : rawValue;
     },
     [schema, fieldName],
   );

--- a/src/components/Shared/Autosave/useAutosave.ts
+++ b/src/components/Shared/Autosave/useAutosave.ts
@@ -48,6 +48,21 @@ export const useAutoSave = <Value extends string | number>({
     [fieldName, schema],
   );
 
+  const transformValue = useCallback(
+    (rawValue: string): string => {
+      try {
+        // Apply any schema transforms defined on the field
+        const transformed = yup
+          .reach(schema, fieldName)
+          .cast(rawValue, { assert: false });
+        return typeof transformed === 'string' ? transformed : rawValue;
+      } catch {
+        return rawValue;
+      }
+    },
+    [schema, fieldName],
+  );
+
   const { parsedValue, errorMessage } = useMemo(
     () => parseValue(internalValue),
     [parseValue, internalValue],
@@ -69,7 +84,7 @@ export const useAutoSave = <Value extends string | number>({
   return {
     value: internalValue,
     onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
-      const newValue = event.target.value;
+      const newValue = transformValue(event.target.value);
       setInternalValue(newValue);
 
       if (saveOnChange) {

--- a/src/lib/yupHelpers.test.ts
+++ b/src/lib/yupHelpers.test.ts
@@ -52,12 +52,12 @@ describe('phoneNumber validation', () => {
     expect(() => schema.validateSync('abcdefghij')).toThrow();
   });
 
-  it('rejects numbers mixed with letters', () => {
-    expect(() => schema.validateSync('123abc4567')).toThrow();
+  it('strips letters mixed with numbers', () => {
+    expect(schema.validateSync('123abc4567')).toBe('1234567');
   });
 
-  it('rejects special characters', () => {
-    expect(() => schema.validateSync('123@456#7890')).toThrow();
+  it('strips special characters', () => {
+    expect(schema.validateSync('123@456#7890')).toBe('1234567890');
   });
 });
 

--- a/src/lib/yupHelpers.ts
+++ b/src/lib/yupHelpers.ts
@@ -17,13 +17,18 @@ export const sanitizePhoneNumber = (value: string) =>
  * - Must contain between 7 and 15 digits (after removing non-digit characters)
  */
 export const phoneNumber = (t: TFunction) =>
-  yup.string().test('is-phone-number', t('Invalid phone number'), (val) => {
-    if (!val) {
-      return false;
-    }
-    const cleaned = val.replace(/\D/g, '');
-    return sanitizePhoneNumber(val) === val && /^\d{7,15}$/.test(cleaned);
-  });
+  yup
+    .string()
+    .transform((val) =>
+      typeof val === 'string' ? sanitizePhoneNumber(val) : val,
+    )
+    .test('is-phone-number', t('Invalid phone number'), (val) => {
+      if (!val) {
+        return false;
+      }
+      const cleaned = val.replace(/\D/g, '');
+      return /^\d{7,15}$/.test(cleaned);
+    });
 
 export const dateTime = () =>
   yup


### PR DESCRIPTION
## Description

Add `transform` schema support to `useAutoSave` to handle raw input value processing in a flexible way.

Builds on #1841

## Testing

- Go to the NSO questionnaire
- Type letters into the phone number input
- Check that they are stripped out

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
