### PR TITLE
MPDX-9766 - Enforce error deferment until fields are touched in useAutosave

### DIFF
--- a/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/Autosave/AutosaveTextField.test.tsx
+++ b/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/Autosave/AutosaveTextField.test.tsx
@@ -124,9 +124,9 @@ describe('AutosaveTextField', () => {
 
     userEvent.clear(input);
     userEvent.type(input, '-100');
-    expect(input).toHaveAccessibleDescription('MHA Amount must be positive');
+    userEvent.tab();
 
-    input.blur();
+    expect(input).toHaveAccessibleDescription('MHA Amount must be positive');
 
     await Promise.resolve();
     await waitFor(() =>
@@ -153,6 +153,8 @@ describe('AutosaveTextField', () => {
 
     userEvent.clear(input);
     userEvent.type(input, 'abc');
+    userEvent.tab();
+
     expect(input).toHaveAccessibleDescription('MHA Amount must be a number');
   });
 

--- a/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategory.test.tsx
+++ b/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategory.test.tsx
@@ -290,8 +290,10 @@ describe('InformationCategory', () => {
       userEvent.type(input, '-1000');
       input.blur();
 
-      expect(input).toHaveAccessibleDescription(
-        'MHA Amount Per Paycheck must be positive',
+      await waitFor(() =>
+        expect(input).toHaveAccessibleDescription(
+          'MHA Amount Per Paycheck must be positive',
+        ),
       );
 
       await waitFor(() =>

--- a/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/FinancialDetails.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/FinancialDetails.test.tsx
@@ -67,10 +67,15 @@ describe('FinancialDetails', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows a required error on each empty payment field', () => {
+  it('shows a required error on each payment field once it is touched', () => {
     const { getByRole, getAllByText } = render(<TestComponent />);
 
     userEvent.click(getByRole('radio', { name: 'Yes' }));
+
+    [studentLoanQuestion, carQuestion, creditCardQuestion].forEach((name) => {
+      getByRole('spinbutton', { name }).focus();
+      userEvent.tab();
+    });
 
     expect(getAllByText(requiredError)).toHaveLength(3);
   });

--- a/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryDetails.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryDetails.test.tsx
@@ -54,6 +54,16 @@ describe('MinistryDetails', () => {
     ).toBeInTheDocument();
   });
 
+  it('marks the location field as required', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(
+      getByRole('textbox', {
+        name: 'What is your expected ministry assignment location?',
+      }),
+    ).toBeRequired();
+  });
+
   it('offers the dummy ministry options', () => {
     const { getByRole } = render(<TestComponent />);
 

--- a/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryDetails.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryDetails.tsx
@@ -75,6 +75,7 @@ export const MinistryDetails: React.FC = () => {
     <Stack spacing={4}>
       <TextField
         select
+        required
         label={t('What ministry are you expecting to serve with?')}
         size="small"
         SelectProps={{ displayEmpty: true }}
@@ -101,9 +102,9 @@ export const MinistryDetails: React.FC = () => {
       </TextField>
 
       <TextField
+        required
         label={t('What is your expected ministry assignment location?')}
         size="small"
-        InputLabelProps={{ shrink: true }}
         {...locationProps}
       />
 
@@ -112,6 +113,7 @@ export const MinistryDetails: React.FC = () => {
       ) : (
         <TextField
           select
+          required
           label={t(
             'Is your ministry assignment location within 50 miles of one of these cities?',
           )}

--- a/src/components/HrTools/NsoMpdQuestionnaire/NsoInformation/NsoDetails.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/NsoInformation/NsoDetails.test.tsx
@@ -64,14 +64,16 @@ describe('NsoDetails', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows required errors on the empty numeric fields', () => {
-    const { getByText } = render(<TestComponent />);
+  it('shows the required error on a numeric field once it is touched', () => {
+    const { getByRole, getByText } = render(<TestComponent />);
+
+    getByRole('spinbutton', {
+      name: 'How much special needs support have you already received for NSO?',
+    }).focus();
+    userEvent.tab();
 
     expect(
       getByText('Please enter an amount, or 0 if you have none.'),
-    ).toBeInTheDocument();
-    expect(
-      getByText('Please enter a number, or 0 if you have none.'),
     ).toBeInTheDocument();
   });
 

--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/ContactInformation.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/ContactInformation.test.tsx
@@ -20,6 +20,12 @@ describe('ContactInformation', () => {
     ).toBeInTheDocument();
   });
 
+  it('marks the cell phone number field as required', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(getByRole('textbox', { name: 'Cell Phone Number' })).toBeRequired();
+  });
+
   it('strips disallowed characters as the user types', () => {
     const { getByRole } = render(<TestComponent />);
 

--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/ContactInformation.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/ContactInformation.tsx
@@ -29,6 +29,7 @@ export const ContactInformation: React.FC = () => {
       <Typography variant="h6">{t('Contact Information')}</Typography>
       <Typography>{t('Please provide your cell phone number.')}</Typography>
       <TextField
+        required
         label={t('Cell Phone Number')}
         placeholder={placeholder}
         size="small"

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NumberQuestion.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NumberQuestion.test.tsx
@@ -34,21 +34,54 @@ describe('NumberQuestion', () => {
     expect(getByRole('spinbutton', { name: 'How many?' })).toBeInTheDocument();
   });
 
-  it('replaces the helper text with the validation error while empty', () => {
+  it('marks the field as required', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(getByRole('spinbutton', { name: 'How many?' })).toBeRequired();
+  });
+
+  it('shows the helper text until the field is touched', () => {
     const { getByText, queryByText } = render(<TestComponent />);
+
+    expect(getByText('Enter 0 if none.')).toBeInTheDocument();
+    expect(queryByText('Please enter a number.')).not.toBeInTheDocument();
+  });
+
+  it('replaces the helper text with the validation error once touched while empty', () => {
+    const { getByRole, getByText, queryByText } = render(<TestComponent />);
+
+    getByRole('spinbutton', { name: 'How many?' }).focus();
+    userEvent.tab();
 
     expect(getByText('Please enter a number.')).toBeInTheDocument();
     expect(queryByText('Enter 0 if none.')).not.toBeInTheDocument();
   });
 
-  it('shows the validation error for an invalid, non-empty value', () => {
+  it('shows the validation error for an invalid, non-empty value once touched', () => {
     const { getByRole, getByText, queryByText } = render(<TestComponent />);
 
     userEvent.type(getByRole('spinbutton', { name: 'How many?' }), '-5');
+    userEvent.tab();
 
     expect(getByText('Please enter a whole number.')).toBeInTheDocument();
     expect(queryByText('Please enter a number.')).not.toBeInTheDocument();
     expect(queryByText('Enter 0 if none.')).not.toBeInTheDocument();
+  });
+
+  it('links the input to its helper text via aria-describedby', () => {
+    const { getByRole, getByText } = render(<TestComponent />);
+
+    const input = getByRole('spinbutton', { name: 'How many?' });
+    input.focus();
+    userEvent.tab();
+
+    const describedBy = input.getAttribute('aria-describedby');
+
+    expect(describedBy).toBeTruthy();
+    expect(getByText('Please enter a number.')).toHaveAttribute(
+      'id',
+      describedBy,
+    );
   });
 
   it('restores the helper text once a valid value is entered', () => {

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NumberQuestion.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NumberQuestion.tsx
@@ -34,6 +34,7 @@ export const NumberQuestion: React.FC<NumberQuestionProps> = ({
       label={question}
       helperText={error ? errorText : helperText}
       error={error}
+      required
       size="small"
       type="number"
       inputProps={{ min: 0, inputMode: 'numeric' }}

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/RadioQuestion.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/RadioQuestion.test.tsx
@@ -35,8 +35,20 @@ describe('RadioQuestion', () => {
     expect(getByRole('radio', { name: 'Option B' })).toBeInTheDocument();
   });
 
-  it('shows the required error while no option is selected', () => {
-    const { getByText } = render(<TestComponent />);
+  it('marks the radio group as required', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(getByRole('radiogroup', { name: 'Pick one' })).toHaveAttribute(
+      'aria-required',
+      'true',
+    );
+  });
+
+  it('shows the required error once the group is touched without a selection', () => {
+    const { getByRole, getByText } = render(<TestComponent />);
+
+    getByRole('radio', { name: 'Option A' }).focus();
+    userEvent.tab();
 
     expect(getByText('Please select an answer.')).toBeInTheDocument();
   });
@@ -51,6 +63,9 @@ describe('RadioQuestion', () => {
 
   it('links the error to the radio group via aria-describedby', () => {
     const { getByRole, getByText } = render(<TestComponent />);
+
+    getByRole('radio', { name: 'Option A' }).focus();
+    userEvent.tab();
 
     const describedBy = getByRole('radiogroup', {
       name: 'Pick one',

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/RadioQuestion.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/RadioQuestion.tsx
@@ -44,7 +44,7 @@ export const RadioQuestion: React.FC<RadioQuestionProps> = ({
   });
 
   return (
-    <FormControl error={error}>
+    <FormControl error={error} required>
       <FormLabel id={labelId} sx={{ color: 'text.primary' }}>
         {label}
       </FormLabel>
@@ -53,6 +53,7 @@ export const RadioQuestion: React.FC<RadioQuestionProps> = ({
         sx={{ paddingInline: 2 }}
         aria-labelledby={labelId}
         aria-describedby={helperText ? helperTextId : undefined}
+        aria-required
         {...fieldProps}
       >
         {options.map((option) => (

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/useQuestionnaireAutoSave.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/useQuestionnaireAutoSave.test.tsx
@@ -32,10 +32,11 @@ describe('useQuestionnaireAutoSave', () => {
     expect(input).toHaveValue('1234567890');
   });
 
-  it('surfaces the schema validation error for an invalid value', () => {
+  it('surfaces the schema validation error for an invalid value once touched', () => {
     const { getByRole, getByText } = render(<TestComponent />);
 
     userEvent.type(getByRole('textbox', { name: 'Field' }), '123');
+    userEvent.tab();
 
     expect(getByText('Too short')).toBeInTheDocument();
   });

--- a/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Setup/SetupStep.test.tsx
@@ -84,16 +84,19 @@ describe('SetupStep', () => {
     await waitFor(() => expect(goalNameInput).toHaveValue('Test Goal'));
 
     userEvent.clear(goalNameInput);
+    userEvent.tab();
 
     const payRateInput = await findByRole('spinbutton', {
       name: 'Hourly Pay Rate',
     });
     userEvent.clear(payRateInput);
+    userEvent.tab();
 
     const hoursInput = await findByRole('spinbutton', {
       name: 'Hours Worked',
     });
     userEvent.clear(hoursInput);
+    userEvent.tab();
 
     expect(
       await findByText('Goal Name is a required field'),

--- a/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/AutosaveTextField.test.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/Shared/Autosave/AutosaveTextField.test.tsx
@@ -114,6 +114,7 @@ describe('AutosaveTextField', () => {
 
     userEvent.clear(input);
     userEvent.type(input, '-100');
+    userEvent.tab();
 
     expect(input).toHaveAccessibleDescription(
       'Pay Rate must be a positive number',
@@ -234,6 +235,7 @@ describe('AutosaveTextField', () => {
 
     userEvent.clear(input);
     userEvent.type(input, '-100');
+    userEvent.tab();
 
     expect(input).toHaveAccessibleDescription(
       'Pay Rate must be a positive number',
@@ -259,11 +261,17 @@ describe('AutosaveTextField', () => {
         </PdsGoalCalculatorTestWrapper>,
       );
 
-    it('shows validation error for an empty required field on load', async () => {
+    it('defers the validation error for an empty required field until touched', async () => {
       const { findByRole } = renderRequired();
 
       const input = await findByRole('textbox', { name: 'Goal Name' });
-      await waitFor(() => expect(input).toHaveValue(''));
+      await waitFor(() => expect(input).toBeEnabled());
+
+      expect(input).toHaveAccessibleDescription('Enter the goal name');
+      expect(input).not.toHaveAttribute('aria-invalid', 'true');
+
+      input.focus();
+      userEvent.tab();
 
       await waitFor(() =>
         expect(input).toHaveAccessibleDescription('Goal Name is required'),
@@ -275,6 +283,10 @@ describe('AutosaveTextField', () => {
       const { findByRole } = renderRequired();
 
       const input = await findByRole('textbox', { name: 'Goal Name' });
+      await waitFor(() => expect(input).toBeEnabled());
+
+      input.focus();
+      userEvent.tab();
       await waitFor(() =>
         expect(input).toHaveAttribute('aria-invalid', 'true'),
       );

--- a/src/components/HrTools/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/YourInformation/MaxAllowableSection/MaxAllowableSection.test.tsx
@@ -122,7 +122,7 @@ describe('MaxAllowableSection', () => {
     });
 
     it('warns when cap exceeds hard cap', async () => {
-      const { findByRole, getByText, getByRole } = render(<TestComponent />);
+      const { findByRole, findByText, getByRole } = render(<TestComponent />);
 
       userEvent.click(
         await findByRole('checkbox', { name: /Check if you prefer to split/ }),
@@ -136,7 +136,9 @@ describe('MaxAllowableSection', () => {
       input.blur();
 
       expect(
-        getByText('Maximum Allowable Salary must not exceed cap of $80,000'),
+        await findByText(
+          'Maximum Allowable Salary must not exceed cap of $80,000',
+        ),
       ).toBeInTheDocument();
     });
 
@@ -166,8 +168,8 @@ describe('MaxAllowableSection', () => {
       );
     });
 
-    it('shows required errors when split cap fields are empty', async () => {
-      const { findByText } = render(
+    it('shows required errors when split cap fields are empty and touched', async () => {
+      const { findByRole, findByText, getByRole } = render(
         <TestComponent
           salaryRequestMock={{
             manuallySplitCap: true,
@@ -176,6 +178,19 @@ describe('MaxAllowableSection', () => {
           }}
         />,
       );
+
+      const input = await findByRole('textbox', {
+        name: 'John Maximum Allowable Salary',
+      });
+      await waitFor(() => expect(input).toBeEnabled());
+      const spouseInput = getByRole('textbox', {
+        name: 'Jane Maximum Allowable Salary',
+      });
+
+      input.focus();
+      userEvent.tab();
+      spouseInput.focus();
+      userEvent.tab();
 
       expect(
         await findByText('Maximum Allowable Salary is required'),

--- a/src/components/Shared/Autosave/useAutosave.test.tsx
+++ b/src/components/Shared/Autosave/useAutosave.test.tsx
@@ -55,6 +55,37 @@ const SelectTestComponent: React.FC = () => {
   );
 };
 
+const SaveOnChangeTextComponent: React.FC = () => {
+  const schema = yup.object({
+    field: amount('Field', i18n.t, { required: true }),
+  });
+
+  const props = useAutoSave({
+    value: 100,
+    saveValue,
+    fieldName: 'field',
+    schema,
+    saveOnChange: true,
+  });
+
+  return <TextField label="Field" {...props} />;
+};
+
+const TouchedTestComponent: React.FC = () => {
+  const schema = yup.object({
+    field: amount('Field', i18n.t, { required: true }),
+  });
+
+  const props = useAutoSave({
+    value: null,
+    saveValue,
+    fieldName: 'field',
+    schema,
+  });
+
+  return <TextField label="Field" {...props} />;
+};
+
 const TransformTestComponent: React.FC = () => {
   const schema = yup.object({
     field: yup.string().transform((val) => val.replace(/\D/g, '')),
@@ -111,16 +142,15 @@ describe('AutosaveTextField', () => {
     expect(saveValue).not.toHaveBeenCalled();
   });
 
-  it('shows validation error', () => {
+  it('shows validation error after blur', () => {
     const { getByRole } = render(<TestComponent />);
 
     const input = getByRole('textbox', { name: 'Field' });
     userEvent.clear(input);
     userEvent.type(input, '-100');
+    userEvent.tab();
+
     expect(input).toHaveAccessibleDescription('Field must be positive');
-
-    input.blur();
-
     expect(saveValue).not.toHaveBeenCalled();
   });
 
@@ -132,12 +162,14 @@ describe('AutosaveTextField', () => {
     expect(input).toHaveAccessibleDescription('');
   });
 
-  it('shows validation error for invalid type', () => {
+  it('shows validation error for invalid type after blur', () => {
     const { getByRole } = render(<TestComponent />);
 
     const input = getByRole('textbox', { name: 'Field' });
     userEvent.clear(input);
     userEvent.type(input, 'abc');
+    userEvent.tab();
+
     expect(input).toHaveAccessibleDescription('Field must be a number');
   });
 
@@ -148,6 +180,42 @@ describe('AutosaveTextField', () => {
     userEvent.type(input, 'a1b2c3');
 
     expect(input).toHaveValue('123');
+  });
+
+  describe('error visibility', () => {
+    it('hides the validation error until the field is blurred', () => {
+      const { getByRole } = render(<TouchedTestComponent />);
+
+      const input = getByRole('textbox', { name: 'Field' });
+      expect(input).toHaveAccessibleDescription('');
+
+      input.focus();
+      userEvent.tab();
+
+      expect(input).toHaveAccessibleDescription('Field is required');
+    });
+
+    it('does not show the validation error while the user types', () => {
+      const { getByRole } = render(<TouchedTestComponent />);
+
+      const input = getByRole('textbox', { name: 'Field' });
+      userEvent.type(input, '-100');
+      expect(input).toHaveAccessibleDescription('');
+
+      userEvent.tab();
+
+      expect(input).toHaveAccessibleDescription('Field must be positive');
+    });
+
+    it('shows the validation error while typing when saveOnChange is true', () => {
+      const { getByRole } = render(<SaveOnChangeTextComponent />);
+
+      const input = getByRole('textbox', { name: 'Field' });
+      userEvent.clear(input);
+      userEvent.type(input, '-100');
+
+      expect(input).toHaveAccessibleDescription('Field must be positive');
+    });
   });
 
   describe('select input', () => {

--- a/src/components/Shared/Autosave/useAutosave.ts
+++ b/src/components/Shared/Autosave/useAutosave.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { TextFieldProps } from '@mui/material';
 import { prepareDataForValidation } from 'formik';
 import * as yup from 'yup';
@@ -25,6 +25,7 @@ export const useAutoSave = <Value extends string | number>({
   const [internalValue, setInternalValue] = useSyncedState(
     value?.toString() ?? '',
   );
+  const [touched, setTouched] = useState(false);
   const { markValid, markInvalid } = useOptionalAutosaveForm() ?? {};
 
   const parseValue = useCallback(
@@ -80,6 +81,8 @@ export const useAutoSave = <Value extends string | number>({
     };
   }, [fieldName, errorMessage, markValid, markInvalid]);
 
+  const showError = !disabled && errorMessage !== null && touched;
+
   return {
     value: internalValue,
     onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -87,6 +90,7 @@ export const useAutoSave = <Value extends string | number>({
       setInternalValue(newValue);
 
       if (saveOnChange) {
+        setTouched(true);
         const { parsedValue, errorMessage } = parseValue(newValue);
         if (errorMessage === null && parsedValue !== value) {
           saveValue(parsedValue);
@@ -94,13 +98,12 @@ export const useAutoSave = <Value extends string | number>({
       }
     },
     onBlur: () => {
+      setTouched(true);
       if (!saveOnChange && errorMessage === null && parsedValue !== value) {
         saveValue(parsedValue);
       }
     },
     disabled,
-    ...(!disabled && errorMessage !== null
-      ? { error: true, helperText: errorMessage }
-      : {}),
+    ...(showError ? { error: true, helperText: errorMessage } : {}),
   } satisfies Partial<TextFieldProps>;
 };


### PR DESCRIPTION
## Description

- This improves UX when going through the NSO form and other forms, making it so users are not bombarded with errors upon rendering each step's view. The default functionality in useAutosave remains the same.
https://jira.cru.org/browse/MPDX-9766

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to NSO Questionnaire, and test that the behavior works as expected.
    - Continue button should remain disabled, but the fields are still required.
 
Considerations:
- We may still want a way to make it apparent to users that all fields in a step are required, since we no longer have the clear indication of immediate errors.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
