### PR TITLE
Allow API_URL env var to override .env.local in codegen

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -1,8 +1,8 @@
 import dotenv from 'dotenv';
 import type { CodegenConfig } from '@graphql-codegen/cli';
 
+dotenv.config({ path: '.env.local' });
 dotenv.config();
-dotenv.config({ path: '.env.local', override: true });
 
 const apiUrl = process.env.API_URL ?? 'https://api.stage.mpdx.org/graphql';
 const schema = [apiUrl, './pages/api/Schema/**/*.graphql'];


### PR DESCRIPTION
## Summary

Makes `API_URL=xxx yarn gql` override an `API_URL` set in `.env.local`.

`dotenv.config()` never overwrites a variable that is already set, so precedence is decided by load order (first writer wins) plus `override`. Previously `.env.local` was loaded last with `override: true`, which clobbered an inline `API_URL=xxx` passed on the command line — so you couldn't point codegen at a different schema ad hoc without editing `.env.local`.

Now `.env.local` is loaded first *without* `override`, so an inline env var wins.

Resulting precedence: **CLI env > `.env.local` > `.env`**.

## Test plan

- `yarn gql` still uses `API_URL` from `.env.local` when no inline var is set.
- `API_URL=https://api.stage.mpdx.org/graphql yarn gql` uses the inline value instead of `.env.local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)