### PR TITLE
MPDX-9830 Relocate report settings

### DIFF
--- a/src/components/Reports/MPGAIncomeExpensesReport/DisplayModes/ScreenOnlyReport.test.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/DisplayModes/ScreenOnlyReport.test.tsx
@@ -3,7 +3,6 @@ import { ThemeProvider } from '@mui/material/styles';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from 'src/theme';
 import { TotalsProvider } from '../TotalsContext/TotalsContext';
@@ -11,7 +10,6 @@ import { mockData, months } from '../mockData';
 import { ScreenOnlyReport } from './ScreenOnlyReport';
 
 const mutationSpy = jest.fn();
-const handleSettingsClick = jest.fn();
 const currency = 'USD';
 
 const emptyData = {
@@ -28,7 +26,6 @@ const TestComponent: React.FC = () => (
             data={mockData}
             last12Months={months}
             currency={currency}
-            handleSettingsClick={handleSettingsClick}
           />
         </TotalsProvider>
       </GqlMockedProvider>
@@ -68,7 +65,6 @@ describe('ScreenOnlyReport', () => {
                 data={emptyData}
                 last12Months={months}
                 currency={currency}
-                handleSettingsClick={handleSettingsClick}
               />
             </TotalsProvider>
           </GqlMockedProvider>
@@ -77,13 +73,5 @@ describe('ScreenOnlyReport', () => {
     );
 
     expect(queryAllByRole('grid')).toHaveLength(2);
-  });
-
-  it('calls handleSettingsClick when the Report Settings button is clicked', () => {
-    const { getByRole } = render(<TestComponent />);
-
-    userEvent.click(getByRole('button', { name: 'Report Settings' }));
-
-    expect(handleSettingsClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Reports/MPGAIncomeExpensesReport/DisplayModes/ScreenOnlyReport.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/DisplayModes/ScreenOnlyReport.tsx
@@ -1,8 +1,7 @@
-import { HourglassDisabled, Settings } from '@mui/icons-material';
+import { HourglassDisabled } from '@mui/icons-material';
 import { Box, Container, Grid } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { EmptyTable } from '../../../HrTools/Shared/EmptyTable/EmptyTable';
-import { StyledFilterButton } from '../../Shared/SettingsDialog/StyledFilterButton';
 import { CardSkeleton } from '../Card/CardSkeleton';
 import { ExpensesPieChart } from '../Charts/ExpensesPieChart';
 import { MonthlySummaryChart } from '../Charts/MonthlySummaryChart';
@@ -15,14 +14,12 @@ interface ScreenOnlyReportProps {
   data: AllData;
   last12Months: string[];
   currency: string;
-  handleSettingsClick: () => void;
 }
 
 export const ScreenOnlyReport: React.FC<ScreenOnlyReportProps> = ({
   data,
   last12Months,
   currency,
-  handleSettingsClick,
 }) => {
   const { t } = useTranslation();
 
@@ -45,16 +42,6 @@ export const ScreenOnlyReport: React.FC<ScreenOnlyReportProps> = ({
               </CardSkeleton>
             </Grid>
           </Grid>
-        </Box>
-        <Box display="flex" justifyContent="flex-end" mb={2}>
-          <StyledFilterButton
-            variant="outlined"
-            startIcon={<Settings />}
-            size="small"
-            onClick={handleSettingsClick}
-          >
-            {t('Report Settings')}
-          </StyledFilterButton>
         </Box>
         <Box mt={2}>
           <TableCard

--- a/src/components/Reports/MPGAIncomeExpensesReport/ExportCsvButton/ExportCsvButton.test.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/ExportCsvButton/ExportCsvButton.test.tsx
@@ -35,10 +35,10 @@ describe('ExportCsvButton', () => {
     userEvent.click(getByRole('button', { name: 'Export CSV' }));
 
     expect(
-      await findByRole('menuitem', { name: 'Income' }),
+      await findByRole('menuitem', { name: 'Income Report' }),
     ).toBeInTheDocument();
     expect(
-      await findByRole('menuitem', { name: 'Expenses' }),
+      await findByRole('menuitem', { name: 'Expenses Report' }),
     ).toBeInTheDocument();
   });
 
@@ -46,7 +46,7 @@ describe('ExportCsvButton', () => {
     const { getByRole, findByRole } = render(<TestComponent />);
 
     userEvent.click(getByRole('button', { name: 'Export CSV' }));
-    userEvent.click(await findByRole('menuitem', { name: 'Income' }));
+    userEvent.click(await findByRole('menuitem', { name: 'Income Report' }));
 
     expect(exportToCsv).toHaveBeenCalledWith(
       mockData.income,
@@ -60,7 +60,7 @@ describe('ExportCsvButton', () => {
     const { getByRole, findByRole } = render(<TestComponent />);
 
     userEvent.click(getByRole('button', { name: 'Export CSV' }));
-    userEvent.click(await findByRole('menuitem', { name: 'Expenses' }));
+    userEvent.click(await findByRole('menuitem', { name: 'Expenses Report' }));
 
     expect(exportToCsv).toHaveBeenCalledWith(
       mockData.expenses,
@@ -78,10 +78,10 @@ describe('ExportCsvButton', () => {
     userEvent.click(getByRole('button', { name: 'Export CSV' }));
 
     expect(
-      await findByRole('menuitem', { name: 'Income' }),
+      await findByRole('menuitem', { name: 'Income Report' }),
     ).not.toHaveAttribute('aria-disabled');
 
-    const expenses = await findByRole('menuitem', { name: 'Expenses' });
+    const expenses = await findByRole('menuitem', { name: 'Expenses Report' });
     expect(expenses).toHaveAttribute('aria-disabled', 'true');
     expect(exportToCsv).not.toHaveBeenCalled();
   });
@@ -93,14 +93,12 @@ describe('ExportCsvButton', () => {
 
     userEvent.click(getByRole('button', { name: 'Export CSV' }));
 
-    expect(await findByRole('menuitem', { name: 'Income' })).toHaveAttribute(
-      'aria-disabled',
-      'true',
-    );
-    expect(await findByRole('menuitem', { name: 'Expenses' })).toHaveAttribute(
-      'aria-disabled',
-      'true',
-    );
+    expect(
+      await findByRole('menuitem', { name: 'Income Report' }),
+    ).toHaveAttribute('aria-disabled', 'true');
+    expect(
+      await findByRole('menuitem', { name: 'Expenses Report' }),
+    ).toHaveAttribute('aria-disabled', 'true');
     expect(exportToCsv).not.toHaveBeenCalled();
   });
 
@@ -108,11 +106,11 @@ describe('ExportCsvButton', () => {
     const { getByRole, findByRole, queryByRole } = render(<TestComponent />);
 
     userEvent.click(getByRole('button', { name: 'Export CSV' }));
-    userEvent.click(await findByRole('menuitem', { name: 'Income' }));
+    userEvent.click(await findByRole('menuitem', { name: 'Income Report' }));
 
     await waitFor(() =>
       expect(
-        queryByRole('menuitem', { name: 'Income' }),
+        queryByRole('menuitem', { name: 'Income Report' }),
       ).not.toBeInTheDocument(),
     );
   });

--- a/src/components/Reports/MPGAIncomeExpensesReport/ExportCsvButton/ExportCsvButton.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/ExportCsvButton/ExportCsvButton.tsx
@@ -23,13 +23,13 @@ export const ExportCsvButton: React.FC<ExportCsvButtonProps> = ({
       label={t('Export CSV')}
       items={[
         {
-          label: t('Income'),
+          label: t('Income Report'),
           disabled: !data.income.length,
           onClick: () =>
             exportToCsv(data.income, ReportTypeEnum.Income, months, locale),
         },
         {
-          label: t('Expenses'),
+          label: t('Expenses Report'),
           disabled: !data.expenses.length,
           onClick: () =>
             exportToCsv(data.expenses, ReportTypeEnum.Expenses, months, locale),

--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.test.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.test.tsx
@@ -136,6 +136,9 @@ describe('MPGAIncomeExpensesReport', () => {
     expect(getByRole('heading', { name: title })).toBeInTheDocument();
     expect(getByRole('button', { name: 'Print' })).toBeInTheDocument();
     expect(getByRole('button', { name: 'Export CSV' })).toBeInTheDocument();
+    expect(
+      getByRole('button', { name: 'Report Settings' }),
+    ).toBeInTheDocument();
 
     expect(await findByText('12345')).toBeInTheDocument();
     expect(await findByText('Test Account')).toBeInTheDocument();

--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
@@ -4,6 +4,7 @@ import PrintIcon from '@mui/icons-material/Print';
 import {
   Box,
   Container,
+  Divider,
   GlobalStyles,
   SvgIcon,
   Typography,
@@ -182,6 +183,7 @@ export const MPGAIncomeExpensesReport: React.FC<
                 >
                   {t('Report Settings')}
                 </StyledFilterButton>
+                <Divider orientation="vertical" flexItem />
                 <ExportCsvButton data={allData} months={last12Months} />
                 <StyledPrintButton
                   startIcon={

--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesReport.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react';
+import { Settings } from '@mui/icons-material';
 import PrintIcon from '@mui/icons-material/Print';
 import {
   Box,
@@ -24,6 +25,7 @@ import {
   SettingsDialog,
   getFiltersWithCalculatedDates,
 } from '../Shared/SettingsDialog/SettingsDialog';
+import { StyledFilterButton } from '../Shared/SettingsDialog/StyledFilterButton';
 import {
   SimplePrintOnly,
   SimpleScreenOnly,
@@ -172,6 +174,14 @@ export const MPGAIncomeExpensesReport: React.FC<
                 alignItems="center"
                 sx={{ gap: 2, '& > button': { ml: 0 } }}
               >
+                <StyledFilterButton
+                  variant="outlined"
+                  startIcon={<Settings />}
+                  size="small"
+                  onClick={handleSettingsClick}
+                >
+                  {t('Report Settings')}
+                </StyledFilterButton>
                 <ExportCsvButton data={allData} months={last12Months} />
                 <StyledPrintButton
                   startIcon={
@@ -201,7 +211,6 @@ export const MPGAIncomeExpensesReport: React.FC<
               data={allData}
               last12Months={last12Months}
               currency={currency}
-              handleSettingsClick={handleSettingsClick}
             />
           </TotalsProvider>
         </SimpleScreenOnly>

--- a/src/components/Reports/MPGAIncomeExpensesReport/Tables/TableCard.test.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/Tables/TableCard.test.tsx
@@ -143,14 +143,6 @@ describe('TableCard', () => {
     expect(getByText('Empty Table')).toBeInTheDocument();
   });
 
-  it('should render pagination', () => {
-    const { getByRole } = render(<TestComponent />);
-
-    expect(
-      getByRole('combobox', { name: /rows per page/i }),
-    ).toBeInTheDocument();
-  });
-
   it('updates the sort order', async () => {
     const { getAllByRole, getByRole } = render(<TestComponent />);
 

--- a/src/components/Reports/MPGAIncomeExpensesReport/Tables/TableCard.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/Tables/TableCard.tsx
@@ -20,6 +20,8 @@ import { DataFields } from '../mockData';
 import { StyledGrid } from '../styledComponents';
 import { TotalRow } from './TotalRow';
 
+const DEFAULT_PAGE_SIZE = 25;
+
 export type RenderCell = GridColDef<DataFields>['renderCell'];
 
 export interface TableCardProps {
@@ -107,7 +109,7 @@ export const TableCard: React.FC<TableCardProps> = ({
 
   const [paginationModel, setPaginationModel] = useState({
     page: 0,
-    pageSize: 5,
+    pageSize: DEFAULT_PAGE_SIZE,
   });
   const [sortModel, setSortModel] = useState<GridSortModel>([
     {
@@ -239,7 +241,7 @@ export const TableCard: React.FC<TableCardProps> = ({
           sortingOrder={['desc', 'asc']}
           sortModel={sortModel}
           onSortModelChange={(model) => setSortModel(model)}
-          pageSizeOptions={[5, 10, 25, 50]}
+          pageSizeOptions={[DEFAULT_PAGE_SIZE]}
           paginationModel={paginationModel}
           onPaginationModelChange={(model) => setPaginationModel(model)}
           disableVirtualization

--- a/src/components/Reports/Shared/SettingsButtonGroup/SettingsButtonGroup.test.tsx
+++ b/src/components/Reports/Shared/SettingsButtonGroup/SettingsButtonGroup.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import theme from 'src/theme';
+import { SettingsButtonGroup } from './SettingsButtonGroup';
+
+const setFilters = jest.fn();
+const handleSettingsClick = jest.fn();
+
+interface TestComponentProps {
+  isFilterDateSelected?: boolean;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({
+  isFilterDateSelected = false,
+}) => (
+  <ThemeProvider theme={theme}>
+    <SettingsButtonGroup
+      isFilterDateSelected={isFilterDateSelected}
+      setFilters={setFilters}
+      handleSettingsClick={handleSettingsClick}
+    />
+  </ThemeProvider>
+);
+
+describe('SettingsButtonGroup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the report settings button', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(
+      getByRole('button', { name: 'Report Settings' }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls handleSettingsClick when the settings button is clicked', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    userEvent.click(getByRole('button', { name: 'Report Settings' }));
+
+    expect(handleSettingsClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the clear button when no filter date is selected', () => {
+    const { queryByRole } = render(
+      <TestComponent isFilterDateSelected={false} />,
+    );
+
+    expect(queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+  });
+
+  it('renders the clear button when a filter date is selected', () => {
+    const { getByRole } = render(<TestComponent isFilterDateSelected={true} />);
+
+    expect(getByRole('button', { name: 'Clear' })).toBeInTheDocument();
+  });
+
+  it('calls setFilters with null when the clear button is clicked', () => {
+    const { getByRole } = render(<TestComponent isFilterDateSelected={true} />);
+
+    userEvent.click(getByRole('button', { name: 'Clear' }));
+
+    expect(setFilters).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/components/Reports/Shared/SettingsButtonGroup/SettingsButtonGroup.tsx
+++ b/src/components/Reports/Shared/SettingsButtonGroup/SettingsButtonGroup.tsx
@@ -1,0 +1,47 @@
+import { FilterListOff, Settings } from '@mui/icons-material';
+import { ButtonGroup } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { Filters } from '../SettingsDialog/SettingsDialog';
+import { StyledFilterButton } from '../SettingsDialog/StyledFilterButton';
+
+interface SettingsButtonGroupProps {
+  isFilterDateSelected: boolean;
+  setFilters: (filters: Filters | null) => void;
+  handleSettingsClick: () => void;
+}
+
+export const SettingsButtonGroup: React.FC<SettingsButtonGroupProps> = ({
+  isFilterDateSelected,
+  setFilters,
+  handleSettingsClick,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <ButtonGroup aria-label={t('Report settings button group')}>
+      {isFilterDateSelected && (
+        <StyledFilterButton
+          variant="outlined"
+          startIcon={<FilterListOff />}
+          size="small"
+          onClick={() => {
+            setFilters(null);
+          }}
+          sx={{
+            color: (theme) => theme.palette.text.secondary,
+          }}
+        >
+          {t('Clear')}
+        </StyledFilterButton>
+      )}
+      <StyledFilterButton
+        variant="outlined"
+        startIcon={<Settings />}
+        size="small"
+        onClick={handleSettingsClick}
+      >
+        {t('Report Settings')}
+      </StyledFilterButton>
+    </ButtonGroup>
+  );
+};

--- a/src/components/Reports/Shared/SettingsDialog/StyledFilterButton.ts
+++ b/src/components/Reports/Shared/SettingsDialog/StyledFilterButton.ts
@@ -5,6 +5,9 @@ import theme from 'src/theme';
 export const StyledFilterButton = styled(Button)({
   color: theme.palette.mpdxGrayDark.main,
   borderColor: theme.palette.mpdxGrayDark.main,
+  borderRadius: theme.spacing(1),
+  paddingTop: theme.spacing(1),
+  paddingBottom: theme.spacing(1),
   '&:hover': {
     backgroundColor: theme.palette.mpdxGrayLight.main,
     borderColor: theme.palette.mpdxGrayDark.main,

--- a/src/components/Reports/Shared/SettingsDialog/StyledFilterButton.ts
+++ b/src/components/Reports/Shared/SettingsDialog/StyledFilterButton.ts
@@ -4,12 +4,12 @@ import theme from 'src/theme';
 
 export const StyledFilterButton = styled(Button)({
   color: theme.palette.mpdxGrayDark.main,
-  borderColor: theme.palette.mpdxGrayDark.main,
+  borderColor: theme.palette.text.secondary,
   borderRadius: theme.spacing(1),
   paddingTop: theme.spacing(1),
   paddingBottom: theme.spacing(1),
   '&:hover': {
     backgroundColor: theme.palette.mpdxGrayLight.main,
-    borderColor: theme.palette.mpdxGrayDark.main,
+    borderColor: theme.palette.text.secondary,
   },
 });

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
@@ -228,6 +228,14 @@ describe('StaffExpenseReport', () => {
     expect(await findByText('$4,000.00')).toBeInTheDocument();
   });
 
+  it('keeps the Report Settings button visible when there are no transactions', async () => {
+    const { findByRole } = render(<TestComponent isEmpty={true} />);
+
+    expect(
+      await findByRole('button', { name: 'Report Settings' }),
+    ).toBeInTheDocument();
+  });
+
   it('initializes with month from query', () => {
     const { getByText } = render(<TestComponent />);
 
@@ -275,6 +283,7 @@ describe('StaffExpenseReport', () => {
   it('shows month title and navigation when only category filters are applied', async () => {
     const { getByRole, findByRole, queryByRole } = render(<TestComponent />);
 
+    await findByRole('heading', { name: 'Primary' });
     userEvent.click(await findByRole('button', { name: 'Report Settings' }));
 
     // Wait for the category checkbox to render, then toggle the Assessment
@@ -306,6 +315,10 @@ describe('StaffExpenseReport', () => {
       <TestComponent />,
     );
 
+    // Wait for the report to finish loading so the Report Settings button is
+    // stable before interacting (otherwise the click can land on the
+    // loading-state button that gets swapped out when data arrives).
+    await findByRole('heading', { name: 'Primary' });
     userEvent.click(await findByRole('button', { name: 'Report Settings' }));
     await findByRole('heading', { name: 'Report Settings' });
 

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
@@ -273,17 +273,17 @@ describe('StaffExpenseReport', () => {
   });
 
   it('shows month title and navigation when only category filters are applied', async () => {
-    const { getByRole, getByText, findByLabelText, queryByRole } = render(
-      <TestComponent />,
+    const { getByRole, findByRole, queryByRole } = render(<TestComponent />);
+
+    userEvent.click(await findByRole('button', { name: 'Report Settings' }));
+
+    // Wait for the category checkbox to render, then toggle the Assessment
+    // filter by clicking its checkbox.
+    userEvent.click(
+      await findByRole('checkbox', {
+        name: 'Assessment',
+      }),
     );
-
-    userEvent.click(getByRole('button', { name: 'Report Settings' }));
-
-    // Wait for the category checkbox to render, then toggle it by clicking its
-    // visible label (as a real user would). Clicking the visually-hidden MUI
-    // Checkbox input directly no longer reliably fires React's onChange here.
-    await findByLabelText('Assessment');
-    userEvent.click(getByText('Assessment'));
     await waitFor(() =>
       expect(getByRole('button', { name: 'Apply Filters' })).not.toBeDisabled(),
     );
@@ -306,7 +306,7 @@ describe('StaffExpenseReport', () => {
       <TestComponent />,
     );
 
-    userEvent.click(getByRole('button', { name: 'Report Settings' }));
+    userEvent.click(await findByRole('button', { name: 'Report Settings' }));
     await findByRole('heading', { name: 'Report Settings' });
 
     userEvent.click(getByLabelText('Select Date Range'));

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { FilterListOff, Settings } from '@mui/icons-material';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import LocalAtmIcon from '@mui/icons-material/LocalAtm';
@@ -26,11 +25,11 @@ import theme from 'src/theme';
 import { AccountInfoBox } from '../../HrTools/Shared/AccountInfoBox/AccountInfoBox';
 import { AccountInfoBoxSkeleton } from '../../HrTools/Shared/AccountInfoBox/AccountInfoBoxSkeleton';
 import { EmptyTable } from '../../HrTools/Shared/EmptyTable/EmptyTable';
+import { SettingsButtonGroup } from '../Shared/SettingsButtonGroup/SettingsButtonGroup';
 import {
   Filters,
   SettingsDialog,
 } from '../Shared/SettingsDialog/SettingsDialog';
-import { StyledFilterButton } from '../Shared/SettingsDialog/StyledFilterButton';
 import {
   SimplePrintOnly,
   SimpleScreenOnly,
@@ -298,27 +297,13 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
                     justifyContent="flex-end"
                     gap={1}
                   >
-                    {isFilterDateSelected ? (
-                      <StyledFilterButton
-                        variant="outlined"
-                        startIcon={<FilterListOff />}
-                        size="small"
-                        onClick={() => {
-                          setFilters(null);
-                        }}
-                      >
-                        {t('Clear Filters')}
-                      </StyledFilterButton>
-                    ) : null}
-                    <StyledFilterButton
-                      variant="outlined"
-                      startIcon={<Settings />}
-                      size="small"
-                      onClick={handleSettingsClick}
-                    >
-                      {t('Report Settings')}
-                    </StyledFilterButton>
+                    <SettingsButtonGroup
+                      isFilterDateSelected={isFilterDateSelected}
+                      setFilters={setFilters}
+                      handleSettingsClick={handleSettingsClick}
+                    />
                   </Box>
+                  <Divider orientation="vertical" flexItem />
                   <ExportCsvButton transactions={selectedFundTransactions} />
                   <StyledPrintButton
                     startIcon={
@@ -331,7 +316,13 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
                     {t('Print')}
                   </StyledPrintButton>
                 </SimpleScreenOnly>
-              ) : null}
+              ) : (
+                <SettingsButtonGroup
+                  isFilterDateSelected={isFilterDateSelected}
+                  setFilters={setFilters}
+                  handleSettingsClick={handleSettingsClick}
+                />
+              )}
             </StyledHeaderBox>
             {loading ? (
               <AccountInfoBoxSkeleton hasOverallBalance />

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
@@ -292,6 +292,33 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
                   alignItems="center"
                   sx={{ gap: 2, '& > button': { ml: 0 } }}
                 >
+                  <Box
+                    display={'flex'}
+                    flexGrow={1}
+                    justifyContent="flex-end"
+                    gap={1}
+                  >
+                    {isFilterDateSelected ? (
+                      <StyledFilterButton
+                        variant="outlined"
+                        startIcon={<FilterListOff />}
+                        size="small"
+                        onClick={() => {
+                          setFilters(null);
+                        }}
+                      >
+                        {t('Clear Filters')}
+                      </StyledFilterButton>
+                    ) : null}
+                    <StyledFilterButton
+                      variant="outlined"
+                      startIcon={<Settings />}
+                      size="small"
+                      onClick={handleSettingsClick}
+                    >
+                      {t('Report Settings')}
+                    </StyledFilterButton>
+                  </Box>
                   <ExportCsvButton transactions={selectedFundTransactions} />
                   <StyledPrintButton
                     startIcon={
@@ -395,37 +422,6 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
           <Divider></Divider>
         </Container>
       </Box>
-      <SimpleScreenOnly>
-        <Container sx={{ gap: 1, display: 'flex', flexDirection: 'row' }}>
-          <Box display={'flex'} flexGrow={1} justifyContent="flex-end" gap={1}>
-            {isFilterDateSelected ? (
-              <StyledFilterButton
-                variant="outlined"
-                startIcon={<FilterListOff />}
-                size="small"
-                onClick={() => {
-                  setFilters(null);
-                }}
-              >
-                {t('Clear Filters')}
-              </StyledFilterButton>
-            ) : null}
-            <StyledFilterButton
-              variant="outlined"
-              startIcon={<Settings />}
-              size="small"
-              onClick={handleSettingsClick}
-            >
-              {t('Report Settings')}
-            </StyledFilterButton>
-          </Box>
-        </Container>
-      </SimpleScreenOnly>
-      <SimpleScreenOnly mt={2} mb={2}>
-        <Container>
-          <Divider />
-        </Container>
-      </SimpleScreenOnly>
       <Box>
         <SettingsDialog
           selectedFilters={filters || undefined}

--- a/src/components/Reports/StaffExpenseReport/Tables/StaffReportTable.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/Tables/StaffReportTable.test.tsx
@@ -153,19 +153,6 @@ describe('StaffReportTable', () => {
     expect(descCells[1]).toHaveTextContent('-$50');
   });
 
-  it('updates the page size without reloading data', async () => {
-    const { getByRole, findByRole } = render(<TestComponent />);
-
-    userEvent.click(await findByRole('combobox', { name: 'Rows per page:' }));
-    userEvent.click(getByRole('option', { name: '10' }));
-
-    await waitFor(() =>
-      expect(mutationSpy).not.toHaveGraphqlOperation('ReportsStaffExpenses', {
-        pageSize: 10,
-      }),
-    );
-  });
-
   it('opens breakdown dialog when info button is clicked for grouped transaction', async () => {
     const { findByRole, getByRole } = render(
       <TestComponent

--- a/src/components/Reports/StaffExpenseReport/Tables/StaffReportTable.tsx
+++ b/src/components/Reports/StaffExpenseReport/Tables/StaffReportTable.tsx
@@ -19,6 +19,8 @@ import { CategoryBreakdownDialog } from '../CategoryBreakdownDialog/CategoryBrea
 import { ReportType } from '../Helpers/StaffReportEnum';
 import { GroupedTransaction, Transaction } from '../Helpers/filterTransactions';
 
+const DEFAULT_PAGE_SIZE = 25;
+
 type RenderCell = GridColDef<StaffReportRow>['renderCell'];
 
 export interface StaffReportTableProps {
@@ -114,7 +116,7 @@ export const StaffReportTable: React.FC<StaffReportTableProps> = ({
 
   const [paginationModel, setPaginationModel] = useState({
     page: 0,
-    pageSize: 10,
+    pageSize: DEFAULT_PAGE_SIZE,
   });
 
   const [breakdownDialog, setBreakdownDialog] = useState<{
@@ -269,7 +271,7 @@ export const StaffReportTable: React.FC<StaffReportTableProps> = ({
         sortingOrder={['desc', 'asc']}
         sortModel={sortModel}
         onSortModelChange={(size) => setSortModel(size)}
-        pageSizeOptions={[5, 10, 25, 50]}
+        pageSizeOptions={[DEFAULT_PAGE_SIZE]}
         paginationModel={paginationModel}
         onPaginationModelChange={(model) => setPaginationModel(model)}
         disableRowSelectionOnClick


### PR DESCRIPTION
## Description

UAT changes for Staff expenses and MPGA reports:
- Move "Report Settings" button to top of page next to export button
- Default rows per page to be 25
- Remove "Rows per page" label from DataGrid tables

Jira ticket: [MPDX-9830](https://jira.cru.org/browse/MPDX-9830)

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

Staff expenses test: ✅
- Go to `/reports/staffExpense`
- Check that "Report Settings" button appears at the top (must have data in order to see)
- Create a filter and ensure "Clear" appears
- Verify "Rows per page" is not present

MPGA test: ✅
- Go to `/reports/mpgaIncomeExpenses`
- Check that "Report Settings" button appears at the top
- Verify "Rows per page" is not present

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
