### PR TITLE
[No Jira] - Fix dimmed address text in contact list

### DIFF
--- a/src/components/Contacts/ContactRow/ContactRow.test.tsx
+++ b/src/components/Contacts/ContactRow/ContactRow.test.tsx
@@ -115,6 +115,14 @@ describe('ContactsRow', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the address dimmed', () => {
+    const { getByText } = render(<Components />);
+
+    expect(getByText('1111 Test Street Any City, TT Test')).toHaveStyle(
+      `color: ${theme.palette.text.secondary}`,
+    );
+  });
+
   it('should render check event', async () => {
     const { getByRole } = render(<Components />);
 

--- a/src/components/Contacts/ContactRow/ContactRow.tsx
+++ b/src/components/Contacts/ContactRow/ContactRow.tsx
@@ -126,6 +126,7 @@ export const ContactRow: React.FC<Props> = ({ contact, useTopMargin }) => {
                 <Typography
                   component="span"
                   variant="body2"
+                  color="textSecondary"
                   sx={{ display: { xs: 'none', sm: 'block' } }}
                 >
                   {[


### PR DESCRIPTION
## Description

- Restores the dimmed appearance of the address text in the contact list rows.
- During the MUI v7 upgrade the `Hidden` wrapper around the address `Typography` was removed. In v5 that wrapper's `ListItemText` secondary context implicitly applied the `text.secondary` color; without it the address rendered in the default (full-strength) text color.
- Fix: explicitly set `color="textSecondary"` on the address `Typography` in `ContactRow` so it renders dimmed again.
- Adds a test asserting the address renders with `theme.palette.text.secondary`.

## Testing

- Go to the Contacts page (contact list view).
- Look at a contact row that has an address.
- Check that the address text (e.g. "1111 Test Street Any City, TT Test") appears dimmed/greyed (secondary text color), matching the pre-v7 appearance, rather than the full-strength primary text color.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
