### PR TITLE
MPDX-9605 Add help link to partner reminders

### DIFF
--- a/src/components/HrTools/MinistryPartnerReminders/PartnerRemindersReport.test.tsx
+++ b/src/components/HrTools/MinistryPartnerReminders/PartnerRemindersReport.test.tsx
@@ -108,6 +108,18 @@ describe('PartnerRemindersReport', () => {
     expect(await findByText('Test Account')).toBeInTheDocument();
   });
 
+  it('should render help link', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    const helpLink = getByRole('link', {
+      name: 'Ministry Partner Reminder help',
+    });
+    expect(helpLink).toHaveAttribute(
+      'href',
+      'https://www.helpducks.org/en_US/hr-tools/ministry-partner-reminders',
+    );
+  });
+
   it('should print', async () => {
     const { getByRole } = render(<TestComponent />);
 

--- a/src/components/HrTools/MinistryPartnerReminders/PartnerRemindersReport.tsx
+++ b/src/components/HrTools/MinistryPartnerReminders/PartnerRemindersReport.tsx
@@ -222,6 +222,7 @@ export const PartnerRemindersReport: React.FC<MPRemindersReportProps> = ({
                         underline="hover"
                         target="_blank"
                         rel="noopener noreferrer"
+                        href="https://www.helpducks.org/en_US/hr-tools/ministry-partner-reminders"
                       >
                         Ministry Partner Reminder help
                       </Link>


### PR DESCRIPTION
## Description

Add new [helpducks link](https://www.helpducks.org/en_US/hr-tools/ministry-partner-reminders) to ministry partner reminders.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `/hrTools/partnerReminders`
- Click "Ministry Partner Reminder help" link
- Check that user was directed to helpducks link

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
