### PR TITLE
MPDX-9711 Fix loading state on submit

### DIFF
--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/RequestPage.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/RequestPage.tsx
@@ -58,8 +58,15 @@ const MainContent: React.FC = () => {
   const [createRequest, { loading: creatingRequest }] =
     useCreateAdditionalSalaryRequestMutation();
 
-  const { values, submitForm, validateForm, submitCount, isValid, errors } =
-    useFormikContext<CompleteFormValues>();
+  const {
+    values,
+    submitForm,
+    validateForm,
+    submitCount,
+    isValid,
+    isSubmitting,
+    errors,
+  } = useFormikContext<CompleteFormValues>();
 
   const handleContinue = async () => {
     if (
@@ -158,6 +165,7 @@ const MainContent: React.FC = () => {
                 validateForm={validateForm}
                 submitCount={submitCount}
                 isValid={isValid}
+                isSubmitting={isSubmitting}
                 actionRequired={isEdit}
                 isEdit={isEdit}
                 additionalApproval={additionalApproval}

--- a/src/components/HrTools/AdditionalSalaryRequest/Shared/useAdditionalSalaryRequestForm.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/Shared/useAdditionalSalaryRequestForm.test.tsx
@@ -719,6 +719,52 @@ describe('useAdditionalSalaryRequestForm', () => {
         expect(mockHandleNextStep).toHaveBeenCalled();
       });
     });
+
+    it('should not submit or advance when the update mutation fails', async () => {
+      const { result } = renderHook(
+        () =>
+          useAdditionalSalaryRequestForm({
+            ...defaultFormValues,
+            phoneNumber: '555-123-4567',
+            emailAddress: 'test@example.com',
+          }),
+        {
+          wrapper: ({ children }) => (
+            <TestWrapper
+              mocks={{
+                ...defaultGqlMocks,
+                UpdateAdditionalSalaryRequest: (() => {
+                  throw new Error('Server Error');
+                }) as unknown as UpdateAdditionalSalaryRequestMutation,
+              }}
+            >
+              {children}
+            </TestWrapper>
+          ),
+        },
+      );
+
+      await waitFor(async () => {
+        const errors = await result.current.validateForm();
+        expect(errors).toEqual({});
+      });
+
+      let submitError: unknown;
+      await act(async () => {
+        submitError = await result.current
+          .submitForm()
+          .then(() => null)
+          .catch((error) => error);
+      });
+
+      expect(submitError).toEqual(
+        expect.objectContaining({ message: 'Server Error' }),
+      );
+      expect(mutationSpy).not.toHaveGraphqlOperation(
+        'SubmitAdditionalSalaryRequest',
+      );
+      expect(mockHandleNextStep).not.toHaveBeenCalled();
+    });
   });
 
   describe('formik integration', () => {

--- a/src/components/HrTools/AdditionalSalaryRequest/Shared/useAdditionalSalaryRequestForm.ts
+++ b/src/components/HrTools/AdditionalSalaryRequest/Shared/useAdditionalSalaryRequestForm.ts
@@ -201,12 +201,12 @@ export const useAdditionalSalaryRequestForm = (
   );
 
   const onSubmit = useCallback(
-    (values: CompleteFormValues) => {
+    async (values: CompleteFormValues) => {
       if (!requestId) {
         return;
       }
 
-      updateAdditionalSalaryRequest({
+      await updateAdditionalSalaryRequest({
         variables: {
           id: requestId,
           attributes: {
@@ -226,17 +226,15 @@ export const useAdditionalSalaryRequestForm = (
             ),
           },
         },
-        onCompleted: () => {
-          submitAdditionalSalaryRequest({
-            variables: {
-              id: requestId,
-            },
-            onCompleted: () => {
-              handleNextStep();
-            },
-          });
+      });
+
+      await submitAdditionalSalaryRequest({
+        variables: {
+          id: requestId,
         },
       });
+
+      handleNextStep();
     },
     [
       requestId,

--- a/src/components/HrTools/MinisterHousingAllowance/Steps/StepThree/Calculation.test.tsx
+++ b/src/components/HrTools/MinisterHousingAllowance/Steps/StepThree/Calculation.test.tsx
@@ -305,6 +305,46 @@ describe('Calculation', () => {
     });
   }, 10000);
 
+  it('keeps the modal open and does not advance when submit fails', async () => {
+    updateMutation.mockRejectedValueOnce(new Error('Server Error'));
+
+    const { getByRole, findByRole } = render(
+      <TestComponent
+        contextValue={{
+          ...defaultContext,
+          requestData: {
+            ...mockMHARequest,
+            id: 'request-id',
+            requestAttributes: {
+              ...mockMHARequest.requestAttributes,
+              rentOrOwn: MhaRentOrOwnEnum.Rent,
+              iUnderstandMhaPolicy: true,
+              phoneNumber: '1234567890',
+              emailAddress: 'john.doe@cru.org',
+            },
+          },
+        }}
+        rentOrOwn={MhaRentOrOwnEnum.Rent}
+      />,
+    );
+
+    const submitButton = await findByRole('button', { name: /submit/i });
+    userEvent.click(submitButton);
+
+    await findByRole('dialog');
+    const confirmButton = getByRole('button', { name: /yes, continue/i });
+    userEvent.click(confirmButton);
+
+    await waitFor(() => expect(updateMutation).toHaveBeenCalled());
+
+    expect(getByRole('dialog')).toBeInTheDocument();
+    expect(handleNextStep).not.toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalledWith(
+      expect.stringContaining('MHA request submitted successfully.'),
+      { variant: 'success' },
+    );
+  });
+
   it('should show discard modal when Discard is clicked', async () => {
     const { getByRole, findByRole } = render(
       <ThemeProvider theme={theme}>

--- a/src/components/HrTools/MinisterHousingAllowance/Steps/StepThree/Calculation.tsx
+++ b/src/components/HrTools/MinisterHousingAllowance/Steps/StepThree/Calculation.tsx
@@ -208,21 +208,22 @@ export const Calculation: React.FC<CalculationProps> = ({
       validateOnChange
       validateOnBlur
       onSubmit={async (values) => {
-        try {
-          await transformNullValues(values);
+        // Let a failed submit reject so DirectionButtons keeps the modal open
+        // for retry (the global Apollo error link surfaces the error toast)
+        await transformNullValues(values);
 
-          await submitMutation({
-            variables: { input: { requestId: requestData?.id ?? '' } },
-          });
-          enqueueSnackbar(t('MHA request submitted successfully.'), {
-            variant: 'success',
-          });
-          handleNextStep();
-        } catch (error) {}
+        await submitMutation({
+          variables: { input: { requestId: requestData?.id ?? '' } },
+        });
+        enqueueSnackbar(t('MHA request submitted successfully.'), {
+          variant: 'success',
+        });
+        handleNextStep();
       }}
     >
       {({
         isValid,
+        isSubmitting,
         submitCount,
         values,
         errors,
@@ -389,6 +390,7 @@ export const Calculation: React.FC<CalculationProps> = ({
                 validateForm={validateForm}
                 submitCount={submitCount}
                 isValid={isValid}
+                isSubmitting={isSubmitting}
                 deadlineDate={deadlineDate ?? ''}
                 actionRequired={actionRequired}
                 isEdit={isEdit}

--- a/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.tsx
@@ -32,6 +32,7 @@ interface DirectionButtonsProps {
   validateForm?: () => Promise<Record<string, string>>;
   submitCount?: number;
   isValid?: boolean;
+  isSubmitting?: boolean;
 }
 
 export const DirectionButtons: React.FC<DirectionButtonsProps> = ({
@@ -52,6 +53,7 @@ export const DirectionButtons: React.FC<DirectionButtonsProps> = ({
   validateForm,
   submitCount,
   isValid,
+  isSubmitting,
   deadlineDate,
   actionRequired,
   additionalApproval,
@@ -187,6 +189,7 @@ export const DirectionButtons: React.FC<DirectionButtonsProps> = ({
           additionalApproval={additionalApproval}
           splitAsr={splitAsr}
           disableSubmit={disableSubmit}
+          submitting={isSubmitting}
         />
       )}
       {openDiscardModal && (

--- a/src/components/HrTools/Shared/CalculationReports/SubmitModal/SubmitModal.test.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/SubmitModal/SubmitModal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
-import { render } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FormikProvider, useFormik } from 'formik';
 import { SnackbarProvider } from 'notistack';
@@ -84,6 +84,7 @@ interface TestComponentProps {
   actionRequired?: boolean;
   additionalApproval?: boolean;
   splitAsr?: boolean;
+  submitting?: boolean;
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({
@@ -98,6 +99,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
   actionRequired,
   additionalApproval,
   splitAsr,
+  submitting,
 }) => (
   <ThemeProvider theme={theme}>
     <TestRouter>
@@ -119,6 +121,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
                 actionRequired={actionRequired}
                 additionalApproval={additionalApproval}
                 splitAsr={splitAsr}
+                submitting={submitting}
               />
             </MinisterHousingAllowanceProvider>
           </FormikWrapper>
@@ -282,6 +285,53 @@ describe('ConfirmationModal', () => {
       expect(
         await findByRole('button', { name: /Submit For Approval/i }),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('submitting state', () => {
+    it('shows a loading spinner on the submit button while submitting', async () => {
+      const { findByRole } = render(
+        <TestComponent pageType={PageEnum.New} submitting={true} />,
+      );
+
+      const submitButton = await findByRole('button', {
+        name: /YES, CONTINUE/i,
+      });
+      expect(within(submitButton).getByRole('progressbar')).toBeInTheDocument();
+      expect(submitButton).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('disables the submit button while submitting', async () => {
+      const { findByRole } = render(
+        <TestComponent pageType={PageEnum.New} submitting={true} />,
+      );
+
+      expect(
+        await findByRole('button', { name: /YES, CONTINUE/i }),
+      ).toBeDisabled();
+    });
+
+    it('disables the GO BACK button while submitting', async () => {
+      const { findByRole } = render(
+        <TestComponent pageType={PageEnum.New} submitting={true} />,
+      );
+
+      expect(await findByRole('button', { name: /BACK/i })).toBeDisabled();
+    });
+
+    it('enables both buttons and hides the spinner when not submitting', async () => {
+      const { findByRole, getByRole } = render(
+        <TestComponent pageType={PageEnum.New} submitting={false} />,
+      );
+
+      const submitButton = await findByRole('button', {
+        name: /YES, CONTINUE/i,
+      });
+      expect(submitButton).toBeEnabled();
+      expect(getByRole('button', { name: /BACK/i })).toBeEnabled();
+      expect(
+        within(submitButton).queryByRole('progressbar'),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/HrTools/Shared/CalculationReports/SubmitModal/SubmitModal.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/SubmitModal/SubmitModal.tsx
@@ -4,6 +4,7 @@ import {
   Alert,
   Box,
   Button,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -32,6 +33,7 @@ interface SubmitModalProps {
   additionalApproval?: boolean;
   splitAsr?: boolean;
   disableSubmit?: boolean;
+  submitting?: boolean;
 }
 
 export const SubmitModal: React.FC<SubmitModalProps> = ({
@@ -49,6 +51,7 @@ export const SubmitModal: React.FC<SubmitModalProps> = ({
   additionalApproval,
   splitAsr,
   disableSubmit,
+  submitting,
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
@@ -79,7 +82,12 @@ export const SubmitModal: React.FC<SubmitModalProps> = ({
   const contentText = overrideSubContent ?? defaultContentText;
 
   return (
-    <Dialog open={true} onClose={handleClose} maxWidth="sm" fullWidth>
+    <Dialog
+      open={true}
+      onClose={submitting ? undefined : handleClose}
+      maxWidth="sm"
+      fullWidth
+    >
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
         <Alert severity={isError || splitAsr ? 'error' : 'warning'}>
@@ -98,19 +106,27 @@ export const SubmitModal: React.FC<SubmitModalProps> = ({
         )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose} sx={{ color: 'text.secondary' }}>
+        <Button
+          onClick={handleClose}
+          disabled={submitting}
+          sx={{ color: 'text.secondary' }}
+        >
           <b>{t('GO BACK')}</b>
         </Button>
         {!splitAsr && (
           <Button
             onClick={handleConfirm}
             color={isError ? 'error' : 'primary'}
-            disabled={disableSubmit}
+            disabled={disableSubmit || submitting}
+            aria-busy={submitting}
+            startIcon={
+              submitting ? <CircularProgress size={20} color="inherit" /> : null
+            }
           >
             <b>
               {additionalApproval ? t('Submit For Approval') : cancelButtonText}
             </b>
-            <ChevronRight sx={{ ml: 1 }} />
+            {!submitting && <ChevronRight sx={{ ml: 1 }} />}
           </Button>
         )}
       </DialogActions>


### PR DESCRIPTION
## Description

Additional Salary Requests are taking too long to submit, and there is no loading state to indicate to the user that the submission is loading. To fix this, I reworked `onSubmit` to await the update and submit mutations so the loading state stays active for the whole request. I also disabled the "continue" button and added a loading spinner so it is clear that the submission is taking place.

Jira ticket: [MPDX-9711](https://jira.cru.org/browse/MPDX-9711)

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

ASR test:
- Impersonate: timothy.ethington@cru.org
- Go to `/hrTools/additionalSalaryRequest`
- Input some valid values and submit the ASR
- Check that both buttons are disabled with a loading spinner present

MHA test:
- Impersonate: courtney.campbell@cru.org
- Go to `/hrTools/mhaCalculator`
- Input some valid values and submit MHA
- Check that both buttons are disabled with a loading spinner present

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
