### PR TITLE
MPDX-9772, MPDX-9773, MPDX-9774 Add more fund types to staff expenses

### DIFF
--- a/.claude/rules/code-review.md
+++ b/.claude/rules/code-review.md
@@ -179,6 +179,7 @@ Every item here is mandatory. The Standards agent must report compliance per ite
 - [ ] Every user-visible string uses `useTranslation` / `t()` — no hard-coded display text in JSX, `Alert`, `Snackbar`, error messages, `aria-label`, or form labels
 - [ ] No string interpolation inside `t()` calls — use interpolation variables: `t('Hello {{name}}', { name })`, not `t(`Hello ${name}`)`
 - [ ] No dynamic `t()` keys (`t(varName)`) — extraction tool can't find them
+- [ ] Every `<Trans>` component is passed a `t` prop (`<Trans t={t}>...</Trans>`)
 
 **GraphQL & Apollo**
 

--- a/src/components/HrTools/SavingsFundTransfer/BalanceCard/BalanceCard.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/BalanceCard/BalanceCard.test.tsx
@@ -102,7 +102,7 @@ describe('BalanceCard', () => {
         />,
       );
 
-      expect(getByTestId('GroupsIcon')).toBeInTheDocument();
+      expect(getByTestId('Diversity1Icon')).toBeInTheDocument();
     });
 
     it('should display staff account icon', () => {

--- a/src/components/HrTools/SavingsFundTransfer/BalanceCard/BalanceCard.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/BalanceCard/BalanceCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Groups, Outbox, Savings, Wallet } from '@mui/icons-material';
+import { Diversity1, Outbox, Savings, Wallet } from '@mui/icons-material';
 import { Box, Button, Card, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { SimpleScreenOnly } from 'src/components/Reports/styledComponents';
@@ -29,7 +29,7 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
       ? Wallet
       : fund.fundType === FundTypeEnum.Savings
         ? Savings
-        : Groups;
+        : Diversity1;
   const iconBgColor =
     fund.fundType === FundTypeEnum.Primary
       ? theme.palette.chartOrange.main

--- a/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBox.test.tsx
+++ b/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBox.test.tsx
@@ -14,32 +14,41 @@ describe('AccountInfoBox', () => {
     expect(getByTestId('account-info')).toBeInTheDocument();
     expect(getByTestId('name')).toBeInTheDocument();
     expect(getByTestId('account-id')).toBeInTheDocument();
+    expect(getByTestId('InfoOutlinedIcon')).toBeInTheDocument();
     expect(getByTestId('overall-balance')).toBeInTheDocument();
   });
 
   it('renders empty strings when name, accountId, and overallBalance are not provided', () => {
     const { getByTestId, queryByTestId } = render(<AccountInfoBox />);
     expect(getByTestId('name').textContent).toBe('');
-    expect(getByTestId('account-id').textContent).toBe('');
+    expect(queryByTestId('account-id')).not.toBeInTheDocument();
+    expect(queryByTestId('InfoOutlinedIcon')).not.toBeInTheDocument();
     expect(queryByTestId('overall-balance')).not.toBeInTheDocument();
   });
 
   it('displays only name when accountId and overallBalance are not provided', () => {
-    const { getByTestId } = render(<AccountInfoBox name="Only Name" />);
+    const { getByTestId, queryByTestId } = render(
+      <AccountInfoBox name="Only Name" />,
+    );
     expect(getByTestId('name').textContent).toBe('Only Name');
-    expect(getByTestId('account-id').textContent).toBe('');
+    expect(queryByTestId('account-id')).not.toBeInTheDocument();
+    expect(queryByTestId('InfoOutlinedIcon')).not.toBeInTheDocument();
   });
 
   it('renders only accountId when name and overallBalance are not provided', () => {
     const { getByTestId } = render(<AccountInfoBox accountId="OnlyId" />);
     expect(getByTestId('account-id').textContent).toBe('OnlyId');
+    expect(getByTestId('InfoOutlinedIcon')).toBeInTheDocument();
     expect(getByTestId('name').textContent).toBe('');
   });
 
   it('renders only overallBalance when name and accountId are not provided', () => {
-    const { getByTestId } = render(<AccountInfoBox overallBalance={1000} />);
+    const { getByTestId, queryByTestId } = render(
+      <AccountInfoBox overallBalance={1000} />,
+    );
     expect(getByTestId('overall-balance').textContent).toBe('$1,000.00');
     expect(getByTestId('name').textContent).toBe('');
-    expect(getByTestId('account-id').textContent).toBe('');
+    expect(queryByTestId('account-id')).not.toBeInTheDocument();
+    expect(queryByTestId('InfoOutlinedIcon')).not.toBeInTheDocument();
   });
 });

