### PR TITLE
[MPDX-9823] - Updates nav menus bg color for consistency

### DIFF
--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenuDropdown.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenuDropdown.tsx
@@ -164,7 +164,7 @@ export const NavMenuDropdown: React.FC<NavMenuDropdownProps> = ({
                 </ClickAwayListener>
               </Paper>
             ) : (
-              <Paper>
+              <Paper className={classes.subMenu}>
                 <ClickAwayListener onClickAway={handleMenuClose}>
                   <MenuList autoFocusItem={menuOpen} id="menu-list-grow">
                     {page.items?.map(({ id, title, href }) => (
@@ -174,13 +174,17 @@ export const NavMenuDropdown: React.FC<NavMenuDropdownProps> = ({
                         href={href ?? ''}
                         onClick={handleMenuClose}
                         tabIndex={0}
+                        className={classes.menuItem}
                         aria-current={
                           pathname.startsWith(href?.toString() ?? '')
                             ? 'page'
                             : undefined
                         }
                       >
-                        <ListItemText primary={title} />
+                        <ListItemText
+                          className={classes.whiteText}
+                          primary={title}
+                        />
                       </MenuItem>
                     ))}
                   </MenuList>


### PR DESCRIPTION
## Description

- Updates the nav menu dropdown (sub-menu) background color and text color for consistency with the rest of the top navigation.
- Applies the `subMenu`, `menuItem`, and `whiteText` classes to the `Paper`, `MenuItem`, and `ListItemText` in `NavMenuDropdown` so the dropdown matches the surrounding nav styling.

Related Jira ticket: MPDX-9823

## Testing

- Log in and go to any page with the top navigation bar.
- Open a nav menu that has a dropdown/sub-menu (e.g. a menu item with child items).
- Check that the dropdown background color and item text color are consistent with the rest of the nav menu (white text on the themed sub-menu background).
- Hover/focus items and confirm they remain readable and consistent.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
