### PR TITLE
[MPDX-9699] - Assign coach modal

### DIFF
--- a/src/components/HrTools/MpdGoalAdmin/AssignCoachModal/AssignCoachModal.test.tsx
+++ b/src/components/HrTools/MpdGoalAdmin/AssignCoachModal/AssignCoachModal.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import theme from 'src/theme';
+import { AssignCoachModal, AssignCoachOption } from './AssignCoachModal';
+
+const coaches: AssignCoachOption[] = [
+  { id: 'coach-1', name: 'Jane Coach' },
+  { id: 'coach-2', name: 'John Mentor' },
+];
+
+const handleClose = jest.fn();
+const handleAssignCoach = jest.fn();
+
+interface TestComponentProps {
+  coaches?: AssignCoachOption[];
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({
+  coaches: coachesProp = coaches,
+}) => (
+  <ThemeProvider theme={theme}>
+    <AssignCoachModal
+      subjectName="Carlos & Michaela Everts"
+      coaches={coachesProp}
+      handleClose={handleClose}
+      handleAssignCoach={handleAssignCoach}
+    />
+  </ThemeProvider>
+);
+
+describe('AssignCoachModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the account list name in the title', () => {
+    const { getByText } = render(<TestComponent />);
+
+    expect(
+      getByText('Assign Coach for Carlos & Michaela Everts'),
+    ).toBeInTheDocument();
+  });
+
+  it('disables Save until a coach is selected', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    expect(getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('keeps Save disabled when there are no coaches to select', () => {
+    const { getByRole } = render(<TestComponent coaches={[]} />);
+
+    expect(getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('closes when Cancel is clicked', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    userEvent.click(getByRole('button', { name: 'Cancel' }));
+
+    expect(handleClose).toHaveBeenCalled();
+    expect(handleAssignCoach).not.toHaveBeenCalled();
+  });
+
+  it('closes when the close icon is clicked', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    userEvent.click(getByRole('button', { name: 'Close' }));
+
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('enables Save and assigns the selected coach on submit', async () => {
+    const { getByRole, findByRole } = render(<TestComponent />);
+
+    const combobox = getByRole('combobox', { name: 'Coach' });
+    userEvent.click(combobox);
+    userEvent.click(await findByRole('option', { name: 'Jane Coach' }));
+
+    const saveButton = getByRole('button', { name: 'Save' });
+    await waitFor(() => expect(saveButton).toBeEnabled());
+
+    userEvent.click(saveButton);
+
+    await waitFor(() =>
+      expect(handleAssignCoach).toHaveBeenCalledWith('coach-1'),
+    );
+    await waitFor(() => expect(handleClose).toHaveBeenCalled());
+  });
+});

--- a/src/components/HrTools/MpdGoalAdmin/AssignCoachModal/AssignCoachModal.test.tsx
+++ b/src/components/HrTools/MpdGoalAdmin/AssignCoachModal/AssignCoachModal.test.tsx
@@ -35,7 +35,7 @@ describe('AssignCoachModal', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the account list name in the title', () => {
+  it('renders the subject name in the title', () => {
     const { getByText } = render(<TestComponent />);
 
     expect(

--- a/src/components/HrTools/MpdGoalAdmin/AssignCoachModal/AssignCoachModal.tsx
+++ b/src/components/HrTools/MpdGoalAdmin/AssignCoachModal/AssignCoachModal.tsx
@@ -1,0 +1,101 @@
+import React, { ReactElement } from 'react';
+import {
+  Autocomplete,
+  DialogActions,
+  DialogContent,
+  TextField,
+} from '@mui/material';
+import { Formik } from 'formik';
+import { useTranslation } from 'react-i18next';
+import * as yup from 'yup';
+import {
+  CancelButton,
+  SubmitButton,
+} from 'src/components/Shared/Modal/ActionButtons/ActionButtons';
+import Modal from 'src/components/Shared/Modal/Modal';
+
+export interface AssignCoachOption {
+  id: string;
+  name: string;
+}
+
+interface AssignCoachModalProps {
+  /** Name shown in the modal title, e.g. the staff member the coach is for. */
+  subjectName: string;
+  coaches: AssignCoachOption[];
+  handleClose: () => void;
+  handleAssignCoach: (coachId: string) => Promise<void> | void;
+}
+
+const assignCoachSchema = yup.object({
+  coachId: yup.string().required(),
+});
+
+type AssignCoachFormValues = yup.InferType<typeof assignCoachSchema>;
+
+export const AssignCoachModal: React.FC<AssignCoachModalProps> = ({
+  subjectName,
+  coaches,
+  handleClose,
+  handleAssignCoach,
+}) => {
+  const { t } = useTranslation();
+
+  const onSubmit = async ({ coachId }: AssignCoachFormValues) => {
+    await handleAssignCoach(coachId);
+    handleClose();
+  };
+
+  return (
+    <Modal
+      isOpen
+      title={t('Assign Coach for {{name}}', { name: subjectName })}
+      handleClose={handleClose}
+      size="sm"
+    >
+      <Formik
+        initialValues={{ coachId: '' }}
+        validationSchema={assignCoachSchema}
+        onSubmit={onSubmit}
+      >
+        {({
+          values: { coachId },
+          handleSubmit,
+          setFieldValue,
+          isSubmitting,
+        }): ReactElement => (
+          <form onSubmit={handleSubmit} noValidate>
+            <DialogContent dividers>
+              <Autocomplete
+                autoHighlight
+                disabled={isSubmitting}
+                value={coaches.find((coach) => coach.id === coachId) ?? null}
+                onChange={(_, value) =>
+                  setFieldValue('coachId', value?.id ?? '')
+                }
+                options={coaches}
+                getOptionLabel={(coach) => coach.name}
+                isOptionEqualToValue={(option, value) => option.id === value.id}
+                fullWidth
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label={t('Coach')}
+                    placeholder={t('Select a coach')}
+                    autoFocus
+                  />
+                )}
+              />
+            </DialogContent>
+            <DialogActions>
+              <CancelButton onClick={handleClose} disabled={isSubmitting} />
+              <SubmitButton disabled={!coachId || isSubmitting}>
+                {t('Save')}
+              </SubmitButton>
+            </DialogActions>
+          </form>
+        )}
+      </Formik>
+    </Modal>
+  );
+};

--- a/src/components/HrTools/MpdGoalAdmin/GoalsTable/GoalsTable.test.tsx
+++ b/src/components/HrTools/MpdGoalAdmin/GoalsTable/GoalsTable.test.tsx
@@ -46,6 +46,17 @@ describe('GoalsTable', () => {
     expect(getAllByText('Assign Coach').length).toBeGreaterThan(0);
   });
 
+  it('opens the Assign Coach modal for the selected staff member', async () => {
+    const { getByRole, findByText } = renderTable();
+    // 'Carlos & Michaela Everts' has no coach on the first page, so it renders
+    // an "Assign Coach" prompt rather than a coach name.
+    await userEvent.click(getByRole('button', { name: 'Assign Coach' }));
+
+    expect(
+      await findByText('Assign Coach for Carlos & Michaela Everts'),
+    ).toBeInTheDocument();
+  });
+
   it('renders a View/Edit action and a menu button for each row on the page', () => {
     const { getAllByText, getAllByRole } = renderTable();
     const onPage = Math.min(rows.length, DEFAULT_ROWS_PER_PAGE);

--- a/src/components/HrTools/MpdGoalAdmin/GoalsTable/GoalsTable.test.tsx
+++ b/src/components/HrTools/MpdGoalAdmin/GoalsTable/GoalsTable.test.tsx
@@ -50,7 +50,7 @@ describe('GoalsTable', () => {
     const { getByRole, findByText } = renderTable();
     // 'Carlos & Michaela Everts' has no coach on the first page, so it renders
     // an "Assign Coach" prompt rather than a coach name.
-    await userEvent.click(getByRole('button', { name: 'Assign Coach' }));
+    userEvent.click(getByRole('button', { name: 'Assign Coach' }));
 
     expect(
       await findByText('Assign Coach for Carlos & Michaela Everts'),

--- a/src/components/HrTools/MpdGoalAdmin/GoalsTable/GoalsTable.tsx
+++ b/src/components/HrTools/MpdGoalAdmin/GoalsTable/GoalsTable.tsx
@@ -21,6 +21,10 @@ import { visuallyHidden } from '@mui/utils';
 import { useTranslation } from 'react-i18next';
 import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat } from 'src/lib/intlFormat';
+import {
+  AssignCoachModal,
+  AssignCoachOption,
+} from '../AssignCoachModal/AssignCoachModal';
 import { useMpdGoalAdmin } from '../MpdGoalAdminContext';
 import { StaffGoalRow, isSendable } from '../mpdGoalAdminHelpers';
 
@@ -37,6 +41,17 @@ export const GoalsTable: React.FC<GoalsTableProps> = ({ rows }) => {
     useMpdGoalAdmin();
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_ROWS_PER_PAGE);
+  // The staff row whose coach is being assigned; null when the modal is closed.
+  const [coachRow, setCoachRow] = useState<StaffGoalRow | null>(null);
+
+  // TODO(MPDX-9699): populate from the assignable-coaches query once the
+  // backend field exists. Empty for now so the modal renders a UI-only dropdown.
+  const assignableCoaches: AssignCoachOption[] = [];
+
+  const handleAssignCoach = async (_coachId: string) => {
+    // TODO(MPDX-9699): call the assign-coach mutation with { staffId, coachId }
+    // and refresh the goal-admin rows. Backend contract pending.
+  };
 
   // Reset to the first page whenever the filter inputs change, so the user
   // isn't stranded on a now-out-of-range page. Keyed on the filter identity
@@ -129,13 +144,11 @@ export const GoalsTable: React.FC<GoalsTableProps> = ({ rows }) => {
               <TableCell>{row.familyStatus}</TableCell>
               <TableCell>
                 {row.coach ?? (
-                  // Disabled until wired up so assistive tech announces the
-                  // inert state instead of a dead control (MPDX-9696).
                   <Link
                     component="button"
                     type="button"
                     underline="hover"
-                    disabled
+                    onClick={() => setCoachRow(row)}
                   >
                     {t('Assign Coach')}
                   </Link>
@@ -182,6 +195,14 @@ export const GoalsTable: React.FC<GoalsTableProps> = ({ rows }) => {
         }}
         labelRowsPerPage={t('Rows per page')}
       />
+      {coachRow && (
+        <AssignCoachModal
+          subjectName={coachRow.name}
+          coaches={assignableCoaches}
+          handleAssignCoach={handleAssignCoach}
+          handleClose={() => setCoachRow(null)}
+        />
+      )}
     </TableContainer>
   );
 };


### PR DESCRIPTION
## Description

- Adds an **Assign Coach** modal (`AssignCoachModal`) to the **MPD Goal Admin** table (HR Tools).
- Wires up the previously-disabled **Assign Coach** link in the goals table: clicking it now opens the modal for that staff member (title reads "Assign Coach for {name}").
- Modal is built with Formik + Yup (`coachId` required) and reuses the shared `Modal` / `CancelButton` / `SubmitButton` components; Save is disabled while submitting or with no selection.
- The assignable-coaches list and assign-coach mutation are stubbed for now (UI-only) — see the `TODO(MPDX-9699)` notes in `GoalsTable.tsx`; the query and mutation will be wired up once the backend contract lands.
- Adds tests for the modal and for the table opening the modal.

Jira: MPDX-9699

## Testing

- Go to **HR Tools → MPD Goal Admin**
- Find a staff row whose **Coach** column shows an **Assign Coach** link (no coach assigned)
- Click it and confirm the **Assign Coach** modal opens with that staff member's name in the title
- Confirm **Save** is disabled until a coach is selected, and that Cancel / the close icon dismisses the modal

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
