### PR TITLE
MPDX-8050 Fix duplicate referrals created when saving contact Other tab

### DIFF
--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.test.tsx
@@ -492,8 +492,115 @@ describe('EditContactOtherModal', () => {
         userId: 'user-2',
         greeting: newGreeting,
         envelopeGreeting: newEnvelopeGreeting,
-        contactReferralsToMe: [{}],
+        contactReferralsToMe: [],
       },
     });
+  });
+
+  it('does not re-create the referral when the referred by is unchanged', async () => {
+    const mutationSpy = jest.fn();
+    const { getByLabelText, getByText } = render(
+      <SnackbarProvider>
+        <TestRouter router={router}>
+          <ThemeProvider theme={theme}>
+            <GqlMockedProvider<{
+              UpdateContactOther: UpdateContactOtherMutation;
+            }>
+              onCall={mutationSpy}
+            >
+              <ContactDetailProvider>
+                <EditContactOtherModal
+                  accountListId={accountListId}
+                  isOpen={true}
+                  handleClose={handleClose}
+                  contact={mockContact}
+                  referral={referral}
+                />
+              </ContactDetailProvider>
+            </GqlMockedProvider>
+          </ThemeProvider>
+        </TestRouter>
+      </SnackbarProvider>,
+    );
+
+    // Edit a field other than the Connecting Partner and save
+    const website = getByLabelText('Website');
+    userEvent.clear(website);
+    userEvent.type(website, 'unchanged-referral.com');
+    userEvent.click(getByText('Save'));
+
+    await waitFor(() =>
+      expect(mockEnqueue).toHaveBeenCalledWith('Contact updated successfully', {
+        variant: 'success',
+      }),
+    );
+
+    const updateCall = mutationSpy.mock.calls
+      .map(([{ operation }]) => operation)
+      .find(({ operationName }) => operationName === 'UpdateContactOther');
+
+    // The existing referral must not be re-submitted, otherwise the API's
+    // nested-attributes handling creates a duplicate ContactReferral row.
+    expect(updateCall?.variables.attributes.contactReferralsToMe).toEqual([]);
+  });
+
+  it('destroys the old referral and creates the new one when the referred by changes', async () => {
+    const mutationSpy = jest.fn();
+    const { getByRole, getByText } = render(
+      <SnackbarProvider>
+        <TestRouter router={router}>
+          <ThemeProvider theme={theme}>
+            <GqlMockedProvider<{
+              ContactOptions: ContactOptionsQuery;
+              UpdateContactOther: UpdateContactOtherMutation;
+            }>
+              onCall={mutationSpy}
+              mocks={{
+                ContactOptions: {
+                  contacts: {
+                    nodes: [{ id: 'new-partner', name: 'Aaa Bbb' }],
+                  },
+                },
+              }}
+            >
+              <ContactDetailProvider>
+                <EditContactOtherModal
+                  accountListId={accountListId}
+                  isOpen={true}
+                  handleClose={handleClose}
+                  contact={mockContact}
+                  referral={referral}
+                />
+              </ContactDetailProvider>
+            </GqlMockedProvider>
+          </ThemeProvider>
+        </TestRouter>
+      </SnackbarProvider>,
+    );
+
+    const referredByElement = getByRole('combobox', {
+      hidden: true,
+      name: 'Connecting Partner',
+    });
+    userEvent.click(referredByElement);
+    userEvent.type(referredByElement, 'Aa');
+    await waitFor(() => expect(getByText('Aaa Bbb')).toBeInTheDocument());
+    userEvent.click(getByText('Aaa Bbb'));
+    userEvent.click(getByText('Save'));
+
+    await waitFor(() =>
+      expect(mockEnqueue).toHaveBeenCalledWith('Contact updated successfully', {
+        variant: 'success',
+      }),
+    );
+
+    const updateCall = mutationSpy.mock.calls
+      .map(([{ operation }]) => operation)
+      .find(({ operationName }) => operationName === 'UpdateContactOther');
+
+    expect(updateCall?.variables.attributes.contactReferralsToMe).toEqual([
+      { id: referral.id, destroy: true },
+      { referredById: 'new-partner' },
+    ]);
   });
 });

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.tsx
@@ -196,24 +196,16 @@ export const EditContactOtherModal: React.FC<EditContactOtherModalProps> = ({
   const onSubmit = async (
     attributes: ContactUpdateInput & { referredById: string },
   ) => {
+    // When the referred-by contact is unchanged, don't re-submit it. Sending a
+    // referral without its `id` makes the API's nested-attributes handling
+    // create a brand new ContactReferral row, duplicating the existing one.
     const referralsInput =
-      referral && referral.referredBy.id !== selectedId
-        ? [
-            {
-              id: referral.id,
-              destroy: true,
-            },
-            {
-              referredById: attributes.referredById,
-            },
-          ]
-        : selectedId
-          ? [
-              {
-                referredById: attributes.referredById,
-              },
-            ]
-          : [{}];
+      referral?.referredBy.id === selectedId
+        ? []
+        : [
+            ...(referral ? [{ id: referral.id, destroy: true }] : []),
+            ...(selectedId ? [{ referredById: selectedId }] : []),
+          ];
     await updateContactOther({
       variables: {
         accountListId,

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/Other/EditContactOtherModal/EditContactOtherModal.tsx
@@ -196,13 +196,12 @@ export const EditContactOtherModal: React.FC<EditContactOtherModalProps> = ({
   const onSubmit = async (
     attributes: ContactUpdateInput & { referredById: string },
   ) => {
-    // When the referred-by contact is unchanged, don't re-submit it. Sending a
-    // referral without its `id` makes the API's nested-attributes handling
-    // create a brand new ContactReferral row, duplicating the existing one.
     const referralsInput =
       referral?.referredBy.id === selectedId
-        ? []
-        : [
+        ? // No changes
+          []
+        : // Remove the old referral and add the new referral (if any)
+          [
             ...(referral ? [{ id: referral.id, destroy: true }] : []),
             ...(selectedId ? [{ referredById: selectedId }] : []),
           ];


### PR DESCRIPTION
## Description

When the referred-by contact is unchanged, don't resubmit it. Sending a referral without its `id` makes the API's nested-attributes handling create a brand new ContactReferral row, duplicating the existing one.

- Saving a contact's **Other** details re-submitted the existing "Referred By" referral without its `id`, so the API's nested-attributes handling created a new `ContactReferral` row instead of updating it — duplicating the referral in the referrer's Referrals tab.
- Now the referral is only touched when it actually changes: left untouched when unchanged, and destroy-old + create-new when changed.
- Related to MPDX-8050.

> Note: this stops new duplicates. Existing duplicate rows in the database need a separate `mpdx_api` cleanup.

## Testing

- Open a contact that has a **Referred By** (Connecting Partner) set, on the contact's **Other** tab.
- Edit any other field (e.g. Website or Church) and click **Save** — do not change the Connecting Partner.
- Go to the referring contact's **Referrals** tab.
- Check that the referral is **not** duplicated.
- Change the Connecting Partner to a different contact and save; check the old referral is removed and the new one appears once.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history