### PR TITLE
MPDX-9819 Relax customized login for partner reminders

### DIFF
--- a/pages/accountLists/[accountListId]/hrTools/partnerReminders/index.page.test.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/partnerReminders/index.page.test.tsx
@@ -75,7 +75,7 @@ describe('Partner Reminders Report Page', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders no staff account page when no staff account', async () => {
+  it('renders even though there is no staff account', async () => {
     const mockNoStaffAccount = {
       GetUser: {
         user: {
@@ -84,35 +84,29 @@ describe('Partner Reminders Report Page', () => {
       },
     };
 
-    const { findByText } = render(
-      <TestRouter>
-        <GqlMockedProvider<{
-          GetUser: GetUserQuery;
-        }>
-          mocks={mockNoStaffAccount}
-          onCall={mutationSpy}
-        >
-          <PartnerRemindersReportPage />
-        </GqlMockedProvider>
-      </TestRouter>,
+    const { findByRole } = render(
+      <ThemeProvider theme={theme}>
+        <SnackbarProvider>
+          <TestRouter>
+            <GqlMockedProvider<{
+              GetUser: GetUserQuery;
+            }>
+              mocks={mockNoStaffAccount}
+              onCall={mutationSpy}
+            >
+              <PartnerRemindersReportPage />
+            </GqlMockedProvider>
+          </TestRouter>
+        </SnackbarProvider>
+      </ThemeProvider>,
     );
 
     expect(
-      await findByText(/access to this feature is limited/i),
+      await findByRole('heading', { name: /online reminder system/i }),
     ).toBeInTheDocument();
   });
 
   it('uses blockImpersonatingNonDevelopers for server-side props', () => {
     expect(getServerSideProps).toBe(blockImpersonatingNonDevelopers);
-  });
-
-  it('should show limited access if user does not have access to page', async () => {
-    const { findByText } = render(
-      <Components userType={UserTypeEnum.NonCru} />,
-    );
-
-    expect(
-      await findByText('Access to this feature is limited.'),
-    ).toBeInTheDocument();
   });
 });

--- a/pages/accountLists/[accountListId]/hrTools/partnerReminders/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/partnerReminders/index.page.tsx
@@ -10,7 +10,6 @@ import {
   MultiPageMenu,
   NavTypeEnum,
 } from 'src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu';
-import { UserTypeAccess } from 'src/components/Shared/UserTypeAccess/UserTypeAccess';
 import { getAppName } from 'src/lib/getAppName';
 
 const PartnerRemindersReportPageWrapper = styled(Box)(({ theme }) => ({
@@ -32,30 +31,28 @@ const PartnerRemindersReportPage: React.FC = () => {
       <Head>
         <title>{`${appName} | ${t('HR Tools | Ministry Partner Reminders')}`}</title>
       </Head>
-      <UserTypeAccess requireStaffAccount>
-        <PartnerRemindersReportPageWrapper>
-          <SidePanelsLayout
-            isScrollBox={false}
-            leftPanel={
-              <MultiPageMenu
-                isOpen={isNavListOpen}
-                selectedId="partnerReminders"
-                onClose={handleNavListToggle}
-                navType={NavTypeEnum.HrTools}
-              />
-            }
-            leftOpen={isNavListOpen}
-            leftWidth="290px"
-            mainContent={
-              <PartnerRemindersReport
-                isNavListOpen={isNavListOpen}
-                onNavListToggle={handleNavListToggle}
-                title={t('Ministry Partner Reminders')}
-              />
-            }
-          />
-        </PartnerRemindersReportPageWrapper>
-      </UserTypeAccess>
+      <PartnerRemindersReportPageWrapper>
+        <SidePanelsLayout
+          isScrollBox={false}
+          leftPanel={
+            <MultiPageMenu
+              isOpen={isNavListOpen}
+              selectedId="partnerReminders"
+              onClose={handleNavListToggle}
+              navType={NavTypeEnum.HrTools}
+            />
+          }
+          leftOpen={isNavListOpen}
+          leftWidth="290px"
+          mainContent={
+            <PartnerRemindersReport
+              isNavListOpen={isNavListOpen}
+              onNavListToggle={handleNavListToggle}
+              title={t('Ministry Partner Reminders')}
+            />
+          }
+        />
+      </PartnerRemindersReportPageWrapper>
     </>
   );
 };

--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
@@ -123,7 +123,7 @@ describe('NavMenu', () => {
   });
 
   it('renders HR Tools submenu items', async () => {
-    const { findByRole, getByRole, getByTestId } = render(
+    const { findByRole, getByRole, getByTestId, queryByRole } = render(
       <TestComponent
         mocks={{
           ...defaultMocks,
@@ -154,8 +154,8 @@ describe('NavMenu', () => {
       getByRole('menuitem', { name: 'Additional Salary Request' }),
     ).toBeInTheDocument();
     expect(
-      getByRole('menuitem', { name: 'Ministry Partner Reminders' }),
-    ).toBeInTheDocument();
+      queryByRole('menuitem', { name: 'Ministry Partner Reminders' }),
+    ).not.toBeInTheDocument();
   });
 
   it('renders MPDX Tools submenu items', async () => {

--- a/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
@@ -502,7 +502,8 @@ describe('MultiPageMenu', () => {
         queryByText('Paid with Designation Support Goal Calculator'),
       ).not.toBeInTheDocument();
       expect(queryByText('New Staff Goal Calculator')).not.toBeInTheDocument();
-      expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
+
+      expect(queryByText('Ministry Partner Reminders')).not.toBeInTheDocument();
     });
 
     it('shows hr tools for new staff', async () => {
@@ -542,7 +543,8 @@ describe('MultiPageMenu', () => {
       expect(
         queryByText('Paid with Designation Support Goal Calculator'),
       ).not.toBeInTheDocument();
-      expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
+
+      expect(queryByText('Ministry Partner Reminders')).not.toBeInTheDocument();
     });
 
     it('shows hr tools for national expat staff', async () => {
@@ -582,7 +584,8 @@ describe('MultiPageMenu', () => {
         queryByText('Paid with Designation Support Goal Calculator'),
       ).not.toBeInTheDocument();
       expect(queryByText('New Staff Goal Calculator')).not.toBeInTheDocument();
-      expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
+
+      expect(queryByText('Ministry Partner Reminders')).not.toBeInTheDocument();
     });
 
     it('shows hr tools for paid with designation', async () => {
@@ -626,7 +629,7 @@ describe('MultiPageMenu', () => {
     });
 
     it('shows hr tools for part time field staff', async () => {
-      const { findByText, getByText, queryByText } = render(
+      const { findByText, queryByText } = render(
         <ThemeProvider theme={theme}>
           <TestRouter router={router}>
             <GqlMockedProvider<{ GetUser: GetUserQuery }>
@@ -654,7 +657,7 @@ describe('MultiPageMenu', () => {
       );
 
       expect(await findByText('Savings Fund Transfer')).toBeInTheDocument();
-      expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
+      expect(queryByText('Ministry Partner Reminders')).not.toBeInTheDocument();
       expect(
         queryByText('Paid with Designation Support Goal Calculator'),
       ).not.toBeInTheDocument();
@@ -666,7 +669,7 @@ describe('MultiPageMenu', () => {
     });
 
     it('shows hr tools for interns', async () => {
-      const { findByText, getByText, queryByText } = render(
+      const { findByText, queryByText } = render(
         <ThemeProvider theme={theme}>
           <TestRouter router={router}>
             <GqlMockedProvider<{ GetUser: GetUserQuery }>
@@ -694,7 +697,7 @@ describe('MultiPageMenu', () => {
       );
 
       expect(await findByText('Savings Fund Transfer')).toBeInTheDocument();
-      expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
+      expect(queryByText('Ministry Partner Reminders')).not.toBeInTheDocument();
       expect(
         queryByText('Paid with Designation Support Goal Calculator'),
       ).not.toBeInTheDocument();

--- a/src/hooks/useHrToolsNavItems.ts
+++ b/src/hooks/useHrToolsNavItems.ts
@@ -81,7 +81,7 @@ export function useHrToolsNavItems(): {
       {
         id: 'partnerReminders',
         title: t('Ministry Partner Reminders'),
-        hideItem: hasNoStaffAccount,
+        hideItem: !developerBypass,
       },
       {
         id: 'mpdSupervisorReport',


### PR DESCRIPTION
## Description

Ministry Partner Reminders broke in staff web, so we want to launch this report before go-live on October 1st. This means we need to relax the restrictions around the customized login work:
- User type = Cru US staff
- Staff group = Senior staff, new staff, PTFS, paid with designation, and interns
- Staff account (staff account numbers will NOT be in production yet)

But, we still want developers to be able to see partner reminders in "HR Tools" dropdown menu.

_**This PR should be reverted when HCM go-live is ready!**_

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

Developer test: ✅
- Using your personal account, click on "HR Tools"
- Check that "Ministry Partner Reminders" is present

Non-developer/Senior staff test: ✅
- Impersonate: courtney.campbell@cru.org
- Click on "HR Tools"
- Check that "Ministry Partner Reminders" is NOT present
- Navigate to `/hrTools/partnerReminders` and ensure user can access page

New Staff test: ✅
- Impersonate: timothy.ethington@cru.org
- Click on "HR Tools"
- Check that "Ministry Partner Reminders" is NOT present
- Navigate to `/hrTools/partnerReminders` and ensure user can access page

PTFS test: ✅
- Impersonate: christina.garber@athletesinaction.org 
- Click on "HR Tools"
- Check that "Ministry Partner Reminders" is NOT present
- Navigate to `/hrTools/partnerReminders` and ensure user can access page

No staff account/Paid with designation test: ✅
- Impersonate: kathryn.hougham@cru.org
- Click on "HR Tools"
- Check that "Ministry Partner Reminders" is NOT present
- Navigate to `/hrTools/partnerReminders` and ensure user can access page

Intern test: ✅
- Impersonate: nataley.guetherman@cru.org
- Click on "HR Tools"
- Check that "Ministry Partner Reminders" is NOT present
- Navigate to `/hrTools/partnerReminders` and ensure user can access page

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
