### PR TITLE
MPDX-9788 - Admin View sidebar and shared 'Present Your Goal' and 'Review Your Goal' view components

### DIFF
--- a/pages/accountLists/[accountListId]/coaching/[coachingId]/nsGoalCalculator/index.page.tsx
+++ b/pages/accountLists/[accountListId]/coaching/[coachingId]/nsGoalCalculator/index.page.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
-import { GoalSettingsForm } from 'src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm';
+import { GoalSettingsView } from 'src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsView';
 import Loading from 'src/components/Loading';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { getAppName } from 'src/lib/getAppName';
@@ -22,7 +22,7 @@ export const NsGoalCalculatorPage: React.FC = () => {
         <title>{`${appName} | ${t('Coaching Accounts | New Staff Goal Calculator')}`}</title>
       </Head>
       {accountListId && coachingId ? (
-        <GoalSettingsForm accountListId={coachingId} />
+        <GoalSettingsView accountListId={coachingId} />
       ) : (
         <Loading loading />
       )}

--- a/pages/accountLists/[accountListId]/hrTools/mpdGoalAdmin/scenario/[scenarioGoalId]/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/mpdGoalAdmin/scenario/[scenarioGoalId]/index.page.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
-import { GoalSettingsForm } from 'src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm';
+import { GoalSettingsView } from 'src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsView';
 import Loading from 'src/components/Loading';
 import { getAppName } from 'src/lib/getAppName';
 import { getQueryParam } from 'src/lib/queryParam';
@@ -20,7 +20,7 @@ export const NsScenarioGoalPage: React.FC = () => {
         <title>{`${appName} | ${t('New Staff Goal Calculator')}`}</title>
       </Head>
       {scenarioGoalId ? (
-        <GoalSettingsForm scenarioGoalId={scenarioGoalId} />
+        <GoalSettingsView scenarioGoalId={scenarioGoalId} />
       ) : (
         <Loading loading />
       )}

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
@@ -9,9 +9,9 @@ import {
 } from '@mui/material';
 import { Form, Formik } from 'formik';
 import { useTranslation } from 'react-i18next';
-import { navBarHeight } from 'src/components/Layouts/Primary/Primary';
 import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
 import { GoalSettingsHeader } from './GoalSettingsHeader';
+import { GoalSettingsScrollContainer } from './GoalSettingsScrollContainer';
 import { ContactInformationSection } from './Sections/ContactInformationSection';
 import { ExemptionsSection } from './Sections/ExemptionsSection';
 import { FinancialInformationSection } from './Sections/FinancialInformationSection';
@@ -31,25 +31,12 @@ import { getGoalSettingsSchema } from './goalSettingsSchema';
 import { GoalSettingsSectionProps } from './goalSettingsSectionProps';
 import { useNewStaffGoalCalculation } from './useNewStaffGoalCalculation';
 
-// Padded, full-height scroll container for the form. The sticky action bar below
-// breaks out of this exact spacing(4) padding, so the two are defined together
-// here to keep the padding and its negative-margin breakout in sync.
-const ScrollContainer = styled('div')(({ theme }) => ({
-  padding: theme.spacing(4),
-  width: '100%',
-  '@media screen': {
-    height: `calc(100vh - ${navBarHeight})`,
-    overflow: 'auto',
-  },
-}));
-
 /**
  * Sticky save/cancel bar pinned to the bottom of the scroll area.
  *
- * ScrollContainer (the scrolling ancestor above) wraps this form in
- * spacing(4) = 32px padding on every side. This bar breaks out of that padding
- * so it spans the full width and sits flush against the scroll-area edges. Each
- * side cancels the 32px:
+ * GoalSettingsScrollContainer wraps this form in spacing(4) = 32px padding on
+ * every side. This bar breaks out of that padding so it spans the full width
+ * and sits flush against the scroll-area edges. Each side cancels the 32px:
  *   marginX -4 + paddingX 4 -> full-bleed width, content stays inset
  *   marginBottom -4         -> flush at the bottom once fully scrolled
  *   bottom spacing(-4)      -> flush while the bar is still stuck
@@ -83,7 +70,9 @@ export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = (props) => {
   } = useNewStaffGoalCalculation(props);
 
   if (!calculation) {
-    return <ScrollContainer>{fallback}</ScrollContainer>;
+    return (
+      <GoalSettingsScrollContainer>{fallback}</GoalSettingsScrollContainer>
+    );
   }
 
   // Whether the saved record has a spouse identity. The header's read-only
@@ -123,7 +112,7 @@ export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = (props) => {
   };
 
   return (
-    <ScrollContainer>
+    <GoalSettingsScrollContainer>
       <Formik
         initialValues={initialValues}
         validationSchema={validationSchema}
@@ -205,6 +194,6 @@ export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = (props) => {
           );
         }}
       </Formik>
-    </ScrollContainer>
+    </GoalSettingsScrollContainer>
   );
 };

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsPresentContent.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsPresentContent.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { beforeTestResizeObserver } from '__tests__/util/windowResizeObserver';
+import { NsGoalCalculatorTestWrapper } from '../NsGoalCalculatorTestWrapper';
+import { GoalSettingsPresentContent } from './GoalSettingsPresentContent';
+
+const TestComponent: React.FC = () => (
+  <NsGoalCalculatorTestWrapper>
+    <GoalSettingsPresentContent accountListId="coaching-account-1" />
+  </NsGoalCalculatorTestWrapper>
+);
+
+const EmptyTestComponent: React.FC = () => (
+  <NsGoalCalculatorTestWrapper
+    goalCalculationMock={{ newStaffGoalCalculation: null }}
+  >
+    <GoalSettingsPresentContent accountListId="coaching-account-1" />
+  </NsGoalCalculatorTestWrapper>
+);
+
+describe('GoalSettingsPresentContent', () => {
+  beforeEach(() => {
+    beforeTestResizeObserver();
+  });
+
+  it('renders the goal presentation once the calculation loads', async () => {
+    const { findByRole, getByText } = render(<TestComponent />);
+
+    expect(
+      await findByRole('heading', { name: 'Presenting Your Goal' }),
+    ).toBeInTheDocument();
+    expect(getByText('John and Jane Doe')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no calculation exists', async () => {
+    const { findByText } = render(<EmptyTestComponent />);
+
+    expect(
+      await findByText(
+        'No new staff goal calculation exists for this account.',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsPresentContent.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsPresentContent.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { PresentingYourGoalContent } from '../PresentingYourGoal/PresentingYourGoalContent';
+import { GoalSettingsFormProps } from './GoalSettingsForm';
+import { useNewStaffGoalCalculation } from './useNewStaffGoalCalculation';
+
+/**
+ * Coaching/admin-side "Presenting Your Goal" content. Loads the saved
+ * calculation (an account-list goal or a scenario goal) and renders the shared
+ * goal presentation.
+ */
+export const GoalSettingsPresentContent: React.FC<GoalSettingsFormProps> = (
+  props,
+) => {
+  const { goalCalculation, fallback } = useNewStaffGoalCalculation(props);
+
+  if (!goalCalculation) {
+    return fallback;
+  }
+
+  return <PresentingYourGoalContent goalCalculation={goalCalculation} />;
+};

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsReviewContent.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsReviewContent.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { NsGoalCalculatorTestWrapper } from '../NsGoalCalculatorTestWrapper';
+import { GoalSettingsReviewContent } from './GoalSettingsReviewContent';
+
+const TestComponent: React.FC = () => (
+  <NsGoalCalculatorTestWrapper>
+    <GoalSettingsReviewContent accountListId="coaching-account-1" />
+  </NsGoalCalculatorTestWrapper>
+);
+
+const EmptyTestComponent: React.FC = () => (
+  <NsGoalCalculatorTestWrapper
+    goalCalculationMock={{ newStaffGoalCalculation: null }}
+  >
+    <GoalSettingsReviewContent accountListId="coaching-account-1" />
+  </NsGoalCalculatorTestWrapper>
+);
+
+describe('GoalSettingsReviewContent', () => {
+  it('renders the calculation review once it loads', async () => {
+    const { findByRole, getByText } = render(<TestComponent />);
+
+    expect(
+      await findByRole('heading', { name: 'Review Your Calculation' }),
+    ).toBeInTheDocument();
+    expect(getByText('Your MPD Goal Calculation')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no calculation exists', async () => {
+    const { findByText } = render(<EmptyTestComponent />);
+
+    expect(
+      await findByText(
+        'No new staff goal calculation exists for this account.',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsReviewContent.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsReviewContent.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ReviewYourCalculationContent } from '../ReviewYourCalculation/ReviewYourCalculationContent';
+import { GoalSettingsFormProps } from './GoalSettingsForm';
+import { useNewStaffGoalCalculation } from './useNewStaffGoalCalculation';
+
+/**
+ * Coaching/admin-side "Review Your Goal" content. Loads the saved calculation
+ * (an account-list goal or a scenario goal) and renders the shared calculation
+ * review.
+ */
+export const GoalSettingsReviewContent: React.FC<GoalSettingsFormProps> = (
+  props,
+) => {
+  const { goalCalculation, fallback } = useNewStaffGoalCalculation(props);
+
+  if (!goalCalculation) {
+    return fallback;
+  }
+
+  return <ReviewYourCalculationContent goalCalculation={goalCalculation} />;
+};

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsScrollContainer.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsScrollContainer.tsx
@@ -1,0 +1,18 @@
+import { styled } from '@mui/material';
+import { navBarHeight } from 'src/components/Layouts/Primary/Primary';
+
+/**
+ * Padded, full-height scroll area shared by the Goal Settings panes.
+ *
+ * The spacing(4) padding is load-bearing: GoalSettingsForm's StickyActionBar
+ * breaks out of it with matching spacing(-4) margins. Keep the padding at
+ * spacing(4) unless you update StickyActionBar to match.
+ */
+export const GoalSettingsScrollContainer = styled('div')(({ theme }) => ({
+  padding: theme.spacing(4),
+  width: '100%',
+  '@media screen': {
+    height: `calc(100vh - ${navBarHeight})`,
+    overflow: 'auto',
+  },
+}));

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsSidebar.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsSidebar.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TestRouter from '__tests__/util/TestRouter';
+import theme from 'src/theme';
+import { GoalSettingsSidebar } from './GoalSettingsSidebar';
+
+const push = jest.fn();
+
+const TestComponent: React.FC<{ view?: string; isScenario?: boolean }> = ({
+  view,
+  isScenario,
+}) => (
+  <ThemeProvider theme={theme}>
+    <TestRouter
+      router={{
+        pathname:
+          '/accountLists/[accountListId]/coaching/[coachingId]/nsGoalCalculator',
+        query: {
+          accountListId: 'account-list-1',
+          coachingId: 'coaching-1',
+          view,
+        },
+        push,
+      }}
+    >
+      <GoalSettingsSidebar isScenario={isScenario} />
+    </TestRouter>
+  </ThemeProvider>
+);
+
+describe('GoalSettingsSidebar', () => {
+  beforeEach(() => push.mockClear());
+
+  it('renders the top-level nav entries with staff sub-items expanded by default', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(getByRole('button', { name: /Goal Settings/ })).toBeInTheDocument();
+    expect(
+      getByRole('button', { name: /Staff Documents/ }),
+    ).toBeInTheDocument();
+    expect(
+      getByRole('button', { name: 'Review Your Goal' }),
+    ).toBeInTheDocument();
+    expect(
+      getByRole('button', { name: 'Presenting Your Goal' }),
+    ).toBeInTheDocument();
+  });
+
+  it('omits Presenting Your Goal for scenario goals', () => {
+    const { getByRole, queryByRole } = render(<TestComponent isScenario />);
+
+    expect(
+      getByRole('button', { name: 'Review Your Goal' }),
+    ).toBeInTheDocument();
+    expect(
+      queryByRole('button', { name: 'Presenting Your Goal' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('marks the active view with aria-current', () => {
+    const { getByRole } = render(<TestComponent view="present-your-goal" />);
+
+    expect(
+      getByRole('button', { name: 'Presenting Your Goal' }),
+    ).toHaveAttribute('aria-current', 'page');
+    expect(getByRole('button', { name: /Goal Settings/ })).not.toHaveAttribute(
+      'aria-current',
+    );
+  });
+
+  it('pushes the Review Your Goal view when its item is clicked', async () => {
+    const { getByRole } = render(<TestComponent />);
+
+    userEvent.click(getByRole('button', { name: 'Review Your Goal' }));
+
+    await waitFor(() =>
+      expect(push).toHaveBeenCalledWith(
+        {
+          pathname:
+            '/accountLists/[accountListId]/coaching/[coachingId]/nsGoalCalculator',
+          query: {
+            accountListId: 'account-list-1',
+            coachingId: 'coaching-1',
+            view: 'review-your-goal',
+          },
+        },
+        undefined,
+        { shallow: true },
+      ),
+    );
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsSidebar.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsSidebar.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import SettingsIcon from '@mui/icons-material/Settings';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Divider,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  SxProps,
+  Theme,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import {
+  GoalSettingsViewEnum,
+  useGoalSettingsView,
+} from './useGoalSettingsView';
+
+interface NavItemProps {
+  label: string;
+  /** Whether this item's view is the active one. */
+  current: boolean;
+  /** Selects this item's view. */
+  onSelect: () => void;
+  icon?: React.ReactNode;
+  secondary?: string;
+  sx?: SxProps<Theme>;
+}
+
+const NavItem: React.FC<NavItemProps> = ({
+  label,
+  current,
+  onSelect,
+  icon,
+  secondary,
+  sx,
+}) => (
+  <ListItemButton
+    sx={sx}
+    selected={current}
+    aria-current={current ? 'page' : undefined}
+    onClick={onSelect}
+  >
+    {icon && <ListItemIcon>{icon}</ListItemIcon>}
+    <ListItemText primary={label} secondary={secondary} />
+  </ListItemButton>
+);
+
+interface GoalSettingsSidebarProps {
+  /**
+   * Whether this is a scenario goal. Scenario goals intentionally omit the
+   * "Presenting Your Goal" navigation item.
+   */
+  isScenario?: boolean;
+}
+
+export const GoalSettingsSidebar: React.FC<GoalSettingsSidebarProps> = ({
+  isScenario = false,
+}) => {
+  const { t } = useTranslation();
+  const { view, setView } = useGoalSettingsView();
+
+  return (
+    <List disablePadding component="nav" aria-label={t('Goal navigation')}>
+      {/* TODO(MPDX-9821): Wire up the Back to Table destination. */}
+      <ListItemButton sx={{ color: 'primary.main' }}>
+        <ListItemIcon sx={{ minWidth: 'auto', mr: 1, color: 'inherit' }}>
+          <ChevronLeftIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText
+          primary={t('Back to Table')}
+          slotProps={{
+            primary: {
+              variant: 'body2',
+              sx: { textTransform: 'uppercase' },
+            },
+          }}
+        />
+      </ListItemButton>
+
+      <Divider />
+
+      <NavItem
+        current={view === GoalSettingsViewEnum.GoalSettings}
+        onSelect={() => setView(GoalSettingsViewEnum.GoalSettings)}
+        icon={<SettingsIcon />}
+        label={t('Goal Settings')}
+        secondary={t('Editable by Admins, Coordinators, and Coaches')}
+      />
+
+      <Divider />
+
+      <Accordion defaultExpanded disableGutters elevation={0}>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-label={t('Staff Documents')}
+          sx={{
+            '.MuiAccordionSummary-content': {
+              alignItems: 'center',
+            },
+          }}
+        >
+          <ListItemIcon>
+            <DescriptionOutlinedIcon />
+          </ListItemIcon>
+          <ListItemText
+            primary={t('Staff Documents')}
+            secondary={t('Staff views generated from Goal Settings')}
+          />
+        </AccordionSummary>
+        <AccordionDetails>
+          <List disablePadding>
+            <NavItem
+              current={view === GoalSettingsViewEnum.ReviewYourGoal}
+              onSelect={() => setView(GoalSettingsViewEnum.ReviewYourGoal)}
+              label={t('Review Your Goal')}
+              sx={{ pl: 6 }}
+            />
+            {!isScenario && (
+              <NavItem
+                current={view === GoalSettingsViewEnum.PresentYourGoal}
+                onSelect={() => setView(GoalSettingsViewEnum.PresentYourGoal)}
+                label={t('Presenting Your Goal')}
+                sx={{ pl: 6 }}
+              />
+            )}
+          </List>
+        </AccordionDetails>
+      </Accordion>
+    </List>
+  );
+};

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsView.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsView.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { beforeTestResizeObserver } from '__tests__/util/windowResizeObserver';
+import { NsGoalCalculatorTestWrapper } from '../NsGoalCalculatorTestWrapper';
+import { GoalSettingsView } from './GoalSettingsView';
+
+const mutationSpy = jest.fn();
+const query = { accountListId: 'coach-1', coachingId: 'coaching-account-1' };
+
+const TestComponent: React.FC<{ view?: string }> = ({ view }) => (
+  <NsGoalCalculatorTestWrapper
+    router={{
+      pathname:
+        '/accountLists/[accountListId]/coaching/[coachingId]/nsGoalCalculator',
+      query: {
+        ...query,
+        view,
+      },
+    }}
+  >
+    <GoalSettingsView accountListId="coaching-account-1" />
+  </NsGoalCalculatorTestWrapper>
+);
+
+describe('GoalSettingsView', () => {
+  beforeEach(() => {
+    beforeTestResizeObserver();
+  });
+
+  it('renders the Goal Settings form by default', async () => {
+    const { findByRole } = render(<TestComponent />);
+
+    expect(
+      await findByRole('heading', { name: 'Personal Information' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the Review content when the view param selects it', async () => {
+    const { findByRole } = render(<TestComponent view="review-your-goal" />);
+
+    expect(
+      await findByRole('heading', { name: 'Review Your Calculation' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the Presenting content', async () => {
+    const { findByRole } = render(<TestComponent view="present-your-goal" />);
+
+    expect(
+      await findByRole('heading', { name: 'Presenting Your Goal' }),
+    ).toBeInTheDocument();
+  });
+
+  it('always renders the sidebar', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(
+      getByRole('button', { name: /Staff Documents/ }),
+    ).toBeInTheDocument();
+  });
+
+  describe('scenario goals', () => {
+    const ScenarioTestComponent: React.FC<{ view?: string }> = ({ view }) => (
+      <NsGoalCalculatorTestWrapper
+        onCall={mutationSpy}
+        router={{
+          pathname:
+            '/accountLists/[accountListId]/hrTools/mpdGoalAdmin/scenario/[scenarioGoalId]',
+          query: {
+            ...query,
+            view,
+          },
+        }}
+      >
+        <GoalSettingsView scenarioGoalId="scenario-1" />
+      </NsGoalCalculatorTestWrapper>
+    );
+
+    it('queries the goal by scenario id', async () => {
+      const { findByRole } = render(<ScenarioTestComponent />);
+
+      await findByRole('heading', { name: 'Contact Info' });
+
+      expect(mutationSpy).toHaveGraphqlOperation('NewStaffGoalCalculation', {
+        accountListId: null,
+        id: 'scenario-1',
+      });
+    });
+
+    it('renders the editable form by default', async () => {
+      const { findByRole } = render(<ScenarioTestComponent />);
+
+      expect(
+        await findByRole('heading', { name: 'Contact Info' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders the Review content for a scenario goal', async () => {
+      const { findByRole } = render(
+        <ScenarioTestComponent view="review-your-goal" />,
+      );
+
+      expect(
+        await findByRole('heading', { name: 'Review Your Calculation' }),
+      ).toBeInTheDocument();
+    });
+
+    it('omits the Presenting content for a scenario goal, falling back to Goal Settings', async () => {
+      const { findByRole, queryByRole } = render(
+        <ScenarioTestComponent view="present-your-goal" />,
+      );
+
+      expect(
+        await findByRole('heading', { name: 'Contact Info' }),
+      ).toBeInTheDocument();
+      expect(
+        queryByRole('heading', { name: 'Presenting Your Goal' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsView.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsView.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Box, styled } from '@mui/material';
+import { navBarHeight } from 'src/components/Layouts/Primary/Primary';
+import { GoalSettingsForm, GoalSettingsFormProps } from './GoalSettingsForm';
+import { GoalSettingsPresentContent } from './GoalSettingsPresentContent';
+import { GoalSettingsReviewContent } from './GoalSettingsReviewContent';
+import { GoalSettingsScrollContainer } from './GoalSettingsScrollContainer';
+import { GoalSettingsSidebar } from './GoalSettingsSidebar';
+import {
+  GoalSettingsViewEnum,
+  useGoalSettingsView,
+} from './useGoalSettingsView';
+
+const Layout = styled(Box)({
+  display: 'flex',
+  '@media print': {
+    '.goal-settings-sidebar': {
+      display: 'none',
+    },
+  },
+});
+
+const Sidebar = styled('div')(({ theme }) => ({
+  flexShrink: 0,
+  width: 290,
+  borderRight: `1px solid ${theme.palette.divider}`,
+  '@media screen': {
+    height: `calc(100vh - ${navBarHeight})`,
+    overflow: 'auto',
+  },
+}));
+
+// The view is a sidebar wrapper around the Goal Settings form and its
+// staff-document panes, so it takes the same goal source (an account-list goal
+// or a scenario goal) and passes it straight through to each pane.
+export const GoalSettingsView: React.FC<GoalSettingsFormProps> = (props) => {
+  const { view } = useGoalSettingsView();
+  const isScenario = 'scenarioGoalId' in props;
+
+  // Scenario goals have no "Presenting Your Goal" view. Fall back to Goal
+  // Settings so a stale or hand-typed `?view=present-your-goal` URL can't reach
+  // it.
+  const effectiveView =
+    isScenario && view === GoalSettingsViewEnum.PresentYourGoal
+      ? GoalSettingsViewEnum.GoalSettings
+      : view;
+
+  const renderMainContent = (): React.ReactNode => {
+    switch (effectiveView) {
+      case GoalSettingsViewEnum.ReviewYourGoal:
+        return (
+          <GoalSettingsScrollContainer>
+            <GoalSettingsReviewContent {...props} />
+          </GoalSettingsScrollContainer>
+        );
+      case GoalSettingsViewEnum.PresentYourGoal:
+        return (
+          <GoalSettingsScrollContainer>
+            <GoalSettingsPresentContent {...props} />
+          </GoalSettingsScrollContainer>
+        );
+      default:
+        // GoalSettingsForm uses GoalSettingsScrollContainer internally
+        return <GoalSettingsForm {...props} />;
+    }
+  };
+
+  return (
+    <Layout>
+      <Sidebar className="goal-settings-sidebar">
+        <GoalSettingsSidebar isScenario={isScenario} />
+      </Sidebar>
+      {renderMainContent()}
+    </Layout>
+  );
+};

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/useGoalSettingsView.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/useGoalSettingsView.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import TestRouter from '__tests__/util/TestRouter';
+import {
+  GoalSettingsViewEnum,
+  parseGoalSettingsView,
+  useGoalSettingsView,
+} from './useGoalSettingsView';
+
+const push = jest.fn();
+
+describe('parseGoalSettingsView', () => {
+  it('parses known values', () => {
+    expect(parseGoalSettingsView('review-your-goal')).toBe(
+      GoalSettingsViewEnum.ReviewYourGoal,
+    );
+    expect(parseGoalSettingsView('present-your-goal')).toBe(
+      GoalSettingsViewEnum.PresentYourGoal,
+    );
+  });
+
+  it('falls back to Goal Settings for missing or unknown values', () => {
+    expect(parseGoalSettingsView(undefined)).toBe(
+      GoalSettingsViewEnum.GoalSettings,
+    );
+    expect(parseGoalSettingsView('nonsense')).toBe(
+      GoalSettingsViewEnum.GoalSettings,
+    );
+  });
+});
+
+describe('useGoalSettingsView', () => {
+  it('reads the current view from the query param', () => {
+    const { result } = renderHook(() => useGoalSettingsView(), {
+      wrapper: ({ children }) => (
+        <TestRouter
+          router={{ query: { accountListId: 'a', view: 'present-your-goal' } }}
+        >
+          {children}
+        </TestRouter>
+      ),
+    });
+
+    expect(result.current.view).toBe(GoalSettingsViewEnum.PresentYourGoal);
+  });
+
+  it('pushes the selected view as a shallow query param', () => {
+    const query = {
+      accountListId: 'account-list-1',
+      coachingId: 'coaching-id-1',
+    };
+    const { result } = renderHook(() => useGoalSettingsView(), {
+      wrapper: ({ children }) => (
+        <TestRouter
+          router={{
+            pathname:
+              '/accountLists/[accountListId]/coaching/[coachingId]/nsGoalCalculator',
+            query,
+            push,
+          }}
+        >
+          {children}
+        </TestRouter>
+      ),
+    });
+
+    result.current.setView(GoalSettingsViewEnum.ReviewYourGoal);
+
+    expect(push).toHaveBeenCalledWith(
+      {
+        pathname:
+          '/accountLists/[accountListId]/coaching/[coachingId]/nsGoalCalculator',
+        query: {
+          ...query,
+          view: 'review-your-goal',
+        },
+      },
+      undefined,
+      { shallow: true },
+    );
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/useGoalSettingsView.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/useGoalSettingsView.ts
@@ -1,0 +1,39 @@
+import { useRouter } from 'next/router';
+import { getQueryParam } from 'src/lib/queryParam';
+
+export enum GoalSettingsViewEnum {
+  GoalSettings = 'goal-settings',
+  ReviewYourGoal = 'review-your-goal',
+  PresentYourGoal = 'present-your-goal',
+}
+
+export const parseGoalSettingsView = (
+  value: string | undefined,
+): GoalSettingsViewEnum => {
+  switch (value) {
+    case GoalSettingsViewEnum.ReviewYourGoal:
+      return GoalSettingsViewEnum.ReviewYourGoal;
+    case GoalSettingsViewEnum.PresentYourGoal:
+      return GoalSettingsViewEnum.PresentYourGoal;
+    default:
+      return GoalSettingsViewEnum.GoalSettings;
+  }
+};
+
+export const useGoalSettingsView = (): {
+  view: GoalSettingsViewEnum;
+  setView: (view: GoalSettingsViewEnum) => void;
+} => {
+  const router = useRouter();
+  const view = parseGoalSettingsView(getQueryParam(router.query, 'view'));
+
+  const setView = (next: GoalSettingsViewEnum): void => {
+    router.push(
+      { pathname: router.pathname, query: { ...router.query, view: next } },
+      undefined,
+      { shallow: true },
+    );
+  };
+
+  return { view, setView };
+};

--- a/src/components/HrTools/NsGoalCalculator/NsGoalCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/NsGoalCalculator/NsGoalCalculatorTestWrapper.tsx
@@ -1,3 +1,4 @@
+import { NextRouter } from 'next/router';
 import { ThemeProvider } from '@mui/material/styles';
 import {
   ApolloErgonoMockMap,
@@ -54,6 +55,7 @@ export interface NsGoalCalculatorTestWrapperProps {
     | DeepPartial<NewStaffGoalCalculationQuery>
     | ApolloErgonoMockMap;
   onCall?: ErgonoMockedProviderProps['onCall'];
+  router?: Partial<NextRouter>;
 }
 
 export const NsGoalCalculatorTestWrapper: React.FC<
@@ -62,15 +64,10 @@ export const NsGoalCalculatorTestWrapper: React.FC<
   children,
   goalCalculationMock = defaultGoalCalculationMock,
   onCall,
+  router = { query: { accountListId } },
 }) => (
   <ThemeProvider theme={theme}>
-    <TestRouter
-      router={{
-        query: {
-          accountListId,
-        },
-      }}
-    >
+    <TestRouter router={router}>
       <SnackbarProvider>
         <GqlMockedProvider<{
           GoalCalculatorConstants: GoalCalculatorConstantsQuery;

--- a/src/components/HrTools/NsGoalCalculator/PresentingYourGoal/PresentingYourGoalContent.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/PresentingYourGoal/PresentingYourGoalContent.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { beforeTestResizeObserver } from '__tests__/util/windowResizeObserver';
+import {
+  NsGoalCalculatorTestWrapper,
+  defaultGoalCalculation,
+} from '../NsGoalCalculatorTestWrapper';
+import { PresentingYourGoalContent } from './PresentingYourGoalContent';
+
+describe('PresentingYourGoalContent', () => {
+  beforeEach(() => {
+    beforeTestResizeObserver();
+  });
+
+  it('renders the presentation and footer', async () => {
+    const { findByRole, getByText } = render(
+      <NsGoalCalculatorTestWrapper>
+        <PresentingYourGoalContent
+          goalCalculation={defaultGoalCalculation}
+          footer={<button type="button">Continue</button>}
+        />
+      </NsGoalCalculatorTestWrapper>,
+    );
+
+    expect(
+      await findByRole('heading', { name: 'Presenting Your Goal' }),
+    ).toBeInTheDocument();
+    expect(getByText('Print Support Needs Presentation')).toBeInTheDocument();
+    expect(getByText('Continue')).toBeInTheDocument();
+  });
+
+  it('renders when support raised is unknown (null)', async () => {
+    const { findByRole } = render(
+      <NsGoalCalculatorTestWrapper>
+        <PresentingYourGoalContent
+          goalCalculation={{
+            ...defaultGoalCalculation,
+            calculations: {
+              ...defaultGoalCalculation.calculations,
+              supportRaised: null,
+            },
+          }}
+        />
+      </NsGoalCalculatorTestWrapper>,
+    );
+
+    expect(
+      await findByRole('heading', { name: 'Presenting Your Goal' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/PresentingYourGoal/PresentingYourGoalContent.tsx
+++ b/src/components/HrTools/NsGoalCalculator/PresentingYourGoal/PresentingYourGoalContent.tsx
@@ -1,0 +1,154 @@
+import React, { useMemo } from 'react';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import PrintIcon from '@mui/icons-material/Print';
+import {
+  Alert,
+  Box,
+  Button,
+  Divider,
+  Grid,
+  Typography,
+  styled,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
+import { MonthlyNeedsCard } from '../../Shared/GoalPresentation/MonthlyNeedsCard';
+import { PersonalInfoCard } from '../../Shared/GoalPresentation/PersonalInfoCard';
+import { PresentationCard } from '../../Shared/GoalPresentation/PresentationCard';
+import { SpecialNeedsCard } from '../../Shared/GoalPresentation/SpecialNeedsCard';
+import { SupportNeedsChart } from '../../Shared/GoalPresentation/SupportNeedsChart';
+import { NsGoalCalculation } from '../Shared/NsGoalCalculatorContext';
+import { ChartPlaceholderCard } from './ChartPlaceholderCard';
+
+const PrintableContent = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(3),
+
+  // Scale down the page to fit on one page
+  '@media print': {
+    zoom: 0.4,
+  },
+}));
+
+// TODO(MPDX-9801): Special needs are not available yet.
+const specialNeedsPlaceholder = 3624;
+
+interface PresentingYourGoalContentProps {
+  goalCalculation: NsGoalCalculation;
+  /** Optional trailing content, e.g. the staff wizard's Continue button. */
+  footer?: React.ReactNode;
+}
+
+/**
+ * The Support Needs Presentation UI. Shared by the staff wizard's Presenting
+ * step and the coaching Goal Settings view so the two presentations never
+ * drift. Both derive their display from the same saved goal calculation.
+ */
+export const PresentingYourGoalContent: React.FC<
+  PresentingYourGoalContentProps
+> = ({ goalCalculation, footer }) => {
+  const { t } = useTranslation();
+
+  const { calculations } = goalCalculation;
+  const married =
+    goalCalculation.maritalStatus ===
+    NewStaffQuestionnaireMaritalStatusEnum.Married;
+  const monthlyNeeds = useMemo(
+    () => ({
+      married,
+      salary: calculations.salary,
+      ministryExpenses:
+        calculations.totalMinistryExpenses +
+        calculations.medicalExpenses +
+        calculations.staffConferenceTransfer +
+        calculations.accountTransfers +
+        calculations.advocacyTransfers +
+        calculations.otherExpenses +
+        calculations.attrition,
+      benefits: calculations.benefitsCharge,
+      socialSecurityAndTaxes: calculations.seca,
+      voluntaryRetirement: calculations.totalContributing403bAmount,
+      adminCharge: calculations.adminCharge,
+      monthlyGoal: calculations.monthlyGoal,
+    }),
+    [married, calculations],
+  );
+
+  const handlePrint = () => {
+    window.print();
+  };
+
+  return (
+    <PrintableContent>
+      <Typography variant="h6">{t('Presenting Your Goal')}</Typography>
+
+      <Typography variant="body1" className="print-hidden">
+        {t(
+          "Now that you've reviewed your goal, you can share your Support Needs Presentation by printing the presentation below.",
+        )}
+      </Typography>
+
+      <Alert
+        severity="info"
+        icon={<InfoOutlinedIcon />}
+        className="print-hidden"
+      >
+        <Typography variant="body1" fontWeight="bold">
+          {t('Some tips for printing:')}
+        </Typography>
+        <Box component="ol" sx={{ my: 1, pl: 3 }}>
+          <li>{t('Toggle off Headers and Footers in your print settings.')}</li>
+          <li>{t('Adjust the Scale to fit on one page.')}</li>
+          <li>
+            {t(
+              'From your Print settings, you may also save the page as a PDF to share digitally.',
+            )}
+          </li>
+        </Box>
+      </Alert>
+
+      <Button
+        variant="outlined"
+        startIcon={<PrintIcon />}
+        onClick={handlePrint}
+        className="print-hidden"
+        sx={{ alignSelf: 'flex-start' }}
+      >
+        {t('Print Support Needs Presentation')}
+      </Button>
+
+      <Divider className="print-hidden" />
+
+      <PersonalInfoCard
+        firstName={goalCalculation.firstName ?? ''}
+        spouseFirstName={married ? goalCalculation.spouseFirstName : undefined}
+        lastName={goalCalculation.lastName ?? ''}
+        ministryLocation={goalCalculation.ministryLocation ?? undefined}
+      />
+
+      <MonthlyNeedsCard
+        monthlyNeeds={monthlyNeeds}
+        supportRaised={calculations.supportRaised ?? null}
+      />
+
+      <SpecialNeedsCard specialNeeds={specialNeedsPlaceholder} />
+
+      <Grid container spacing={3}>
+        <Grid size={{ xs: 12, lg: 6 }}>
+          <PresentationCard
+            title={t('Monthly Support Needs Chart')}
+            horizontalScroll={false}
+          >
+            <SupportNeedsChart monthlyNeeds={monthlyNeeds} />
+          </PresentationCard>
+        </Grid>
+        <Grid size={{ xs: 12, lg: 6 }}>
+          <ChartPlaceholderCard title={t('Special Needs Chart')} />
+        </Grid>
+      </Grid>
+
+      {footer}
+    </PrintableContent>
+  );
+};

--- a/src/components/HrTools/NsGoalCalculator/PresentingYourGoal/PresentingYourGoalStep.tsx
+++ b/src/components/HrTools/NsGoalCalculator/PresentingYourGoal/PresentingYourGoalStep.tsx
@@ -1,42 +1,11 @@
-import React, { useMemo } from 'react';
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import PrintIcon from '@mui/icons-material/Print';
-import {
-  Alert,
-  Box,
-  Button,
-  Divider,
-  Grid,
-  Typography,
-  styled,
-} from '@mui/material';
+import React from 'react';
+import { Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
-import theme from 'src/theme';
-import { MonthlyNeedsCard } from '../../Shared/GoalPresentation/MonthlyNeedsCard';
-import { PersonalInfoCard } from '../../Shared/GoalPresentation/PersonalInfoCard';
-import { PresentationCard } from '../../Shared/GoalPresentation/PresentationCard';
-import { SpecialNeedsCard } from '../../Shared/GoalPresentation/SpecialNeedsCard';
-import { SupportNeedsChart } from '../../Shared/GoalPresentation/SupportNeedsChart';
 import {
   NsGoalCalculation,
   useNsGoalCalculator,
 } from '../Shared/NsGoalCalculatorContext';
-import { ChartPlaceholderCard } from './ChartPlaceholderCard';
-
-const PrintableContent = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: theme.spacing(3),
-
-  // Scale down the page to fit on one page
-  '@media print': {
-    zoom: 0.4,
-  },
-}));
-
-// TODO(MPDX-9801): Special needs are not available yet.
-const specialNeedsPlaceholder = 3624;
+import { PresentingYourGoalContent } from './PresentingYourGoalContent';
 
 interface PresentingYourGoalStepProps {
   goalCalculation: NsGoalCalculation;
@@ -48,112 +17,19 @@ export const PresentingYourGoalStep: React.FC<PresentingYourGoalStepProps> = ({
   const { t } = useTranslation();
   const { handleContinue } = useNsGoalCalculator();
 
-  const { calculations } = goalCalculation;
-  const married =
-    goalCalculation.maritalStatus ===
-    NewStaffQuestionnaireMaritalStatusEnum.Married;
-  const monthlyNeeds = useMemo(
-    () => ({
-      married,
-      salary: calculations.salary,
-      ministryExpenses:
-        calculations.totalMinistryExpenses +
-        calculations.medicalExpenses +
-        calculations.staffConferenceTransfer +
-        calculations.accountTransfers +
-        calculations.advocacyTransfers +
-        calculations.otherExpenses +
-        calculations.attrition,
-      benefits: calculations.benefitsCharge,
-      socialSecurityAndTaxes: calculations.seca,
-      voluntaryRetirement: calculations.totalContributing403bAmount,
-      adminCharge: calculations.adminCharge,
-      monthlyGoal: calculations.monthlyGoal,
-    }),
-    [married, calculations],
-  );
-
-  const handlePrint = () => {
-    window.print();
-  };
-
   return (
-    <PrintableContent>
-      <Typography variant="h6">{t('Presenting Your Goal')}</Typography>
-
-      <Typography variant="body1" className="print-hidden">
-        {t(
-          "Now that you've reviewed your goal, you can share your Support Needs Presentation by printing the presentation below.",
-        )}
-      </Typography>
-
-      <Alert
-        severity="info"
-        icon={<InfoOutlinedIcon />}
-        className="print-hidden"
-      >
-        <Typography variant="body1" fontWeight="bold">
-          {t('Some tips for printing:')}
-        </Typography>
-        <Box component="ol" sx={{ my: 1, pl: 3 }}>
-          <li>{t('Toggle off Headers and Footers in your print settings.')}</li>
-          <li>{t('Adjust the Scale to fit on one page.')}</li>
-          <li>
-            {t(
-              'From your Print settings, you may also save the page as a PDF to share digitally.',
-            )}
-          </li>
-        </Box>
-      </Alert>
-
-      <Button
-        variant="outlined"
-        startIcon={<PrintIcon />}
-        onClick={handlePrint}
-        className="print-hidden"
-        sx={{ alignSelf: 'flex-start' }}
-      >
-        {t('Print Support Needs Presentation')}
-      </Button>
-
-      <Divider className="print-hidden" />
-
-      <PersonalInfoCard
-        firstName={goalCalculation.firstName ?? ''}
-        spouseFirstName={married ? goalCalculation.spouseFirstName : undefined}
-        lastName={goalCalculation.lastName ?? ''}
-        ministryLocation={goalCalculation.ministryLocation ?? undefined}
-      />
-
-      <MonthlyNeedsCard
-        monthlyNeeds={monthlyNeeds}
-        supportRaised={calculations.supportRaised ?? null}
-      />
-
-      <SpecialNeedsCard specialNeeds={specialNeedsPlaceholder} />
-
-      <Grid container spacing={theme.spacing(3)}>
-        <Grid size={{ xs: 12, lg: 6 }}>
-          <PresentationCard
-            title={t('Monthly Support Needs Chart')}
-            horizontalScroll={false}
-          >
-            <SupportNeedsChart monthlyNeeds={monthlyNeeds} />
-          </PresentationCard>
-        </Grid>
-        <Grid size={{ xs: 12, lg: 6 }}>
-          <ChartPlaceholderCard title={t('Special Needs Chart')} />
-        </Grid>
-      </Grid>
-
-      <Button
-        variant="contained"
-        onClick={handleContinue}
-        className="print-hidden"
-        sx={{ alignSelf: 'flex-start' }}
-      >
-        {t('Continue')}
-      </Button>
-    </PrintableContent>
+    <PresentingYourGoalContent
+      goalCalculation={goalCalculation}
+      footer={
+        <Button
+          variant="contained"
+          onClick={handleContinue}
+          className="print-hidden"
+          sx={{ alignSelf: 'flex-start' }}
+        >
+          {t('Continue')}
+        </Button>
+      }
+    />
   );
 };

--- a/src/components/HrTools/NsGoalCalculator/ReviewYourCalculation/ReviewYourCalculationContent.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/ReviewYourCalculation/ReviewYourCalculationContent.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  NsGoalCalculatorTestWrapper,
+  defaultGoalCalculation,
+} from '../NsGoalCalculatorTestWrapper';
+import { ReviewYourCalculationContent } from './ReviewYourCalculationContent';
+
+describe('ReviewYourCalculationContent', () => {
+  it('renders the review heading and summary cards', async () => {
+    const { findByRole, getByText } = render(
+      <NsGoalCalculatorTestWrapper>
+        <ReviewYourCalculationContent
+          goalCalculation={defaultGoalCalculation}
+        />
+      </NsGoalCalculatorTestWrapper>,
+    );
+
+    expect(
+      await findByRole('heading', { name: 'Review Your Calculation' }),
+    ).toBeInTheDocument();
+    expect(getByText('Your MPD Goal Calculation')).toBeInTheDocument();
+    expect(getByText('Monthly Needs')).toBeInTheDocument();
+    expect(getByText('Minimum Staff Account Balance')).toBeInTheDocument();
+  });
+
+  it('renders the footer when provided', async () => {
+    const { findByText } = render(
+      <NsGoalCalculatorTestWrapper>
+        <ReviewYourCalculationContent
+          goalCalculation={defaultGoalCalculation}
+          footer={<button type="button">Continue</button>}
+        />
+      </NsGoalCalculatorTestWrapper>,
+    );
+
+    expect(await findByText('Continue')).toBeInTheDocument();
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/ReviewYourCalculation/ReviewYourCalculationContent.tsx
+++ b/src/components/HrTools/NsGoalCalculator/ReviewYourCalculation/ReviewYourCalculationContent.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { Alert, Box, Stack, Typography } from '@mui/material';
+import { Trans, useTranslation } from 'react-i18next';
+import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
+import { NsGoalCalculation } from '../Shared/NsGoalCalculatorContext';
+import { AccountBalanceCard } from './AccountBalanceCard';
+import { GoalSummaryCard } from './GoalSummaryCard';
+import { MonthlyNeedsCard } from './MonthlyNeedsCard';
+import { SpecialNeedsCard } from './SpecialNeedsCard';
+
+interface ReviewYourCalculationContentProps {
+  goalCalculation: NsGoalCalculation;
+  /** Optional trailing content, e.g. the staff wizard's Continue button. */
+  footer?: React.ReactNode;
+}
+
+/**
+ * The MPD-goal calculation review UI, without any data loading. Shared by the
+ * staff wizard's Review step and the coaching Goal Settings view so the two
+ * reviews never drift.
+ */
+export const ReviewYourCalculationContent: React.FC<
+  ReviewYourCalculationContentProps
+> = ({ goalCalculation, footer }) => {
+  const { t } = useTranslation();
+
+  const married =
+    goalCalculation.maritalStatus ===
+    NewStaffQuestionnaireMaritalStatusEnum.Married;
+  const columnLabel =
+    married && goalCalculation.spouseFirstName
+      ? t('{{firstName}} & {{spouseFirstName}}', {
+          firstName: goalCalculation.firstName,
+          spouseFirstName: goalCalculation.spouseFirstName,
+        })
+      : (goalCalculation.firstName ?? '');
+
+  return (
+    <Stack spacing={3}>
+      <Typography variant="h6">{t('Review Your Calculation')}</Typography>
+
+      <Typography variant="body1">
+        <Trans t={t}>
+          Please review your MPD Goal Calculation and contact your coach if you
+          have questions. If everything looks good, continue to “Presenting your
+          Goal”.
+        </Trans>
+      </Typography>
+
+      <GoalSummaryCard
+        monthlyGoal={goalCalculation.calculations.monthlyGoal}
+        // TODO(MPDX-9801): special needs are not available yet; pass null so
+        // the summary shows "Coming soon" rather than a fabricated figure.
+        specialNeedsGoal={null}
+        minStaffAccountBalance={
+          goalCalculation.calculations.minimumAccountBalance
+        }
+      />
+
+      <MonthlyNeedsCard
+        calculations={goalCalculation.calculations}
+        columnLabel={columnLabel}
+      />
+
+      <SpecialNeedsCard
+        columnLabel={columnLabel}
+        adminRate={goalCalculation.calculations.adminRate}
+      />
+
+      <AccountBalanceCard
+        minAccountBalance={goalCalculation.calculations.minimumAccountBalance}
+        columnLabel={columnLabel}
+      />
+
+      <Alert severity="info" icon={<InfoOutlinedIcon />}>
+        <Typography variant="body1" fontWeight="bold">
+          {t(
+            'In order to report to your assignment, new staff must do the following:',
+          )}
+        </Typography>
+        <Box component="ol" sx={{ my: 1, pl: 3 }}>
+          <li>
+            {t(
+              'Call MPD Coach to verify support goal has been raised (monthly and special gifts).',
+            )}
+          </li>
+          <li>{t('First checks have been collected.')}</li>
+        </Box>
+      </Alert>
+
+      {footer}
+    </Stack>
+  );
+};

--- a/src/components/HrTools/NsGoalCalculator/ReviewYourCalculation/ReviewYourCalculationStep.tsx
+++ b/src/components/HrTools/NsGoalCalculator/ReviewYourCalculation/ReviewYourCalculationStep.tsx
@@ -1,15 +1,11 @@
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import { Alert, Box, Button, Stack, Typography } from '@mui/material';
-import { Trans, useTranslation } from 'react-i18next';
-import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
+import React from 'react';
+import { Button } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 import {
   NsGoalCalculation,
   useNsGoalCalculator,
 } from '../Shared/NsGoalCalculatorContext';
-import { AccountBalanceCard } from './AccountBalanceCard';
-import { GoalSummaryCard } from './GoalSummaryCard';
-import { MonthlyNeedsCard } from './MonthlyNeedsCard';
-import { SpecialNeedsCard } from './SpecialNeedsCard';
+import { ReviewYourCalculationContent } from './ReviewYourCalculationContent';
 
 interface ReviewYourCalculationStepProps {
   goalCalculation: NsGoalCalculation;
@@ -21,77 +17,18 @@ export const ReviewYourCalculationStep: React.FC<
   const { t } = useTranslation();
   const { handleContinue } = useNsGoalCalculator();
 
-  const married =
-    goalCalculation.maritalStatus ===
-    NewStaffQuestionnaireMaritalStatusEnum.Married;
-  const columnLabel =
-    married && goalCalculation.spouseFirstName
-      ? t('{{firstName}} & {{spouseFirstName}}', {
-          firstName: goalCalculation.firstName,
-          spouseFirstName: goalCalculation.spouseFirstName,
-        })
-      : (goalCalculation.firstName ?? '');
-
   return (
-    <Stack spacing={3}>
-      <Typography variant="h6">{t('Review Your Calculation')}</Typography>
-
-      <Typography variant="body1">
-        <Trans t={t}>
-          Please review your MPD Goal Calculation and contact your coach if you
-          have questions. If everything looks good, continue to “Presenting your
-          Goal”.
-        </Trans>
-      </Typography>
-
-      <GoalSummaryCard
-        monthlyGoal={goalCalculation.calculations.monthlyGoal}
-        // TODO(MPDX-9801): special needs are not available yet; pass null so
-        // the summary shows "Coming soon" rather than a fabricated figure.
-        specialNeedsGoal={null}
-        minStaffAccountBalance={
-          goalCalculation.calculations.minimumAccountBalance
-        }
-      />
-
-      <MonthlyNeedsCard
-        calculations={goalCalculation.calculations}
-        columnLabel={columnLabel}
-      />
-
-      <SpecialNeedsCard
-        columnLabel={columnLabel}
-        adminRate={goalCalculation.calculations.adminRate}
-      />
-
-      <AccountBalanceCard
-        minAccountBalance={goalCalculation.calculations.minimumAccountBalance}
-        columnLabel={columnLabel}
-      />
-
-      <Alert severity="info" icon={<InfoOutlinedIcon />}>
-        <Typography variant="body1" fontWeight="bold">
-          {t(
-            'In order to report to your assignment, new staff must do the following:',
-          )}
-        </Typography>
-        <Box component="ol" sx={{ my: 1, pl: 3 }}>
-          <li>
-            {t(
-              'Call MPD Coach to verify support goal has been raised (monthly and special gifts).',
-            )}
-          </li>
-          <li>{t('First checks have been collected.')}</li>
-        </Box>
-      </Alert>
-
-      <Button
-        variant="contained"
-        onClick={handleContinue}
-        sx={{ alignSelf: 'flex-start' }}
-      >
-        {t('Continue')}
-      </Button>
-    </Stack>
+    <ReviewYourCalculationContent
+      goalCalculation={goalCalculation}
+      footer={
+        <Button
+          variant="contained"
+          onClick={handleContinue}
+          sx={{ alignSelf: 'flex-start' }}
+        >
+          {t('Continue')}
+        </Button>
+      }
+    />
   );
 };


### PR DESCRIPTION
## Description

- Adds the Nav Bar in the Admin/Coach view to 'Present Your Goal' and 'Review Your Goal'
- Makes Presenting Your Goal and Review Your Goal components shared between the NS Goal Calc and the Admin view.

## Testing

- Go to `/accountLists/308c5567-a0b6-49f6-922e-f0c338e170ca/coaching/45ef99a5-c7b9-4873-b194-ca4d5b28d09e/nsGoalCalculator?view=goal-settings`
- Test the sidebar navigation, ensuring that it renders the 'Presenting Your Goal' view and 'Review Your Goal' view
- Go to the NS Goal Calculator and test that these two views also render successfully there.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
