### PR TITLE
MPDX-9763 - NSO Questionnaire: Improve text field designs (while still honoring Figma design)

### DIFF
--- a/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryDetails.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryDetails.test.tsx
@@ -30,9 +30,7 @@ const TestComponent: React.FC = () => (
 
 describe('MinistryDetails', () => {
   it('renders the four questions', async () => {
-    const { getByRole, getByPlaceholderText, findByRole } = render(
-      <TestComponent />,
-    );
+    const { getByRole, findByRole } = render(<TestComponent />);
 
     expect(
       getByRole('combobox', {
@@ -40,9 +38,9 @@ describe('MinistryDetails', () => {
       }),
     ).toBeInTheDocument();
     expect(
-      getByPlaceholderText(
-        'What is your expected ministry assignment location?',
-      ),
+      getByRole('textbox', {
+        name: 'What is your expected ministry assignment location?',
+      }),
     ).toBeInTheDocument();
     expect(
       await findByRole('combobox', {

--- a/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryDetails.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryDetails.tsx
@@ -101,7 +101,7 @@ export const MinistryDetails: React.FC = () => {
       </TextField>
 
       <TextField
-        placeholder={t('What is your expected ministry assignment location?')}
+        label={t('What is your expected ministry assignment location?')}
         size="small"
         InputLabelProps={{ shrink: true }}
         {...locationProps}

--- a/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryInformation.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryInformation.test.tsx
@@ -12,9 +12,7 @@ const TestComponent: React.FC = () => (
 
 describe('MinistryInformation', () => {
   it('keeps Continue disabled until all four fields are answered', async () => {
-    const { getByRole, getByPlaceholderText, findByRole } = render(
-      <TestComponent />,
-    );
+    const { getByRole, findByRole } = render(<TestComponent />);
 
     const continueButton = getByRole('button', { name: 'Continue' });
     expect(continueButton).toBeDisabled();
@@ -27,9 +25,9 @@ describe('MinistryInformation', () => {
     userEvent.click(getByRole('option', { name: 'Cru' }));
 
     userEvent.type(
-      getByPlaceholderText(
-        'What is your expected ministry assignment location?',
-      ),
+      getByRole('textbox', {
+        name: 'What is your expected ministry assignment location?',
+      }),
       'Orlando, FL',
     );
 

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NumberQuestion.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NumberQuestion.test.tsx
@@ -51,20 +51,6 @@ describe('NumberQuestion', () => {
     expect(queryByText('Enter 0 if none.')).not.toBeInTheDocument();
   });
 
-  it('links the input to its helper text via aria-describedby', () => {
-    const { getByRole, getByText } = render(<TestComponent />);
-
-    const describedBy = getByRole('spinbutton', {
-      name: 'How many?',
-    }).getAttribute('aria-describedby');
-
-    expect(describedBy).toBeTruthy();
-    expect(getByText('Please enter a number.')).toHaveAttribute(
-      'id',
-      describedBy,
-    );
-  });
-
   it('restores the helper text once a valid value is entered', () => {
     const { getByRole, getByText, queryByText } = render(<TestComponent />);
 

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NumberQuestion.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NumberQuestion.tsx
@@ -1,5 +1,5 @@
-import React, { useId } from 'react';
-import { FormControl, FormHelperText, OutlinedInput } from '@mui/material';
+import React from 'react';
+import { TextField } from '@mui/material';
 import * as yup from 'yup';
 import { useQuestionnaireAutoSave } from './useQuestionnaireAutoSave';
 
@@ -28,27 +28,17 @@ export const NumberQuestion: React.FC<NumberQuestionProps> = ({
     helperText: errorText,
     ...fieldProps
   } = useQuestionnaireAutoSave({ fieldName, schema });
-  const helperTextId = useId();
 
   return (
-    <FormControl error={error}>
-      <OutlinedInput
-        size="small"
-        type="number"
-        inputProps={{
-          min: 0,
-          inputMode: 'numeric',
-          'aria-label': question,
-          'aria-describedby': helperTextId,
-        }}
-        startAdornment={startAdornment}
-        placeholder={question}
-        sx={{ 'input::placeholder': { opacity: 0.8 } }}
-        {...fieldProps}
-      />
-      <FormHelperText id={helperTextId}>
-        {error ? errorText : helperText}
-      </FormHelperText>
-    </FormControl>
+    <TextField
+      label={question}
+      helperText={error ? errorText : helperText}
+      error={error}
+      size="small"
+      type="number"
+      inputProps={{ min: 0, inputMode: 'numeric' }}
+      InputProps={{ startAdornment }}
+      {...fieldProps}
+    />
   );
 };


### PR DESCRIPTION
## Description

- With the current Figma design, all of the questions exist inside of the fields.
    - This is a great design, but there are some complications around the start adornments overlapping with the labels (we can add custom logic surrounding that to fix this, I'm just on the fence about doing this)
- I am wondering if we would prefer to have Typography labels _above_ the text fields instead. I think this would diminish the cool design but honestly make the form more readable.

Future considerations:
- We may also want to include the dollar sign start adornment for some of these.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to NSO Questionnaire
- Check the steps and observe the appearance of the form fields.
- Feel free to give an opinion.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
