### PR TITLE
MPDX-9815 - Add completion state to sub-steps in questionnaire components

### DIFF
--- a/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/FinancialInformation.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/FinancialInformation.tsx
@@ -1,16 +1,27 @@
 import React from 'react';
 import { Box, Stack, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { NsoMpdQuestionnaireStepEnum } from '../NsoMpdQuestionnaireHelper';
+import { useNsoMpdQuestionnaire } from '../Shared/NsoMpdQuestionnaireContext';
 import { StepPage } from '../Shared/StepPage';
 import { SubStep } from '../Shared/SubStepList';
+import { isStepComplete } from '../Shared/stepCompletion';
 import { DebtQuestions } from './DebtQuestions';
 import { VariantQuestions } from './VariantQuestions';
 
 export const FinancialInformation: React.FC = () => {
   const { t } = useTranslation();
+  const { questionnaire } = useNsoMpdQuestionnaire();
 
   const subSteps: SubStep[] = [
-    { id: 'financial-information', title: t('Financial Information') },
+    {
+      id: 'financial-information',
+      title: t('Financial Information'),
+      complete: isStepComplete(
+        NsoMpdQuestionnaireStepEnum.FinancialInformation,
+        questionnaire,
+      ),
+    },
   ];
 
   return (

--- a/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryInformation.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryInformation.tsx
@@ -1,15 +1,26 @@
 import React from 'react';
 import { Box, Stack, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { NsoMpdQuestionnaireStepEnum } from '../NsoMpdQuestionnaireHelper';
+import { useNsoMpdQuestionnaire } from '../Shared/NsoMpdQuestionnaireContext';
 import { StepPage } from '../Shared/StepPage';
 import { SubStep } from '../Shared/SubStepList';
+import { isStepComplete } from '../Shared/stepCompletion';
 import { MinistryDetails } from './MinistryDetails';
 
 export const MinistryInformation: React.FC = () => {
   const { t } = useTranslation();
+  const { questionnaire } = useNsoMpdQuestionnaire();
 
   const subSteps: SubStep[] = [
-    { id: 'ministry-information', title: t('Ministry Information') },
+    {
+      id: 'ministry-information',
+      title: t('Ministry Information'),
+      complete: isStepComplete(
+        NsoMpdQuestionnaireStepEnum.MinistryInformation,
+        questionnaire,
+      ),
+    },
   ];
 
   return (

--- a/src/components/HrTools/NsoMpdQuestionnaire/NsoInformation/NsoInformation.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/NsoInformation/NsoInformation.tsx
@@ -1,15 +1,26 @@
 import React from 'react';
 import { Box, Stack, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { NsoMpdQuestionnaireStepEnum } from '../NsoMpdQuestionnaireHelper';
+import { useNsoMpdQuestionnaire } from '../Shared/NsoMpdQuestionnaireContext';
 import { StepPage } from '../Shared/StepPage';
 import { SubStep } from '../Shared/SubStepList';
+import { isStepComplete } from '../Shared/stepCompletion';
 import { NsoDetails } from './NsoDetails';
 
 export const NsoInformation: React.FC = () => {
   const { t } = useTranslation();
+  const { questionnaire } = useNsoMpdQuestionnaire();
 
   const subSteps: SubStep[] = [
-    { id: 'nso-information', title: t('NSO Information') },
+    {
+      id: 'nso-information',
+      title: t('NSO Information'),
+      complete: isStepComplete(
+        NsoMpdQuestionnaireStepEnum.NsoInformation,
+        questionnaire,
+      ),
+    },
   ];
 
   return (

--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/PersonalInformation.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/PersonalInformation.tsx
@@ -1,18 +1,30 @@
 import React from 'react';
 import { Box, Divider } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { NsoMpdQuestionnaireStepEnum } from '../NsoMpdQuestionnaireHelper';
+import { useNsoMpdQuestionnaire } from '../Shared/NsoMpdQuestionnaireContext';
 import { StepPage } from '../Shared/StepPage';
 import { SubStep } from '../Shared/SubStepList';
+import { isStepComplete } from '../Shared/stepCompletion';
 import { ContactInformation } from './ContactInformation';
 import { Settings } from './Settings';
 import { StaffInformation } from './StaffInformation';
 
 export const PersonalInformation: React.FC = () => {
   const { t } = useTranslation();
+  const { questionnaire } = useNsoMpdQuestionnaire();
 
   const subSteps: SubStep[] = [
-    { id: 'staff-information', title: t('Staff Information') },
-    { id: 'contact-information', title: t('Contact Information') },
+    // Staff Information is a read-only review card with nothing to fill in.
+    { id: 'staff-information', title: t('Staff Information'), complete: true },
+    {
+      id: 'contact-information',
+      title: t('Contact Information'),
+      complete: isStepComplete(
+        NsoMpdQuestionnaireStepEnum.PersonalInformation,
+        questionnaire,
+      ),
+    },
   ];
 
   return (

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/StepPage.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/StepPage.test.tsx
@@ -5,8 +5,8 @@ import { StepPage } from './StepPage';
 import { SubStep } from './SubStepList';
 
 const subSteps: SubStep[] = [
-  { id: 'one', title: 'Section One' },
-  { id: 'two', title: 'Section Two' },
+  { id: 'one', title: 'Section One', complete: false },
+  { id: 'two', title: 'Section Two', complete: false },
 ];
 
 const renderStepPage = (steps: SubStep[] = subSteps) =>

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/SubStepList.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/SubStepList.test.tsx
@@ -5,13 +5,21 @@ import theme from 'src/theme';
 import { SubStep, SubStepList } from './SubStepList';
 
 const subSteps: SubStep[] = [
-  { id: 'one', title: 'Section One' },
-  { id: 'two', title: 'Section Two' },
+  { id: 'one', title: 'Section One', complete: false },
+  { id: 'two', title: 'Section Two', complete: false },
 ];
 
-const TestComponent: React.FC = () => (
+interface TestComponentProps {
+  subSteps?: SubStep[];
+  currentSubStepId?: string;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({
+  subSteps: subStepsProp = subSteps,
+  currentSubStepId = subSteps[0].id,
+}) => (
   <ThemeProvider theme={theme}>
-    <SubStepList subSteps={subSteps} currentSubStepId={subSteps[0].id} />
+    <SubStepList subSteps={subStepsProp} currentSubStepId={currentSubStepId} />
   </ThemeProvider>
 );
 
@@ -33,5 +41,26 @@ describe('SubStepList', () => {
     expect(getByText('2. Section Two').closest('li')).not.toHaveAttribute(
       'aria-current',
     );
+  });
+
+  it('leaves incomplete sub-step dots outlined even when current', () => {
+    const { getAllByTestId, queryByTestId } = render(<TestComponent />);
+
+    expect(getAllByTestId('RadioButtonUncheckedIcon')).toHaveLength(2);
+    expect(queryByTestId('CircleIcon')).not.toBeInTheDocument();
+  });
+
+  it('fills a sub-step dot blue once its data is complete', () => {
+    const { getByTestId } = render(
+      <TestComponent
+        subSteps={[
+          { id: 'one', title: 'Section One', complete: true },
+          { id: 'two', title: 'Section Two', complete: false },
+        ]}
+      />,
+    );
+
+    expect(getByTestId('CircleIcon')).toBeInTheDocument();
+    expect(getByTestId('RadioButtonUncheckedIcon')).toBeInTheDocument();
   });
 });

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/SubStepList.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/SubStepList.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
-import { render } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 import theme from 'src/theme';
 import { SubStep, SubStepList } from './SubStepList';
 
@@ -50,8 +50,8 @@ describe('SubStepList', () => {
     expect(queryByTestId('CircleIcon')).not.toBeInTheDocument();
   });
 
-  it('fills a sub-step dot blue once its data is complete', () => {
-    const { getByTestId } = render(
+  it('fills the complete row blue and leaves the incomplete row outlined', () => {
+    const { getByText } = render(
       <TestComponent
         subSteps={[
           { id: 'one', title: 'Section One', complete: true },
@@ -60,7 +60,34 @@ describe('SubStepList', () => {
       />,
     );
 
-    expect(getByTestId('CircleIcon')).toBeInTheDocument();
-    expect(getByTestId('RadioButtonUncheckedIcon')).toBeInTheDocument();
+    const completeRow = within(
+      getByText('1. Section One').closest('li') as HTMLElement,
+    );
+    const incompleteRow = within(
+      getByText('2. Section Two').closest('li') as HTMLElement,
+    );
+
+    expect(completeRow.getByTestId('CircleIcon')).toBeInTheDocument();
+    expect(
+      completeRow.queryByTestId('RadioButtonUncheckedIcon'),
+    ).not.toBeInTheDocument();
+    expect(
+      incompleteRow.getByTestId('RadioButtonUncheckedIcon'),
+    ).toBeInTheDocument();
+    expect(incompleteRow.queryByTestId('CircleIcon')).not.toBeInTheDocument();
+  });
+
+  it('fills every dot blue when all sub-steps are complete', () => {
+    const { getAllByTestId, queryByTestId } = render(
+      <TestComponent
+        subSteps={[
+          { id: 'one', title: 'Section One', complete: true },
+          { id: 'two', title: 'Section Two', complete: true },
+        ]}
+      />,
+    );
+
+    expect(getAllByTestId('CircleIcon')).toHaveLength(2);
+    expect(queryByTestId('RadioButtonUncheckedIcon')).not.toBeInTheDocument();
   });
 });

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/SubStepList.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/SubStepList.tsx
@@ -1,11 +1,24 @@
 import React from 'react';
-import { List, ListItem } from '@mui/material';
-import { CategoryListItemStyles } from 'src/components/HrTools/Shared/CalculationReports/Shared/styledComponents/StepsListStyles';
-import { ListItemContent } from 'src/components/HrTools/Shared/CalculationReports/StepsList/ListItemContent';
+import CircleIcon from '@mui/icons-material/Circle';
+import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
+import { List, ListItem, ListItemText, styled } from '@mui/material';
+import {
+  CategoryListItemIcon,
+  CategoryListItemStyles,
+} from 'src/components/HrTools/Shared/CalculationReports/Shared/styledComponents/StepsListStyles';
+
+const StyledCategoryListItemIcon = styled(CategoryListItemIcon, {
+  shouldForwardProp: (prop) => prop !== 'complete',
+})<{ complete: boolean }>(({ theme, complete }) => ({
+  color: complete
+    ? theme.palette.mpdxBlue.main
+    : theme.palette.mpdxGrayDark.main,
+}));
 
 export interface SubStep {
   id: string;
   title: string;
+  complete: boolean;
 }
 
 interface SubStepListProps {
@@ -16,30 +29,30 @@ interface SubStepListProps {
 /**
  * Renders the sidebar list of sub-steps for a single view step (page). Each page owns its own list,
  * so the contents and completion state are local to the current page, not the questionnaire as a
- * whole.
+ * whole. A sub-step's dot is filled blue once its data has been entered; otherwise it stays
+ * outlined. `currentSubStepId` only drives `aria-current` for assistive tech.
  */
 export const SubStepList: React.FC<SubStepListProps> = ({
   subSteps,
   currentSubStepId,
 }) => {
-  const currentIndex = subSteps.findIndex(
-    (subStep) => subStep.id === currentSubStepId,
-  );
-
   return (
     <List disablePadding>
       {subSteps.map((subStep, index) => {
         const current = subStep.id === currentSubStepId;
+        const { complete } = subStep;
         return (
           <ListItem
             key={subStep.id}
             sx={CategoryListItemStyles}
             aria-current={current ? 'step' : undefined}
           >
-            <ListItemContent
-              title={`${index + 1}. ${subStep.title}`}
-              complete={index < currentIndex}
-              current={current}
+            <StyledCategoryListItemIcon complete={complete}>
+              {complete ? <CircleIcon /> : <RadioButtonUncheckedIcon />}
+            </StyledCategoryListItemIcon>
+            <ListItemText
+              primary={`${index + 1}. ${subStep.title}`}
+              primaryTypographyProps={{ variant: 'body2' }}
             />
           </ListItem>
         );

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.test.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.test.ts
@@ -5,8 +5,9 @@ import {
   NewStaffQuestionnaireNsoSessionsEnum,
   NewStaffQuestionnaireVariantEnum,
 } from 'src/graphql/types.generated';
+import { NsoMpdQuestionnaireStepEnum } from '../NsoMpdQuestionnaireHelper';
 import { NewStaffQuestionnaireQuery } from './NewStaffQuestionnaire.generated';
-import { getCompletionPercentage } from './stepCompletion';
+import { getCompletionPercentage, isStepComplete } from './stepCompletion';
 
 type Questionnaire = NonNullable<
   NewStaffQuestionnaireQuery['newStaffQuestionnaire']
@@ -54,5 +55,93 @@ describe('getCompletionPercentage', () => {
         spousePhoneNumber: '(305) 222-3333',
       }),
     ).toBe(100);
+  });
+});
+
+describe('isStepComplete', () => {
+  it('returns false for a missing questionnaire', () => {
+    expect(
+      isStepComplete(NsoMpdQuestionnaireStepEnum.PersonalInformation, null),
+    ).toBe(false);
+  });
+
+  it('is complete for every data-entry step when its fields are filled', () => {
+    expect(
+      isStepComplete(
+        NsoMpdQuestionnaireStepEnum.PersonalInformation,
+        completeSingle,
+      ),
+    ).toBe(true);
+    expect(
+      isStepComplete(
+        NsoMpdQuestionnaireStepEnum.MinistryInformation,
+        completeSingle,
+      ),
+    ).toBe(true);
+    expect(
+      isStepComplete(
+        NsoMpdQuestionnaireStepEnum.FinancialInformation,
+        completeSingle,
+      ),
+    ).toBe(true);
+    expect(
+      isStepComplete(
+        NsoMpdQuestionnaireStepEnum.NsoInformation,
+        completeSingle,
+      ),
+    ).toBe(true);
+  });
+
+  it('treats 0 as a filled value but null as missing', () => {
+    expect(
+      isStepComplete(NsoMpdQuestionnaireStepEnum.FinancialInformation, {
+        ...completeSingle,
+        carLoanMonthlyPayment: 0,
+      }),
+    ).toBe(true);
+    expect(
+      isStepComplete(NsoMpdQuestionnaireStepEnum.FinancialInformation, {
+        ...completeSingle,
+        carLoanMonthlyPayment: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('is incomplete when a required field is missing', () => {
+    expect(
+      isStepComplete(NsoMpdQuestionnaireStepEnum.PersonalInformation, {
+        ...completeSingle,
+        phoneNumber: '',
+      }),
+    ).toBe(false);
+    expect(
+      isStepComplete(NsoMpdQuestionnaireStepEnum.MinistryInformation, {
+        ...completeSingle,
+        ministryLocation: null,
+      }),
+    ).toBe(false);
+    expect(
+      isStepComplete(NsoMpdQuestionnaireStepEnum.NsoInformation, {
+        ...completeSingle,
+        childcareChildrenCount: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('requires the spouse phone number for the Personal step when married', () => {
+    const married: Questionnaire = {
+      ...completeSingle,
+      maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Married,
+    };
+
+    expect(
+      isStepComplete(NsoMpdQuestionnaireStepEnum.PersonalInformation, married),
+    ).toBe(false);
+    expect(
+      isStepComplete(NsoMpdQuestionnaireStepEnum.PersonalInformation, {
+        ...married,
+        spousePhoneNumber: '(305) 222-3333',
+      }),
+    ).toBe(true);
   });
 });

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.ts
@@ -53,7 +53,7 @@ const variantRequiredFields: Partial<
 };
 
 // 0 and false are valid answers, only null, undefined, and empty strings count as missing.
-export const isFieldFilled = (value: unknown): boolean =>
+const isFieldFilled = (value: unknown): boolean =>
   value !== null && value !== undefined && value !== '';
 
 const getRequiredFields = (

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.ts
@@ -53,7 +53,7 @@ const variantRequiredFields: Partial<
 };
 
 // 0 and false are valid answers, only null, undefined, and empty strings count as missing.
-const isFieldFilled = (value: unknown): boolean =>
+export const isFieldFilled = (value: unknown): boolean =>
   value !== null && value !== undefined && value !== '';
 
 const getRequiredFields = (
@@ -75,10 +75,11 @@ const getRequiredFields = (
   return [...baseFields, ...variantFields];
 };
 
-const isStepComplete = (
+export const isStepComplete = (
   step: NsoMpdQuestionnaireStepEnum,
-  questionnaire: NonNullable<NewStaffQuestionnaire>,
+  questionnaire: NewStaffQuestionnaire,
 ): boolean =>
+  !!questionnaire &&
   getRequiredFields(step, questionnaire).every((field) =>
     isFieldFilled(questionnaire[field]),
   );

--- a/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.tsx
@@ -20,7 +20,9 @@ export const Summary: React.FC = () => {
     useNsoMpdQuestionnaire();
   const [confirmOpen, setConfirmOpen] = useState(false);
 
-  const subSteps: SubStep[] = [{ id: 'summary', title: t('Summary') }];
+  const subSteps: SubStep[] = [
+    { id: 'summary', title: t('Summary'), complete: true },
+  ];
   const sections = useSummarySections();
 
   // Complete the questionnaire, then redirect to the dashboard on success.


### PR DESCRIPTION
## Description

This adds a completion prop for SubStep array items based on which subsections of the form is completed. It is relatively simple since the form does not have many split-up sections.

https://jira.cru.org/browse/MPDX-9815

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to NSO MPD Questionnaire
- Ideally, start with a fresh form
- Test the full flow and ensure that the substep circle icon fills in as the form is completed. Also good to double check here that the circular percentage bar works well.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
