### PR TITLE
MPDX-9513,MPDX-9517 - NSO Questionnaire SOSA and Senior Staff Spouse financial questions

### DIFF
--- a/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/DebtQuestions.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/DebtQuestions.test.tsx
@@ -3,7 +3,7 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MockLinkCallHandler } from 'graphql-ergonomock/dist/apollo/MockLink';
 import { NsoMpdQuestionnaireTestWrapper } from '../NsoMpdQuestionnaireTestWrapper';
-import { FinancialDetails } from './FinancialDetails';
+import { DebtQuestions } from './DebtQuestions';
 
 const mutationSpy = jest.fn();
 
@@ -17,7 +17,7 @@ const TestComponent: React.FC<{
     onCall={onCall}
     newStaffQuestionnaire={newStaffQuestionnaire}
   >
-    <FinancialDetails />
+    <DebtQuestions />
   </NsoMpdQuestionnaireTestWrapper>
 );
 
@@ -28,7 +28,7 @@ const creditCardQuestion =
   'What is your monthly payment for all of your credit card debt?';
 const requiredError = 'Please enter an amount, or 0 if you have none.';
 
-describe('FinancialDetails', () => {
+describe('DebtQuestions', () => {
   it('renders the debt question with Yes and No options', () => {
     const { getByRole } = render(<TestComponent />);
 

--- a/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/DebtQuestions.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/DebtQuestions.tsx
@@ -10,7 +10,6 @@ import {
   InputAdornment,
   Radio,
   RadioGroup,
-  Stack,
 } from '@mui/material';
 import { TFunction, useTranslation } from 'react-i18next';
 import * as yup from 'yup';
@@ -21,26 +20,32 @@ import { NumberQuestion } from '../Shared/NumberQuestion';
 import { getAmountSchema } from '../Shared/helpers/getAmountSchema';
 import { QuestionnaireField } from '../Shared/useQuestionnaireAutoSave';
 
-export const getFinancialDetailsSchema = (t: TFunction) =>
+export const getDebtSchema = (t: TFunction) =>
   yup.object({
     studentLoanMonthlyPayment: getAmountSchema(t),
     carLoanMonthlyPayment: getAmountSchema(t),
     creditCardDebtMonthlyPayment: getAmountSchema(t),
   });
 
-export const FinancialDetails: React.FC = () => {
+export const DebtQuestions: React.FC = () => {
   const { t } = useTranslation();
 
-  const schema = useMemo(() => getFinancialDetailsSchema(t), [t]);
+  const schema = useMemo(() => getDebtSchema(t), [t]);
 
   const { saveField, questionnaire } = useNsoMpdQuestionnaire();
+
+  const {
+    studentLoanMonthlyPayment,
+    carLoanMonthlyPayment,
+    creditCardDebtMonthlyPayment,
+  } = questionnaire ?? {};
 
   // UI-only toggle, seeded from the saved debt fields
   const savedHasDebt = useMemo(() => {
     const debtAmounts = [
-      questionnaire?.studentLoanMonthlyPayment,
-      questionnaire?.carLoanMonthlyPayment,
-      questionnaire?.creditCardDebtMonthlyPayment,
+      studentLoanMonthlyPayment,
+      carLoanMonthlyPayment,
+      creditCardDebtMonthlyPayment,
     ];
     return debtAmounts.some((amount) => (amount ?? 0) > 0)
       ? 'Yes'
@@ -48,13 +53,12 @@ export const FinancialDetails: React.FC = () => {
         ? 'No'
         : '';
   }, [
-    questionnaire?.studentLoanMonthlyPayment,
-    questionnaire?.carLoanMonthlyPayment,
-    questionnaire?.creditCardDebtMonthlyPayment,
+    studentLoanMonthlyPayment,
+    carLoanMonthlyPayment,
+    creditCardDebtMonthlyPayment,
   ]);
   const [hasDebt, setHasDebt] = useSyncedState(savedHasDebt);
   const [hasDebtTouched, setHasDebtTouched] = useState(false);
-  const showDebtFields = hasDebt === 'Yes';
   const hasDebtError = !hasDebt;
   const showHasDebtError = hasDebtError && hasDebtTouched;
 
@@ -103,7 +107,7 @@ export const FinancialDetails: React.FC = () => {
   ];
 
   return (
-    <Stack spacing={4}>
+    <>
       <FormControl error={showHasDebtError}>
         <FormLabel id="has-debt-label" sx={{ color: 'text.primary' }}>
           {t('Do you have any student loan, car, or credit card debt?')}
@@ -124,7 +128,7 @@ export const FinancialDetails: React.FC = () => {
         )}
       </FormControl>
 
-      {showDebtFields &&
+      {hasDebt === 'Yes' &&
         debtFields.map(({ fieldName, debtType, icon }) => (
           <NumberQuestion
             key={fieldName}
@@ -142,6 +146,6 @@ export const FinancialDetails: React.FC = () => {
             }
           />
         ))}
-    </Stack>
+    </>
   );
 };

--- a/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/FinancialInformation.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/FinancialInformation.tsx
@@ -3,7 +3,8 @@ import { Box, Stack, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { StepPage } from '../Shared/StepPage';
 import { SubStep } from '../Shared/SubStepList';
-import { FinancialDetails } from './FinancialDetails';
+import { DebtQuestions } from './DebtQuestions';
+import { VariantQuestions } from './VariantQuestions';
 
 export const FinancialInformation: React.FC = () => {
   const { t } = useTranslation();
@@ -20,7 +21,10 @@ export const FinancialInformation: React.FC = () => {
           <Typography variant="body1">
             {t('Tell us about your financial situation.')}
           </Typography>
-          <FinancialDetails />
+          <Stack spacing={4}>
+            <VariantQuestions />
+            <DebtQuestions />
+          </Stack>
         </Stack>
       </Box>
     </StepPage>

--- a/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/VariantQuestions.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/VariantQuestions.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { MockLinkCallHandler } from 'graphql-ergonomock/dist/apollo/MockLink';
+import { NewStaffQuestionnaireVariantEnum } from 'src/graphql/types.generated';
+import { NsoMpdQuestionnaireTestWrapper } from '../NsoMpdQuestionnaireTestWrapper';
+import { VariantQuestions } from './VariantQuestions';
+
+const mutationSpy = jest.fn();
+
+const TestComponent: React.FC<{
+  onCall?: MockLinkCallHandler;
+  newStaffQuestionnaire?: React.ComponentProps<
+    typeof NsoMpdQuestionnaireTestWrapper
+  >['newStaffQuestionnaire'];
+}> = ({ onCall, newStaffQuestionnaire }) => (
+  <NsoMpdQuestionnaireTestWrapper
+    onCall={onCall}
+    newStaffQuestionnaire={newStaffQuestionnaire}
+  >
+    <VariantQuestions />
+  </NsoMpdQuestionnaireTestWrapper>
+);
+
+describe('VariantQuestions', () => {
+  it('renders no questions for the single or married variant', async () => {
+    const { queryByRole } = render(
+      <TestComponent
+        onCall={mutationSpy}
+        newStaffQuestionnaire={{
+          variant: NewStaffQuestionnaireVariantEnum.SingleMarried,
+        }}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('NewStaffQuestionnaire'),
+    );
+
+    expect(queryByRole('spinbutton')).not.toBeInTheDocument();
+    expect(
+      queryByRole('spinbutton', {
+        name: 'How many total dependents would you like to cover by your Cru healthcare?',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      queryByRole('spinbutton', {
+        name: "What is Jane's current requested annual salary?",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  describe('SOSA', () => {
+    it('shows only the healthcare dependents question', async () => {
+      const { findByRole, queryByRole } = render(
+        <TestComponent
+          newStaffQuestionnaire={{
+            variant: NewStaffQuestionnaireVariantEnum.Sosa,
+          }}
+        />,
+      );
+
+      expect(
+        await findByRole('spinbutton', {
+          name: 'How many total dependents would you like to cover by your Cru healthcare?',
+        }),
+      ).toBeInTheDocument();
+      expect(
+        queryByRole('spinbutton', {
+          name: "What is Jane's current requested annual salary?",
+        }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Spouse Senior Staff', () => {
+    it('shows the spouse salary, 403(b), MHA, and account-transfer questions', async () => {
+      const { findByRole, getByRole, queryByRole } = render(
+        <TestComponent
+          newStaffQuestionnaire={{
+            variant: NewStaffQuestionnaireVariantEnum.SpouseSeniorStaff,
+          }}
+        />,
+      );
+
+      expect(
+        await findByRole('spinbutton', {
+          name: "What is Jane's current requested annual salary?",
+        }),
+      ).toBeInTheDocument();
+      expect(
+        getByRole('spinbutton', {
+          name: "What is Jane's 403(b) contribution percentage?",
+        }),
+      ).toBeInTheDocument();
+      expect(
+        getByRole('spinbutton', {
+          name: "What is Jane's current requested MHA?",
+        }),
+      ).toBeInTheDocument();
+      expect(
+        getByRole('spinbutton', {
+          name: 'How much do you set aside automatically each month for biannual staff conference?',
+        }),
+      ).toBeInTheDocument();
+      expect(
+        getByRole('spinbutton', {
+          name: 'How much do you transfer in giving to other staff each month from your staff account?',
+        }),
+      ).toBeInTheDocument();
+      expect(
+        getByRole('spinbutton', {
+          name: 'How much do you have raised in Solid Support?',
+        }),
+      ).toBeInTheDocument();
+      expect(
+        queryByRole('spinbutton', {
+          name: 'How many total dependents would you like to cover by your Cru healthcare?',
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("interpolates the spouse's first name into the questions", async () => {
+      const { findByRole } = render(
+        <TestComponent
+          newStaffQuestionnaire={{
+            variant: NewStaffQuestionnaireVariantEnum.SpouseSeniorStaff,
+            spouseFirstName: 'Maria',
+          }}
+        />,
+      );
+
+      expect(
+        await findByRole('spinbutton', {
+          name: "What is Maria's current requested annual salary?",
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to "your spouse" when the spouse first name is missing', async () => {
+      const { findByRole } = render(
+        <TestComponent
+          newStaffQuestionnaire={{
+            variant: NewStaffQuestionnaireVariantEnum.SpouseSeniorStaff,
+            spouseFirstName: null,
+          }}
+        />,
+      );
+
+      expect(
+        await findByRole('spinbutton', {
+          name: "What is your spouse's current requested annual salary?",
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/VariantQuestions.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/VariantQuestions.tsx
@@ -1,0 +1,114 @@
+import React, { useMemo } from 'react';
+import { TFunction, useTranslation } from 'react-i18next';
+import * as yup from 'yup';
+import { NewStaffQuestionnaireVariantEnum } from 'src/graphql/types.generated';
+import { percentage } from 'src/lib/yupHelpers';
+import { useNsoMpdQuestionnaire } from '../Shared/NsoMpdQuestionnaireContext';
+import { NumberQuestion } from '../Shared/NumberQuestion';
+import { getAmountSchema } from '../Shared/helpers/getAmountSchema';
+import { getWholeNumberSchema } from '../Shared/helpers/getWholeNumberSchema';
+
+export const getVariantQuestionsSchema = (t: TFunction) =>
+  yup.object({
+    healthcareDependentsCount: getWholeNumberSchema(
+      t,
+      t('Please enter a number of dependents, or 0 if you have none.'),
+    ),
+    spouseRequestedAnnualSalary: getAmountSchema(t),
+    spouseContribution403bPercentage: percentage(
+      t('403(b) contribution percentage'),
+      t,
+    ).required(t('Please enter a percentage, or 0 if you contribute none.')),
+    spouseMhaAmount: getAmountSchema(t),
+    staffConferenceTransfer: getAmountSchema(t),
+    accountTransfers: getAmountSchema(t),
+    solidSupportRaised: getAmountSchema(t),
+  });
+
+export const VariantQuestions: React.FC = () => {
+  const { t } = useTranslation();
+
+  const schema = useMemo(() => getVariantQuestionsSchema(t), [t]);
+
+  const { questionnaire } = useNsoMpdQuestionnaire();
+  const { spouseFirstName, variant } = questionnaire ?? {};
+  const spouseName = spouseFirstName || t('your spouse');
+
+  return (
+    <>
+      {variant === NewStaffQuestionnaireVariantEnum.Sosa && (
+        <NumberQuestion
+          fieldName="healthcareDependentsCount"
+          schema={schema}
+          question={t(
+            'How many total dependents would you like to cover by your Cru healthcare?',
+          )}
+          helperText={t(
+            'Include your spouse as a dependent along with any unborn children and in process adoptions.',
+          )}
+        />
+      )}
+
+      {variant === NewStaffQuestionnaireVariantEnum.SpouseSeniorStaff && (
+        <>
+          <NumberQuestion
+            fieldName="spouseRequestedAnnualSalary"
+            schema={schema}
+            question={t(
+              "What is {{spouseName}}'s current requested annual salary?",
+              {
+                spouseName,
+              },
+            )}
+            helperText={t('Round to the nearest dollar.')}
+          />
+          <NumberQuestion
+            fieldName="spouseContribution403bPercentage"
+            schema={schema}
+            question={t(
+              "What is {{spouseName}}'s 403(b) contribution percentage?",
+              {
+                spouseName,
+              },
+            )}
+            helperText={t('Enter a percentage between 0 and 100.')}
+          />
+          <NumberQuestion
+            fieldName="spouseMhaAmount"
+            schema={schema}
+            question={t("What is {{spouseName}}'s current requested MHA?", {
+              spouseName,
+            })}
+            helperText={t('Please enter zero if you have not requested MHA.')}
+          />
+          <NumberQuestion
+            fieldName="staffConferenceTransfer"
+            schema={schema}
+            question={t(
+              'How much do you set aside automatically each month for biannual staff conference?',
+            )}
+            helperText={t(
+              'Please enter zero if you do not have a monthly amount taken out of your staff account for staff conference.',
+            )}
+          />
+          <NumberQuestion
+            fieldName="accountTransfers"
+            schema={schema}
+            question={t(
+              'How much do you transfer in giving to other staff each month from your staff account?',
+            )}
+            helperText={t(
+              'Please enter zero if you do not transfer money from your staff account each month as giving to other staff.',
+            )}
+          />
+          <NumberQuestion
+            fieldName="solidSupportRaised"
+            schema={schema}
+            question={t('How much do you have raised in Solid Support?')}
+            helperText={t('Please enter as a monthly amount.')}
+          />
+        </>
+      )}
+    </>
+  );
+};

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NewStaffQuestionnaire.graphql
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NewStaffQuestionnaire.graphql
@@ -1,33 +1,41 @@
 fragment NewStaffInformationFields on NewStaffQuestionnaire {
   id
-  personNumber
+  address
+  age
   firstName
   lastName
-  spousePersonNumber
+  maritalStatus
+  personNumber
+  spouseAge
   spouseFirstName
   spouseJoining
-  maritalStatus
-  age
-  spouseAge
-  tenure
+  spousePersonNumber
   spouseTenure
-  address
+  tenure
+  variant
 }
 
 fragment NewStaffQuestionnaireFields on NewStaffQuestionnaire {
   id
-  phoneNumber
-  ministryName
-  ministryLocation
-  geographicLocation
+  accountTransfers
   assignmentType
+  carLoanMonthlyPayment
+  childcareChildrenCount
+  creditCardDebtMonthlyPayment
+  geographicLocation
+  healthcareDependentsCount
+  ministryLocation
+  ministryName
   nsoHousing
   nsoSessions
   nsoSpecialNeedsSupportReceived
-  childcareChildrenCount
+  phoneNumber
+  solidSupportRaised
+  spouseContribution403bPercentage
+  spouseMhaAmount
+  spouseRequestedAnnualSalary
+  staffConferenceTransfer
   studentLoanMonthlyPayment
-  carLoanMonthlyPayment
-  creditCardDebtMonthlyPayment
 }
 
 query NewStaffQuestionnaire($accountListId: ID!) {

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NumberQuestion.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NumberQuestion.tsx
@@ -42,6 +42,7 @@ export const NumberQuestion: React.FC<NumberQuestionProps> = ({
       type="number"
       inputProps={{ min: 0, inputMode: 'numeric' }}
       InputProps={{ startAdornment }}
+      InputLabelProps={{ sx: { color: 'text.primary' } }}
       {...fieldProps}
     />
   );


### PR DESCRIPTION
## Description

- This PR adds the Senior Staff spouse and SOSA specific fields to Step 3, the Financial Information section of the NSO Questionnaire

Tickets:
- https://jira.cru.org/browse/MPDX-9513
- https://jira.cru.org/browse/MPDX-9517

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to NSO MPD Questionnaire > Step 3
- Check that the financial questions for senior staff spouses only show iff the variant/spouse is senior staff
- Check that the financial questions for SOSA staff only show iff the user variant is SOSA

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
