### PR TITLE
MPDX-9787 - Scenario Goals support in NS GoalSettingsForm

### DIFF
--- a/pages/accountLists/[accountListId]/hrTools/mpdGoalAdmin/scenario/[scenarioGoalId]/index.page.test.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/mpdGoalAdmin/scenario/[scenarioGoalId]/index.page.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { render } from '@testing-library/react';
+import { SnackbarProvider } from 'notistack';
+import TestRouter from '__tests__/util/TestRouter';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
+import { constantsMock } from 'src/components/HrTools/GoalCalculator/GoalCalculatorTestWrapper';
+import { NewStaffGoalCalculationQuery } from 'src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.generated';
+import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
+import { GoalCalculatorConstantsQuery } from 'src/hooks/goalCalculatorConstants.generated';
+import theme from 'src/theme';
+import { NsScenarioGoalPage, getServerSideProps } from './index.page';
+
+const TestComponent: React.FC = () => (
+  <TestRouter
+    router={{
+      query: {
+        accountListId: 'account-list-1',
+        scenarioGoalId: 'scenario-1',
+      },
+    }}
+  >
+    <ThemeProvider theme={theme}>
+      <SnackbarProvider>
+        <GqlMockedProvider<{
+          GoalCalculatorConstants: GoalCalculatorConstantsQuery;
+          NewStaffGoalCalculation: NewStaffGoalCalculationQuery;
+        }>
+          mocks={{
+            GoalCalculatorConstants: { constant: constantsMock },
+            NewStaffGoalCalculation: {
+              newStaffGoalCalculation: {
+                id: 'scenario-1',
+                firstName: 'John',
+                lastName: 'Doe',
+                spouseFirstName: 'Jane',
+                maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Married,
+                spouseJoining: false,
+              },
+            },
+          }}
+        >
+          <NsScenarioGoalPage />
+        </GqlMockedProvider>
+      </SnackbarProvider>
+    </ThemeProvider>
+  </TestRouter>
+);
+
+describe('Scenario NsGoalCalculator page', () => {
+  it('uses ensureSessionAndAccountList for server-side props', () => {
+    expect(getServerSideProps).toBe(ensureSessionAndAccountList);
+  });
+
+  it('renders the goal settings form in scenario mode', async () => {
+    const { findByRole } = render(<TestComponent />);
+
+    expect(
+      await findByRole('heading', { name: 'Contact Info' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/pages/accountLists/[accountListId]/hrTools/mpdGoalAdmin/scenario/[scenarioGoalId]/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/mpdGoalAdmin/scenario/[scenarioGoalId]/index.page.tsx
@@ -5,24 +5,22 @@ import { useTranslation } from 'react-i18next';
 import { ensureSessionAndAccountList } from 'pages/api/utils/pagePropsHelpers';
 import { GoalSettingsForm } from 'src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm';
 import Loading from 'src/components/Loading';
-import { useAccountListId } from 'src/hooks/useAccountListId';
 import { getAppName } from 'src/lib/getAppName';
 import { getQueryParam } from 'src/lib/queryParam';
 
-export const NsGoalCalculatorPage: React.FC = () => {
+export const NsScenarioGoalPage: React.FC = () => {
   const { t } = useTranslation();
   const appName = getAppName();
-  const accountListId = useAccountListId();
   const { query } = useRouter();
-  const coachingId = getQueryParam(query, 'coachingId');
+  const scenarioGoalId = getQueryParam(query, 'scenarioGoalId');
 
   return (
     <>
       <Head>
-        <title>{`${appName} | ${t('Coaching Accounts | New Staff Goal Calculator')}`}</title>
+        <title>{`${appName} | ${t('New Staff Goal Calculator')}`}</title>
       </Head>
-      {accountListId && coachingId ? (
-        <GoalSettingsForm accountListId={coachingId} />
+      {scenarioGoalId ? (
+        <GoalSettingsForm scenarioGoalId={scenarioGoalId} />
       ) : (
         <Loading loading />
       )}
@@ -32,4 +30,4 @@ export const NsGoalCalculatorPage: React.FC = () => {
 
 export const getServerSideProps = ensureSessionAndAccountList;
 
-export default NsGoalCalculatorPage;
+export default NsScenarioGoalPage;

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.test.tsx
@@ -55,6 +55,14 @@ const TestComponent: React.FC<
   </NsGoalCalculatorTestWrapper>
 );
 
+const ScenarioTestComponent: React.FC<
+  Omit<NsGoalCalculatorTestWrapperProps, 'children'>
+> = (props) => (
+  <NsGoalCalculatorTestWrapper onCall={mutationSpy} {...props}>
+    <GoalSettingsForm scenarioGoalId="scenario-1" />
+  </NsGoalCalculatorTestWrapper>
+);
+
 describe('GoalSettingsForm', () => {
   it('renders all six section headings', async () => {
     const { findByRole, getByRole } = render(<TestComponent />);
@@ -473,6 +481,81 @@ describe('GoalSettingsForm', () => {
                 accountTransfers: null,
                 advocacyTransfers: null,
               },
+            },
+          },
+        ),
+      );
+    });
+  });
+
+  it('does not send identity fields in real (account-list) mode', async () => {
+    const { findByRole } = render(<TestComponent />);
+
+    const saveButton = await findByRole('button', { name: 'Save & Share' });
+    await waitFor(() => expect(saveButton).toBeEnabled());
+    userEvent.click(saveButton);
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation(
+        'UpdateNewStaffGoalCalculation',
+      ),
+    );
+    const realOp = mutationSpy.mock.calls
+      .map(([{ operation }]) => operation)
+      .find((op) => op.operationName === 'UpdateNewStaffGoalCalculation');
+    expect(realOp?.variables.input.attributes).not.toHaveProperty('firstName');
+  });
+
+  describe('scenario mode', () => {
+    it('renders the editable Contact Info section and hides the person cards', async () => {
+      const { findByRole, queryByText } = render(<ScenarioTestComponent />);
+
+      expect(
+        await findByRole('heading', { name: 'Contact Info' }),
+      ).toBeInTheDocument();
+      expect(await findByRole('textbox', { name: 'First Name' })).toHaveValue(
+        'John',
+      );
+      expect(queryByText(/Person Number:/)).not.toBeInTheDocument();
+    });
+
+    it('updates other sections’ labels as the name is edited, before saving', async () => {
+      const { findByRole } = render(<ScenarioTestComponent />);
+
+      const firstName = await findByRole('textbox', { name: 'First Name' });
+      userEvent.clear(firstName);
+      userEvent.type(firstName, 'Johnny');
+
+      expect(
+        await findByRole('spinbutton', {
+          name: 'Annual Requested Salary — Johnny',
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the Scenario Only tag', async () => {
+      const { findByText } = render(<ScenarioTestComponent />);
+      expect(await findByText('Scenario Only')).toBeInTheDocument();
+    });
+
+    it('saves identity edits through updateNewStaffGoalCalculation by id', async () => {
+      const { findByRole, getByRole } = render(<ScenarioTestComponent />);
+
+      const firstName = await findByRole('textbox', { name: 'First Name' });
+      userEvent.clear(firstName);
+      userEvent.type(firstName, 'Johnny');
+
+      const saveButton = getByRole('button', { name: 'Save & Share' });
+      await waitFor(() => expect(saveButton).toBeEnabled());
+      userEvent.click(saveButton);
+
+      await waitFor(() =>
+        expect(mutationSpy).toHaveGraphqlOperation(
+          'UpdateNewStaffGoalCalculation',
+          {
+            input: {
+              id: 'scenario-1',
+              attributes: { firstName: 'Johnny' },
             },
           },
         ),

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
@@ -9,9 +9,10 @@ import {
 } from '@mui/material';
 import { Form, Formik } from 'formik';
 import { useTranslation } from 'react-i18next';
+import { navBarHeight } from 'src/components/Layouts/Primary/Primary';
 import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
 import { GoalSettingsHeader } from './GoalSettingsHeader';
-import { useUpdateNewStaffGoalCalculationMutation } from './NewStaffGoalCalculation.generated';
+import { ContactInformationSection } from './Sections/ContactInformationSection';
 import { ExemptionsSection } from './Sections/ExemptionsSection';
 import { FinancialInformationSection } from './Sections/FinancialInformationSection';
 import { HealthcareInformationSection } from './Sections/HealthcareInformationSection';
@@ -30,13 +31,25 @@ import { getGoalSettingsSchema } from './goalSettingsSchema';
 import { GoalSettingsSectionProps } from './goalSettingsSectionProps';
 import { useNewStaffGoalCalculation } from './useNewStaffGoalCalculation';
 
+// Padded, full-height scroll container for the form. The sticky action bar below
+// breaks out of this exact spacing(4) padding, so the two are defined together
+// here to keep the padding and its negative-margin breakout in sync.
+const ScrollContainer = styled('div')(({ theme }) => ({
+  padding: theme.spacing(4),
+  width: '100%',
+  '@media screen': {
+    height: `calc(100vh - ${navBarHeight})`,
+    overflow: 'auto',
+  },
+}));
+
 /**
  * Sticky save/cancel bar pinned to the bottom of the scroll area.
  *
- * MainContent (the scrolling ancestor) wraps this form in spacing(4) = 32px
- * padding on every side. This bar breaks out of that padding so it spans the
- * full width and sits flush against the scroll-area edges. Each side cancels the
- * 32px:
+ * ScrollContainer (the scrolling ancestor above) wraps this form in
+ * spacing(4) = 32px padding on every side. This bar breaks out of that padding
+ * so it spans the full width and sits flush against the scroll-area edges. Each
+ * side cancels the 32px:
  *   marginX -4 + paddingX 4 -> full-bleed width, content stays inset
  *   marginBottom -4         -> flush at the bottom once fully scrolled
  *   bottom spacing(-4)      -> flush while the bar is still stuck
@@ -54,22 +67,23 @@ const StickyActionBar = styled(Box)(({ theme }) => ({
   borderTop: `1px solid ${theme.palette.divider}`,
 }));
 
-interface GoalSettingsFormProps {
-  accountListId: string;
-}
+export type GoalSettingsFormProps =
+  | { accountListId: string }
+  | { scenarioGoalId: string };
 
-export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = ({
-  accountListId,
-}) => {
+export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = (props) => {
   const { t } = useTranslation();
   const validationSchema = useMemo(() => getGoalSettingsSchema(t), [t]);
 
-  const { goalCalculation: calculation, fallback } =
-    useNewStaffGoalCalculation(accountListId);
-  const [updateCalculation] = useUpdateNewStaffGoalCalculationMutation();
+  const {
+    goalCalculation: calculation,
+    fallback,
+    isScenario,
+    save,
+  } = useNewStaffGoalCalculation(props);
 
   if (!calculation) {
-    return fallback;
+    return <ScrollContainer>{fallback}</ScrollContainer>;
   }
 
   // Whether the saved record has a spouse identity. The header's read-only
@@ -78,8 +92,6 @@ export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = ({
   // entered yet). The editable spouse columns instead follow the live form
   // value (see `isMarried` below).
   const hasSavedSpouse = Boolean(calculation.spouseFirstName);
-  const primaryName = calculation.firstName ?? '';
-  const spouseName = calculation.spouseFirstName || t('Spouse');
 
   const initialValues = calculationToFormValues(calculation);
 
@@ -104,92 +116,90 @@ export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = ({
 
   const mpdGoal = calculation.calculations.monthlyGoal;
 
-  const primaryHeader = `${primaryName} (${t('Joining')})`;
-  const spouseHeader = `${spouseName} (${calculation.spouseJoining ? t('Joining') : t('Senior')})`;
-
   const handleSubmit = async (
     values: GoalSettingsFormValues,
   ): Promise<void> => {
-    await updateCalculation({
-      variables: {
-        input: {
-          accountListId,
-          id: calculation.id,
-          attributes: formValuesToAttributes(values),
-        },
-      },
-    });
+    await save(formValuesToAttributes(values, { includeIdentity: isScenario }));
   };
 
   return (
-    <Formik
-      initialValues={initialValues}
-      validationSchema={validationSchema}
-      enableReinitialize
-      validateOnMount
-      onSubmit={handleSubmit}
-    >
-      {({ isSubmitting, isValid, resetForm, values }) => {
-        // Spouse columns follow the live form value, so they appear the moment
-        // marital status is set to married — before the change is saved.
-        const hasSpouse =
-          values.maritalStatus ===
-          NewStaffQuestionnaireMaritalStatusEnum.Married;
-        const seniorStaffSpouse = hasSpouse && values.spouseJoining === 'false';
-        const sectionProps: GoalSettingsSectionProps = {
-          hasSpouse,
-          calculations: calculation.calculations,
-          primaryName,
-          spouseName,
-          visibleHeaders: hasSpouse
-            ? [primaryHeader, spouseHeader]
-            : [primaryHeader],
-          sharedHeader: hasSpouse
-            ? `${primaryHeader} & ${spouseHeader}`
-            : primaryHeader,
-          seniorStaff: seniorStaffSpouse,
-        };
+    <ScrollContainer>
+      <Formik
+        initialValues={initialValues}
+        validationSchema={validationSchema}
+        enableReinitialize
+        validateOnMount
+        onSubmit={handleSubmit}
+      >
+        {({ isSubmitting, isValid, resetForm, values }) => {
+          // Spouse columns follow the live form value, so they appear the moment
+          // marital status is set to married — before the change is saved.
+          const hasSpouse =
+            values.maritalStatus ===
+            NewStaffQuestionnaireMaritalStatusEnum.Married;
+          const seniorStaffSpouse =
+            hasSpouse && values.spouseJoining === 'false';
+          const primaryName = values.firstName;
+          const spouseName = values.spouseFirstName || t('Spouse');
+          const primaryHeader = `${primaryName} (${t('Joining')})`;
+          const spouseHeader = `${spouseName} (${calculation.spouseJoining ? t('Joining') : t('Senior')})`;
+          const sectionProps: GoalSettingsSectionProps = {
+            hasSpouse,
+            calculations: calculation.calculations,
+            primaryName,
+            spouseName,
+            visibleHeaders: hasSpouse
+              ? [primaryHeader, spouseHeader]
+              : [primaryHeader],
+            sharedHeader: hasSpouse
+              ? `${primaryHeader} & ${spouseHeader}`
+              : primaryHeader,
+            seniorStaff: seniorStaffSpouse,
+          };
 
-        return (
-          <Form>
-            <GoalSettingsHeader
-              primaryPerson={primaryPerson}
-              spousePerson={spousePerson}
-              mpdGoal={mpdGoal}
-              joinedStaffYear={calculation.joinedStaffYear}
-            />
+          return (
+            <Form>
+              <GoalSettingsHeader
+                primaryPerson={primaryPerson}
+                spousePerson={spousePerson}
+                mpdGoal={mpdGoal}
+                joinedStaffYear={calculation.joinedStaffYear}
+                isScenario={isScenario}
+              />
 
-            <Divider sx={{ mb: 3 }} />
+              <Divider sx={{ mb: 3 }} />
 
-            <PersonalInformationSection {...sectionProps} />
-            <FinancialInformationSection {...sectionProps} />
-            <HealthcareInformationSection {...sectionProps} />
-            <MinistryInformationSection {...sectionProps} />
-            <NsoInformationSection {...sectionProps} />
-            <ExemptionsSection {...sectionProps} />
+              {isScenario && <ContactInformationSection {...sectionProps} />}
+              <PersonalInformationSection {...sectionProps} />
+              <FinancialInformationSection {...sectionProps} />
+              <HealthcareInformationSection {...sectionProps} />
+              <MinistryInformationSection {...sectionProps} />
+              <NsoInformationSection {...sectionProps} />
+              <ExemptionsSection {...sectionProps} />
 
-            <StickyActionBar>
-              <Stack direction="row" spacing={2} justifyContent="flex-end">
-                <Button color="inherit" onClick={() => resetForm()}>
-                  {t('Cancel')}
-                </Button>
-                <Button
-                  type="submit"
-                  variant="contained"
-                  disabled={!isValid || isSubmitting}
-                  startIcon={
-                    isSubmitting ? (
-                      <CircularProgress color="inherit" size={20} />
-                    ) : undefined
-                  }
-                >
-                  {t('Save & Share')}
-                </Button>
-              </Stack>
-            </StickyActionBar>
-          </Form>
-        );
-      }}
-    </Formik>
+              <StickyActionBar>
+                <Stack direction="row" spacing={2} justifyContent="flex-end">
+                  <Button color="inherit" onClick={() => resetForm()}>
+                    {t('Cancel')}
+                  </Button>
+                  <Button
+                    type="submit"
+                    variant="contained"
+                    disabled={!isValid || isSubmitting}
+                    startIcon={
+                      isSubmitting ? (
+                        <CircularProgress color="inherit" size={20} />
+                      ) : undefined
+                    }
+                  >
+                    {t('Save & Share')}
+                  </Button>
+                </Stack>
+              </StickyActionBar>
+            </Form>
+          );
+        }}
+      </Formik>
+    </ScrollContainer>
   );
 };

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.test.tsx
@@ -29,12 +29,14 @@ interface TestComponentProps {
   spouse?: GoalSettingsPerson | null;
   mpdGoal?: number;
   joinedStaffYear?: number | null;
+  isScenario?: boolean;
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({
   spouse = spousePerson,
   mpdGoal = 50000,
   joinedStaffYear = 2018,
+  isScenario = false,
 }) => (
   <ThemeProvider theme={theme}>
     <Formik initialValues={{ calculationsYear: '2020' }} onSubmit={jest.fn()}>
@@ -44,6 +46,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
           spousePerson={spouse}
           mpdGoal={mpdGoal}
           joinedStaffYear={joinedStaffYear}
+          isScenario={isScenario}
         />
       </Form>
     </Formik>
@@ -155,5 +158,33 @@ describe('GoalSettingsHeader', () => {
     const options = within(getByRole('listbox')).getAllByRole('option');
 
     expect(options.map((option) => option.textContent)).toEqual(['2020']);
+  });
+
+  describe('scenario mode', () => {
+    it('shows the Scenario Only chip and hides the person, coach, and coordinator cards', () => {
+      const { getByText, queryByText, queryByRole } = render(
+        <TestComponent isScenario />,
+      );
+
+      expect(getByText('Scenario Only')).toBeInTheDocument();
+      expect(queryByText('Incomplete')).not.toBeInTheDocument();
+      // Person cards render the "Person Number:" line; it must be absent.
+      expect(queryByText(/Person Number:/)).not.toBeInTheDocument();
+      expect(queryByRole('textbox', { name: 'Coach' })).not.toBeInTheDocument();
+      expect(
+        queryByRole('textbox', { name: 'Coordinator' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows the person, coach, and coordinator cards and no Scenario Only chip by default', () => {
+      const { getAllByText, getByRole, queryByText } = render(
+        <TestComponent />,
+      );
+
+      expect(queryByText('Scenario Only')).not.toBeInTheDocument();
+      expect(getAllByText(/Person Number:/).length).toBeGreaterThan(0);
+      expect(getByRole('textbox', { name: 'Coach' })).toBeInTheDocument();
+      expect(getByRole('textbox', { name: 'Coordinator' })).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.tsx
@@ -75,6 +75,10 @@ interface GoalSettingsHeaderProps {
    * this year up to the current year (newest first).
    */
   joinedStaffYear?: number | null;
+  /**
+   * Scenario goals hide the read-only person cards
+   */
+  isScenario?: boolean;
 }
 
 export const GoalSettingsHeader: React.FC<GoalSettingsHeaderProps> = ({
@@ -82,6 +86,7 @@ export const GoalSettingsHeader: React.FC<GoalSettingsHeaderProps> = ({
   spousePerson,
   mpdGoal,
   joinedStaffYear,
+  isScenario = false,
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
@@ -112,12 +117,21 @@ export const GoalSettingsHeader: React.FC<GoalSettingsHeaderProps> = ({
         flexWrap="wrap"
       >
         <Typography variant="h5">{householdTitle}</Typography>
-        <Chip
-          color="warning"
-          variant="outlined"
-          label={t('Incomplete')}
-          size="small"
-        />
+        {isScenario ? (
+          <Chip
+            color="info"
+            variant="outlined"
+            label={t('Scenario Only')}
+            size="small"
+          />
+        ) : (
+          <Chip
+            color="warning"
+            variant="outlined"
+            label={t('Incomplete')}
+            size="small"
+          />
+        )}
       </Stack>
       <Stack
         direction="row"
@@ -155,56 +169,59 @@ export const GoalSettingsHeader: React.FC<GoalSettingsHeaderProps> = ({
           })}
         </Typography>
       </Stack>
-      <Grid container spacing={3}>
-        <Grid
-          size={{
-            xs: 12,
-            md: 8,
-          }}
-        >
-          <Grid container spacing={3}>
-            <Grid
-              size={{
-                xs: 12,
-                sm: 6,
-              }}
-            >
-              <PersonInfoCard person={primaryPerson} />
-            </Grid>
-            {spousePerson && (
+
+      {!isScenario && (
+        <Grid container spacing={3}>
+          <Grid
+            size={{
+              xs: 12,
+              md: 8,
+            }}
+          >
+            <Grid container spacing={3}>
               <Grid
                 size={{
                   xs: 12,
                   sm: 6,
                 }}
               >
-                <PersonInfoCard person={spousePerson} />
+                <PersonInfoCard person={primaryPerson} />
               </Grid>
-            )}
+              {spousePerson && (
+                <Grid
+                  size={{
+                    xs: 12,
+                    sm: 6,
+                  }}
+                >
+                  <PersonInfoCard person={spousePerson} />
+                </Grid>
+              )}
+            </Grid>
+          </Grid>
+          <Grid
+            size={{
+              xs: 12,
+              md: 4,
+            }}
+          >
+            <Stack spacing={3}>
+              {/* TODO(MPDX-9796): Attendee field */}
+              <GoalSettingsPlaceholder
+                label={t('Coach')}
+                value={t('Amy Wilson')}
+                showLabel
+              />
+              {/* TODO(MPDX-9796): Attendee field */}
+              <GoalSettingsPlaceholder
+                label={t('Coordinator')}
+                value={t('Nancy Coleman')}
+                showLabel
+              />
+            </Stack>
           </Grid>
         </Grid>
-        <Grid
-          size={{
-            xs: 12,
-            md: 4,
-          }}
-        >
-          <Stack spacing={3}>
-            {/* TODO(MPDX-9796): Attendee field */}
-            <GoalSettingsPlaceholder
-              label={t('Coach')}
-              value={t('Amy Wilson')}
-              showLabel
-            />
-            {/* TODO(MPDX-9796): Attendee field */}
-            <GoalSettingsPlaceholder
-              label={t('Coordinator')}
-              value={t('Nancy Coleman')}
-              showLabel
-            />
-          </Stack>
-        </Grid>
-      </Grid>
+      )}
     </Box>
   );
 };

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
@@ -99,8 +99,8 @@ fragment NewStaffGoalCalculationFields on NewStaffGoalCalculation {
   calculationsYear
 }
 
-query NewStaffGoalCalculation($accountListId: ID!) {
-  newStaffGoalCalculation(accountListId: $accountListId) {
+query NewStaffGoalCalculation($accountListId: ID, $id: ID) {
+  newStaffGoalCalculation(accountListId: $accountListId, id: $id) {
     ...NewStaffGoalCalculationFields
   }
 }

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/ContactInformationSection.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/ContactInformationSection.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { render } from '@testing-library/react';
+import { Formik } from 'formik';
+import { I18nextProvider } from 'react-i18next';
+import i18n from 'src/lib/i18n';
+import theme from 'src/theme';
+import { defaultGoalCalculation } from '../../NsGoalCalculatorTestWrapper';
+import { GoalSettingsSectionProps } from '../goalSettingsSectionProps';
+import { ContactInformationSection } from './ContactInformationSection';
+
+const marriedProps: GoalSettingsSectionProps = {
+  hasSpouse: true,
+  seniorStaff: false,
+  calculations: defaultGoalCalculation.calculations,
+  primaryName: 'John',
+  spouseName: 'Jane',
+  visibleHeaders: ['John (Joining)', 'Jane (Senior)'],
+  sharedHeader: 'John (Joining) & Jane (Senior)',
+};
+
+const renderSection = (props: GoalSettingsSectionProps) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <I18nextProvider i18n={i18n}>
+        <Formik
+          initialValues={{
+            firstName: 'John',
+            lastName: 'Doe',
+            emailAddress: 'john.doe@cru.org',
+            spouseFirstName: 'Jane',
+            spouseEmailAddress: 'jane.doe@cru.org',
+          }}
+          onSubmit={jest.fn()}
+        >
+          <ContactInformationSection {...props} />
+        </Formik>
+      </I18nextProvider>
+    </ThemeProvider>,
+  );
+
+describe('ContactInformationSection', () => {
+  it('renders the primary editable fields', () => {
+    const { getByRole } = renderSection(marriedProps);
+    expect(getByRole('textbox', { name: 'First Name' })).toHaveValue('John');
+    expect(getByRole('textbox', { name: 'Last Name' })).toHaveValue('Doe');
+    expect(getByRole('textbox', { name: 'Email address' })).toHaveValue(
+      'john.doe@cru.org',
+    );
+  });
+
+  it('renders spouse fields when married, with a disabled last-name mirror', () => {
+    const { getByRole } = renderSection(marriedProps);
+    expect(getByRole('textbox', { name: "Spouse's First Name" })).toHaveValue(
+      'Jane',
+    );
+    expect(getByRole('textbox', { name: "Spouse's Email" })).toHaveValue(
+      'jane.doe@cru.org',
+    );
+    const spouseLastName = getByRole('textbox', { name: "Spouse's Last Name" });
+    expect(spouseLastName).toBeDisabled();
+    expect(spouseLastName).toHaveValue('Doe');
+  });
+
+  it('hides spouse fields when not married', () => {
+    const { queryByRole } = renderSection({
+      ...marriedProps,
+      hasSpouse: false,
+    });
+    expect(
+      queryByRole('textbox', { name: "Spouse's First Name" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/ContactInformationSection.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/ContactInformationSection.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Grid, TextField } from '@mui/material';
+import { useFormikContext } from 'formik';
+import { useTranslation } from 'react-i18next';
+import { GoalSettingsTextField } from '../Fields/GoalSettingsTextField';
+import { Section } from '../GoalSettingsLayout';
+import { GoalSettingsFormValues } from '../goalSettingsFormValues';
+import { GoalSettingsSectionProps } from '../goalSettingsSectionProps';
+
+/**
+ * Editable identity section shown only for scenario goals. Real goals show the
+ * read-only person cards in the header instead.
+ *
+ * The API has no distinct spouse last name, so "Spouse's Last Name" is a
+ * disabled mirror of the shared `lastName` field.
+ */
+export const ContactInformationSection: React.FC<GoalSettingsSectionProps> = ({
+  hasSpouse,
+}) => {
+  const { t } = useTranslation();
+  const { values } = useFormikContext<GoalSettingsFormValues>();
+
+  return (
+    <Section title={t('Contact Info')}>
+      <Grid container spacing={3}>
+        <Grid container size={{ xs: 12, md: 6 }} spacing={2}>
+          <GoalSettingsTextField
+            name="firstName"
+            label={t('First Name')}
+            showLabel
+          />
+          <GoalSettingsTextField
+            name="lastName"
+            label={t('Last Name')}
+            showLabel
+          />
+          <GoalSettingsTextField
+            name="emailAddress"
+            label={t('Email address')}
+            showLabel
+          />
+        </Grid>
+        {hasSpouse && (
+          <Grid container size={{ xs: 12, md: 6 }} spacing={2}>
+            <GoalSettingsTextField
+              name="spouseFirstName"
+              label={t("Spouse's First Name")}
+              showLabel
+            />
+            <TextField
+              label={t("Spouse's Last Name")}
+              value={values.lastName}
+              disabled
+              fullWidth
+              size="small"
+            />
+            <GoalSettingsTextField
+              name="spouseEmailAddress"
+              label={t("Spouse's Email")}
+              showLabel
+            />
+          </Grid>
+        )}
+      </Grid>
+    </Section>
+  );
+};

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.test.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.test.ts
@@ -26,6 +26,11 @@ const baseCalculation = gqlMock<NewStaffGoalCalculationFieldsFragment>(
   NewStaffGoalCalculationFieldsFragmentDoc,
   {
     mocks: {
+      firstName: 'John',
+      lastName: 'Doe',
+      emailAddress: 'john@cru.org',
+      spouseFirstName: 'Jane',
+      spouseEmailAddress: 'jane@cru.org',
       maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Married,
       spouseJoining: true,
       age: GoalCalculationAge.ThirtyToThirtyFour,
@@ -214,5 +219,51 @@ describe('formValuesToAttributes', () => {
     expect(attributes.solidSupportRaised).toBe(0);
     expect(attributes.tenure).toBe(0);
     expect(attributes.childcareChildrenCount).toBe(0);
+  });
+});
+
+describe('identity fields', () => {
+  it('prefills identity values from the calculation', () => {
+    const values = calculationToFormValues(baseCalculation);
+    expect(values.firstName).toBe('John');
+    expect(values.lastName).toBe('Doe');
+    expect(values.emailAddress).toBe('john@cru.org');
+    expect(values.spouseFirstName).toBe('Jane');
+    expect(values.spouseEmailAddress).toBe('jane@cru.org');
+  });
+
+  it('omits identity fields by default (real-goal save)', () => {
+    const attributes = formValuesToAttributes(
+      calculationToFormValues(baseCalculation),
+    );
+    expect(attributes).not.toHaveProperty('firstName');
+    expect(attributes).not.toHaveProperty('lastName');
+    expect(attributes).not.toHaveProperty('emailAddress');
+    expect(attributes).not.toHaveProperty('spouseFirstName');
+    expect(attributes).not.toHaveProperty('spouseEmailAddress');
+  });
+
+  it('includes identity fields when includeIdentity is set (scenario save)', () => {
+    const attributes = formValuesToAttributes(
+      calculationToFormValues(baseCalculation),
+      { includeIdentity: true },
+    );
+    expect(attributes.firstName).toBe('John');
+    expect(attributes.lastName).toBe('Doe');
+    expect(attributes.emailAddress).toBe('john@cru.org');
+    expect(attributes.spouseFirstName).toBe('Jane');
+    expect(attributes.spouseEmailAddress).toBe('jane@cru.org');
+  });
+
+  it('nulls spouse identity fields when not married, even with includeIdentity', () => {
+    const attributes = formValuesToAttributes(
+      {
+        ...calculationToFormValues(baseCalculation),
+        maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Single,
+      },
+      { includeIdentity: true },
+    );
+    expect(attributes.spouseFirstName).toBeNull();
+    expect(attributes.spouseEmailAddress).toBeNull();
   });
 });

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
@@ -34,6 +34,12 @@ export const calculationToFormValues = (
       ? String(calc.calculationsYear)
       : '',
 
+  firstName: calc.firstName ?? '',
+  lastName: calc.lastName ?? '',
+  emailAddress: calc.emailAddress ?? '',
+  spouseFirstName: calc.spouseFirstName ?? '',
+  spouseEmailAddress: calc.spouseEmailAddress ?? '',
+
   maritalStatus: toEnumInput(calc.maritalStatus),
   spouseJoining: toYesNo(calc.spouseJoining),
   age: toEnumInput(calc.age),
@@ -92,14 +98,27 @@ export const calculationToFormValues = (
  * when there is a senior spouse, so they are cleared when the spouse is missing
  * or is joining staff.
  */
+interface FormValuesToAttributesOptions {
+  /** Scenario goals may edit identity; real goals must not send it. */
+  includeIdentity?: boolean;
+}
+
 export const formValuesToAttributes = (
   values: GoalSettingsFormValues,
+  { includeIdentity = false }: FormValuesToAttributesOptions = {},
 ): NewStaffGoalCalculationAttributesInput => {
   const hasSpouse =
     values.maritalStatus === NewStaffQuestionnaireMaritalStatusEnum.Married;
   const seniorStaff = hasSpouse && !toBoolean(values.spouseJoining);
 
   return {
+    ...(includeIdentity && {
+      firstName: values.firstName || null,
+      lastName: values.lastName || null,
+      emailAddress: values.emailAddress || null,
+      spouseFirstName: hasSpouse ? values.spouseFirstName || null : null,
+      spouseEmailAddress: hasSpouse ? values.spouseEmailAddress || null : null,
+    }),
     maritalStatus: values.maritalStatus || null,
     spouseJoining: hasSpouse ? toBoolean(values.spouseJoining) : null,
     age: toEnumOrNull(values.age),

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsFormValues.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsFormValues.ts
@@ -36,6 +36,13 @@ export interface GoalSettingsFormValues {
   // --- Header ---
   calculationsYear: string; // API Int, edited as a string for the Select
 
+  // --- Contact Info (editable in scenario mode only) ---
+  firstName: string;
+  lastName: string; // shared by primary and spouse (API has no spouseLastName)
+  emailAddress: string;
+  spouseFirstName: string;
+  spouseEmailAddress: string;
+
   // --- 1. Personal Information ---
   maritalStatus: NewStaffQuestionnaireMaritalStatusEnum | '';
   spouseJoining: YesNo; // API spouseJoining (Boolean); edited only when married

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/useNewStaffGoalCalculation.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/useNewStaffGoalCalculation.test.tsx
@@ -1,0 +1,164 @@
+import { ReactElement } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ApolloErgonoMockMap } from 'graphql-ergonomock';
+import { DeepPartial } from 'ts-essentials';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { NewStaffGoalCalculationQuery } from './NewStaffGoalCalculation.generated';
+import { useNewStaffGoalCalculation } from './useNewStaffGoalCalculation';
+
+const mutationSpy = jest.fn();
+
+const makeWrapper = (
+  newStaffGoalCalculation:
+    | DeepPartial<
+        NonNullable<NewStaffGoalCalculationQuery['newStaffGoalCalculation']>
+      >
+    | null
+    | (() => never),
+) => {
+  const Wrapper = ({ children }: { children: ReactElement }) => (
+    <GqlMockedProvider<{
+      NewStaffGoalCalculation: NewStaffGoalCalculationQuery;
+    }>
+      mocks={
+        {
+          NewStaffGoalCalculation: { newStaffGoalCalculation },
+        } as ApolloErgonoMockMap
+      }
+      onCall={mutationSpy}
+    >
+      {children}
+    </GqlMockedProvider>
+  );
+  return Wrapper;
+};
+
+describe('useNewStaffGoalCalculation', () => {
+  it('fetches the real goal by account list in accountList mode', async () => {
+    const { result } = renderHook(
+      () => useNewStaffGoalCalculation({ accountListId: 'account-list-1' }),
+      { wrapper: makeWrapper({ id: 'goal-1', firstName: 'John' }) },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.isScenario).toBe(false);
+    expect(result.current.goalCalculation?.id).toBe('goal-1');
+    expect(mutationSpy).toHaveGraphqlOperation('NewStaffGoalCalculation', {
+      accountListId: 'account-list-1',
+      id: null,
+    });
+  });
+
+  it('fetches the scenario goal by id in scenario mode', async () => {
+    const { result } = renderHook(
+      () => useNewStaffGoalCalculation({ scenarioGoalId: 'scenario-2' }),
+      { wrapper: makeWrapper({ id: 'scenario-2', firstName: 'Grace' }) },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.isScenario).toBe(true);
+    expect(result.current.goalCalculation?.id).toBe('scenario-2');
+    expect(result.current.goalCalculation?.firstName).toBe('Grace');
+    expect(mutationSpy).toHaveGraphqlOperation('NewStaffGoalCalculation', {
+      accountListId: null,
+      id: 'scenario-2',
+    });
+  });
+
+  it('skips the query and returns null when no account list is given', async () => {
+    const { result } = renderHook(
+      () => useNewStaffGoalCalculation({ accountListId: undefined }),
+      { wrapper: makeWrapper({ id: 'goal-1' }) },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.goalCalculation).toBeNull();
+    expect(mutationSpy).not.toHaveGraphqlOperation('NewStaffGoalCalculation');
+  });
+
+  it('returns null when the scenario goal is not found', async () => {
+    const { result } = renderHook(
+      () => useNewStaffGoalCalculation({ scenarioGoalId: 'missing' }),
+      { wrapper: makeWrapper(null) },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.goalCalculation).toBeNull();
+  });
+
+  it('surfaces a query error', async () => {
+    const { result } = renderHook(
+      () => useNewStaffGoalCalculation({ scenarioGoalId: 'scenario-1' }),
+      {
+        wrapper: makeWrapper(() => {
+          throw new Error('boom');
+        }),
+      },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeDefined();
+    expect(result.current.goalCalculation).toBeNull();
+  });
+
+  it('saves scenario edits through updateNewStaffGoalCalculation by id', async () => {
+    const { result } = renderHook(
+      () => useNewStaffGoalCalculation({ scenarioGoalId: 'scenario-1' }),
+      { wrapper: makeWrapper({ id: 'scenario-1', firstName: 'Ada' }) },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await result.current.save({ firstName: 'Ada Lovelace' });
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation(
+        'UpdateNewStaffGoalCalculation',
+        {
+          input: {
+            id: 'scenario-1',
+            attributes: { firstName: 'Ada Lovelace' },
+          },
+        },
+      ),
+    );
+  });
+
+  it('does not save when no goal has loaded', async () => {
+    const { result } = renderHook(
+      () => useNewStaffGoalCalculation({ accountListId: 'account-list-1' }),
+      { wrapper: makeWrapper(null) },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.goalCalculation).toBeNull();
+
+    await result.current.save({ annualRequestedSalary: 5 });
+
+    expect(mutationSpy).not.toHaveGraphqlOperation(
+      'UpdateNewStaffGoalCalculation',
+    );
+  });
+
+  it('saves real edits through updateNewStaffGoalCalculation', async () => {
+    const { result } = renderHook(
+      () => useNewStaffGoalCalculation({ accountListId: 'account-list-1' }),
+      { wrapper: makeWrapper({ id: 'goal-1', firstName: 'John' }) },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await result.current.save({ annualRequestedSalary: 5 });
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation(
+        'UpdateNewStaffGoalCalculation',
+        {
+          input: {
+            accountListId: 'account-list-1',
+            id: 'goal-1',
+            attributes: { annualRequestedSalary: 5 },
+          },
+        },
+      ),
+    );
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/useNewStaffGoalCalculation.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/useNewStaffGoalCalculation.tsx
@@ -1,35 +1,68 @@
 import React, { ReactElement } from 'react';
+import { ApolloError } from '@apollo/client';
 import { Alert, Skeleton } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { NewStaffGoalCalculationAttributesInput } from 'src/graphql/types.generated';
 import {
   NewStaffGoalCalculationQuery,
   useNewStaffGoalCalculationQuery,
+  useUpdateNewStaffGoalCalculationMutation,
 } from './NewStaffGoalCalculation.generated';
 
 export type NewStaffGoalCalculation = NonNullable<
   NewStaffGoalCalculationQuery['newStaffGoalCalculation']
 >;
 
+/**
+ * Where the goal comes from: a real goal scoped by an account list, or one of
+ * the current user's scenario goals fetched by id (no account list).
+ */
+export type GoalSettingsSource =
+  | { accountListId: string | null | undefined }
+  | { scenarioGoalId: string };
+
 interface UseNewStaffGoalCalculationResult {
   /** The loaded calculation, or `null` while loading / on error / when absent. */
   goalCalculation: NewStaffGoalCalculation | null;
   loading: boolean;
+  error?: ApolloError;
   /** The loading/error/empty element to render while `goalCalculation` is `null`. */
   fallback: ReactElement | null;
+  /** True when the source is a scenario goal (fetched/saved by id). */
+  isScenario: boolean;
+  /**
+   * Save edits to the goal. Real goals save by account list + id; scenario goals
+   * by id alone. Both go through the updateNewStaffGoalCalculation mutation.
+   */
+  save: (
+    attributes: NewStaffGoalCalculationAttributesInput,
+  ) => Promise<unknown>;
 }
 
 /**
- * Loads the new staff goal calculation for an account list and centralizes the
- * loading skeleton, error alert, and empty-state.
+ * Loads and saves a New Staff goal calculation, hiding the difference between a
+ * real goal (scoped by account list) and a scenario goal (admin-built, no
+ * account list, fetched by id). Both modes go through the same
+ * newStaffGoalCalculation query and updateNewStaffGoalCalculation mutation.
  */
 export const useNewStaffGoalCalculation = (
-  accountListId: string | null | undefined,
+  source: GoalSettingsSource,
 ): UseNewStaffGoalCalculationResult => {
   const { t } = useTranslation();
 
+  const isScenario = 'scenarioGoalId' in source;
+  const scenarioGoalId =
+    'scenarioGoalId' in source ? source.scenarioGoalId : '';
+  const accountListId =
+    'accountListId' in source ? source.accountListId : undefined;
+
+  // A real goal is fetched by its account list; a scenario goal by id, with the
+  // account list omitted.
   const { data, loading, error } = useNewStaffGoalCalculationQuery({
-    variables: { accountListId: accountListId ?? '' },
-    skip: !accountListId,
+    variables: isScenario
+      ? { accountListId: null, id: scenarioGoalId }
+      : { accountListId, id: null },
+    skip: !isScenario && !accountListId,
   });
   const goalCalculation = data?.newStaffGoalCalculation ?? null;
 
@@ -46,5 +79,25 @@ export const useNewStaffGoalCalculation = (
     );
   }
 
-  return { goalCalculation, loading, fallback };
+  const [updateGoalCalculation] = useUpdateNewStaffGoalCalculationMutation();
+
+  return {
+    goalCalculation,
+    loading,
+    error,
+    fallback,
+    isScenario,
+    save: async (attributes) => {
+      if (!goalCalculation) {
+        return;
+      }
+      return updateGoalCalculation({
+        variables: {
+          input: isScenario
+            ? { id: scenarioGoalId, attributes }
+            : { accountListId, id: goalCalculation.id, attributes },
+        },
+      });
+    },
+  };
 };

--- a/src/components/HrTools/NsGoalCalculator/NsGoalCalculator.tsx
+++ b/src/components/HrTools/NsGoalCalculator/NsGoalCalculator.tsx
@@ -11,8 +11,9 @@ export const NsGoalCalculator: React.FC = () => {
   const { currentStep } = useNsGoalCalculator();
   const accountListId = useAccountListId();
 
-  const { goalCalculation, fallback } =
-    useNewStaffGoalCalculation(accountListId);
+  const { goalCalculation, fallback } = useNewStaffGoalCalculation({
+    accountListId,
+  });
 
   if (!goalCalculation) {
     return fallback;

--- a/src/components/HrTools/NsGoalCalculator/NsGoalCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/NsGoalCalculator/NsGoalCalculatorTestWrapper.tsx
@@ -45,7 +45,11 @@ export const defaultGoalCalculation =
 
 export interface NsGoalCalculatorTestWrapperProps {
   children?: React.ReactNode;
-  /** Overrides the NewStaffGoalCalculation query response */
+  /**
+   * Overrides the NewStaffGoalCalculation query response.
+   * Serves both real (account-list) and scenario (by-id) goals,
+   * which share the query.
+   */
   goalCalculationMock?:
     | DeepPartial<NewStaffGoalCalculationQuery>
     | ApolloErgonoMockMap;


### PR DESCRIPTION
## Description

- Adds Scenario goal editing to the Admin View
- Uses the shared query and mutation GraphQL document (that still needs to be merged in the API)
https://jira.cru.org/browse/MPDX-9787

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to the Admin View and check a scenario goal.
- Path to use: `accountLists/308c5567-a0b6-49f6-922e-f0c338e170ca/hrTools/mpdGoalAdmin/scenario/019f4389-8823-7627-95e8-560fcc1ffc2a`

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
