### PR TITLE
[MPDX-9820] Use support raised from the calculations

### DIFF
--- a/src/components/HrTools/NsGoalCalculator/NsGoalCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/NsGoalCalculator/NsGoalCalculatorTestWrapper.tsx
@@ -11,7 +11,6 @@ import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.genera
 import { GoalCalculatorConstantsQuery } from 'src/hooks/goalCalculatorConstants.generated';
 import theme from 'src/theme';
 import { constantsMock } from '../GoalCalculator/GoalCalculatorTestWrapper';
-import { AccountListSupportRaisedQuery } from '../GoalCalculator/Shared/GoalLineItems.generated';
 import {
   NewStaffGoalCalculationDocument,
   NewStaffGoalCalculationQuery,
@@ -46,7 +45,6 @@ export const defaultGoalCalculation =
 
 export interface NsGoalCalculatorTestWrapperProps {
   children?: React.ReactNode;
-  supportRaisedMock?: number;
   /** Overrides the NewStaffGoalCalculation query response */
   goalCalculationMock?:
     | DeepPartial<NewStaffGoalCalculationQuery>
@@ -58,7 +56,6 @@ export const NsGoalCalculatorTestWrapper: React.FC<
   NsGoalCalculatorTestWrapperProps
 > = ({
   children,
-  supportRaisedMock = 1200,
   goalCalculationMock = defaultGoalCalculationMock,
   onCall,
 }) => (
@@ -72,16 +69,10 @@ export const NsGoalCalculatorTestWrapper: React.FC<
     >
       <SnackbarProvider>
         <GqlMockedProvider<{
-          AccountListSupportRaised: AccountListSupportRaisedQuery;
           GoalCalculatorConstants: GoalCalculatorConstantsQuery;
           NewStaffGoalCalculation: NewStaffGoalCalculationQuery;
         }>
           mocks={{
-            AccountListSupportRaised: {
-              accountList: {
-                receivedPledges: supportRaisedMock,
-              },
-            },
             GoalCalculatorConstants: { constant: constantsMock },
             NewStaffGoalCalculation: goalCalculationMock,
           }}

--- a/src/components/HrTools/NsGoalCalculator/PresentingYourGoal/PresentingYourGoalStep.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/PresentingYourGoal/PresentingYourGoalStep.test.tsx
@@ -11,7 +11,13 @@ import {
 } from '../NsGoalCalculatorTestWrapper';
 import { PresentingYourGoalStep } from './PresentingYourGoalStep';
 
-const TestComponent: React.FC = () => (
+interface TestComponentProps {
+  supportRaised?: number | null;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({
+  supportRaised = null,
+}) => (
   <NsGoalCalculatorTestWrapper>
     <PresentingYourGoalStep
       goalCalculation={{
@@ -31,6 +37,7 @@ const TestComponent: React.FC = () => (
           adminCharge: 1200,
           attrition: 600,
           monthlyGoal: 20000,
+          supportRaised,
         },
       }}
     />
@@ -112,11 +119,10 @@ describe('PresentingYourGoalStep', () => {
     });
   });
 
-  it('hides the total solid support row until the support raised data loads', async () => {
-    const { queryByText, findByText } = render(<TestComponent />);
+  it('hides the total solid support for scenario goals', () => {
+    const { queryByText } = render(<TestComponent supportRaised={null} />);
 
     expect(queryByText('Total Solid Support')).not.toBeInTheDocument();
-    expect(await findByText('Total Solid Support')).toBeInTheDocument();
   });
 
   it('renders the special needs section', async () => {

--- a/src/components/HrTools/NsGoalCalculator/PresentingYourGoal/PresentingYourGoalStep.tsx
+++ b/src/components/HrTools/NsGoalCalculator/PresentingYourGoal/PresentingYourGoalStep.tsx
@@ -12,9 +12,7 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
-import { useAccountListId } from 'src/hooks/useAccountListId';
 import theme from 'src/theme';
-import { useAccountListSupportRaisedQuery } from '../../GoalCalculator/Shared/GoalLineItems.generated';
 import { MonthlyNeedsCard } from '../../Shared/GoalPresentation/MonthlyNeedsCard';
 import { PersonalInfoCard } from '../../Shared/GoalPresentation/PersonalInfoCard';
 import { PresentationCard } from '../../Shared/GoalPresentation/PresentationCard';
@@ -49,12 +47,6 @@ export const PresentingYourGoalStep: React.FC<PresentingYourGoalStepProps> = ({
 }) => {
   const { t } = useTranslation();
   const { handleContinue } = useNsGoalCalculator();
-  const accountListId = useAccountListId() ?? '';
-  const { data } = useAccountListSupportRaisedQuery({
-    variables: { accountListId },
-    skip: !accountListId,
-  });
-  const supportRaised = data?.accountList.receivedPledges ?? null;
 
   const { calculations } = goalCalculation;
   const married =
@@ -135,7 +127,7 @@ export const PresentingYourGoalStep: React.FC<PresentingYourGoalStepProps> = ({
 
       <MonthlyNeedsCard
         monthlyNeeds={monthlyNeeds}
-        supportRaised={supportRaised}
+        supportRaised={calculations.supportRaised ?? null}
       />
 
       <SpecialNeedsCard specialNeeds={specialNeedsPlaceholder} />


### PR DESCRIPTION
## Description

Load the support raised from the new staff goal calculator `calculations` instead of a separate GraphQL query.

MPDX-9820

## Testing

- Go to Mark Kohman's goal calculation (`/accountLists/90935daa-0e49-4b31-a41b-d6b46854ebca/hrTools/nsGoalCalculator`)
- Check that the "Solid Monthly Support Developed" line is populated

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
