### PR TITLE
MPDX-9742 - NSO Questionnaire Staff Info

### DIFF
--- a/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategory.test.tsx
+++ b/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategory.test.tsx
@@ -95,9 +95,9 @@ describe('InformationCategory', () => {
   });
 
   it("renders the user's first name", async () => {
-    const { getByTestId } = render(<TestComponent />);
+    const { getByRole } = render(<TestComponent />);
     await waitFor(() => {
-      expect(getByTestId('info-name-typography')).toHaveTextContent('John');
+      expect(getByRole('heading', { name: 'John' })).toBeInTheDocument();
     });
   });
 

--- a/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategory.tsx
+++ b/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategory.tsx
@@ -1,7 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import RightArrowIcon from '@mui/icons-material/ArrowForward';
-import { Avatar, Box, Button, Card, Typography } from '@mui/material';
-import { styled } from '@mui/system';
+import { Box } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
@@ -12,14 +10,11 @@ import {
   MpdGoalBenefitsConstantSizeEnum,
 } from 'src/graphql/types.generated';
 import { amount, integer, percentage } from 'src/lib/yupHelpers';
+import { StaffInfoCard } from '../../../../Shared/StaffInfoCard/StaffInfoCard';
 import { useGoalCalculator } from '../../../Shared/GoalCalculatorContext';
 import { hasStaffSpouse } from '../../../Shared/calculateTotals';
 import { InformationCategoryFinancialForm } from './InformationCategoryForm/InformationCategoryFinancialForm';
 import { InformationCategoryPersonalForm } from './InformationCategoryForm/InformationCategoryPersonalForm';
-
-const StyledCard = styled(Card)({
-  width: '100%',
-});
 
 export const InformationCategory: React.FC = () => {
   const { t } = useTranslation();
@@ -109,71 +104,38 @@ export const InformationCategory: React.FC = () => {
     setViewingSpouse(!viewingSpouse);
   };
 
+  const toggleName = viewingSpouse
+    ? (firstName ?? t('Your Information'))
+    : (spouseFirstName ?? t('Spouse Information'));
+
   return (
-    <StyledCard>
+    <StaffInfoCard
+      person={{
+        name: (viewingSpouse ? spouseFirstName : firstName) ?? t('User'),
+        avatarSrc: viewingSpouse ? undefined : userData?.user.avatar,
+      }}
+      toggle={
+        hasSpouse
+          ? { name: toggleName, onClick: onClickSpouseInformation }
+          : undefined
+      }
+    >
       <Box
-        display="flex"
-        gap={2}
-        m={2}
-        alignItems="center"
-        justifyContent="space-between"
+        data-testid={
+          viewingSpouse ? 'spouse-information-form' : 'user-information-form'
+        }
       >
-        <Box display="flex" alignItems="center" justifyContent="center" gap={1}>
-          <Avatar
-            data-testid="info-avatar"
-            src={viewingSpouse ? undefined : userData?.user.avatar}
-            alt={(viewingSpouse ? spouseFirstName : firstName) ?? t('User')}
-            variant="rounded"
-            sx={{ width: 36, height: 36, marginRight: 1 }}
+        <InformationCategoryPersonalForm
+          schema={validationSchema}
+          isSpouse={viewingSpouse}
+        />
+        <Box sx={{ mt: 3 }}>
+          <InformationCategoryFinancialForm
+            schema={validationSchema}
+            isSpouse={viewingSpouse}
           />
-          <Typography data-testid="info-name-typography" sx={{ fontSize: 18 }}>
-            {(viewingSpouse ? spouseFirstName : firstName) ?? t('User')}
-          </Typography>
         </Box>
-        {hasSpouse && (
-          <Button
-            endIcon={<RightArrowIcon />}
-            onClick={onClickSpouseInformation}
-            sx={{ fontWeight: 'bold', fontSize: '15px' }}
-          >
-            {viewingSpouse
-              ? t('View {{name}}', {
-                  name: firstName ?? t('Your Information'),
-                })
-              : t('View {{name}}', {
-                  name: spouseFirstName ?? t('Spouse Information'),
-                })}
-          </Button>
-        )}
       </Box>
-
-      {!viewingSpouse && (
-        <StyledCard>
-          <Box sx={{ p: 3 }} data-testid="user-information-form">
-            <InformationCategoryPersonalForm schema={validationSchema} />
-            <Box sx={{ mt: 3 }}>
-              <InformationCategoryFinancialForm schema={validationSchema} />
-            </Box>
-          </Box>
-        </StyledCard>
-      )}
-
-      {viewingSpouse && (
-        <StyledCard>
-          <Box sx={{ p: 3 }} data-testid="spouse-information-form">
-            <InformationCategoryPersonalForm
-              schema={validationSchema}
-              isSpouse
-            />
-            <Box sx={{ mt: 3 }}>
-              <InformationCategoryFinancialForm
-                schema={validationSchema}
-                isSpouse
-              />
-            </Box>
-          </Box>
-        </StyledCard>
-      )}
-    </StyledCard>
+    </StaffInfoCard>
   );
 };

