### PR TITLE
MPDX-9768 - Remove required asterisk from MHA amount fields in MhaRequestSection

### DIFF
--- a/src/components/HrTools/SalaryCalculator/YourInformation/MhaRequestSection/MhaRequestSection.tsx
+++ b/src/components/HrTools/SalaryCalculator/YourInformation/MhaRequestSection/MhaRequestSection.tsx
@@ -228,7 +228,6 @@ export const MhaRequestSection: React.FC = () => {
                     label={t('New Requested {{kind}}', { kind: userKind })}
                     fieldName="mhaAmount"
                     schema={schema}
-                    required
                   />
                 )}
                 {showSpouseFields && (
@@ -236,7 +235,6 @@ export const MhaRequestSection: React.FC = () => {
                     label={t('New Requested {{kind}}', { kind: spouseKind })}
                     fieldName="spouseMhaAmount"
                     schema={schema}
-                    required
                   />
                 )}
               </SpouseLayout>


### PR DESCRIPTION
## Description

These two fields do not require input from the user. This PR removes the `required` prop.
https://jira.cru.org/browse/MPDX-9768

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to Salary Calculator
- Check that the MHA Request section no longer has asterisks for the user entered MHA amounts
- Check that Salary Calculator submission still succeeds.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
