### PR TITLE
MPDX-9675 Add basic next steps page

### DIFF
--- a/src/components/HrTools/NsGoalCalculator/NextSteps/NextStepsStep.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/NextSteps/NextStepsStep.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { NsGoalCalculatorTestWrapper } from '../NsGoalCalculatorTestWrapper';
+import { NextStepsStep } from './NextStepsStep';
+
+const TestComponent: React.FC = () => (
+  <NsGoalCalculatorTestWrapper>
+    <NextStepsStep />
+  </NsGoalCalculatorTestWrapper>
+);
+
+describe('NextStepsStep', () => {
+  it('renders the step title', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(getByRole('heading', { name: 'Next Steps' })).toBeInTheDocument();
+  });
+
+  it('renders the completion text', () => {
+    const { getByText } = render(<TestComponent />);
+
+    expect(
+      getByText('Great job completing the MPD Goal Calculation process!'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/NextSteps/NextStepsStep.tsx
+++ b/src/components/HrTools/NsGoalCalculator/NextSteps/NextStepsStep.tsx
@@ -1,5 +1,6 @@
+import React from 'react';
 import { Box, Typography } from '@mui/material';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { NsGoalCalculatorLayout } from '../Shared/NsGoalCalculatorLayout';
 
 export const NextStepsStep: React.FC = () => {
@@ -8,10 +9,19 @@ export const NextStepsStep: React.FC = () => {
   return (
     <NsGoalCalculatorLayout
       mainContent={
-        <Box mx={4} my={2}>
+        <Box mx={4} display="flex" flexDirection="column" gap={3}>
           <Typography variant="h6">{t('Next Steps')}</Typography>
-          <Typography variant="body1" color="textSecondary">
-            {t('This step is coming soon.')}
+
+          <Typography variant="body1">
+            {t('Great job completing the MPD Goal Calculation process!')}
+          </Typography>
+
+          <Typography variant="body1">
+            <Trans t={t}>
+              You can return to this New Staff Goal Calculation under HR Tools
+              in your top navigation at any time. If you have any questions or
+              need to make changes to your goal, please contact your coach.
+            </Trans>
           </Typography>
         </Box>
       }


### PR DESCRIPTION
## Description

- Fills in the **Next Steps** step of the New Staff Goal Calculator with real content, replacing the "This step is coming soon." placeholder.
- Adds a congratulations message and guidance pointing the user back to the New Staff Goal Calculation under HR Tools, with a note to contact their coach for questions or changes.
- Uses `<Trans>` for the multi-sentence guidance copy and switches the layout to a flex column with consistent spacing.
- Adds `NextStepsStep.test.tsx` covering the step heading and intro/guidance copy.

Related Jira ticket: MPDX-9675

## Testing

- Go to HR Tools → New Staff Goal Calculation
- Navigate to the **Next Steps** step
- Check that the congratulations message and HR Tools guidance render (no more "coming soon" placeholder)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