--- a/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategoryForm/InformationCategoryFinancialForm.tsx
+++ b/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategoryForm/InformationCategoryFinancialForm.tsx
@@ -83,7 +83,7 @@ export const InformationCategoryFinancialForm: React.FC<
 
         <Grid item xs={12}>
           <TextField
-            value={data?.goalCalculation[secaField]?.toString()}
+            value={data?.goalCalculation[secaField]?.toString() ?? ''}
             onChange={(event) => {
               saveField({ [secaField]: event.target.value === 'true' });
             }}

--- a/src/components/HrTools/NsoMpdQuestionnaire/NsoMpdQuestionnaireTestWrapper.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/NsoMpdQuestionnaireTestWrapper.tsx
@@ -1,25 +1,89 @@
 import { ThemeProvider } from '@mui/material/styles';
+import { MockLinkCallHandler } from 'graphql-ergonomock/dist/apollo/MockLink';
+import { merge } from 'lodash';
 import { SnackbarProvider } from 'notistack';
+import { DeepPartial } from 'ts-essentials';
 import TestRouter from '__tests__/util/TestRouter';
-import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { GqlMockedProvider, gqlMock } from '__tests__/util/graphqlMocking';
+import { GetUserQuery } from 'src/components/User/GetUser.generated';
+import { AssignmentStatusEnum } from 'src/graphql/types.generated';
 import { GoalCalculatorConstantsQuery } from 'src/hooks/goalCalculatorConstants.generated';
 import theme from 'src/theme';
+import {
+  HcmDocument,
+  HcmQuery,
+  HcmQueryVariables,
+} from '../Shared/HcmData/Hcm.generated';
 import { NsoMpdQuestionnaireProvider } from './Shared/NsoMpdQuestionnaireContext';
 
