### PR TITLE
MPDX-9783 Add loading indicator while creating goals

### DIFF
--- a/src/components/HrTools/GoalCalculator/GoalsList/GoalsList.test.tsx
+++ b/src/components/HrTools/GoalCalculator/GoalsList/GoalsList.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { GoalCalculationsQuery } from './GoalCalculations.generated';
@@ -84,6 +85,23 @@ describe('GoalsList', () => {
     const { findByRole } = render(<TestComponent noGoals />);
 
     expect(await findByRole('img')).toBeInTheDocument();
+  });
+
+  it('disables the create button while creating a goal', async () => {
+    const { getByRole } = render(<TestComponent />);
+
+    const button = getByRole('button', { name: 'Create a New Goal' });
+    expect(button).not.toBeDisabled();
+
+    userEvent.click(button);
+
+    expect(button).toBeDisabled();
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('CreateGoalCalculation', {
+        accountListId: 'account-list-1',
+      }),
+    );
   });
 
   it('fetches additional pages when hasNextPage is true', async () => {

--- a/src/components/HrTools/GoalCalculator/GoalsList/GoalsList.tsx
+++ b/src/components/HrTools/GoalCalculator/GoalsList/GoalsList.tsx
@@ -35,9 +35,10 @@ export const GoalsList: React.FC = () => {
     error,
     pageInfo: data?.goalCalculations.pageInfo,
   });
-  const [createGoalCalculation] = useCreateGoalCalculationMutation({
-    variables: { accountListId },
-  });
+  const [createGoalCalculation, { loading: creating }] =
+    useCreateGoalCalculationMutation({
+      variables: { accountListId },
+    });
   const goals = data?.goalCalculations.nodes
     ?.slice()
     .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
@@ -60,7 +61,12 @@ export const GoalsList: React.FC = () => {
     <Container>
       <GoalsListWelcome firstName={firstName} />
       <Stack direction="row" gap={2} pb={3}>
-        <Button variant="contained" onClick={handleCreateGoal}>
+        <Button
+          variant="contained"
+          onClick={handleCreateGoal}
+          disabled={creating}
+          startIcon={creating && <CircularProgress size={16} color="inherit" />}
+        >
           {t('Create a New Goal')}
         </Button>
         <Button


### PR DESCRIPTION
## Description

- Disable the "Create a New Goal" button while a goal is being created to prevent duplicate submissions.
- Show a `CircularProgress` spinner in the button's `startIcon` while the `CreateGoalCalculation` mutation is in flight.

Related Jira ticket: MPDX-9783

## Testing

- Go to HR Tools → Goal Calculator → Goals list
- Click "Create a New Goal"
- Check that the button is disabled and shows a loading spinner while the goal is being created

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
