### PR TITLE
MPDX-9810 Remove 0% from MPGA pie chart

### DIFF
--- a/src/components/Reports/MPGAIncomeExpensesReport/Charts/ExpensesPieChart.test.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/Charts/ExpensesPieChart.test.tsx
@@ -61,4 +61,14 @@ describe('ExpensesPieChart', () => {
     expect(getByText('Other')).toBeInTheDocument();
     expect(getByText('Assessment, Benefits, Salary')).toBeInTheDocument();
   });
+
+  it('shows a percentage label for each non-empty slice', async () => {
+    const { findByText, getByText, queryByText } = render(<TestComponent />);
+
+    expect(await findByText('78%')).toBeInTheDocument();
+    expect(getByText('11%')).toBeInTheDocument();
+    expect(getByText('10%')).toBeInTheDocument();
+
+    expect(queryByText('0%')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/Reports/MPGAIncomeExpensesReport/Charts/ExpensesPieChart.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/Charts/ExpensesPieChart.tsx
@@ -44,6 +44,8 @@ export const ExpensesPieChart: React.FC<ExpensesPieChartProps> = ({
             const x = cx + radius * Math.cos(-midAngle * RADIAN);
             const y = cy + radius * Math.sin(-midAngle * RADIAN);
 
+            const percentage = (percent * 100).toFixed(0);
+
             return (
               <text
                 x={x}
@@ -52,7 +54,7 @@ export const ExpensesPieChart: React.FC<ExpensesPieChartProps> = ({
                 textAnchor="middle"
                 dominantBaseline="central"
               >
-                {(percent * 100).toFixed(0)}%
+                {percentage === '0' ? null : `${percentage}%`}
               </text>
             );
           }}

--- a/src/components/Reports/MPGAIncomeExpensesReport/Charts/sharedRechartMock.ts
+++ b/src/components/Reports/MPGAIncomeExpensesReport/Charts/sharedRechartMock.ts
@@ -2,6 +2,11 @@ import * as React from 'react';
 
 const Original = jest.requireActual('recharts');
 
+Original.Pie.defaultProps = {
+  ...Original.Pie.defaultProps,
+  isAnimationActive: false,
+};
+
 const MockResponsiveContainer = ({ heightValue, aspect, children }) => {
   const width = 800;
   const height =


### PR DESCRIPTION
## Description

MPGA's pie chart rendered `0%` for any categories not present in expenses. This caused the percentages to overlap each other. I removed `0%` from rendering.

Jira ticket: [MPDX-9810](https://jira.cru.org/browse/MPDX-9810)

**Before:**
<img width="480" height="371" alt="Screenshot 2026-07-01 at 10 38 49 AM" src="https://github.com/user-attachments/assets/b2ceccec-d332-4858-b873-1e98f300599d" />

**After:**
<img width="475" height="436" alt="Screenshot 2026-07-01 at 11 11 45 AM" src="https://github.com/user-attachments/assets/bd46c351-dc3c-41ec-b928-b173800df8d6" />


## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Impersonate: courtney.campbell@cru.org
- Go to `/reports/mpgaIncomeExpenses`
- Check that both 0%'s were removed from the pie chart

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
