### PR TITLE
MPDX-9758 - Integrate OneApp Ministry List into NSO Questionnaire

### DIFF
--- a/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/Ministries.graphql
+++ b/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/Ministries.graphql
@@ -1,0 +1,10 @@
+query Ministries {
+  ministries {
+    id
+    name
+    children {
+      id
+      name
+    }
+  }
+}

--- a/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryDetails.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryDetails.test.tsx
@@ -49,19 +49,39 @@ describe('MinistryDetails', () => {
     ).toBeRequired();
   });
 
-  it('offers the dummy ministry options', () => {
-    const { getByRole } = render(<TestComponent />);
+  it('offers the flattened OneApp ministry options', async () => {
+    const { getByRole, findByRole, queryByRole } = render(<TestComponent />);
 
-    userEvent.click(
-      getByRole('combobox', {
-        name: 'What ministry are you expecting to serve with?',
-      }),
+    const ministryCombobox = getByRole('combobox', {
+      name: 'What ministry are you expecting to serve with?',
+    });
+    await waitFor(() =>
+      expect(ministryCombobox).not.toHaveAttribute('aria-disabled', 'true'),
     );
+    userEvent.click(ministryCombobox);
 
-    expect(getByRole('option', { name: 'Cru' })).toBeInTheDocument();
+    // Sub-ministry surfaced by expanding the "Campus Ministry" root
+    expect(
+      await findByRole('option', { name: 'University' }),
+    ).toBeInTheDocument();
+    // Non-expanded root shown as-is
     expect(
       getByRole('option', { name: 'Athletes in Action' }),
     ).toBeInTheDocument();
+    // Expandable root itself is never an option
+    expect(
+      queryByRole('option', { name: 'Campus Ministry' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables the ministry select while the OneApp list loads', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(
+      getByRole('combobox', {
+        name: 'What ministry are you expecting to serve with?',
+      }),
+    ).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('populates the nearest-city options from the geographic constants', async () => {

--- a/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryDetails.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryDetails.tsx
@@ -14,19 +14,13 @@ import * as yup from 'yup';
 import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
 import { RadioQuestion } from '../Shared/RadioQuestion';
 import { useQuestionnaireAutoSave } from '../Shared/useQuestionnaireAutoSave';
-
-// TODO(MPDX-9758): Replace with the real ministry list from OneApp.
-const ministries = [
-  'Cru',
-  'Cru High School',
-  'Cru City',
-  'Athletes in Action',
-  'Bridges International',
-];
+import { useOneAppMinistries } from './useOneAppMinistries';
 
 export const MinistryDetails: React.FC = () => {
   const { t } = useTranslation();
   const { goalGeographicConstantMap, loading } = useGoalCalculatorConstants();
+  const { ministries, loading: ministriesLoading } = useOneAppMinistries();
+  const ministriesUnavailable = !ministriesLoading && ministries.length === 0;
 
   const cities = useMemo(
     () => Array.from(goalGeographicConstantMap.keys()),
@@ -88,15 +82,21 @@ export const MinistryDetails: React.FC = () => {
           ),
         }}
         {...ministryProps}
+        disabled={ministriesLoading || ministriesUnavailable}
+        {...(ministriesUnavailable
+          ? { error: true, helperText: t('Failed to load ministries') }
+          : {})}
       >
         <MenuItem value="" disabled>
           <Typography component="span" color="text.secondary">
-            {t('Select a ministry')}
+            {ministriesLoading
+              ? t('Loading ministries…')
+              : t('Select a ministry')}
           </Typography>
         </MenuItem>
         {ministries.map((ministry) => (
-          <MenuItem key={ministry} value={ministry}>
-            {ministry}
+          <MenuItem key={ministry.id} value={ministry.name}>
+            {ministry.name}
           </MenuItem>
         ))}
       </TextField>

--- a/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryInformation.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryInformation.test.tsx
@@ -17,12 +17,14 @@ describe('MinistryInformation', () => {
     const continueButton = getByRole('button', { name: 'Continue' });
     expect(continueButton).toBeDisabled();
 
-    userEvent.click(
-      getByRole('combobox', {
-        name: 'What ministry are you expecting to serve with?',
-      }),
+    const ministryCombobox = getByRole('combobox', {
+      name: 'What ministry are you expecting to serve with?',
+    });
+    await waitFor(() =>
+      expect(ministryCombobox).not.toHaveAttribute('aria-disabled', 'true'),
     );
-    userEvent.click(getByRole('option', { name: 'Cru' }));
+    userEvent.click(ministryCombobox);
+    userEvent.click(await findByRole('option', { name: 'University' }));
 
     userEvent.type(
       getByRole('textbox', {

--- a/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/useOneAppMinistries.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/useOneAppMinistries.test.tsx
@@ -1,0 +1,91 @@
+import { ReactElement } from 'react';
+import { waitFor } from '@testing-library/dom';
+import { renderHook } from '@testing-library/react-hooks';
+import { NsoMpdQuestionnaireTestWrapper } from '../NsoMpdQuestionnaireTestWrapper';
+import { MinistriesQuery } from './Ministries.generated';
+import { flattenMinistries, useOneAppMinistries } from './useOneAppMinistries';
+
+const ministries: MinistriesQuery['ministries'] = [
+  {
+    id: 'campus',
+    name: 'Campus Ministry',
+    children: [
+      { id: 'univ', name: 'University' },
+      { id: 'hs', name: 'High School' },
+    ],
+  },
+  {
+    id: 'other',
+    name: 'Other Ministries',
+    children: [
+      { id: 'film', name: 'Jesus Film Project' },
+      { id: 'other', name: 'Other' },
+    ],
+  },
+  { id: 'aia', name: 'Athletes in Action', children: [] },
+  {
+    id: 'city',
+    name: 'City',
+    children: [{ id: 'nyc', name: 'New York City' }],
+  },
+];
+
+describe('flattenMinistries', () => {
+  it('expands allowlisted roots and sorts alphabetically with "Other" pinned last', () => {
+    expect(flattenMinistries(ministries)).toEqual([
+      { id: 'aia', name: 'Athletes in Action' },
+      { id: 'city', name: 'City' },
+      { id: 'hs', name: 'High School' },
+      { id: 'film', name: 'Jesus Film Project' },
+      { id: 'univ', name: 'University' },
+      { id: 'other', name: 'Other' },
+    ]);
+  });
+
+  it('keeps non-allowlisted roots as single options even when they have children', () => {
+    const result = flattenMinistries(ministries);
+    expect(result).toContainEqual({ id: 'city', name: 'City' });
+    expect(result).not.toContainEqual({ id: 'nyc', name: 'New York City' });
+  });
+
+  it('drops ministries without a name', () => {
+    const withNulls: MinistriesQuery['ministries'] = [
+      { id: 'nameless-root', name: null, children: [] },
+      {
+        id: 'campus',
+        name: 'Campus Ministry',
+        children: [
+          { id: 'univ', name: 'University' },
+          { id: 'nameless-child', name: null },
+        ],
+      },
+    ];
+    expect(flattenMinistries(withNulls)).toEqual([
+      { id: 'univ', name: 'University' },
+    ]);
+  });
+});
+
+describe('useOneAppMinistries', () => {
+  const wrapper = ({ children }: { children: ReactElement }) => (
+    <NsoMpdQuestionnaireTestWrapper>{children}</NsoMpdQuestionnaireTestWrapper>
+  );
+
+  it('returns an empty list while loading', () => {
+    const { result } = renderHook(() => useOneAppMinistries(), { wrapper });
+
+    expect(result.current).toEqual({ ministries: [], loading: true });
+  });
+
+  it('flattens and sorts the ministries once the query resolves', async () => {
+    const { result } = renderHook(() => useOneAppMinistries(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.ministries.map((ministry) => ministry.name)).toEqual([
+      'Athletes in Action',
+      'High School',
+      'Jesus Film Project',
+      'University',
+    ]);
+  });
+});

--- a/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/useOneAppMinistries.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/useOneAppMinistries.ts
@@ -1,0 +1,64 @@
+import { useMemo } from 'react';
+import { MinistriesQuery, useMinistriesQuery } from './Ministries.generated';
+
+export interface MinistryOption {
+  id: string;
+  name: string;
+}
+
+interface UseOneAppMinistriesResult {
+  ministries: MinistryOption[];
+  loading: boolean;
+}
+
+/**
+ * OneApp root names whose sub-ministries are shown directly in the flat list.
+ * These must match the upstream OneApp labels exactly.
+ */
+const EXPANDABLE_ROOT_MINISTRIES = ['Campus Ministry', 'Other Ministries'];
+/** Catch-all option pinned to the bottom of the list. */
+const PINNED_LAST_MINISTRY = 'Other';
+
+/** Alphabetical sort, with "Other" pinned to the end of the list. */
+const compareMinistries = (a: MinistryOption, b: MinistryOption): number => {
+  const aIsOther = a.name === PINNED_LAST_MINISTRY;
+  const bIsOther = b.name === PINNED_LAST_MINISTRY;
+  if (aIsOther || bIsOther) {
+    return Number(aIsOther) - Number(bIsOther);
+  }
+  return a.name.localeCompare(b.name);
+};
+
+/**
+ * Flattens the OneApp ministry tree into the options shown in the
+ * questionnaire's ministry dropdown. Roots in {@link EXPANDABLE_ROOT_MINISTRIES}
+ * are replaced by their sub-ministries; every other root is kept as a single
+ * option. Ministries without a name are dropped. Options are sorted
+ * alphabetically, with "Other" pinned to the end.
+ */
+export const flattenMinistries = (
+  ministries: MinistriesQuery['ministries'],
+): MinistryOption[] =>
+  ministries
+    .flatMap((root) =>
+      EXPANDABLE_ROOT_MINISTRIES.includes(root.name ?? '')
+        ? root.children
+        : [root],
+    )
+    .flatMap((ministry) =>
+      ministry.name ? [{ id: ministry.id, name: ministry.name }] : [],
+    )
+    .sort(compareMinistries);
+
+export const useOneAppMinistries = (): UseOneAppMinistriesResult => {
+  const { data, loading } = useMinistriesQuery({
+    fetchPolicy: 'cache-first',
+  });
+
+  const ministries = useMemo(
+    () => (data ? flattenMinistries(data.ministries) : []),
+    [data],
+  );
+
+  return { ministries, loading };
+};

--- a/src/components/HrTools/NsoMpdQuestionnaire/NsoMpdQuestionnaireTestWrapper.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/NsoMpdQuestionnaireTestWrapper.tsx
@@ -12,6 +12,7 @@ import {
 } from 'src/graphql/types.generated';
 import { GoalCalculatorConstantsQuery } from 'src/hooks/goalCalculatorConstants.generated';
 import theme from 'src/theme';
+import { MinistriesQuery } from './MinistryInformation/Ministries.generated';
 import { NewStaffQuestionnaireQuery } from './Shared/NewStaffQuestionnaire.generated';
 import { NsoMpdQuestionnaireProvider } from './Shared/NsoMpdQuestionnaireContext';
 
@@ -61,6 +62,7 @@ export const NsoMpdQuestionnaireTestWrapper: React.FC<
           GetUser: GetUserQuery;
           GoalCalculatorConstants: GoalCalculatorConstantsQuery;
           NewStaffQuestionnaire: NewStaffQuestionnaireQuery;
+          Ministries: MinistriesQuery;
         }>
           mocks={{
             GetUser: {
@@ -90,6 +92,19 @@ export const NsoMpdQuestionnaireTestWrapper: React.FC<
                   { location: 'None' },
                 ],
               },
+            },
+            Ministries: {
+              ministries: [
+                {
+                  name: 'Campus Ministry',
+                  children: [{ name: 'University' }, { name: 'High School' }],
+                },
+                {
+                  name: 'Other Ministries',
+                  children: [{ name: 'Jesus Film Project' }],
+                },
+                { name: 'Athletes in Action', children: [] },
+              ],
             },
           }}
           onCall={onCall}

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/RadioQuestion.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/RadioQuestion.tsx
@@ -48,7 +48,7 @@ export const RadioQuestion: React.FC<RadioQuestionProps> = ({
 
   return (
     <FormControl error={error} required>
-      <FormLabel id={labelId} sx={{ color: 'text.primary' }}>
+      <FormLabel component="span" id={labelId} sx={{ color: 'text.primary' }}>
         {label}
       </FormLabel>
       <RadioGroup


### PR DESCRIPTION
## Description

- Integrates the OneApp ministry list into NSO Questionnaire that was previously unavailable.
https://jira.cru.org/browse/MPDX-9758

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to NSO Questionnaire
- Select the Ministry dropdown on step 2, and ensure that saving a ministry is successful, including upon submission.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
