### PR TITLE
[No-Jira] Make fund type cards responsive

### DIFF
--- a/src/components/Reports/StaffExpenseReport/BalanceCardList/BalanceCardList.tsx
+++ b/src/components/Reports/StaffExpenseReport/BalanceCardList/BalanceCardList.tsx
@@ -13,10 +13,10 @@ const StyledCardsBox = styled(Box, {
   shouldForwardProp: (prop) => prop !== 'isSelected',
 })<{ isSelected: boolean }>(({ theme, isSelected }) => ({
   flex: isSelected ? 2 : 1,
-  minWidth: 0,
+  minWidth: isSelected ? 250 : 200,
   display: 'flex',
   gap: theme.spacing(4),
-  transition: 'flex 0.3s ease-in-out',
+  transition: 'flex 0.3s ease-in-out, min-width 0.3s ease-in-out',
 }));
 
 export interface BalanceCardListProps {


### PR DESCRIPTION
## Description

Make fund type cards in Staff expenses report responsive to differing screen size.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `/reports/staffExpense`
- Shrink the size of the screen
- Check that the cards move down a row

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