--- a/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBox.test.tsx
+++ b/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBox.test.tsx
@@ -3,29 +3,43 @@ import { render } from '@testing-library/react';
 import { AccountInfoBox } from './AccountInfoBox';
 
 describe('AccountInfoBox', () => {
-  it('renders name and accountId when provided', () => {
+  it('renders name, accountId, and overallBalance when provided', () => {
     const { getByTestId } = render(
-      <AccountInfoBox name="Test Name" accountId="12345" />,
+      <AccountInfoBox
+        name="Test Name"
+        accountId="12345"
+        overallBalance={1000}
+      />,
     );
     expect(getByTestId('account-info')).toBeInTheDocument();
     expect(getByTestId('name')).toBeInTheDocument();
     expect(getByTestId('account-id')).toBeInTheDocument();
+    expect(getByTestId('overall-balance')).toBeInTheDocument();
   });
 
-  it('renders empty strings when name and accountId are not provided', () => {
-    const { getByTestId } = render(<AccountInfoBox />);
+  it('renders empty strings when name, accountId, and overallBalance are not provided', () => {
+    const { getByTestId, queryByTestId } = render(<AccountInfoBox />);
     expect(getByTestId('name').textContent).toBe('');
     expect(getByTestId('account-id').textContent).toBe('');
+    expect(queryByTestId('overall-balance')).not.toBeInTheDocument();
   });
 
-  it('displays only name when accountId is not provided', () => {
+  it('displays only name when accountId and overallBalance are not provided', () => {
     const { getByTestId } = render(<AccountInfoBox name="Only Name" />);
     expect(getByTestId('name').textContent).toBe('Only Name');
     expect(getByTestId('account-id').textContent).toBe('');
   });
 
-  it('renders only accountId when name is not provided', () => {
+  it('renders only accountId when name and overallBalance are not provided', () => {
     const { getByTestId } = render(<AccountInfoBox accountId="OnlyId" />);
     expect(getByTestId('account-id').textContent).toBe('OnlyId');
+    expect(getByTestId('name').textContent).toBe('');
+  });
+
+  it('renders only overallBalance when name and accountId are not provided', () => {
+    const { getByTestId } = render(<AccountInfoBox overallBalance={1000} />);
+    expect(getByTestId('overall-balance').textContent).toBe('$1,000.00');
+    expect(getByTestId('name').textContent).toBe('');
+    expect(getByTestId('account-id').textContent).toBe('');
   });
 });

--- a/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBox.test.tsx
+++ b/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBox.test.tsx
@@ -51,4 +51,9 @@ describe('AccountInfoBox', () => {
     expect(queryByTestId('account-id')).not.toBeInTheDocument();
     expect(queryByTestId('InfoOutlinedIcon')).not.toBeInTheDocument();
   });
+
+  it('renders zero overallBalance correctly', () => {
+    const { getByTestId } = render(<AccountInfoBox overallBalance={0} />);
+    expect(getByTestId('overall-balance').textContent).toBe('$0.00');
+  });
 });

--- a/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBox.tsx
+++ b/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBox.tsx
@@ -1,23 +1,39 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
+import { useLocale } from 'src/hooks/useLocale';
+import { currencyFormat } from 'src/lib/intlFormat';
 
 interface AccountInfoBoxProps {
   name?: string;
   accountId?: string;
+  overallBalance?: number;
 }
 
 export const AccountInfoBox: React.FC<AccountInfoBoxProps> = ({
   name,
   accountId,
-}) => (
-  <Box
-    display="flex"
-    flexDirection="row"
-    gap={3}
-    mb={2}
-    data-testid="account-info"
-  >
-    <Typography data-testid="name">{name}</Typography>
-    <Typography data-testid="account-id">{accountId}</Typography>
-  </Box>
-);
+  overallBalance,
+}) => {
+  const locale = useLocale();
+  const currency = 'USD';
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="row"
+      gap={3}
+      mb={2}
+      data-testid="account-info"
+    >
+      <Typography data-testid="name">{name}</Typography>
+      <Typography data-testid="account-id">{accountId}</Typography>
+      {overallBalance && (
+        <Typography data-testid="overall-balance">
+          {currencyFormat(overallBalance, currency, locale, {
+            showTrailingZeros: true,
+          })}
+        </Typography>
+      )}
+    </Box>
+  );
+};

--- a/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBox.tsx
+++ b/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBox.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import { InfoOutlined } from '@mui/icons-material';
+import { Box, Tooltip, Typography } from '@mui/material';
+import { Trans } from 'react-i18next';
 import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat } from 'src/lib/intlFormat';
 
@@ -17,6 +19,16 @@ export const AccountInfoBox: React.FC<AccountInfoBoxProps> = ({
   const locale = useLocale();
   const currency = 'USD';
 
+  const title = (
+    <Trans>
+      Your Person Number is unique and assigned to you by Oracle HCM, Cru&apos;s
+      new HR system. It replaces the Employee ID (EMPLID) previously used in
+      PeopleSoft. If you need help with anything related to HR or payroll —
+      salary calculations, housing allowance, or additional salary requests —
+      this is the number HR staff will use to look you up in the system.
+    </Trans>
+  );
+
   return (
     <Box
       display="flex"
@@ -26,7 +38,14 @@ export const AccountInfoBox: React.FC<AccountInfoBoxProps> = ({
       data-testid="account-info"
     >
       <Typography data-testid="name">{name}</Typography>
-      <Typography data-testid="account-id">{accountId}</Typography>
+      {accountId && (
+        <Box display="flex" alignItems="center" gap={0.5}>
+          <Typography data-testid="account-id">{accountId}</Typography>
+          <Tooltip title={title}>
+            <InfoOutlined fontSize="small" />
+          </Tooltip>
+        </Box>
+      )}
       {overallBalance && (
         <Typography data-testid="overall-balance">
           {currencyFormat(overallBalance, currency, locale, {

--- a/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBox.tsx
+++ b/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBox.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { InfoOutlined } from '@mui/icons-material';
 import { Box, Tooltip, Typography } from '@mui/material';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
+import { SimpleScreenOnly } from 'src/components/Reports/styledComponents';
 import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat } from 'src/lib/intlFormat';
 
@@ -16,11 +17,12 @@ export const AccountInfoBox: React.FC<AccountInfoBoxProps> = ({
   accountId,
   overallBalance,
 }) => {
+  const { t } = useTranslation();
   const locale = useLocale();
   const currency = 'USD';
 
   const title = (
-    <Trans>
+    <Trans t={t}>
       Your Person Number is unique and assigned to you by Oracle HCM, Cru&apos;s
       new HR system. It replaces the Employee ID (EMPLID) previously used in
       PeopleSoft. If you need help with anything related to HR or payroll —
@@ -41,12 +43,18 @@ export const AccountInfoBox: React.FC<AccountInfoBoxProps> = ({
       {accountId && (
         <Box display="flex" alignItems="center" gap={0.5}>
           <Typography data-testid="account-id">{accountId}</Typography>
-          <Tooltip title={title}>
-            <InfoOutlined fontSize="small" />
-          </Tooltip>
+          <SimpleScreenOnly display="flex" alignItems="center">
+            <Tooltip title={title}>
+              <InfoOutlined
+                fontSize="small"
+                tabIndex={0}
+                titleAccess={t('Person number information')}
+              />
+            </Tooltip>
+          </SimpleScreenOnly>
         </Box>
       )}
-      {overallBalance && (
+      {overallBalance !== undefined && (
         <Typography data-testid="overall-balance">
           {currencyFormat(overallBalance, currency, locale, {
             showTrailingZeros: true,

--- a/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBoxSkeleton.test.tsx
+++ b/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBoxSkeleton.test.tsx
@@ -17,4 +17,11 @@ describe('AccountInfoBoxSkeleton', () => {
     const { getByTestId } = render(<AccountInfoBoxSkeleton />);
     expect(getByTestId('account-id-skeleton')).toBeInTheDocument();
   });
+
+  it('renders the overall balance skeleton when provided', () => {
+    const { getByTestId } = render(
+      <AccountInfoBoxSkeleton hasOverallBalance />,
+    );
+    expect(getByTestId('overall-balance-skeleton')).toBeInTheDocument();
+  });
 });

--- a/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBoxSkeleton.tsx
+++ b/src/components/HrTools/Shared/AccountInfoBox/AccountInfoBoxSkeleton.tsx
@@ -16,7 +16,13 @@ const StyledSkeletonBox = styled(Box)(({ theme }) => ({
   borderRadius: theme.spacing(0.5),
 }));
 
-export const AccountInfoBoxSkeleton: React.FC = () => (
+interface AccountInfoBoxSkeletonProps {
+  hasOverallBalance?: boolean;
+}
+
+export const AccountInfoBoxSkeleton: React.FC<AccountInfoBoxSkeletonProps> = ({
+  hasOverallBalance,
+}) => (
   <StyledAccountInfoContainer data-testid="account-info">
     <Skeleton variant="text" data-testid="name-skeleton">
       <StyledSkeletonBox />
@@ -24,5 +30,10 @@ export const AccountInfoBoxSkeleton: React.FC = () => (
     <Skeleton variant="text" data-testid="account-id-skeleton">
       <StyledSkeletonBox />
     </Skeleton>
+    {hasOverallBalance && (
+      <Skeleton variant="text" data-testid="overall-balance-skeleton">
+        <StyledSkeletonBox />
+      </Skeleton>
+    )}
   </StyledAccountInfoContainer>
 );

--- a/src/components/Reports/StaffExpenseReport/BalanceCard/BalanceCard.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/BalanceCard/BalanceCard.test.tsx
@@ -75,7 +75,7 @@ describe('BalanceCard', () => {
     const { getByText } = render(
       <BalanceCard {...defaultProps} transfersIn={0} isSelected={true} />,
     );
-    expect(getByText('+ Transfers in: $0')).toBeInTheDocument();
+    expect(getByText('+ Transfers in: $0.00')).toBeInTheDocument();
   });
 
   it('should handle large numbers correctly', () => {
@@ -87,6 +87,17 @@ describe('BalanceCard', () => {
       />,
     );
     expect(getByText('= Ending Balance: $1,000,000.99')).toBeInTheDocument();
+  });
+
+  it('should handle negative end balance correctly', () => {
+    const { getByText } = render(
+      <BalanceCard
+        {...defaultProps}
+        endBalance={-1234.56}
+        isSelected={false}
+      />,
+    );
+    expect(getByText('($1,234.56)')).toBeInTheDocument();
   });
 
   it('should use Math.abs for transfers out display', () => {

--- a/src/components/Reports/StaffExpenseReport/BalanceCard/BalanceCard.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/BalanceCard/BalanceCard.test.tsx
@@ -51,35 +51,47 @@ describe('BalanceCard', () => {
 
   it('should format positive balances correctly', () => {
     const { getByText } = render(
-      <BalanceCard {...defaultProps} startBalance={1234.56} />,
+      <BalanceCard
+        {...defaultProps}
+        startBalance={1234.56}
+        isSelected={true}
+      />,
     );
     expect(getByText('Starting Balance: $1,234.56')).toBeInTheDocument();
   });
 
   it('should format negative balances correctly', () => {
     const { getByText } = render(
-      <BalanceCard {...defaultProps} startBalance={-500.25} />,
+      <BalanceCard
+        {...defaultProps}
+        startBalance={-500.25}
+        isSelected={true}
+      />,
     );
     expect(getByText('Starting Balance: -$500.25')).toBeInTheDocument();
   });
 
   it('should format zero values correctly', () => {
     const { getByText } = render(
-      <BalanceCard {...defaultProps} transfersIn={0} />,
+      <BalanceCard {...defaultProps} transfersIn={0} isSelected={true} />,
     );
     expect(getByText('+ Transfers in: $0')).toBeInTheDocument();
   });
 
   it('should handle large numbers correctly', () => {
     const { getByText } = render(
-      <BalanceCard {...defaultProps} endBalance={1000000.99} />,
+      <BalanceCard
+        {...defaultProps}
+        endBalance={1000000.99}
+        isSelected={true}
+      />,
     );
     expect(getByText('= Ending Balance: $1,000,000.99')).toBeInTheDocument();
   });
 
   it('should use Math.abs for transfers out display', () => {
     const { getByText } = render(
-      <BalanceCard {...defaultProps} transfersOut={-250.5} />,
+      <BalanceCard {...defaultProps} transfersOut={-250.5} isSelected={true} />,
     );
     expect(getByText('- Transfers out: $250.50')).toBeInTheDocument();
   });

--- a/src/components/Reports/StaffExpenseReport/BalanceCard/BalanceCard.tsx
+++ b/src/components/Reports/StaffExpenseReport/BalanceCard/BalanceCard.tsx
@@ -79,6 +79,13 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
   const { t } = useTranslation();
   const locale = useLocale();
 
+  const formatBalance = (amount: number) =>
+    currencyFormat(amount, 'USD', locale, {
+      showTrailingZeros: true,
+    });
+
+  const isNegative = endBalance < 0;
+
   return (
     <StyledCard variant="outlined" isSelected={isSelected}>
       <StyledHeaderBox isSelected={isSelected}>
@@ -92,7 +99,7 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
           {title}
         </Typography>
       </StyledHeaderBox>
-      {isSelected && (
+      {isSelected ? (
         <Box
           display="flex"
           flexDirection="column"
@@ -102,23 +109,34 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
         >
           <Typography>
             {t('Starting Balance: ')}
-            {currencyFormat(startBalance, 'USD', locale)}
+            {formatBalance(startBalance)}
           </Typography>
           <Typography>
             {t('+ Transfers in: ')}
-            {currencyFormat(transfersIn, 'USD', locale)}
+            {formatBalance(transfersIn)}
           </Typography>
           <Typography>
             {t('- Transfers out: ')}
-            {currencyFormat(Math.abs(transfersOut), 'USD', locale)}
+            {formatBalance(Math.abs(transfersOut))}
           </Typography>
           <Typography>
             <strong>
               {t('= Ending Balance: ')}
-              {currencyFormat(endBalance, 'USD', locale)}
+              {formatBalance(endBalance)}
             </strong>
           </Typography>
         </Box>
+      ) : (
+        <Typography
+          variant="h6"
+          color={isNegative ? 'error.main' : 'text.primary'}
+        >
+          {isNegative ? '(' : ''}
+          {currencyFormat(Math.abs(endBalance), 'USD', locale, {
+            showTrailingZeros: true,
+          })}
+          {isNegative ? ')' : ''}
+        </Typography>
       )}
 
       <ScreenOnly>

--- a/src/components/Reports/StaffExpenseReport/BalanceCard/BalanceCard.tsx
+++ b/src/components/Reports/StaffExpenseReport/BalanceCard/BalanceCard.tsx
@@ -48,10 +48,12 @@ interface BalanceCardProps {
   isSelected?: boolean;
 }
 
-const StyledHeaderBox = styled(Box)(({ theme }) => ({
+const StyledHeaderBox = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'isSelected',
+})<{ isSelected: boolean }>(({ theme, isSelected }) => ({
   display: 'flex',
   flex: 1,
-  flexDirection: 'row',
+  flexDirection: isSelected ? 'row' : 'column',
   alignItems: 'start',
   gap: theme.spacing(1),
 }));
@@ -79,30 +81,45 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
 
   return (
     <StyledCard variant="outlined" isSelected={isSelected}>
-      <StyledHeaderBox>
+      <StyledHeaderBox isSelected={isSelected}>
         <StyledIconBox iconBgColor={iconBgColor}>
           <Icon />
         </StyledIconBox>
-        <Typography variant="h6">{title}</Typography>
+        <Typography
+          variant="h6"
+          sx={{ whiteSpace: isSelected ? 'nowrap' : 'normal' }}
+        >
+          {title}
+        </Typography>
       </StyledHeaderBox>
-      <Box display="flex" flexDirection="column" mt={3} mb={2}>
-        <Typography>
-          {t('Starting Balance: ')}
-          {currencyFormat(startBalance, 'USD', locale)}
-        </Typography>
-        <Typography>
-          {t('+ Transfers in: ')}
-          {currencyFormat(transfersIn, 'USD', locale)}
-        </Typography>
-        <Typography>
-          {t('- Transfers out: ')}
-          {currencyFormat(Math.abs(transfersOut), 'USD', locale)}
-        </Typography>
-        <Typography>
-          {t('= Ending Balance: ')}
-          {currencyFormat(endBalance, 'USD', locale)}
-        </Typography>
-      </Box>
+      {isSelected && (
+        <Box
+          display="flex"
+          flexDirection="column"
+          mt={3}
+          mb={2}
+          sx={{ whiteSpace: 'nowrap' }}
+        >
+          <Typography>
+            {t('Starting Balance: ')}
+            {currencyFormat(startBalance, 'USD', locale)}
+          </Typography>
+          <Typography>
+            {t('+ Transfers in: ')}
+            {currencyFormat(transfersIn, 'USD', locale)}
+          </Typography>
+          <Typography>
+            {t('- Transfers out: ')}
+            {currencyFormat(Math.abs(transfersOut), 'USD', locale)}
+          </Typography>
+          <Typography>
+            <strong>
+              {t('= Ending Balance: ')}
+              {currencyFormat(endBalance, 'USD', locale)}
+            </strong>
+          </Typography>
+        </Box>
+      )}
 
       <ScreenOnly>
         <StyledCardActionArea
@@ -117,6 +134,7 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
               color="primary.main"
               fontWeight={600}
               textAlign="center"
+              sx={{ whiteSpace: 'nowrap' }}
             >
               {t('Currently Viewing')}
             </Typography>

--- a/src/components/Reports/StaffExpenseReport/BalanceCardList/BalanceCardList.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/BalanceCardList/BalanceCardList.test.tsx
@@ -36,7 +36,7 @@ const mockFunds: Fund[] = [
 
 const defaultProps = {
   funds: mockFunds,
-  selectedFundType: null,
+  selectedFundType: 'Primary',
   transferTotals: {
     Primary: { in: 500, out: 100 },
     Savings: { in: 300, out: 50 },
@@ -72,7 +72,7 @@ describe('BalanceCardList', () => {
     const { getAllByRole } = render(<TestComponent {...defaultProps} />);
 
     userEvent.click(getAllByRole('button', { name: 'View Account' })[0]);
-    expect(onCardClick).toHaveBeenCalledWith('Primary');
+    expect(onCardClick).toHaveBeenCalledWith('Savings');
   });
 
   it('displays selected state on correct card', () => {
@@ -86,20 +86,15 @@ describe('BalanceCardList', () => {
     expect(getAllByRole('button', { name: 'View Account' })).toHaveLength(2);
   });
 
-  it('displays values for each card', () => {
-    const { getByText } = render(<TestComponent {...defaultProps} />);
-    expect(getByText('+ Transfers in: $500')).toBeInTheDocument();
+  it('displays values for the selected card', async () => {
+    const { getByText, findByText } = render(
+      <TestComponent {...defaultProps} />,
+    );
+
+    expect(await findByText('+ Transfers in: $500')).toBeInTheDocument();
     expect(getByText('- Transfers out: $100')).toBeInTheDocument();
-    expect(getByText('+ Transfers in: $300')).toBeInTheDocument();
-    expect(getByText('- Transfers out: $50')).toBeInTheDocument();
-    expect(getByText('+ Transfers in: $0')).toBeInTheDocument();
-    expect(getByText('- Transfers out: $200')).toBeInTheDocument();
     expect(getByText('Starting Balance: $1,000')).toBeInTheDocument();
-    expect(getByText('Starting Balance: $2,000')).toBeInTheDocument();
-    expect(getByText('Starting Balance: $500')).toBeInTheDocument();
     expect(getByText('= Ending Balance: $1,400')).toBeInTheDocument();
-    expect(getByText('= Ending Balance: $2,250')).toBeInTheDocument();
-    expect(getByText('= Ending Balance: $300')).toBeInTheDocument();
   });
 
   it('renders empty when no funds provided', () => {

--- a/src/components/Reports/StaffExpenseReport/BalanceCardList/BalanceCardList.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/BalanceCardList/BalanceCardList.test.tsx
@@ -91,10 +91,10 @@ describe('BalanceCardList', () => {
       <TestComponent {...defaultProps} />,
     );
 
-    expect(await findByText('+ Transfers in: $500')).toBeInTheDocument();
-    expect(getByText('- Transfers out: $100')).toBeInTheDocument();
-    expect(getByText('Starting Balance: $1,000')).toBeInTheDocument();
-    expect(getByText('= Ending Balance: $1,400')).toBeInTheDocument();
+    expect(await findByText('+ Transfers in: $500.00')).toBeInTheDocument();
+    expect(getByText('- Transfers out: $100.00')).toBeInTheDocument();
+    expect(getByText('Starting Balance: $1,000.00')).toBeInTheDocument();
+    expect(getByText('= Ending Balance: $1,400.00')).toBeInTheDocument();
   });
 
   it('renders empty when no funds provided', () => {

--- a/src/components/Reports/StaffExpenseReport/BalanceCardList/BalanceCardList.tsx
+++ b/src/components/Reports/StaffExpenseReport/BalanceCardList/BalanceCardList.tsx
@@ -9,11 +9,14 @@ import {
   getIconForFundType,
 } from '../Helpers/fundTypeHelpers';
 
-const StyledCardsBox = styled(Box)(({ theme }) => ({
-  flex: 1,
-  minWidth: 240,
+const StyledCardsBox = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'isSelected',
+})<{ isSelected: boolean }>(({ theme, isSelected }) => ({
+  flex: isSelected ? 2 : 1,
+  minWidth: 0,
   display: 'flex',
   gap: theme.spacing(4),
+  transition: 'flex 0.3s ease-in-out',
 }));
 
 export interface BalanceCardListProps {
@@ -35,7 +38,7 @@ export const BalanceCardList: React.FC<BalanceCardListProps> = ({
 
   if (loading) {
     return (
-      <StyledCardsBox>
+      <StyledCardsBox isSelected={false}>
         <BalanceCardSkeleton />
         <BalanceCardSkeleton />
         <BalanceCardSkeleton />
@@ -46,7 +49,10 @@ export const BalanceCardList: React.FC<BalanceCardListProps> = ({
   return (
     <>
       {funds.map((fund) => (
-        <StyledCardsBox key={fund.fundType}>
+        <StyledCardsBox
+          key={fund.fundType}
+          isSelected={selectedFundType === fund.fundType}
+        >
           <BalanceCard
             fundType={fund.fundType}
             icon={getIconForFundType(fund.fundType)}

--- a/src/components/Reports/StaffExpenseReport/Helpers/fundTypeHelpers.ts
+++ b/src/components/Reports/StaffExpenseReport/Helpers/fundTypeHelpers.ts
@@ -1,6 +1,8 @@
 import {
   Diversity1,
+  Flight,
   Groups,
+  Home,
   Savings,
   SvgIconComponent,
   Wallet,
@@ -17,6 +19,12 @@ export const getIconForFundType = (fundType: string): SvgIconComponent => {
   if (fundType === 'Staff Conference Savings') {
     return Diversity1;
   }
+  if (fundType === 'Return Travel') {
+    return Flight;
+  }
+  if (fundType === 'Re-Entry') {
+    return Home;
+  }
   return Groups;
 };
 
@@ -31,7 +39,13 @@ export const getIconColorForFundType = (
     return theme.palette.chartBlueDark.main;
   }
   if (fundType === 'Staff Conference Savings') {
-    return theme.palette.chartBlueLight.main;
+    return theme.palette.chartBlue.main;
+  }
+  if (fundType === 'Return Travel') {
+    return theme.palette.chipYellowDark.main;
+  }
+  if (fundType === 'Re-Entry') {
+    return theme.palette.chartGray.main;
   }
   return theme.palette.chartBlue.main;
 };

--- a/src/components/Reports/StaffExpenseReport/Helpers/fundTypeHelpers.ts
+++ b/src/components/Reports/StaffExpenseReport/Helpers/fundTypeHelpers.ts
@@ -9,43 +9,44 @@ import {
 } from '@mui/icons-material';
 import { Theme } from '@mui/material/styles';
 
-export const getIconForFundType = (fundType: string): SvgIconComponent => {
-  if (fundType === 'Primary') {
-    return Wallet;
-  }
-  if (fundType === 'Savings') {
-    return Savings;
-  }
-  if (fundType === 'Staff Conference Savings') {
-    return Diversity1;
-  }
-  if (fundType === 'Return Travel') {
-    return Flight;
-  }
-  if (fundType === 'Re-Entry') {
-    return Home;
-  }
-  return Groups;
+interface FundTypeConfig {
+  icon: SvgIconComponent;
+  getColor: (theme: Theme) => string;
+}
+
+const fundTypeConfig: Record<string, FundTypeConfig> = {
+  Primary: {
+    icon: Wallet,
+    getColor: (theme) => theme.palette.chartOrange.main,
+  },
+  Savings: {
+    icon: Savings,
+    getColor: (theme) => theme.palette.chartBlueDark.main,
+  },
+  'Staff Conference Savings': {
+    icon: Diversity1,
+    getColor: (theme) => theme.palette.chartBlue.main,
+  },
+  'Return Travel': {
+    icon: Flight,
+    getColor: (theme) => theme.palette.chipYellowDark.main,
+  },
+  'Re-Entry': {
+    icon: Home,
+    getColor: (theme) => theme.palette.chartGray.main,
+  },
 };
+
+const defaultFundTypeConfig: FundTypeConfig = {
+  icon: Groups,
+  getColor: (theme) => theme.palette.chartBlue.main,
+};
+
+export const getIconForFundType = (fundType: string): SvgIconComponent =>
+  (fundTypeConfig[fundType] ?? defaultFundTypeConfig).icon;
 
 export const getIconColorForFundType = (
   fundType: string,
   theme: Theme,
-): string => {
-  if (fundType === 'Primary') {
-    return theme.palette.chartOrange.main;
-  }
-  if (fundType === 'Savings') {
-    return theme.palette.chartBlueDark.main;
-  }
-  if (fundType === 'Staff Conference Savings') {
-    return theme.palette.chartBlue.main;
-  }
-  if (fundType === 'Return Travel') {
-    return theme.palette.chipYellowDark.main;
-  }
-  if (fundType === 'Re-Entry') {
-    return theme.palette.chartGray.main;
-  }
-  return theme.palette.chartBlue.main;
-};
+): string =>
+  (fundTypeConfig[fundType] ?? defaultFundTypeConfig).getColor(theme);

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
@@ -225,6 +225,7 @@ describe('StaffExpenseReport', () => {
     expect(getByRole('heading', { name: 'Report title' })).toBeInTheDocument();
     expect(await findByText('Test Account')).toBeInTheDocument();
     expect(await findByText('1000000001')).toBeInTheDocument();
+    expect(await findByText('$4,000.00')).toBeInTheDocument();
   });
 
   it('initializes with month from query', () => {

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
@@ -246,9 +246,9 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
     return null;
   }, [filters, locale, t]);
 
-  const overallBalance = allFunds.reduce(
-    (sum, fund) => sum + (fund.endBalance ?? 0),
-    0,
+  const overallBalance = useMemo(
+    () => allFunds.reduce((sum, fund) => sum + (fund.endBalance ?? 0), 0),
+    [allFunds],
   );
 
   return (
@@ -311,7 +311,7 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
             <SimpleScreenOnly>
               <Box
                 display="flex"
-                flexWrap="nowrap"
+                flexWrap="wrap"
                 gap={2}
                 sx={{
                   flexDirection: { xs: 'column', sm: 'row' },

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
@@ -246,6 +246,11 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
     return null;
   }, [filters, locale, t]);
 
+  const overallBalance = allFunds.reduce(
+    (sum, fund) => sum + (fund.endBalance ?? 0),
+    0,
+  );
+
   return (
     <Box>
       <SimpleScreenOnly>
@@ -295,9 +300,13 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
               ) : null}
             </StyledHeaderBox>
             {loading ? (
-              <AccountInfoBoxSkeleton />
+              <AccountInfoBoxSkeleton hasOverallBalance />
             ) : (
-              <AccountInfoBox name={name} accountId={id} />
+              <AccountInfoBox
+                name={name}
+                accountId={id}
+                overallBalance={overallBalance}
+              />
             )}
             <SimpleScreenOnly>
               <Box

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
@@ -98,7 +98,13 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
 
   const { data, loading } = useReportsStaffExpensesQuery({
     variables: {
-      fundTypes: ['Primary', 'Savings', 'Staff Conference Savings'],
+      fundTypes: [
+        'Primary',
+        'Savings',
+        'Staff Conference Savings',
+        'Return Travel',
+        'Re-Entry',
+      ],
       ...getStaffExpenseMonthRange(filters, time),
     },
   });
@@ -296,7 +302,7 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
             <SimpleScreenOnly>
               <Box
                 display="flex"
-                flexWrap="wrap"
+                flexWrap="nowrap"
                 gap={2}
                 sx={{
                   flexDirection: { xs: 'column', sm: 'row' },


### PR DESCRIPTION
## Description

UAT issues:
- Add information tooltip to explain staff account id for users
- Add account total on top of page
- Add two more fund types to report: Return Travel and Re-Entry

Jira tickets: [MPDX-9772](https://jira.cru.org/browse/MPDX-9772), [MPDX-9773](https://jira.cru.org/browse/MPDX-9773), and [MPDX-9774](https://jira.cru.org/browse/MPDX-9774)

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Impersonate: courtney.campbell@cru.org
- Go to `/reports/staffExpense`
- Hover over information icon and check explanation is present
- Verify the account total is at the top of the page
- Click through each fund type and ensure styling is correct

Extra test:
- You can remove fund types from staff expenses query in `StaffExpenseReport.tsx` to ensure 1-5 fund styling is good
```
fundTypes: [
  'Primary',
  'Savings',
  'Staff Conference Savings',
  'Return Travel',
  'Re-Entry',
],
```

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
