### PR TITLE
[HS-1620291] Widen contact donations date column so the year is visible

### DIFF
--- a/src/components/DonationTable/DonationTable.tsx
+++ b/src/components/DonationTable/DonationTable.tsx
@@ -261,14 +261,14 @@ export const DonationTable: React.FC<DonationTableProps> = ({
       field: 'date',
       headerName: t('Date'),
       flex: 1,
-      minWidth: 80,
+      minWidth: 90,
       renderCell: date,
     },
     {
       field: 'donorAccountName',
       headerName: hideDisplayName ? t('Partner No.') : t('Partner'),
-      flex: 3,
-      minWidth: 200,
+      flex: hideDisplayName ? 1 : 3,
+      minWidth: hideDisplayName ? 100 : 200,
       renderCell: donor,
     },
     {


### PR DESCRIPTION
## Description

- Fixes the contact **Donations** tab clipping the year off gift dates that are 10 characters long (e.g. a `MM/DD/YYYY` date with a two-digit month **and** two-digit day).
- Root cause: the contact tab renders the shared `DonationTable` in a narrow panel, where the MUI DataGrid flex columns collapse to their `minWidth`. The date column's `minWidth: 80` only fits a 9-character date, so 10-character dates were truncated — the year became unreadable and users had to manually widen the column for every contact (the resize doesn't persist).
- Bump the date column `minWidth` `80 → 90` (fits the ~65.5px 10-character date with margin, and restores room for the header sort arrow).
- Narrow the **Partner No.** column only in the contact tab: `donorAccountName` `flex`/`minWidth` are now conditional on `hideDisplayName`. The contact tab shows a 9-digit account number (`100`/`flex 1`); the full Donations report still shows partner display names at the original width (`200`/`flex 3`).

Related: https://secure.helpscout.net/conversation/3324593949/1620291?viewId=320670

## Testing

- Go to **Contacts** and open any contact that has donations dated on a two-digit month **and** two-digit day (so the date renders as 10 characters, e.g. `12/12/2025`). Contacts giving on the 1st–9th won't show the bug.
- Open the **Donations** tab and look at the **Date** column.
  - Before: the year is cut off on 10-character dates; the column has to be widened by hand, and it resets when you switch contacts.
  - After: the full date (including the year) is visible without resizing, and the **Partner No.** column is narrower so the **Designation** column gets the reclaimed space.
- Confirm the full Donations **report** (Reports → Donations) is unchanged — the **Partner** column still shows full partner names at the original width.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
