### PR TITLE
MPDX-9813 - NSO MPD Questionnaire Spouse Phone Number input

### DIFF
--- a/src/components/HrTools/NsoMpdQuestionnaire/NsoMpdQuestionnaire.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/NsoMpdQuestionnaire.test.tsx
@@ -28,7 +28,11 @@ describe('NsoMpdQuestionnaire', () => {
     const { findByRole, getByRole } = render(<TestComponent />);
 
     userEvent.type(
-      await findByRole('textbox', { name: 'Cell Phone Number' }),
+      await findByRole('textbox', { name: "John's cell phone number" }),
+      '1234567',
+    );
+    userEvent.type(
+      getByRole('textbox', { name: "Jane's cell phone number" }),
       '1234567',
     );
     userEvent.click(getByRole('button', { name: 'Continue' }));
@@ -44,7 +48,14 @@ describe('NsoMpdQuestionnaire', () => {
     expect(await findByRole('button', { name: 'Continue' })).toBeDisabled();
 
     userEvent.type(
-      getByRole('textbox', { name: 'Cell Phone Number' }),
+      await findByRole('textbox', { name: "John's cell phone number" }),
+      '1234567',
+    );
+
+    expect(getByRole('button', { name: 'Continue' })).toBeDisabled();
+
+    userEvent.type(
+      getByRole('textbox', { name: "Jane's cell phone number" }),
       '1234567',
     );
 

--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/ContactInformation.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/ContactInformation.test.tsx
@@ -14,25 +14,58 @@ const TestComponent: React.FC<{ onCall?: MockLinkCallHandler }> = ({
 );
 
 describe('ContactInformation', () => {
-  it('renders the cell phone number field', () => {
-    const { getByRole } = render(<TestComponent />);
+  it('renders a required phone field for the user and the spouse', async () => {
+    const { findByRole, getByRole } = render(<TestComponent />);
+
+    const spousePhone = await findByRole('textbox', {
+      name: "Jane's cell phone number",
+    });
+    const userPhone = getByRole('textbox', {
+      name: "John's cell phone number",
+    });
+
+    expect(userPhone).toBeRequired();
+    expect(spousePhone).toBeRequired();
+  });
+
+  it('has a column for the user and the spouse', async () => {
+    const { findByRole, getByRole } = render(<TestComponent />);
 
     expect(
-      getByRole('textbox', { name: 'Cell Phone Number' }),
+      await findByRole('columnheader', { name: 'Jane' }),
+    ).toBeInTheDocument();
+    expect(getByRole('columnheader', { name: 'John' })).toBeInTheDocument();
+    expect(
+      getByRole('rowheader', { name: 'Cell Phone Number' }),
     ).toBeInTheDocument();
   });
 
-  it('marks the cell phone number field as required', () => {
-    const { getByRole } = render(<TestComponent />);
+  it('only shows the user column without a spouse', async () => {
+    const { findByRole, queryByRole } = render(
+      <NsoMpdQuestionnaireTestWrapper hasSpouse={false}>
+        <ContactInformation />
+      </NsoMpdQuestionnaireTestWrapper>,
+    );
 
-    expect(getByRole('textbox', { name: 'Cell Phone Number' })).toBeRequired();
+    expect(
+      await findByRole('textbox', { name: "John's cell phone number" }),
+    ).toBeInTheDocument();
+    expect(
+      queryByRole('columnheader', { name: 'Jane' }),
+    ).not.toBeInTheDocument();
+    expect(
+      queryByRole('textbox', { name: "Jane's cell phone number" }),
+    ).not.toBeInTheDocument();
   });
 
-  it('saves the cell phone number through the upsert on blur', async () => {
+  it("saves the user's phone number on blur", async () => {
     const mutationSpy = jest.fn();
-    const { getByRole } = render(<TestComponent onCall={mutationSpy} />);
+    const { findByRole } = render(<TestComponent onCall={mutationSpy} />);
 
-    const input = getByRole('textbox', { name: 'Cell Phone Number' });
+    const input = await findByRole('textbox', {
+      name: "John's cell phone number",
+    });
+    userEvent.clear(input);
     userEvent.type(input, '(123) 456-7890');
     userEvent.tab();
 
@@ -41,7 +74,6 @@ describe('ContactInformation', () => {
         'UpdateNewStaffQuestionnaire',
         {
           input: {
-            accountListId: 'account-list-1',
             attributes: { phoneNumber: '(123) 456-7890' },
           },
         },
@@ -49,44 +81,55 @@ describe('ContactInformation', () => {
     );
   });
 
-  it('seeds the cell phone number from the loaded questionnaire', async () => {
+  it("saves the spouse's phone number on blur", async () => {
+    const mutationSpy = jest.fn();
+    const { findByRole } = render(<TestComponent onCall={mutationSpy} />);
+
+    const input = await findByRole('textbox', {
+      name: "Jane's cell phone number",
+    });
+    userEvent.clear(input);
+    userEvent.type(input, '(123) 456-7890');
+    userEvent.tab();
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation(
+        'UpdateNewStaffQuestionnaire',
+        {
+          input: {
+            attributes: { spousePhoneNumber: '(123) 456-7890' },
+          },
+        },
+      ),
+    );
+  });
+
+  it('seeds each phone number from the loaded questionnaire', async () => {
     const { findByDisplayValue } = render(
       <NsoMpdQuestionnaireTestWrapper
-        newStaffQuestionnaire={{ phoneNumber: '(305) 111-2222' }}
+        newStaffQuestionnaire={{
+          phoneNumber: '(305) 111-2222',
+          spousePhoneNumber: '(305) 333-4444',
+        }}
       >
         <ContactInformation />
       </NsoMpdQuestionnaireTestWrapper>,
     );
 
     expect(await findByDisplayValue('(305) 111-2222')).toBeInTheDocument();
+    expect(await findByDisplayValue('(305) 333-4444')).toBeInTheDocument();
   });
 
-  it('strips disallowed characters as the user types', () => {
-    const { getByRole } = render(<TestComponent />);
+  it('shows a validation error for too few digits on blur', async () => {
+    const { findByRole, getByText } = render(<TestComponent />);
 
-    const input = getByRole('textbox', { name: 'Cell Phone Number' });
-    userEvent.type(input, 'abc(123) 456-7890xyz');
-
-    expect(input).toHaveValue('(123) 456-7890');
-  });
-
-  it('shows a validation error for too few digits on blur', () => {
-    const { getByRole, getByText } = render(<TestComponent />);
-
-    const input = getByRole('textbox', { name: 'Cell Phone Number' });
+    const input = await findByRole('textbox', {
+      name: "John's cell phone number",
+    });
+    userEvent.clear(input);
     userEvent.type(input, '123');
     userEvent.tab();
 
     expect(getByText('Invalid phone number')).toBeInTheDocument();
-  });
-
-  it('accepts a valid number without error', () => {
-    const { getByRole, queryByText } = render(<TestComponent />);
-
-    const input = getByRole('textbox', { name: 'Cell Phone Number' });
-    userEvent.type(input, '(123) 456-7890');
-    userEvent.tab();
-
-    expect(queryByText('Invalid phone number')).not.toBeInTheDocument();
   });
 });

--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/ContactInformation.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/ContactInformation.tsx
@@ -1,50 +1,84 @@
-import React, { useMemo } from 'react';
-import Phone from '@mui/icons-material/Phone';
-import { InputAdornment, Stack, TextField, Typography } from '@mui/material';
+import React from 'react';
+import {
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
-import * as yup from 'yup';
-import { phoneNumber } from 'src/lib/yupHelpers';
-import { useQuestionnaireAutoSave } from '../Shared/useQuestionnaireAutoSave';
-
-const placeholder = '000-000-0000';
+import { useNsoMpdQuestionnaire } from '../Shared/NsoMpdQuestionnaireContext';
+import { PhoneNumberField } from './PhoneNumberField';
 
 export const ContactInformation: React.FC = () => {
   const { t } = useTranslation();
+  const theme = useTheme();
+  const { questionnaire, hasSpouse } = useNsoMpdQuestionnaire();
+  const { firstName, spouseFirstName } = questionnaire ?? {};
 
-  const schema = useMemo(
-    () =>
-      yup.object({
-        phoneNumber: phoneNumber(t).required(
-          t('Cell phone number is required'),
-        ),
-      }),
-    [t],
-  );
+  const userName = firstName ?? t('You');
+  const spouseColumnName = spouseFirstName ?? t('Spouse');
+  const spouseName = spouseFirstName ?? t('your spouse');
 
-  const fieldProps = useQuestionnaireAutoSave({
-    fieldName: 'phoneNumber',
-    schema,
-  });
+  const userLabel = firstName
+    ? t("{{name}}'s cell phone number", { name: firstName })
+    : t('Your cell phone number');
 
   return (
     <Stack spacing={2}>
       <Typography variant="h6">{t('Contact Information')}</Typography>
-      <Typography>{t('Please provide your cell phone number.')}</Typography>
-      <TextField
-        required
-        label={t('Cell Phone Number')}
-        placeholder={placeholder}
+      <Typography>
+        {hasSpouse
+          ? t('Please provide a cell phone number for each person below.')
+          : t('Please provide your cell phone number.')}
+      </Typography>
+      <Table
         size="small"
-        sx={{ maxWidth: (theme) => theme.spacing(40) }}
-        InputProps={{
-          startAdornment: (
-            <InputAdornment position="start">
-              <Phone />
-            </InputAdornment>
-          ),
+        sx={{
+          maxWidth: theme.spacing(90),
+          '.MuiTableCell-root': { paddingBlock: theme.spacing(1) },
         }}
-        {...fieldProps}
-      />
+      >
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ width: theme.spacing(25) }} />
+            <TableCell scope="col" sx={{ color: theme.palette.mpdxBlue.main }}>
+              {userName}
+            </TableCell>
+            {hasSpouse && (
+              <TableCell
+                scope="col"
+                sx={{ color: theme.palette.mpdxBlue.main }}
+              >
+                {spouseColumnName}
+              </TableCell>
+            )}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell component="th" scope="row" sx={{ fontWeight: 'medium' }}>
+              {t('Cell Phone Number')}
+            </TableCell>
+            <TableCell>
+              <PhoneNumberField fieldName="phoneNumber" label={userLabel} />
+            </TableCell>
+            {hasSpouse && (
+              <TableCell>
+                <PhoneNumberField
+                  fieldName="spousePhoneNumber"
+                  label={t("{{spouseName}}'s cell phone number", {
+                    spouseName,
+                  })}
+                />
+              </TableCell>
+            )}
+          </TableRow>
+        </TableBody>
+      </Table>
     </Stack>
   );
 };

--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/PhoneNumberField.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/PhoneNumberField.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MockLinkCallHandler } from 'graphql-ergonomock/dist/apollo/MockLink';
+import { NsoMpdQuestionnaireTestWrapper } from '../NsoMpdQuestionnaireTestWrapper';
+import { PhoneNumberField } from './PhoneNumberField';
+
+const TestComponent: React.FC<{
+  onCall?: MockLinkCallHandler;
+  fieldName?: 'phoneNumber' | 'spousePhoneNumber';
+}> = ({ onCall, fieldName = 'phoneNumber' }) => (
+  <NsoMpdQuestionnaireTestWrapper onCall={onCall}>
+    <PhoneNumberField fieldName={fieldName} label="Cell phone number" />
+  </NsoMpdQuestionnaireTestWrapper>
+);
+
+describe('PhoneNumberField', () => {
+  it('renders a required cell phone number field', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    const input = getByRole('textbox', { name: 'Cell phone number' });
+    expect(input).toBeInTheDocument();
+    expect(input).toBeRequired();
+  });
+
+  it('seeds the value from the loaded questionnaire', async () => {
+    const { findByDisplayValue } = render(
+      <NsoMpdQuestionnaireTestWrapper
+        newStaffQuestionnaire={{ phoneNumber: '(305) 111-2222' }}
+      >
+        <PhoneNumberField fieldName="phoneNumber" label="Cell phone number" />
+      </NsoMpdQuestionnaireTestWrapper>,
+    );
+
+    expect(await findByDisplayValue('(305) 111-2222')).toBeInTheDocument();
+  });
+
+  it('saves phoneNumber through the upsert on blur', async () => {
+    const mutationSpy = jest.fn();
+    const { getByRole } = render(<TestComponent onCall={mutationSpy} />);
+
+    const input = getByRole('textbox', { name: 'Cell phone number' });
+    userEvent.clear(input);
+    userEvent.type(input, '(123) 456-7890');
+    userEvent.tab();
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation(
+        'UpdateNewStaffQuestionnaire',
+        {
+          input: {
+            accountListId: 'account-list-1',
+            attributes: { phoneNumber: '(123) 456-7890' },
+          },
+        },
+      ),
+    );
+  });
+
+  it('saves spousePhoneNumber when bound to the spouse field', async () => {
+    const mutationSpy = jest.fn();
+    const { getByRole } = render(
+      <TestComponent onCall={mutationSpy} fieldName="spousePhoneNumber" />,
+    );
+
+    const input = getByRole('textbox', { name: 'Cell phone number' });
+    userEvent.clear(input);
+    userEvent.type(input, '(123) 456-7890');
+    userEvent.tab();
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation(
+        'UpdateNewStaffQuestionnaire',
+        {
+          input: {
+            attributes: { spousePhoneNumber: '(123) 456-7890' },
+          },
+        },
+      ),
+    );
+  });
+
+  it('strips disallowed characters as the user types', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    const input = getByRole('textbox', { name: 'Cell phone number' });
+    userEvent.clear(input);
+    userEvent.type(input, 'abc(123) 456-7890xyz');
+
+    expect(input).toHaveValue('(123) 456-7890');
+  });
+
+  it('shows a validation error for too few digits on blur', () => {
+    const { getByRole, getByText } = render(<TestComponent />);
+
+    const input = getByRole('textbox', { name: 'Cell phone number' });
+    userEvent.clear(input);
+    userEvent.type(input, '123');
+    userEvent.tab();
+
+    expect(getByText('Invalid phone number')).toBeInTheDocument();
+  });
+});

--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/PhoneNumberField.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/PhoneNumberField.tsx
@@ -1,0 +1,58 @@
+import React, { useMemo } from 'react';
+import Phone from '@mui/icons-material/Phone';
+import { InputAdornment, TextField } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import * as yup from 'yup';
+import { phoneNumber } from 'src/lib/yupHelpers';
+import {
+  QuestionnaireField,
+  useQuestionnaireAutoSave,
+} from '../Shared/useQuestionnaireAutoSave';
+
+const placeholder = '000-000-0000';
+
+interface PhoneNumberFieldProps {
+  fieldName: Extract<QuestionnaireField, 'phoneNumber' | 'spousePhoneNumber'>;
+  /**
+   * Visible, person-scoped label (e.g. "Jane's cell phone number") so the user and spouse fields
+   * have distinct accessible names for screen readers.
+   */
+  label: string;
+}
+
+export const PhoneNumberField: React.FC<PhoneNumberFieldProps> = ({
+  fieldName,
+  label,
+}) => {
+  const { t } = useTranslation();
+
+  const schema = useMemo(
+    () =>
+      yup.object({
+        [fieldName]: phoneNumber(t).required(
+          t('Cell phone number is required'),
+        ),
+      }),
+    [t, fieldName],
+  );
+
+  const fieldProps = useQuestionnaireAutoSave({ fieldName, schema });
+
+  return (
+    <TextField
+      required
+      label={label}
+      placeholder={placeholder}
+      size="small"
+      fullWidth
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <Phone />
+          </InputAdornment>
+        ),
+      }}
+      {...fieldProps}
+    />
+  );
+};

--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/StaffInformation.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/StaffInformation.tsx
@@ -2,22 +2,16 @@ import React, { useState } from 'react';
 import { Stack, TextField, Typography } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
-import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
 import { getLocalizedAge } from 'src/lib/functions/getLocalizedAge';
 import { StaffInfoCard } from '../../Shared/StaffInfoCard/StaffInfoCard';
 import { useNsoMpdQuestionnaire } from '../Shared/NsoMpdQuestionnaireContext';
 
 export const StaffInformation: React.FC = () => {
   const { t } = useTranslation();
-  const { questionnaire } = useNsoMpdQuestionnaire();
+  const { questionnaire, hasSpouse } = useNsoMpdQuestionnaire();
   const { data: userData } = useGetUserQuery();
 
   const [viewingSpouse, setViewingSpouse] = useState(false);
-
-  const maritalStatus = questionnaire?.maritalStatus;
-  const hasSpouse =
-    !!maritalStatus &&
-    maritalStatus !== NewStaffQuestionnaireMaritalStatusEnum.Single;
 
   // Primary user is always new/joining staff
   const isJoining = viewingSpouse ? questionnaire?.spouseJoining : true;

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NewStaffQuestionnaire.graphql
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NewStaffQuestionnaire.graphql
@@ -34,6 +34,7 @@ fragment NewStaffQuestionnaireFields on NewStaffQuestionnaire {
   solidSupportRaised
   spouseContribution403bPercentage
   spouseMhaAmount
+  spousePhoneNumber
   spouseRequestedAnnualSalary
   staffConferenceTransfer
   studentLoanMonthlyPayment

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NsoMpdQuestionnaireContext.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NsoMpdQuestionnaireContext.tsx
@@ -9,6 +9,7 @@ import {
   useNewStaffQuestionnaireQuery,
 } from './NewStaffQuestionnaire.generated';
 import { useUpdateNewStaffQuestionnaireMutation } from './UpdateNewStaffQuestionnaire.generated';
+import { getHasSpouse } from './helpers/getHasSpouse';
 import { getCompletionPercentage } from './stepCompletion';
 import { NsoMpdQuestionnaireStep, useSteps } from './useSteps';
 
@@ -28,6 +29,8 @@ export type NsoMpdQuestionnaireType = {
   toggleDrawer: () => void;
   setDrawerOpen: (open: boolean) => void;
   questionnaire: NewStaffQuestionnaire | null;
+  /** Whether the questionnaire belongs to a married staff member (has a spouse to collect info for). */
+  hasSpouse: boolean;
   loading: boolean;
   isMutating: boolean;
   saveField: (
@@ -68,6 +71,8 @@ export const NsoMpdQuestionnaireProvider: React.FC<Props> = ({ children }) => {
     skip: !accountListId,
   });
   const questionnaire = questionnaireData?.newStaffQuestionnaire ?? null;
+
+  const hasSpouse = getHasSpouse(questionnaire?.maritalStatus);
 
   const percentComplete = useMemo(
     () => getCompletionPercentage(questionnaire),
@@ -152,6 +157,7 @@ export const NsoMpdQuestionnaireProvider: React.FC<Props> = ({ children }) => {
       toggleDrawer,
       setDrawerOpen,
       questionnaire,
+      hasSpouse,
       loading,
       isMutating,
       saveField,
@@ -170,6 +176,7 @@ export const NsoMpdQuestionnaireProvider: React.FC<Props> = ({ children }) => {
       toggleDrawer,
       setDrawerOpen,
       questionnaire,
+      hasSpouse,
       loading,
       isMutating,
       saveField,

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/helpers/getHasSpouse.test.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/helpers/getHasSpouse.test.ts
@@ -1,0 +1,27 @@
+import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
+import { getHasSpouse } from './getHasSpouse';
+
+describe('getHasSpouse', () => {
+  it('returns false when the status is missing', () => {
+    expect(getHasSpouse(null)).toBe(false);
+    expect(getHasSpouse(undefined)).toBe(false);
+  });
+
+  it('returns false for a single staff member', () => {
+    expect(getHasSpouse(NewStaffQuestionnaireMaritalStatusEnum.Single)).toBe(
+      false,
+    );
+  });
+
+  it('returns true for a married staff member', () => {
+    expect(getHasSpouse(NewStaffQuestionnaireMaritalStatusEnum.Married)).toBe(
+      true,
+    );
+  });
+
+  it('returns true for a sosa staff member', () => {
+    expect(getHasSpouse(NewStaffQuestionnaireMaritalStatusEnum.Sosa)).toBe(
+      true,
+    );
+  });
+});

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/helpers/getHasSpouse.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/helpers/getHasSpouse.ts
@@ -1,0 +1,12 @@
+import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
+
+/**
+ * Whether the questionnaire belongs to a staff member with a spouse whose information we need to
+ * collect. A missing status or an explicit Single counts as no spouse. Every other status
+ * (Married, Sosa) counts as having a spouse.
+ */
+export const getHasSpouse = (
+  maritalStatus: NewStaffQuestionnaireMaritalStatusEnum | null | undefined,
+): boolean =>
+  !!maritalStatus &&
+  maritalStatus !== NewStaffQuestionnaireMaritalStatusEnum.Single;

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.test.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.test.ts
@@ -1,0 +1,58 @@
+import {
+  GoalCalculationRole,
+  NewStaffQuestionnaireMaritalStatusEnum,
+  NewStaffQuestionnaireNsoHousingEnum,
+  NewStaffQuestionnaireNsoSessionsEnum,
+  NewStaffQuestionnaireVariantEnum,
+} from 'src/graphql/types.generated';
+import { NewStaffQuestionnaireQuery } from './NewStaffQuestionnaire.generated';
+import { getCompletionPercentage } from './stepCompletion';
+
+type Questionnaire = NonNullable<
+  NewStaffQuestionnaireQuery['newStaffQuestionnaire']
+>;
+
+const completeSingle: Questionnaire = {
+  id: 'questionnaire-1',
+  personNumber: '000123456',
+  updatedAt: '2026-01-01T00:00:00Z',
+  maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Single,
+  variant: NewStaffQuestionnaireVariantEnum.SingleMarried,
+  phoneNumber: '(305) 000-1111',
+  ministryName: 'Campus',
+  ministryLocation: 'Miami, FL',
+  geographicLocation: 'Miami, FL',
+  assignmentType: GoalCalculationRole.Field,
+  studentLoanMonthlyPayment: 0,
+  carLoanMonthlyPayment: 0,
+  creditCardDebtMonthlyPayment: 0,
+  nsoHousing: NewStaffQuestionnaireNsoHousingEnum.SingleRoom,
+  nsoSessions: NewStaffQuestionnaireNsoSessionsEnum.Nso,
+  nsoSpecialNeedsSupportReceived: 0,
+  childcareChildrenCount: 0,
+};
+
+describe('getCompletionPercentage', () => {
+  it('returns 0 for a missing questionnaire', () => {
+    expect(getCompletionPercentage(null)).toBe(0);
+  });
+
+  it('completes a single staff member without a spouse phone number', () => {
+    expect(getCompletionPercentage(completeSingle)).toBe(100);
+  });
+
+  it('requires the spouse phone number when married', () => {
+    const married: Questionnaire = {
+      ...completeSingle,
+      maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Married,
+    };
+
+    expect(getCompletionPercentage(married)).toBe(75);
+    expect(
+      getCompletionPercentage({
+        ...married,
+        spousePhoneNumber: '(305) 222-3333',
+      }),
+    ).toBe(100);
+  });
+});

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.ts
@@ -2,6 +2,7 @@ import { NewStaffQuestionnaireVariantEnum } from 'src/graphql/types.generated';
 import { safeProgressRatio } from '../../Shared/helpers/safeProgressRatio';
 import { NsoMpdQuestionnaireStepEnum } from '../NsoMpdQuestionnaireHelper';
 import { NewStaffQuestionnaireQuery } from './NewStaffQuestionnaire.generated';
+import { getHasSpouse } from './helpers/getHasSpouse';
 
 type NewStaffQuestionnaire =
   NewStaffQuestionnaireQuery['newStaffQuestionnaire'];
@@ -60,6 +61,13 @@ const getRequiredFields = (
   questionnaire: NonNullable<NewStaffQuestionnaire>,
 ): QuestionnaireField[] => {
   const baseFields = stepRequiredFields[step] ?? [];
+
+  if (step === NsoMpdQuestionnaireStepEnum.PersonalInformation) {
+    return getHasSpouse(questionnaire.maritalStatus)
+      ? [...baseFields, 'spousePhoneNumber']
+      : baseFields;
+  }
+
   if (step !== NsoMpdQuestionnaireStepEnum.FinancialInformation) {
     return baseFields;
   }

--- a/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.test.tsx
@@ -70,6 +70,33 @@ describe('Summary', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('shows the spouse cell phone for a married staff member', async () => {
+    const { findByRole, getByRole } = render(
+      <TestComponent
+        newStaffQuestionnaire={{ spousePhoneNumber: '(305) 222-3333' }}
+      />,
+    );
+    expect(
+      await findByRole('rowheader', { name: 'Spouse cell phone' }),
+    ).toBeInTheDocument();
+    expect(getByRole('cell', { name: '(305) 222-3333' })).toBeInTheDocument();
+  });
+
+  it('omits the spouse cell phone for a single staff member', async () => {
+    const { findByRole, queryByRole } = render(
+      <TestComponent
+        hasSpouse={false}
+        newStaffQuestionnaire={{
+          maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Single,
+        }}
+      />,
+    );
+    await findByRole('heading', { level: 6, name: 'Personal Information' });
+    expect(
+      queryByRole('rowheader', { name: 'Spouse cell phone' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('lists unanswered fields with a placeholder', async () => {
     const { findByRole, getAllByRole } = render(
       <TestComponent newStaffQuestionnaire={{ carLoanMonthlyPayment: null }} />,

--- a/src/components/HrTools/NsoMpdQuestionnaire/Summary/useSummarySections.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Summary/useSummarySections.ts
@@ -33,7 +33,7 @@ const formatNumber = (value?: number | null): string | null =>
 export const useSummarySections = (): SummarySectionData[] => {
   const { t } = useTranslation();
   const locale = useLocale();
-  const { questionnaire } = useNsoMpdQuestionnaire();
+  const { questionnaire, hasSpouse } = useNsoMpdQuestionnaire();
 
   return useMemo<SummarySectionData[]>(() => {
     const {
@@ -45,6 +45,7 @@ export const useSummarySections = (): SummarySectionData[] => {
       tenure,
       address,
       phoneNumber,
+      spousePhoneNumber,
       spouseFirstName,
       spouseAge,
       spouseTenure,
@@ -87,9 +88,6 @@ export const useSummarySections = (): SummarySectionData[] => {
       : null;
 
     // Gate variant/spouse-dependent rows
-    const hasSpouse =
-      !!maritalStatus &&
-      maritalStatus !== NewStaffQuestionnaireMaritalStatusEnum.Single;
     const isSosa = variant === NewStaffQuestionnaireVariantEnum.Sosa;
     const isSpouseSeniorStaff =
       variant === NewStaffQuestionnaireVariantEnum.SpouseSeniorStaff;
@@ -112,7 +110,9 @@ export const useSummarySections = (): SummarySectionData[] => {
             ? [
                 {
                   label: t('Spouse name'),
-                  value: formatText(spouseFirstName),
+                  value:
+                    [spouseFirstName, lastName].filter(Boolean).join(' ') ||
+                    null,
                 },
                 {
                   label: t('Spouse age'),
@@ -121,6 +121,10 @@ export const useSummarySections = (): SummarySectionData[] => {
                 {
                   label: t('Spouse tenure'),
                   value: formatNumber(spouseTenure),
+                },
+                {
+                  label: t('Spouse cell phone'),
+                  value: formatText(spousePhoneNumber),
                 },
               ]
             : []),
@@ -217,5 +221,5 @@ export const useSummarySections = (): SummarySectionData[] => {
         ],
       },
     ];
-  }, [questionnaire, t, locale]);
+  }, [questionnaire, hasSpouse, t, locale]);
 };


### PR DESCRIPTION
## Description

- Adds a single row table for collecting Staff and Spouse phone numbers in ContactInformation
- Makes the repeated `hasSpouse` logic a shared function and variable in the context.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to NSO Questionnaire
- Test that the Contact Information section works as expected and that both staff and spouse phone numbers are required if married
- Check that Continue is blocked until both inputs are filled
- Check that error handling works correctly
- Check that this step works for single, married, SOSA, and senior spouse

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
