### PR TITLE
HS-1620291 - Increase minimum width of date column in DonationTable

### DIFF
--- a/src/components/DonationTable/DonationTable.tsx
+++ b/src/components/DonationTable/DonationTable.tsx
@@ -261,7 +261,7 @@ export const DonationTable: React.FC<DonationTableProps> = ({
       field: 'date',
       headerName: t('Date'),
       flex: 1,
-      minWidth: 90,
+      minWidth: 120,
       renderCell: date,
     },
     {


### PR DESCRIPTION
## Description

A user with a unique display and aspect ratio is unable to see full dates in DonationTable unless they manually widen the date column. Since their display is different, it is hard to determine what width works best for their own display. As a result, the wider the width, the more likely their issue will resolve. I chose 120 as a reasonable option to align with other rows.

HS ticket: https://secure.helpscout.net/conversation/3324593949/1620291?viewId=8745276
Related, prior PR: https://github.com/CruGlobal/mpdx-react/pull/1861/changes

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to the Contacts List, select a contact with a populated donation table and donations with 2 digit months and days (e.g. 12/13/2025)
- Check that the table still appears as expected.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
