### PR TITLE
MPDX-9816 Remove user MHA field from goal settings

### DIFF
--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.test.tsx
@@ -4,7 +4,7 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ApolloErgonoMockMap } from 'graphql-ergonomock';
 import TestRouter from '__tests__/util/TestRouter';
-import { GqlMockedProvider, gqlMock } from '__tests__/util/graphqlMocking';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
 import theme from 'src/theme';
 import {
@@ -13,36 +13,44 @@ import {
   defaultGoalCalculation,
 } from '../NsGoalCalculatorTestWrapper';
 import { GoalSettingsForm } from './GoalSettingsForm';
-import {
-  NewStaffGoalCalculationDocument,
-  NewStaffGoalCalculationQuery,
-  NewStaffGoalCalculationQueryVariables,
-} from './NewStaffGoalCalculation.generated';
+import { NewStaffGoalCalculationQuery } from './NewStaffGoalCalculation.generated';
 
 const accountListId = 'account-list-1';
 
-const singleMock = gqlMock<
-  NewStaffGoalCalculationQuery,
-  NewStaffGoalCalculationQueryVariables
->(NewStaffGoalCalculationDocument, {
-  variables: { accountListId },
-  mocks: {
-    newStaffGoalCalculation: {
-      id: 'goal-calculation-1',
-      firstName: 'John',
-      lastName: 'Doe',
-      spouseFirstName: null,
-      maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Single,
-    },
+const defaultMock = {
+  newStaffGoalCalculation: {
+    ...defaultGoalCalculation,
+    maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Married,
+    spouseJoining: true,
   },
-});
+};
+
+const seniorStaffMock = {
+  newStaffGoalCalculation: {
+    ...defaultGoalCalculation,
+    maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Married,
+    spouseJoining: false,
+  },
+};
+
+const singleMock = {
+  newStaffGoalCalculation: {
+    ...defaultMock.newStaffGoalCalculation,
+    spouseFirstName: null,
+    maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Single,
+  },
+};
 
 const mutationSpy = jest.fn();
 
 const TestComponent: React.FC<
   Omit<NsGoalCalculatorTestWrapperProps, 'children'>
 > = (props) => (
-  <NsGoalCalculatorTestWrapper onCall={mutationSpy} {...props}>
+  <NsGoalCalculatorTestWrapper
+    onCall={mutationSpy}
+    goalCalculationMock={defaultMock}
+    {...props}
+  >
     <GoalSettingsForm accountListId={accountListId} />
   </NsGoalCalculatorTestWrapper>
 );
@@ -385,5 +393,90 @@ describe('GoalSettingsForm', () => {
     expect(
       await findByRole('button', { name: 'Save & Share' }),
     ).toBeInTheDocument();
+  });
+
+  describe('Senior Staff Only fields', () => {
+    it('shows the senior-staff-only fields when the spouse is senior staff', async () => {
+      const { findByRole, getByRole } = render(
+        <TestComponent goalCalculationMock={seniorStaffMock} />,
+      );
+
+      expect(
+        await findByRole('spinbutton', { name: 'MHA Amount' }),
+      ).toBeInTheDocument();
+      expect(
+        getByRole('spinbutton', { name: 'Staff Conference Transfer — John' }),
+      ).toBeInTheDocument();
+      expect(
+        getByRole('spinbutton', { name: 'Account Transfers — John' }),
+      ).toBeInTheDocument();
+      expect(
+        getByRole('spinbutton', { name: 'Advocacy — John' }),
+      ).toBeInTheDocument();
+    });
+
+    it('hides the senior-staff-only fields when there is no spouse', async () => {
+      const { findByRole, queryByRole } = render(
+        <TestComponent goalCalculationMock={singleMock} />,
+      );
+
+      await findByRole('spinbutton', {
+        name: 'Annual Requested Salary — John',
+      });
+      expect(
+        queryByRole('spinbutton', { name: 'MHA Amount' }),
+      ).not.toBeInTheDocument();
+      expect(
+        queryByRole('spinbutton', { name: 'Staff Conference Transfer — John' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides the senior-staff-only fields when the spouse is joining staff', async () => {
+      const { findByRole, getByRole, queryByRole } = render(<TestComponent />);
+
+      userEvent.click(
+        await findByRole('combobox', { name: 'Staff Status — Jane' }),
+      );
+      userEvent.click(getByRole('option', { name: 'Joining Staff' }));
+
+      await waitFor(() =>
+        expect(
+          queryByRole('spinbutton', { name: 'MHA Amount' }),
+        ).not.toBeInTheDocument(),
+      );
+      expect(
+        queryByRole('spinbutton', { name: 'Staff Conference Transfer — John' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('clears the senior-staff-only fields on save when the spouse is joining staff', async () => {
+      const { findByRole, getByRole } = render(<TestComponent />);
+
+      // Switch the senior spouse to joining staff, which hides — and clears on
+      // save — the senior-staff-only fields.
+      userEvent.click(
+        await findByRole('combobox', { name: 'Staff Status — Jane' }),
+      );
+      userEvent.click(getByRole('option', { name: 'Joining Staff' }));
+      userEvent.click(getByRole('button', { name: 'Save & Share' }));
+
+      await waitFor(() =>
+        expect(mutationSpy).toHaveGraphqlOperation(
+          'UpdateNewStaffGoalCalculation',
+          {
+            input: {
+              accountListId,
+              id: 'goal-calculation-1',
+              attributes: {
+                spouseMhaAmount: null,
+                staffConferenceTransfer: null,
+                accountTransfers: null,
+                advocacyTransfers: null,
+              },
+            },
+          },
+        ),
+      );
+    });
   });
 });

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
@@ -135,6 +135,7 @@ export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = ({
         const hasSpouse =
           values.maritalStatus ===
           NewStaffQuestionnaireMaritalStatusEnum.Married;
+        const seniorStaffSpouse = hasSpouse && values.spouseJoining === 'false';
         const sectionProps: GoalSettingsSectionProps = {
           hasSpouse,
           calculations: calculation.calculations,
@@ -146,6 +147,7 @@ export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = ({
           sharedHeader: hasSpouse
             ? `${primaryHeader} & ${spouseHeader}`
             : primaryHeader,
+          seniorStaff: seniorStaffSpouse,
         };
 
         return (

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
@@ -45,7 +45,6 @@ fragment NewStaffGoalCalculationFields on NewStaffGoalCalculation {
   spouseRequestedAnnualSalary
   contribution403bPercentage
   spouseContribution403bPercentage
-  mhaAmount
   spouseMhaAmount
   staffConferenceTransfer
   accountTransfers

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/FinancialInformationSection.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/FinancialInformationSection.tsx
@@ -99,21 +99,13 @@ export const FinancialInformationSection: React.FC<
         )}
       </FieldRow>
 
-      <FieldRow label={t('MHA')} helperText={seniorStaffOnly}>
+      <FieldRow label={t('MHA Amount')} helperText={seniorStaffOnly}>
         <GoalSettingsNumberField
-          name="mhaAmount"
-          label={t('MHA')}
-          personName={primaryName}
+          name="spouseMhaAmount"
+          label={t('MHA Amount')}
+          personName={spouseName}
           adornment="currency"
         />
-        {hasSpouse && (
-          <GoalSettingsNumberField
-            name="spouseMhaAmount"
-            label={t('MHA')}
-            personName={spouseName}
-            adornment="currency"
-          />
-        )}
       </FieldRow>
 
       <FieldRow

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/FinancialInformationSection.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/FinancialInformationSection.tsx
@@ -14,6 +14,7 @@ export const FinancialInformationSection: React.FC<
   GoalSettingsSectionProps
 > = ({
   hasSpouse,
+  seniorStaff,
   calculations,
   primaryName,
   spouseName,
@@ -99,44 +100,47 @@ export const FinancialInformationSection: React.FC<
         )}
       </FieldRow>
 
-      <FieldRow label={t('MHA Amount')} helperText={seniorStaffOnly}>
-        <GoalSettingsNumberField
-          name="spouseMhaAmount"
-          label={t('MHA Amount')}
-          personName={spouseName}
-          adornment="currency"
-        />
-      </FieldRow>
+      {seniorStaff && (
+        <>
+          <FieldRow label={t('MHA Amount')} helperText={seniorStaffOnly}>
+            <GoalSettingsNumberField
+              name="spouseMhaAmount"
+              label={t('MHA Amount')}
+              adornment="currency"
+            />
+          </FieldRow>
 
-      <FieldRow
-        label={t('Staff Conference Transfer')}
-        helperText={seniorStaffOnly}
-      >
-        <GoalSettingsNumberField
-          name="staffConferenceTransfer"
-          label={t('Staff Conference Transfer')}
-          personName={primaryName}
-          adornment="currency"
-        />
-      </FieldRow>
+          <FieldRow
+            label={t('Staff Conference Transfer')}
+            helperText={seniorStaffOnly}
+          >
+            <GoalSettingsNumberField
+              name="staffConferenceTransfer"
+              label={t('Staff Conference Transfer')}
+              personName={primaryName}
+              adornment="currency"
+            />
+          </FieldRow>
 
-      <FieldRow label={t('Account Transfers')} helperText={seniorStaffOnly}>
-        <GoalSettingsNumberField
-          name="accountTransfers"
-          label={t('Account Transfers')}
-          personName={primaryName}
-          adornment="currency"
-        />
-      </FieldRow>
+          <FieldRow label={t('Account Transfers')} helperText={seniorStaffOnly}>
+            <GoalSettingsNumberField
+              name="accountTransfers"
+              label={t('Account Transfers')}
+              personName={primaryName}
+              adornment="currency"
+            />
+          </FieldRow>
 
-      <FieldRow label={t('Advocacy')} helperText={seniorStaffOnly}>
-        <GoalSettingsNumberField
-          name="advocacyTransfers"
-          label={t('Advocacy')}
-          personName={primaryName}
-          adornment="currency"
-        />
-      </FieldRow>
+          <FieldRow label={t('Advocacy')} helperText={seniorStaffOnly}>
+            <GoalSettingsNumberField
+              name="advocacyTransfers"
+              label={t('Advocacy')}
+              personName={primaryName}
+              adornment="currency"
+            />
+          </FieldRow>
+        </>
+      )}
 
       <ColumnHeaderRow columns={[sharedHeader]} />
 

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.test.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.test.ts
@@ -177,6 +177,39 @@ describe('formValuesToAttributes', () => {
     expect(attributes.spouseMhaAmount).toBeNull();
   });
 
+  it('sends the senior-staff-only fields when the spouse is senior staff', () => {
+    const attributes = formValuesToAttributes({
+      ...coupleValues,
+      spouseJoining: 'false',
+    });
+
+    expect(attributes.spouseMhaAmount).toBe(200);
+    expect(attributes.staffConferenceTransfer).toBe(10);
+    expect(attributes.accountTransfers).toBe(20);
+    expect(attributes.advocacyTransfers).toBe(30);
+  });
+
+  it('clears the senior-staff-only fields when the spouse is joining staff', () => {
+    const attributes = formValuesToAttributes({
+      ...coupleValues,
+      spouseJoining: 'true',
+    });
+
+    expect(attributes.spouseMhaAmount).toBeNull();
+    expect(attributes.staffConferenceTransfer).toBeNull();
+    expect(attributes.accountTransfers).toBeNull();
+    expect(attributes.advocacyTransfers).toBeNull();
+  });
+
+  it('clears the senior-staff-only fields when there is no spouse', () => {
+    const attributes = formValuesToAttributes(singleValues);
+
+    expect(attributes.spouseMhaAmount).toBeNull();
+    expect(attributes.staffConferenceTransfer).toBeNull();
+    expect(attributes.accountTransfers).toBeNull();
+    expect(attributes.advocacyTransfers).toBeNull();
+  });
+
   it('passes the age enum through to the API', () => {
     const attributes = formValuesToAttributes(coupleValues);
 

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.test.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.test.ts
@@ -62,7 +62,6 @@ const baseCalculation: NewStaffGoalCalculationFieldsFragment = {
   spouseRequestedAnnualSalary: 47000,
   contribution403bPercentage: 7,
   spouseContribution403bPercentage: 6,
-  mhaAmount: 100,
   spouseMhaAmount: 200,
   staffConferenceTransfer: 10,
   accountTransfers: 20,
@@ -175,6 +174,7 @@ describe('formValuesToAttributes', () => {
     expect(attributes.spouseAge).toBeNull();
     expect(attributes.spouseRequestedAnnualSalary).toBeNull();
     expect(attributes.spouseHealthcareExempt).toBeNull();
+    expect(attributes.spouseMhaAmount).toBeNull();
   });
 
   it('passes the age enum through to the API', () => {

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
@@ -88,12 +88,16 @@ export const calculationToFormValues = (
  *
  * `hasSpouse` gates the spouse fields so a single person's save clears spouse
  * data rather than persisting stale values.
+ * `seniorStaff` likewise gates the "Senior Staff Only" fields, which apply only
+ * when there is a senior spouse, so they are cleared when the spouse is missing
+ * or is joining staff.
  */
 export const formValuesToAttributes = (
   values: GoalSettingsFormValues,
 ): NewStaffGoalCalculationAttributesInput => {
   const hasSpouse =
     values.maritalStatus === NewStaffQuestionnaireMaritalStatusEnum.Married;
+  const seniorStaff = hasSpouse && !toBoolean(values.spouseJoining);
 
   return {
     maritalStatus: values.maritalStatus || null,
@@ -114,11 +118,19 @@ export const formValuesToAttributes = (
     spouseContribution403bPercentage: hasSpouse
       ? toNumberOrNull(values.spouseContribution403bPercentage)
       : null,
-    spouseMhaAmount: hasSpouse ? toNumberOrNull(values.spouseMhaAmount) : null,
+    spouseMhaAmount: seniorStaff
+      ? toNumberOrNull(values.spouseMhaAmount)
+      : null,
 
-    staffConferenceTransfer: toNumberOrNull(values.staffConferenceTransfer),
-    accountTransfers: toNumberOrNull(values.accountTransfers),
-    advocacyTransfers: toNumberOrNull(values.advocacyTransfers),
+    staffConferenceTransfer: seniorStaff
+      ? toNumberOrNull(values.staffConferenceTransfer)
+      : null,
+    accountTransfers: seniorStaff
+      ? toNumberOrNull(values.accountTransfers)
+      : null,
+    advocacyTransfers: seniorStaff
+      ? toNumberOrNull(values.advocacyTransfers)
+      : null,
 
     geographicLocation: values.geographicLocation || null,
 

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
@@ -47,7 +47,6 @@ export const calculationToFormValues = (
   spouseContribution403bPercentage: toNumberInput(
     calc.spouseContribution403bPercentage,
   ),
-  mhaAmount: toNumberInput(calc.mhaAmount),
   spouseMhaAmount: toNumberInput(calc.spouseMhaAmount),
   staffConferenceTransfer: toNumberInput(calc.staffConferenceTransfer),
   accountTransfers: toNumberInput(calc.accountTransfers),
@@ -115,7 +114,6 @@ export const formValuesToAttributes = (
     spouseContribution403bPercentage: hasSpouse
       ? toNumberOrNull(values.spouseContribution403bPercentage)
       : null,
-    mhaAmount: toNumberOrNull(values.mhaAmount),
     spouseMhaAmount: hasSpouse ? toNumberOrNull(values.spouseMhaAmount) : null,
 
     staffConferenceTransfer: toNumberOrNull(values.staffConferenceTransfer),

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsFormValues.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsFormValues.ts
@@ -49,7 +49,6 @@ export interface GoalSettingsFormValues {
   spouseRequestedAnnualSalary: number | '';
   contribution403bPercentage: number | '';
   spouseContribution403bPercentage: number | '';
-  mhaAmount: number | '';
   spouseMhaAmount: number | '';
   staffConferenceTransfer: number | '';
   accountTransfers: number | '';

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsSchema.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsSchema.ts
@@ -42,7 +42,6 @@ export const getGoalSettingsSchema = (t: TFunction) =>
       t('403(b) Contribution'),
       t,
     ),
-    mhaAmount: optionalAmount(t('MHA Amount'), t),
     spouseMhaAmount: optionalAmount(t('MHA Amount'), t),
     staffConferenceTransfer: optionalAmount(t('Staff Conference Transfer'), t),
     accountTransfers: optionalAmount(t('Account Transfers'), t),

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsSectionProps.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsSectionProps.ts
@@ -3,6 +3,11 @@ import { NewStaffGoalCalculationFieldsFragment } from './NewStaffGoalCalculation
 export interface GoalSettingsSectionProps {
   hasSpouse: boolean;
   /**
+   * Whether the "Senior Staff Only" rows should be shown. They are hidden when
+   * the staff is single/SOSA or the spouse is joining staff.
+   */
+  seniorStaff: boolean;
+  /**
    * Computed worksheet amounts for the saved calculation, used for read-only
    * derived displays (e.g. the 403(b) contribution amount).
    */


### PR DESCRIPTION
## Description

Removes the **joining staff member's** MHA (Minister Housing Allowance) field from the New Staff Goal Calculator's Goal Settings (admin view). Joining staff never have MHA, so the field is dropped from the UI, the form, and the GraphQL operation. A senior-staff **spouse** can still have MHA, so `spouseMhaAmount` is untouched.

- Removed `mhaAmount` from the `NewStaffGoalCalculationFields` GraphQL fragment (query + mutation).
- Removed the user MHA number field from the Financial Information section; the MHA row now shows only the spouse field.
- Removed `mhaAmount` from the form values type, Yup schema, and the API ↔ form mapping (both directions).
- Updated tests: dropped `mhaAmount` from the API-mapping mock; added a `GoalSettingsForm` test asserting the joining staff has no MHA field while the spouse field remains.

Related: [MPDX-9816](https://jira.cru.org/browse/MPDX-9816). The API/model side of the ticket is handled separately; this is the frontend.

## Testing

- Go to the New Staff Goal Calculator → Goal Settings (coaching/admin view) for a married account list.
- Open the **Financial Information** section.
- Check that the **MHA** row has no field for the joining staff member (primary column), and that the spouse's MHA field is still present and editable.
- Edit and save; confirm the `updateNewStaffGoalCalculation` mutation no longer sends a `mhaAmount` for the joining staff.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
