### PR TITLE
MPDX-9812 - Add validation for future start dates in SettingsDialog schema in StaffExpenseReport

### DIFF
--- a/src/components/Reports/Shared/SettingsDialog/SettingsDialog.test.tsx
+++ b/src/components/Reports/Shared/SettingsDialog/SettingsDialog.test.tsx
@@ -9,7 +9,12 @@ import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { StaffExpenseCategoryEnum } from 'src/graphql/types.generated';
 import { ReportsStaffExpensesQuery } from '../../StaffExpenseReport/GetStaffExpense.generated';
 import { DateRange } from '../../StaffExpenseReport/Helpers/StaffReportEnum';
-import { Filters, SettingsDialog, SettingsDialogProps } from './SettingsDialog';
+import {
+  Filters,
+  SettingsDialog,
+  SettingsDialogProps,
+  getValidationSchema,
+} from './SettingsDialog';
 
 const mutationSpy = jest.fn();
 const TestComponent: React.FC<
@@ -253,6 +258,32 @@ describe('SettingsDialog', () => {
     expect(
       queryByText('Start date must be earlier than end date'),
     ).not.toBeInTheDocument();
+  });
+
+  it('rejects a start date after the viewed month when no end date is set', async () => {
+    await expect(
+      getValidationSchema(DateTime.fromISO('2019-06-01')).validateAt(
+        'startDate',
+        {
+          startDate: DateTime.fromISO('2019-09-01'),
+          endDate: null,
+        },
+      ),
+    ).rejects.toThrow(
+      'Select an end date when the start date is later than the month being viewed',
+    );
+  });
+
+  it('accepts a start date within the viewed month when no end date is set', async () => {
+    await expect(
+      getValidationSchema(DateTime.fromISO('2019-06-01')).validateAt(
+        'startDate',
+        {
+          startDate: DateTime.fromISO('2019-06-30'),
+          endDate: null,
+        },
+      ),
+    ).resolves.toBeTruthy();
   });
 
   it('checks all available categories by default when no selection exists', async () => {

--- a/src/components/Reports/Shared/SettingsDialog/SettingsDialog.tsx
+++ b/src/components/Reports/Shared/SettingsDialog/SettingsDialog.tsx
@@ -48,40 +48,55 @@ export interface Filters {
   categories: string[] | null;
 }
 
-const validationSchema = yup.object({
-  selectedDateRange: yup.mixed().nullable(),
-  startDate: yup
-    .mixed()
-    .nullable()
-    .test(
-      'start-date-validation',
-      i18n.t('Start date must be earlier than or equal to end date'),
-      function (value) {
-        const { endDate } = this.parent;
-        if (!value || !endDate) {
-          return true;
-        }
+export const getValidationSchema = (currentTime: DateTime) =>
+  yup.object({
+    selectedDateRange: yup.mixed().nullable(),
+    startDate: yup
+      .mixed()
+      .nullable()
+      .test(
+        'start-date-validation',
+        i18n.t('Start date must be earlier than or equal to end date'),
+        function (value) {
+          const { endDate } = this.parent;
+          if (!value || !endDate) {
+            return true;
+          }
 
-        return value <= endDate;
-      },
-    ),
-  endDate: yup
-    .mixed()
-    .nullable()
-    .test(
-      'end-date-validation',
-      i18n.t('End date must be later than or equal to start date'),
-      function (value) {
-        const { startDate } = this.parent;
-        if (!value || !startDate) {
-          return true;
-        }
+          return value <= endDate;
+        },
+      )
+      .test(
+        'start-date-not-future-without-end',
+        i18n.t(
+          'Select an end date when the start date is later than the month being viewed',
+        ),
+        function (value) {
+          const { endDate } = this.parent;
+          if (!value || endDate) {
+            return true;
+          }
 
-        return startDate <= value;
-      },
-    ),
-  categories: yup.array().of(yup.string()).nullable(),
-});
+          return value <= currentTime.endOf('month');
+        },
+      ),
+    endDate: yup
+      .mixed()
+      .nullable()
+      .test(
+        'end-date-validation',
+        i18n.t('End date must be later than or equal to start date'),
+        function (value) {
+          const { startDate } = this.parent;
+          if (!value || !startDate) {
+            return true;
+          }
+
+          return startDate <= value;
+        },
+      ),
+    categories: yup.array().of(yup.string()).nullable(),
+  });
 
 const calculateDateRange = (
   range: DateRange,
@@ -136,6 +151,11 @@ export const SettingsDialog: React.FC<SettingsDialogProps> = ({
   const currentTime = useMemo(
     () => time ?? DateTime.now().startOf('month'),
     [time],
+  );
+
+  const validationSchema = useMemo(
+    () => getValidationSchema(currentTime),
+    [currentTime],
   );
 
   const handleClose = () => {


### PR DESCRIPTION
## Description

Fixes an issue where an SAA side error occurs if a start date is after the end date (automatically set to the end of current month)

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to StaffExpenseReport
- Test setting the start and end dates
- Check that no SAA side errors occur, and validation is appropriately handled.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