-interface NsoMpdQuestionnaireTestWrapperProps {
+const hcmMock = gqlMock<HcmQuery, HcmQueryVariables>(HcmDocument, {
+  mocks: {
+    hcm: [
+      {
+        staffInfo: {
+          preferredName: 'John',
+          lastName: 'Doe',
+          age: 34,
+          tenure: 4,
+          assignmentStatus: AssignmentStatusEnum.ActivePayrollEligible,
+          addressLine1: '123 Main St',
+          addressLine2: 'Apt 4',
+          city: 'Miami',
+          state: 'FL',
+          zipCode: '33101',
+        },
+      },
+      {
+        staffInfo: {
+          preferredName: 'Jane',
+          lastName: 'Doe',
+          age: 32,
+          tenure: 2,
+          assignmentStatus: AssignmentStatusEnum.ActivePaidLeave,
+          addressLine1: '456 Oak Ave',
+          addressLine2: '',
+          city: 'Tampa',
+          state: 'FL',
+          zipCode: '33601',
+        },
+      },
+    ],
+  },
+}).hcm;
+
+export const hcmUserMock = hcmMock[0];
+export const hcmSpouseMock = hcmMock[1];
+
+export interface NsoMpdQuestionnaireTestWrapperProps {
+  hcmUser?: DeepPartial<HcmQuery['hcm'][number]>;
+  hcmSpouse?: DeepPartial<HcmQuery['hcm'][number]>;
+  hasSpouse?: boolean;
+  onCall?: MockLinkCallHandler;
   children?: React.ReactNode;
 }
 
 export const NsoMpdQuestionnaireTestWrapper: React.FC<
   NsoMpdQuestionnaireTestWrapperProps
-> = ({ children }) => (
-  <ThemeProvider theme={theme}>
-    <TestRouter>
-      <SnackbarProvider>
+> = ({ hcmUser, hcmSpouse, hasSpouse = true, onCall, children }) => {
+  const hcmUserMerged = merge({}, hcmUserMock, hcmUser);
+  const hcmSpouseMerged = merge({}, hcmSpouseMock, hcmSpouse);
+  return (
+    <ThemeProvider theme={theme}>
+      <TestRouter>
         <GqlMockedProvider<{
+          Hcm: HcmQuery;
+          GetUser: GetUserQuery;
           GoalCalculatorConstants: GoalCalculatorConstantsQuery;
         }>
           mocks={{
+            GetUser: {
+              user: { avatar: 'avatar.jpg', staffAccountId: '000123456' },
+            },
+            Hcm: {
+              hcm: hasSpouse
+                ? [hcmUserMerged, hcmSpouseMerged]
+                : [hcmUserMerged],
+            },
             GoalCalculatorConstants: {
               constant: {
                 mpdGoalGeographicConstants: [
@@ -30,10 +94,15 @@ export const NsoMpdQuestionnaireTestWrapper: React.FC<
               },
             },
           }}
+          onCall={onCall}
         >
-          <NsoMpdQuestionnaireProvider>{children}</NsoMpdQuestionnaireProvider>
+          <SnackbarProvider>
+            <NsoMpdQuestionnaireProvider>
+              {children}
+            </NsoMpdQuestionnaireProvider>
+          </SnackbarProvider>
         </GqlMockedProvider>
-      </SnackbarProvider>
-    </TestRouter>
-  </ThemeProvider>
-);
+      </TestRouter>
+    </ThemeProvider>
+  );
+};

--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/PersonalInformation.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/PersonalInformation.tsx
@@ -5,6 +5,7 @@ import { StepPage } from '../Shared/StepPage';
 import { SubStep } from '../Shared/SubStepList';
 import { ContactInformation } from './ContactInformation';
 import { Settings } from './Settings';
+import { StaffInformation } from './StaffInformation';
 
 export const PersonalInformation: React.FC = () => {
   const { t } = useTranslation();
@@ -18,6 +19,8 @@ export const PersonalInformation: React.FC = () => {
     <StepPage subSteps={subSteps}>
       <Box mx={4} my={2}>
         <Settings />
+        <Divider sx={{ mx: -4, my: 4 }} />
+        <StaffInformation />
         <Divider sx={{ mx: -4, my: 4 }} />
         <ContactInformation />
       </Box>

--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/StaffInformation.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/StaffInformation.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NsoMpdQuestionnaireTestWrapper } from '../NsoMpdQuestionnaireTestWrapper';
+import { StaffInformation } from './StaffInformation';
+
+describe('StaffInformation', () => {
+  it("shows the staff member's information from HCM", async () => {
+    const { findByRole, getByRole, getByText } = render(
+      <NsoMpdQuestionnaireTestWrapper>
+        <StaffInformation />
+      </NsoMpdQuestionnaireTestWrapper>,
+    );
+
+    expect(
+      await findByRole('heading', { name: 'John Doe' }),
+    ).toBeInTheDocument();
+    expect(getByRole('textbox', { name: 'Staff Status' })).toHaveValue(
+      'Active - Payroll Eligible',
+    );
+    expect(getByRole('textbox', { name: 'Family Status' })).toHaveValue(
+      'Married',
+    );
+    expect(getByRole('textbox', { name: 'Age' })).toHaveValue('34');
+    expect(getByRole('textbox', { name: 'Tenure' })).toHaveValue('4');
+    expect(getByRole('textbox', { name: 'Address' })).toHaveValue(
+      '123 Main St, Apt 4, Miami, FL 33101',
+    );
+    expect(getByText('Staff Account Number: 000123456')).toBeInTheDocument();
+  });
+
+  it("toggles to the spouse's information", async () => {
+    const { findByRole, getByRole } = render(
+      <NsoMpdQuestionnaireTestWrapper>
+        <StaffInformation />
+      </NsoMpdQuestionnaireTestWrapper>,
+    );
+
+    userEvent.click(await findByRole('button', { name: 'View Jane' }));
+
+    expect(getByRole('heading', { name: 'Jane Doe' })).toBeInTheDocument();
+    expect(getByRole('textbox', { name: 'Age' })).toHaveValue('32');
+    expect(getByRole('textbox', { name: 'Staff Status' })).toHaveValue(
+      'Active - Paid Leave',
+    );
+  });
+
+  it('hides the spouse toggle and shows Single without a spouse', async () => {
+    const { findByRole, getByRole, queryByRole } = render(
+      <NsoMpdQuestionnaireTestWrapper hasSpouse={false}>
+        <StaffInformation />
+      </NsoMpdQuestionnaireTestWrapper>,
+    );
+
+    expect(
+      await findByRole('heading', { name: 'John Doe' }),
+    ).toBeInTheDocument();
+    expect(queryByRole('button', { name: /View/ })).not.toBeInTheDocument();
+    expect(getByRole('textbox', { name: 'Family Status' })).toHaveValue(
+      'Single',
+    );
+  });
+});

--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/StaffInformation.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/StaffInformation.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+import { Stack, TextField, Typography } from '@mui/material';
+import { Trans, useTranslation } from 'react-i18next';
+import { useGetUserQuery } from 'src/components/User/GetUser.generated';
+import { getLocalizedAssignmentStatus } from '../../Shared/Helpers/getLocalizedAssignmentStatus';
+import { StaffInfoCard } from '../../Shared/StaffInfoCard/StaffInfoCard';
+import { useNsoMpdQuestionnaire } from '../Shared/NsoMpdQuestionnaireContext';
+
+export const StaffInformation: React.FC = () => {
+  const { t } = useTranslation();
+  const { hcmUser, hcmSpouse } = useNsoMpdQuestionnaire();
+  const { data: userData } = useGetUserQuery();
+
+  const [viewingSpouse, setViewingSpouse] = useState(false);
+
+  const staffInfo = (viewingSpouse ? hcmSpouse : hcmUser)?.staffInfo;
+  const otherStaffInfo = (viewingSpouse ? hcmUser : hcmSpouse)?.staffInfo;
+
+  const name =
+    [staffInfo?.preferredName, staffInfo?.lastName].filter(Boolean).join(' ') ||
+    t('User');
+  const toggleName =
+    otherStaffInfo?.preferredName ??
+    (viewingSpouse ? t('Yourself') : t('Spouse'));
+
+  const fields = [
+    {
+      label: t('Staff Status'),
+      value: getLocalizedAssignmentStatus(t, staffInfo?.assignmentStatus),
+    },
+    {
+      label: t('Family Status'),
+      value: !!hcmSpouse ? t('Married') : t('Single'),
+    },
+    { label: t('Age'), value: staffInfo?.age?.toString() ?? '' },
+    { label: t('Tenure'), value: staffInfo?.tenure?.toString() ?? '' },
+    {
+      label: t('Address'),
+      value: [
+        staffInfo?.addressLine1,
+        staffInfo?.addressLine2,
+        staffInfo?.city,
+        [staffInfo?.state, staffInfo?.zipCode].filter(Boolean).join(' '),
+      ]
+        .filter(Boolean)
+        .join(', '),
+    },
+  ];
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="h6">{t('Staff Information')}</Typography>
+      <Typography>
+        <Trans t={t}>
+          Take a moment to verify the staff information we have on record. If
+          something is incorrect, please inform your MPD coordinator during New
+          Staff Orientation and they will make a correction.
+        </Trans>
+      </Typography>
+      <StaffInfoCard
+        person={{
+          name,
+          // Backend doesn't currently support accessing the spouse's avatar
+          avatarSrc: viewingSpouse ? null : userData?.user.avatar,
+          staffAccountId: userData?.user.staffAccountId,
+        }}
+        toggle={
+          hcmSpouse
+            ? {
+                name: toggleName,
+                onClick: () => setViewingSpouse((prev) => !prev),
+              }
+            : undefined
+        }
+      >
+        <Stack spacing={2}>
+          {fields.map((field) => (
+            <TextField
+              key={field.label}
+              label={field.label}
+              value={field.value}
+              // readOnly instead of disabled purely for accessibility
+              InputProps={{ readOnly: true }}
+              size="small"
+            />
+          ))}
+        </Stack>
+      </StaffInfoCard>
+    </Stack>
+  );
+};

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NsoMpdQuestionnaireContext.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NsoMpdQuestionnaireContext.tsx
@@ -1,6 +1,9 @@
 import React, { createContext, useCallback, useMemo, useState } from 'react';
+import { HcmQuery, useHcmQuery } from '../../Shared/HcmData/Hcm.generated';
 import { NsoMpdQuestionnaireStepEnum } from '../NsoMpdQuestionnaireHelper';
 import { NsoMpdQuestionnaireStep, useSteps } from './useSteps';
+
+export type HcmPerson = HcmQuery['hcm'][number];
 
 export type NsoMpdQuestionnaireType = {
   steps: NsoMpdQuestionnaireStep[];
@@ -12,6 +15,8 @@ export type NsoMpdQuestionnaireType = {
   handleContinue: () => void;
   toggleDrawer: () => void;
   setDrawerOpen: (open: boolean) => void;
+  hcmUser: HcmPerson | null;
+  hcmSpouse: HcmPerson | null;
 };
 
 const NsoMpdQuestionnaireContext =
@@ -38,6 +43,10 @@ export const NsoMpdQuestionnaireProvider: React.FC<Props> = ({ children }) => {
 
   const currentStep = steps[currentIndex];
   const isLastStep = currentIndex === steps.length - 1;
+
+  const { data: hcmData } = useHcmQuery();
+  const hcmUser = hcmData?.hcm[0] ?? null;
+  const hcmSpouse = hcmData?.hcm[1] ?? null;
 
   const toggleDrawer = useCallback(() => {
     setIsDrawerOpen((prev) => !prev);
@@ -74,6 +83,8 @@ export const NsoMpdQuestionnaireProvider: React.FC<Props> = ({ children }) => {
       handleContinue,
       toggleDrawer,
       setDrawerOpen,
+      hcmUser,
+      hcmSpouse,
     }),
     [
       steps,
@@ -85,6 +96,8 @@ export const NsoMpdQuestionnaireProvider: React.FC<Props> = ({ children }) => {
       handleContinue,
       toggleDrawer,
       setDrawerOpen,
+      hcmUser,
+      hcmSpouse,
     ],
   );
 

--- a/src/components/HrTools/Shared/Helpers/getLocalizedAssignmentStatus.test.ts
+++ b/src/components/HrTools/Shared/Helpers/getLocalizedAssignmentStatus.test.ts
@@ -1,0 +1,56 @@
+import { AssignmentStatusEnum } from 'src/graphql/types.generated';
+import { getLocalizedAssignmentStatus } from './getLocalizedAssignmentStatus';
+
+const t = (key: string) => key;
+
+describe('getLocalizedAssignmentStatus', () => {
+  it.each([
+    [AssignmentStatusEnum.ActiveFmlaLeave, 'Active - FMLA Leave'],
+    [AssignmentStatusEnum.ActiveNoPayroll, 'Active - No Payroll'],
+    [AssignmentStatusEnum.ActivePaidLeave, 'Active - Paid Leave'],
+    [AssignmentStatusEnum.ActivePayrollEligible, 'Active - Payroll Eligible'],
+    [AssignmentStatusEnum.ActiveUnpaidLeave, 'Active - Unpaid Leave'],
+    [
+      AssignmentStatusEnum.DisabilityPayrollEligible,
+      'Disability - Payroll Eligible',
+    ],
+    [AssignmentStatusEnum.InactiveNoPayroll, 'Inactive - No Payroll'],
+    [
+      AssignmentStatusEnum.InactivePayrollEligible,
+      'Inactive - Payroll Eligible',
+    ],
+    [
+      AssignmentStatusEnum.InactiveProcessWhenEarnings,
+      'Inactive - Process when Earnings',
+    ],
+    [AssignmentStatusEnum.PendingNoPayroll, 'Pending - No Payroll'],
+    [
+      AssignmentStatusEnum.RaisingInitialSupportNoPayroll,
+      'Raising Initial Support - No Payroll',
+    ],
+    [
+      AssignmentStatusEnum.RaisingInitialSupportPayrollEligible,
+      'Raising Initial Support - Payroll Eligible',
+    ],
+  ])('maps %s to "%s"', (status, expected) => {
+    expect(getLocalizedAssignmentStatus(t, status)).toBe(expected);
+  });
+
+  it('returns an empty string for an undefined or null status', () => {
+    expect(getLocalizedAssignmentStatus(t, undefined)).toBe(
+      'Unknown Assignment Status',
+    );
+    expect(getLocalizedAssignmentStatus(t, null)).toBe(
+      'Unknown Assignment Status',
+    );
+  });
+
+  it('returns an empty string for an unrecognized status', () => {
+    expect(
+      getLocalizedAssignmentStatus(
+        t,
+        'some unrecognized status' as AssignmentStatusEnum,
+      ),
+    ).toBe('Unknown Assignment Status');
+  });
+});

--- a/src/components/HrTools/Shared/Helpers/getLocalizedAssignmentStatus.ts
+++ b/src/components/HrTools/Shared/Helpers/getLocalizedAssignmentStatus.ts
@@ -1,0 +1,39 @@
+import { TFunction } from 'react-i18next';
+import { AssignmentStatusEnum } from 'src/graphql/types.generated';
+
+/**
+ * Maps an HCM assignment status to a localized, human-readable label
+ */
+export const getLocalizedAssignmentStatus = (
+  t: TFunction,
+  assignmentStatus: AssignmentStatusEnum | null | undefined,
+): string => {
+  switch (assignmentStatus) {
+    case AssignmentStatusEnum.ActiveFmlaLeave:
+      return t('Active - FMLA Leave');
+    case AssignmentStatusEnum.ActiveNoPayroll:
+      return t('Active - No Payroll');
+    case AssignmentStatusEnum.ActivePaidLeave:
+      return t('Active - Paid Leave');
+    case AssignmentStatusEnum.ActivePayrollEligible:
+      return t('Active - Payroll Eligible');
+    case AssignmentStatusEnum.ActiveUnpaidLeave:
+      return t('Active - Unpaid Leave');
+    case AssignmentStatusEnum.DisabilityPayrollEligible:
+      return t('Disability - Payroll Eligible');
+    case AssignmentStatusEnum.InactiveNoPayroll:
+      return t('Inactive - No Payroll');
+    case AssignmentStatusEnum.InactivePayrollEligible:
+      return t('Inactive - Payroll Eligible');
+    case AssignmentStatusEnum.InactiveProcessWhenEarnings:
+      return t('Inactive - Process when Earnings');
+    case AssignmentStatusEnum.PendingNoPayroll:
+      return t('Pending - No Payroll');
+    case AssignmentStatusEnum.RaisingInitialSupportNoPayroll:
+      return t('Raising Initial Support - No Payroll');
+    case AssignmentStatusEnum.RaisingInitialSupportPayrollEligible:
+      return t('Raising Initial Support - Payroll Eligible');
+    default:
+      return t('Unknown Assignment Status');
+  }
+};

--- a/src/components/HrTools/Shared/StaffInfoCard/StaffInfoCard.test.tsx
+++ b/src/components/HrTools/Shared/StaffInfoCard/StaffInfoCard.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StaffInfoCard } from './StaffInfoCard';
+
+interface RenderOptions {
+  hasSpouse?: boolean;
+  onClick?: () => void;
+  staffAccountId?: string | null;
+}
+
+const renderCard = ({
+  hasSpouse = true,
+  onClick = jest.fn(),
+  staffAccountId,
+}: RenderOptions = {}) =>
+  render(
+    <StaffInfoCard
+      person={{ name: 'John Doe', avatarSrc: 'avatar.jpg', staffAccountId }}
+      toggle={hasSpouse ? { name: 'Jane', onClick } : undefined}
+    >
+      <div>Card body</div>
+    </StaffInfoCard>,
+  );
+
+describe('StaffInfoCard', () => {
+  it('renders the name, avatar, and body children', () => {
+    const { getByRole, getByText } = renderCard();
+
+    expect(getByRole('heading', { name: 'John Doe' })).toBeInTheDocument();
+    expect(getByRole('img', { name: 'John Doe' })).toHaveAttribute(
+      'src',
+      'avatar.jpg',
+    );
+    expect(getByText('Card body')).toBeInTheDocument();
+  });
+
+  it('shows the toggle button and fires onClick when a spouse is provided', () => {
+    const onClick = jest.fn();
+    const { getByRole } = renderCard({ onClick });
+
+    userEvent.click(getByRole('button', { name: 'View Jane' }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the toggle button when no spouse is provided', () => {
+    const { queryByRole } = renderCard({ hasSpouse: false });
+
+    expect(
+      queryByRole('button', { name: 'View Jane' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the staff account number when provided', () => {
+    const { getByText } = renderCard({ staffAccountId: '000123456' });
+
+    expect(getByText('Staff Account Number: 000123456')).toBeInTheDocument();
+  });
+
+  it('omits the staff account number when not provided', () => {
+    const { queryByText } = renderCard();
+
+    expect(queryByText(/Staff Account Number/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/HrTools/Shared/StaffInfoCard/StaffInfoCard.tsx
+++ b/src/components/HrTools/Shared/StaffInfoCard/StaffInfoCard.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import RightArrowIcon from '@mui/icons-material/ArrowForward';
+import { Avatar, Button, Card, Stack, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { useTranslation } from 'react-i18next';
+
+interface StaffInfoCardProps {
+  /** The person currently displayed in the card header. */
+  person: {
+    name: string;
+    avatarSrc?: string | null;
+    /** Optional staff account number shown beneath the name. */
+    staffAccountId?: string | null;
+  };
+  /** The other person to switch to */
+  toggle?: { name: string; onClick: () => void };
+  /** Card body rendered below the header. */
+  children?: React.ReactNode;
+}
+
+/**
+ * A card with a staff member's avatar/name and an optional spouse toggle header, plus a body slot
+ * for the details of the selected person.
+ */
+export const StaffInfoCard: React.FC<StaffInfoCardProps> = ({
+  person,
+  toggle,
+  children,
+}) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+
+  return (
+    <Card sx={{ p: 3 }}>
+      <Stack spacing={3}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          <Stack direction="row" alignItems="center" spacing={1}>
+            <Avatar
+              src={person.avatarSrc ?? undefined}
+              alt={person.name}
+              variant="rounded"
+              sx={{
+                width: theme.spacing(5),
+                height: theme.spacing(5),
+              }}
+            />
+            <Stack>
+              <Typography variant="h6" lineHeight={1.2}>
+                {person.name}
+              </Typography>
+              {person.staffAccountId && (
+                <Typography color="text.secondary" lineHeight={1.2}>
+                  {t('Staff Account Number: {{number}}', {
+                    number: person.staffAccountId,
+                  })}
+                </Typography>
+              )}
+            </Stack>
+          </Stack>
+          {toggle && (
+            <Button endIcon={<RightArrowIcon />} onClick={toggle.onClick}>
+              {t('View {{name}}', { name: toggle.name })}
+            </Button>
+          )}
+        </Stack>
+        {children}
+      </Stack>
+    </Card>
+  );
+};


### PR DESCRIPTION
## Description

- This adds the necessary Staff Information portion of the first step of the questionnaire.
- This Staff Information card exists in the GoalCalculator, and although not used > 3 times, I found it to be a good reuse candidate. The unique fields for both are passed as children.

Also fixes a bug in the Staff Information card for the SECA exemption field:
```
installHook.js:1 MUI: A component is changing the uncontrolled value state of Select to be controlled.
Elements should not switch from uncontrolled to controlled (or vice versa).
Decide between using a controlled or uncontrolled Select element for the lifetime of the component.
The nature of the state is determined during the first render. It's considered controlled if the value is not `undefined`.
```

https://jira.cru.org/browse/MPDX-9742

---

### Needed follow up PR:
- Include Financial Information for Senior Staff

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to nsoMpdQuestionnaire (NSO MPD Questionnaire in HR Tool)
- Check that the StaffInfo card works as expected, switching between the user and the spouse
- Check that the StaffInfo card has the same behavior as it did before this PR.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
