### PR TITLE
[MPDX-9780] - Distinguish Expenses table color from Income table

### DIFF
--- a/src/components/Reports/StaffExpenseReport/Tables/StaffReportTable.tsx
+++ b/src/components/Reports/StaffExpenseReport/Tables/StaffReportTable.tsx
@@ -27,9 +27,14 @@ export interface StaffReportTableProps {
   loading?: boolean;
 }
 
-const StyledGrid = styled(DataGrid)(({ theme }) => ({
+const StyledGrid = styled(DataGrid, {
+  shouldForwardProp: (prop) => prop !== 'tableType',
+})<{ tableType: ReportType }>(({ theme, tableType }) => ({
   '.MuiDataGrid-row:nth-of-type(2n + 1):not(:hover)': {
-    backgroundColor: theme.palette.mpdxGrayLight.main,
+    backgroundColor:
+      tableType === ReportType.Expense
+        ? theme.palette.chipRedLight.main
+        : theme.palette.mpdxGrayLight.main,
   },
   '.MuiDataGrid-cell': {
     overflow: 'hidden',
@@ -238,6 +243,7 @@ export const StaffReportTable: React.FC<StaffReportTableProps> = ({
         )}
       </Box>
       <StyledGrid
+        tableType={tableType}
         rows={rowsWithSortPriority || []}
         columns={columns}
         getRowId={(row) => row.id}

--- a/src/components/Reports/StaffExpenseReport/Tables/StaffReportTable.tsx
+++ b/src/components/Reports/StaffExpenseReport/Tables/StaffReportTable.tsx
@@ -21,7 +21,7 @@ type RenderCell = GridColDef<StaffReportRow>['renderCell'];
 
 export interface StaffReportTableProps {
   transactions: (Transaction | GroupedTransaction)[];
-  tableType: ReportType;
+  tableType: ReportType.Income | ReportType.Expense;
   transferTotal: number;
   emptyPlaceholder: React.ReactElement;
   loading?: boolean;
@@ -29,21 +29,23 @@ export interface StaffReportTableProps {
 
 const StyledGrid = styled(DataGrid, {
   shouldForwardProp: (prop) => prop !== 'tableType',
-})<{ tableType: ReportType }>(({ theme, tableType }) => ({
-  '.MuiDataGrid-row:nth-of-type(2n + 1):not(:hover)': {
-    backgroundColor:
-      tableType === ReportType.Expense
-        ? theme.palette.chipRedLight.main
-        : theme.palette.mpdxGrayLight.main,
-  },
-  '.MuiDataGrid-cell': {
-    overflow: 'hidden',
-    whiteSpace: 'nowrap',
-    textOverflow: 'ellipsis',
-    display: 'flex',
-    alignItems: 'center',
-  },
-}));
+})<{ tableType: ReportType.Income | ReportType.Expense }>(
+  ({ theme, tableType }) => ({
+    '.MuiDataGrid-row:nth-of-type(2n + 1):not(:hover)': {
+      backgroundColor:
+        tableType === ReportType.Expense
+          ? theme.palette.chipRedLight.main
+          : theme.palette.mpdxGrayLight.main,
+    },
+    '.MuiDataGrid-cell': {
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+      textOverflow: 'ellipsis',
+      display: 'flex',
+      alignItems: 'center',
+    },
+  }),
+);
 
 const LoadingBox = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.mpdxGrayLight.main,


### PR DESCRIPTION
## Description

- Made the **Expenses** table visually distinct from the **Income** table in the Staff Expense Report. The two tables share the `StaffReportTable` component, so the alternating-row background color is now driven by `tableType`.
- **Income** keeps its existing gray tint (`theme.palette.mpdxGrayLight.main`).
- **Expenses** now uses a light-red theme token (`theme.palette.chipRedLight.main`, `#FEEBEE`), which pairs with the existing red "Total Expenses" figure and contrasts clearly with Income.
- Used `shouldForwardProp` so the custom `tableType` prop isn't forwarded to the underlying MUI `DataGrid`.

Related Jira ticket: [MPDX-9780](https://jira.cru.org/browse/MPDX-9780)

## Testing

- Go to the Staff Expense Report (Reports → Staff Expense Report)
- View the on-screen Income and Expenses tables
- Check that the Expenses table's alternating rows are a light red, distinct from the gray alternating rows of the Income table

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)
