### PR TITLE
MPDX-9779 Surface Income & Expenses CSV export as a labeled header menu

### DIFF
--- a/src/components/Reports/MPGAIncomeExpensesReport/CustomToolbar/CustomToolbar.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/CustomToolbar/CustomToolbar.tsx
@@ -1,4 +1,3 @@
-import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import ViewColumnIcon from '@mui/icons-material/ViewColumn';
 import { Box, Divider, Tooltip } from '@mui/material';
@@ -10,25 +9,14 @@ import {
   ToolbarButton,
 } from '@mui/x-data-grid';
 import { useTranslation } from 'react-i18next';
-import { useLocale } from 'src/hooks/useLocale';
-import { exportToCsv } from '../CustomExport/CustomExport';
-import { ReportTypeEnum } from '../Helper/MPGAReportEnum';
 import { TableCardHead } from '../Tables/TableCardHead';
-import { DataFields } from '../mockData';
 
 interface CustomToolbarProps {
-  data: DataFields[];
-  type: ReportTypeEnum;
   months: string[];
 }
 
-export const CustomToolbar: React.FC<CustomToolbarProps> = ({
-  data,
-  type,
-  months,
-}) => {
+export const CustomToolbar: React.FC<CustomToolbarProps> = ({ months }) => {
   const { t } = useTranslation();
-  const locale = useLocale();
 
   return (
     <Toolbar style={{ display: 'flex', justifyContent: 'left' }}>
@@ -72,11 +60,6 @@ export const CustomToolbar: React.FC<CustomToolbarProps> = ({
         sx={{ mx: 0.5, height: 30, alignSelf: 'center' }}
       />
 
-      <Tooltip title={t('Download as CSV')}>
-        <ToolbarButton onClick={() => exportToCsv(data, type, months, locale)}>
-          <FileDownloadIcon fontSize="small" color="primary" />
-        </ToolbarButton>
-      </Tooltip>
       <Box mb={2}>
         <TableCardHead months={months} />
       </Box>

--- a/src/components/Reports/MPGAIncomeExpensesReport/ExportCsvButton/ExportCsvButton.test.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/ExportCsvButton/ExportCsvButton.test.tsx
@@ -5,16 +5,16 @@ import userEvent from '@testing-library/user-event';
 import theme from 'src/theme';
 import { exportToCsv } from '../CustomExport/CustomExport';
 import { ReportTypeEnum } from '../Helper/MPGAReportEnum';
-import { mockData, months } from '../mockData';
+import { AllData, mockData, months } from '../mockData';
 import { ExportCsvButton } from './ExportCsvButton';
 
 jest.mock('../CustomExport/CustomExport', () => ({
   exportToCsv: jest.fn(),
 }));
 
-const TestComponent: React.FC = () => (
+const TestComponent: React.FC<{ data?: AllData }> = ({ data = mockData }) => (
   <ThemeProvider theme={theme}>
-    <ExportCsvButton data={mockData} months={months} />
+    <ExportCsvButton data={data} months={months} />
   </ThemeProvider>
 );
 
@@ -52,7 +52,7 @@ describe('ExportCsvButton', () => {
       mockData.income,
       ReportTypeEnum.Income,
       months,
-      expect.any(String),
+      'en-US',
     );
   });
 
@@ -66,8 +66,42 @@ describe('ExportCsvButton', () => {
       mockData.expenses,
       ReportTypeEnum.Expenses,
       months,
-      expect.any(String),
+      'en-US',
     );
+  });
+
+  it('disables an export option when its dataset is empty', async () => {
+    const { getByRole, findByRole } = render(
+      <TestComponent data={{ income: mockData.income, expenses: [] }} />,
+    );
+
+    userEvent.click(getByRole('button', { name: 'Export CSV' }));
+
+    expect(
+      await findByRole('menuitem', { name: 'Income' }),
+    ).not.toHaveAttribute('aria-disabled');
+
+    const expenses = await findByRole('menuitem', { name: 'Expenses' });
+    expect(expenses).toHaveAttribute('aria-disabled', 'true');
+    expect(exportToCsv).not.toHaveBeenCalled();
+  });
+
+  it('disables both export options when all datasets are empty', async () => {
+    const { getByRole, findByRole } = render(
+      <TestComponent data={{ income: [], expenses: [] }} />,
+    );
+
+    userEvent.click(getByRole('button', { name: 'Export CSV' }));
+
+    expect(await findByRole('menuitem', { name: 'Income' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+    expect(await findByRole('menuitem', { name: 'Expenses' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+    expect(exportToCsv).not.toHaveBeenCalled();
   });
 
   it('closes the menu after an export is selected', async () => {

--- a/src/components/Reports/MPGAIncomeExpensesReport/ExportCsvButton/ExportCsvButton.test.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/ExportCsvButton/ExportCsvButton.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import theme from 'src/theme';
+import { exportToCsv } from '../CustomExport/CustomExport';
+import { ReportTypeEnum } from '../Helper/MPGAReportEnum';
+import { mockData, months } from '../mockData';
+import { ExportCsvButton } from './ExportCsvButton';
+
+jest.mock('../CustomExport/CustomExport', () => ({
+  exportToCsv: jest.fn(),
+}));
+
+const TestComponent: React.FC = () => (
+  <ThemeProvider theme={theme}>
+    <ExportCsvButton data={mockData} months={months} />
+  </ThemeProvider>
+);
+
+describe('ExportCsvButton', () => {
+  beforeEach(() => {
+    (exportToCsv as jest.Mock).mockClear();
+  });
+
+  it('renders an Export CSV button', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(getByRole('button', { name: 'Export CSV' })).toBeInTheDocument();
+  });
+
+  it('opens a menu with Income and Expenses options when clicked', async () => {
+    const { getByRole, findByRole } = render(<TestComponent />);
+
+    userEvent.click(getByRole('button', { name: 'Export CSV' }));
+
+    expect(
+      await findByRole('menuitem', { name: 'Income' }),
+    ).toBeInTheDocument();
+    expect(
+      await findByRole('menuitem', { name: 'Expenses' }),
+    ).toBeInTheDocument();
+  });
+
+  it('exports the income CSV when Income is selected', async () => {
+    const { getByRole, findByRole } = render(<TestComponent />);
+
+    userEvent.click(getByRole('button', { name: 'Export CSV' }));
+    userEvent.click(await findByRole('menuitem', { name: 'Income' }));
+
+    expect(exportToCsv).toHaveBeenCalledWith(
+      mockData.income,
+      ReportTypeEnum.Income,
+      months,
+      expect.any(String),
+    );
+  });
+
+  it('exports the expenses CSV when Expenses is selected', async () => {
+    const { getByRole, findByRole } = render(<TestComponent />);
+
+    userEvent.click(getByRole('button', { name: 'Export CSV' }));
+    userEvent.click(await findByRole('menuitem', { name: 'Expenses' }));
+
+    expect(exportToCsv).toHaveBeenCalledWith(
+      mockData.expenses,
+      ReportTypeEnum.Expenses,
+      months,
+      expect.any(String),
+    );
+  });
+
+  it('closes the menu after an export is selected', async () => {
+    const { getByRole, findByRole, queryByRole } = render(<TestComponent />);
+
+    userEvent.click(getByRole('button', { name: 'Export CSV' }));
+    userEvent.click(await findByRole('menuitem', { name: 'Income' }));
+
+    await waitFor(() =>
+      expect(
+        queryByRole('menuitem', { name: 'Income' }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/src/components/Reports/MPGAIncomeExpensesReport/ExportCsvButton/ExportCsvButton.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/ExportCsvButton/ExportCsvButton.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import { Menu, MenuItem, SvgIcon } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useLocale } from 'src/hooks/useLocale';
+import { StyledPrintButton } from '../../styledComponents';
+import { exportToCsv } from '../CustomExport/CustomExport';
+import { ReportTypeEnum } from '../Helper/MPGAReportEnum';
+import { AllData } from '../mockData';
+
+interface ExportCsvButtonProps {
+  data: AllData;
+  months: string[];
+}
+
+export const ExportCsvButton: React.FC<ExportCsvButtonProps> = ({
+  data,
+  months,
+}) => {
+  const { t } = useTranslation();
+  const locale = useLocale();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleExport = (type: ReportTypeEnum) => {
+    const rows = type === ReportTypeEnum.Income ? data.income : data.expenses;
+    exportToCsv(rows, type, months, locale);
+    handleClose();
+  };
+
+  return (
+    <>
+      <StyledPrintButton
+        id="export-csv-button"
+        aria-controls={open ? 'export-csv-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        startIcon={
+          <SvgIcon fontSize="small">
+            <FileDownloadIcon titleAccess={t('Export CSV')} />
+          </SvgIcon>
+        }
+        endIcon={<ArrowDropDownIcon />}
+        onClick={handleOpen}
+      >
+        {t('Export CSV')}
+      </StyledPrintButton>
+      <Menu
+        id="export-csv-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{ 'aria-labelledby': 'export-csv-button' }}
+      >
+        <MenuItem onClick={() => handleExport(ReportTypeEnum.Income)}>
+          {t('Income')}
+        </MenuItem>
+        <MenuItem onClick={() => handleExport(ReportTypeEnum.Expenses)}>
+          {t('Expenses')}
+        </MenuItem>
+      </Menu>
+    </>
+  );
+};

--- a/src/components/Reports/MPGAIncomeExpensesReport/ExportCsvButton/ExportCsvButton.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/ExportCsvButton/ExportCsvButton.tsx
@@ -32,7 +32,19 @@ export const ExportCsvButton: React.FC<ExportCsvButtonProps> = ({
   };
 
   const handleExport = (type: ReportTypeEnum) => {
-    const rows = type === ReportTypeEnum.Income ? data.income : data.expenses;
+    let rows: AllData['income'];
+    switch (type) {
+      case ReportTypeEnum.Income:
+        rows = data.income;
+        break;
+      case ReportTypeEnum.Expenses:
+        rows = data.expenses;
+        break;
+      default:
+        // Exhaustiveness check: adding a ReportTypeEnum member without
+        // handling it here becomes a compile-time error.
+        return ((_exhaustive: never) => _exhaustive)(type);
+    }
     exportToCsv(rows, type, months, locale);
     handleClose();
   };
@@ -46,7 +58,7 @@ export const ExportCsvButton: React.FC<ExportCsvButtonProps> = ({
         aria-expanded={open ? 'true' : undefined}
         startIcon={
           <SvgIcon fontSize="small">
-            <FileDownloadIcon titleAccess={t('Export CSV')} />
+            <FileDownloadIcon />
           </SvgIcon>
         }
         endIcon={<ArrowDropDownIcon />}
@@ -61,10 +73,16 @@ export const ExportCsvButton: React.FC<ExportCsvButtonProps> = ({
         onClose={handleClose}
         MenuListProps={{ 'aria-labelledby': 'export-csv-button' }}
       >
-        <MenuItem onClick={() => handleExport(ReportTypeEnum.Income)}>
+        <MenuItem
+          disabled={!data.income.length}
+          onClick={() => handleExport(ReportTypeEnum.Income)}
+        >
           {t('Income')}
         </MenuItem>
-        <MenuItem onClick={() => handleExport(ReportTypeEnum.Expenses)}>
+        <MenuItem
+          disabled={!data.expenses.length}
+          onClick={() => handleExport(ReportTypeEnum.Expenses)}
+        >
           {t('Expenses')}
         </MenuItem>
       </Menu>

--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.test.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.test.tsx
@@ -64,6 +64,7 @@ describe('MPGAIncomeExpensesReport', () => {
     const { getByRole, findByText } = render(<TestComponent />);
     expect(getByRole('heading', { name: title })).toBeInTheDocument();
     expect(getByRole('button', { name: 'Print' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Export CSV' })).toBeInTheDocument();
 
     expect(await findByText('12345')).toBeInTheDocument();
     expect(await findByText('Test Account')).toBeInTheDocument();

--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
@@ -140,12 +140,16 @@ export const MPGAIncomeExpensesReport: React.FC<
                   {t('Income & Expenses Analysis: Last 12 Months')}
                 </Typography>
               </SimplePrintOnly>
-              <SimpleScreenOnly display="flex" alignItems="center">
+              <SimpleScreenOnly
+                display="flex"
+                alignItems="center"
+                sx={{ gap: 2, '& > button': { ml: 0 } }}
+              >
                 <ExportCsvButton data={allData} months={last12Months} />
                 <StyledPrintButton
                   startIcon={
                     <SvgIcon fontSize="small">
-                      <PrintIcon titleAccess={t('Print')} />
+                      <PrintIcon />
                     </SvgIcon>
                   }
                   onClick={handlePrint}

--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
@@ -30,6 +30,7 @@ import {
 } from '../styledComponents';
 import { PrintOnlyReport } from './DisplayModes/PrintOnlyReport';
 import { ScreenOnlyReport } from './DisplayModes/ScreenOnlyReport';
+import { ExportCsvButton } from './ExportCsvButton/ExportCsvButton';
 import { FundTypes, Funds } from './Helper/MPGAReportEnum';
 import { convertMonths } from './Helper/convertMonths';
 import { useMpgaTransactionsQuery } from './MPGATransactions.generated';
@@ -139,7 +140,8 @@ export const MPGAIncomeExpensesReport: React.FC<
                   {t('Income & Expenses Analysis: Last 12 Months')}
                 </Typography>
               </SimplePrintOnly>
-              <SimpleScreenOnly>
+              <SimpleScreenOnly display="flex" alignItems="center">
+                <ExportCsvButton data={allData} months={last12Months} />
                 <StyledPrintButton
                   startIcon={
                     <SvgIcon fontSize="small">

--- a/src/components/Reports/MPGAIncomeExpensesReport/Tables/TableCard.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/Tables/TableCard.tsx
@@ -37,14 +37,8 @@ export const descriptionWidth = 175;
 export const monthWidth = 65;
 export const summaryWidth = 98.5;
 
-const createToolbar = (
-  data: DataFields[],
-  type: ReportTypeEnum,
-  months: string[],
-) => {
-  const Toolbar = () => (
-    <CustomToolbar data={data} type={type} months={months} />
-  );
+const createToolbar = (months: string[]) => {
+  const Toolbar = () => <CustomToolbar months={months} />;
   Toolbar.displayName = 'MPGATableCustomToolbar';
   return Toolbar;
 };
@@ -162,7 +156,7 @@ export const TableCard: React.FC<TableCardProps> = ({
           pagination
           disableColumnMenu
           slots={{
-            toolbar: createToolbar(data, type, months),
+            toolbar: createToolbar(months),
           }}
           showToolbar
         />

--- a/src/components/Reports/MPGAIncomeExpensesReport/styledComponents.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/styledComponents.tsx
@@ -7,6 +7,7 @@ import { DataFields } from './mockData';
 export const StyledHeaderBox = styled(Box)({
   display: 'flex',
   alignItems: 'center',
+  flexWrap: 'wrap',
   gap: theme.spacing(2),
   justifyContent: 'space-between',
 });


### PR DESCRIPTION
## Description

- Replaced the easy-to-miss, icon-only CSV download buttons (one buried in each table's data-grid toolbar) with a single, clearly labeled **Export CSV** button in the report header, next to **Print**.
- The button opens a menu to choose **Income** or **Expenses**; each downloads the same CSV file as before (export logic unchanged).
- Styled to match the existing `StyledPrintButton` so it stays on the MPDX theme; added `aria-haspopup`/`aria-controls`/`aria-expanded` and localized strings (`Export CSV`, `Income`, `Expenses`).
- Removed the per-table download button from `CustomToolbar` and the now-unused `data`/`type` threading through `TableCard`.

Related ticket: [MPDX-9779](https://jira.cru.org/browse/MPDX-9779)

## Testing

- Go to **Reports → MPGA Income & Expenses** (`/accountLists/[accountListId]/reports/mpgaIncomeExpenses`)
- Check the report header shows an **Export CSV** button immediately left of **Print**
- Click **Export CSV** and confirm a menu appears with **Income** and **Expenses**
- Click **Income** → `MPGA Income Monthly Report.csv` downloads; click **Expenses** → `MPGA Expenses Monthly Report.csv` downloads
- Confirm the Income and Expenses table toolbars no longer show the standalone download icon

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)
