### PR TITLE
MPDX-9835 Internal MPD Goal Summary print format

### DIFF
--- a/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoal/MpdGoalPrintTable/MpdGoalPrintTable.test.tsx
+++ b/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoal/MpdGoalPrintTable/MpdGoalPrintTable.test.tsx
@@ -1,0 +1,58 @@
+import { render } from '@testing-library/react';
+import { GoalCalculatorTestWrapper } from '../../../GoalCalculatorTestWrapper';
+import { MpdGoalPrintTable } from './MpdGoalPrintTable';
+
+const TestComponent: React.FC = () => (
+  <GoalCalculatorTestWrapper>
+    <MpdGoalPrintTable supportRaised={1000} />
+  </GoalCalculatorTestWrapper>
+);
+
+describe('MpdGoalPrintTable', () => {
+  it('renders the column headers', async () => {
+    const { findByRole, getByRole } = render(<TestComponent />);
+
+    expect(
+      await findByRole('columnheader', { name: 'Line' }),
+    ).toBeInTheDocument();
+    expect(getByRole('columnheader', { name: 'Category' })).toBeInTheDocument();
+    expect(
+      getByRole('columnheader', { name: 'NS Reference' }),
+    ).toBeInTheDocument();
+    expect(getByRole('columnheader', { name: 'Amount' })).toBeInTheDocument();
+  });
+
+  it('renders a row for each goal line', async () => {
+    const { findByRole, getByRole } = render(<TestComponent />);
+
+    expect(
+      await findByRole('cell', { name: 'Gross Monthly Salary' }),
+    ).toBeInTheDocument();
+    expect(getByRole('cell', { name: 'MPD' })).toBeInTheDocument();
+    expect(
+      getByRole('cell', { name: 'Ministry Expenses Subtotal' }),
+    ).toBeInTheDocument();
+  });
+
+  it('bolds subtotal/total lines and adds top borders to lines 1 and 6', async () => {
+    const { findByRole, getByRole } = render(<TestComponent />);
+
+    expect(
+      await findByRole('cell', { name: 'Gross Annual Salary' }),
+    ).toHaveStyle('font-weight: 700');
+    expect(getByRole('cell', { name: 'Gross Monthly Salary' })).toHaveStyle(
+      'border-top: 3px solid black',
+    );
+  });
+
+  it('indents category cells for sub-lines but not whole lines', async () => {
+    const { findByRole, getByRole } = render(<TestComponent />);
+
+    expect(
+      await findByRole('cell', { name: 'Net Monthly Combined Salary' }),
+    ).toHaveStyle('padding-left: 32px');
+    expect(getByRole('cell', { name: 'Gross Monthly Salary' })).not.toHaveStyle(
+      'padding-left: 32px',
+    );
+  });
+});

--- a/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoal/MpdGoalPrintTable/MpdGoalPrintTable.tsx
+++ b/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoal/MpdGoalPrintTable/MpdGoalPrintTable.tsx
@@ -7,13 +7,19 @@ import {
   TableRow,
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { MpdGoalRow, useMpdGoalRows } from 'src/hooks/useMpdGoalRows';
+import {
+  MpdGoalRow,
+  isBoldLine,
+  isIndentedLine,
+  isTopBorderLine,
+  useMpdGoalRows,
+} from 'src/hooks/useMpdGoalRows';
 
-interface MpdGoalTableProps {
+interface MpdGoalPrintTableProps {
   supportRaised: number;
 }
 
-export const MpdGoalPrintTable: React.FC<MpdGoalTableProps> = ({
+export const MpdGoalPrintTable: React.FC<MpdGoalPrintTableProps> = ({
   supportRaised,
 }) => {
   const { t } = useTranslation();
@@ -41,9 +47,9 @@ export const MpdGoalPrintTable: React.FC<MpdGoalTableProps> = ({
         </TableHead>
         <TableBody>
           {rows.map((row: MpdGoalRow) => {
-            const isBold = ['1J', '6', '8'].includes(row.line);
-            const hasTopBorder = ['1', '6'].includes(row.line);
-            const isIndented = /[a-z]/i.test(row.line);
+            const isBold = isBoldLine(row.line);
+            const hasTopBorder = isTopBorderLine(row.line);
+            const isIndented = isIndentedLine(row.line);
 
             return (
               <TableRow

--- a/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoal/MpdGoalPrintTable/MpdGoalPrintTable.tsx
+++ b/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoal/MpdGoalPrintTable/MpdGoalPrintTable.tsx
@@ -1,0 +1,73 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { MpdGoalRow, useMpdGoalRows } from 'src/hooks/useMpdGoalRows';
+
+interface MpdGoalTableProps {
+  supportRaised: number;
+}
+
+export const MpdGoalPrintTable: React.FC<MpdGoalTableProps> = ({
+  supportRaised,
+}) => {
+  const { t } = useTranslation();
+  const { rows, valueFormatter } = useMpdGoalRows(supportRaised);
+
+  return (
+    <TableContainer>
+      <Table
+        sx={{
+          WebkitPrintColorAdjust: 'exact',
+          printColorAdjust: 'exact',
+        }}
+      >
+        <TableHead>
+          <TableRow>
+            <TableCell>{t('Line')}</TableCell>
+            <TableCell>{t('Category')}</TableCell>
+            <TableCell
+              sx={{ backgroundColor: 'mpdxBlue.light', whiteSpace: 'nowrap' }}
+            >
+              {t('NS Reference')}
+            </TableCell>
+            <TableCell>{t('Amount')}</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row: MpdGoalRow) => {
+            const isBold = ['1J', '6', '8'].includes(row.line);
+            const hasTopBorder = ['1', '6'].includes(row.line);
+            const isIndented = /[a-z]/i.test(row.line);
+
+            return (
+              <TableRow
+                key={row.line}
+                sx={{
+                  '& td': {
+                    ...(isBold && { fontWeight: 'bold' }),
+                    ...(hasTopBorder && { borderTop: '3px solid black' }),
+                  },
+                }}
+              >
+                <TableCell>{row.line}</TableCell>
+                <TableCell sx={{ pl: isIndented ? 4 : 0 }}>
+                  {row.category}
+                </TableCell>
+                <TableCell sx={{ backgroundColor: 'mpdxBlue.light' }}>
+                  {valueFormatter(row.reference, row)}
+                </TableCell>
+                <TableCell>{valueFormatter(row.amount, row)}</TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};

--- a/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoal/MpdGoalTable.tsx
+++ b/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoal/MpdGoalTable.tsx
@@ -1,31 +1,17 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { styled } from '@mui/material/styles';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { useTranslation } from 'react-i18next';
-import { PrimaryBudgetCategoryEnum } from 'src/graphql/types.generated';
-import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
-import { useLocale } from 'src/hooks/useLocale';
+import {
+  SimplePrintOnly,
+  SimpleScreenOnly,
+} from 'src/components/Reports/styledComponents';
+import { useMpdGoalRows } from 'src/hooks/useMpdGoalRows';
 import { useDataGridLocaleText } from 'src/hooks/useMuiLocaleText';
-import { currencyFormat, percentageFormat } from 'src/lib/intlFormat';
 import { safeProgressRatio } from '../../../Shared/helpers/safeProgressRatio';
 import { useGoalCalculator } from '../../Shared/GoalCalculatorContext';
-import {
-  calculateNewStaffGoalTotals,
-  getNewStaffBudgetCategory,
-} from '../../Shared/calculateNewStaffTotals';
-import {
-  GoalTotals,
-  calculateCategoryEnumTotal,
-} from '../../Shared/calculateTotals';
 import { MpdGoalHeaderCards } from './MpdGoalHeaderCards/MpdGoalHeaderCards';
-
-interface MpdGoalRow {
-  line: string;
-  category: string;
-  amount: number;
-  reference: number;
-  percentage?: boolean;
-}
+import { MpdGoalPrintTable } from './MpdGoalPrintTable/MpdGoalPrintTable';
 
 const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
   '.MuiDataGrid-columnHeaderTitle': {
@@ -53,263 +39,9 @@ export const MpdGoalTable: React.FC<MpdGoalTableProps> = ({
   supportRaised,
 }) => {
   const { t } = useTranslation();
-  const locale = useLocale();
   const localeText = useDataGridLocaleText();
-  const { goalCalculationResult, goalTotals } = useGoalCalculator();
-  const constants = useGoalCalculatorConstants();
-  const { goalMiscConstants } = constants;
-
-  const valueFormatter = useCallback(
-    (value: number, row: MpdGoalRow) =>
-      row.percentage
-        ? percentageFormat(value, locale, { fractionDigits: 2 })
-        : currencyFormat(value, 'USD', locale, { fractionDigits: 0 }),
-    [locale],
-  );
-
-  const newStaffReference = useMemo(
-    () =>
-      calculateNewStaffGoalTotals(
-        goalCalculationResult.data?.goalCalculation ?? null,
-        constants,
-      ),
-    [goalCalculationResult, constants],
-  );
-
-  const goalCalculation = goalCalculationResult.data?.goalCalculation;
-  const rows = useMemo((): MpdGoalRow[] => {
-    const ministryExpenseCategories = [
-      {
-        line: '3A',
-        category: t('Ministry Miles'),
-        categories: [PrimaryBudgetCategoryEnum.MinistryAndMedicalMileage],
-      },
-      {
-        line: '3B',
-        category: t('Ministry Travel'),
-        categories: [PrimaryBudgetCategoryEnum.MinistryTravel],
-      },
-      {
-        line: '3C',
-        category: t('Meetings, Retreats, Conferences'),
-        categories: [
-          PrimaryBudgetCategoryEnum.MeetingsRetreatsConferences,
-          PrimaryBudgetCategoryEnum.UsStaffConference,
-        ],
-      },
-      {
-        line: '3D',
-        category: t('Meals and Per Diem'),
-        categories: [PrimaryBudgetCategoryEnum.MealsAndPerDiem],
-      },
-      {
-        line: '3E',
-        category: t('MPD'),
-        categories: [PrimaryBudgetCategoryEnum.MinistryPartnerDevelopment],
-      },
-      {
-        line: '3F',
-        category: t('Supplies and Materials'),
-        categories: [PrimaryBudgetCategoryEnum.SuppliesAndMaterials],
-      },
-      {
-        line: '3G',
-        category: t('Summer Assignment Expenses'),
-        categories: [PrimaryBudgetCategoryEnum.SummerAssignmentExpenses],
-      },
-      {
-        line: '3H',
-        category: t('Reimbursable Medical Expenses'),
-        categories: [PrimaryBudgetCategoryEnum.ReimbursableMedicalExpenses],
-      },
-      {
-        line: '3I',
-        category: t(
-          'Account transfers to staff members, ministries, projects, etc.',
-        ),
-        categories: [PrimaryBudgetCategoryEnum.AccountTransfers],
-      },
-      {
-        line: '3J',
-        category: t('Other (includes credit card charges)'),
-        categories: [
-          PrimaryBudgetCategoryEnum.InternetServiceProviderFee,
-          PrimaryBudgetCategoryEnum.CellPhoneWorkLine,
-          PrimaryBudgetCategoryEnum.CreditCardProcessingCharges,
-          PrimaryBudgetCategoryEnum.MinistryOther,
-        ],
-      },
-    ];
-    const ministryExpenseRows = ministryExpenseCategories.map(
-      ({ categories, ...rowFields }): MpdGoalRow => ({
-        ...rowFields,
-        amount: categories.reduce(
-          (sum, category) =>
-            sum +
-            calculateCategoryEnumTotal(
-              goalCalculation?.ministryFamily,
-              category,
-            ),
-          0,
-        ),
-        reference: categories.reduce(
-          (sum, category) =>
-            sum +
-            getNewStaffBudgetCategory(
-              goalCalculation,
-              category,
-              goalMiscConstants,
-            ),
-          0,
-        ),
-      }),
-    );
-
-    // The rows can have an amount and reference value, or a value function that calculates the
-    // amount and reference value from the goal total and new staff goal total
-    const rows: Array<
-      | MpdGoalRow
-      | (Omit<MpdGoalRow, 'amount' | 'reference'> & {
-          value: (goalTotals: GoalTotals) => number;
-        })
-    > = [
-      {
-        line: '1A',
-        category: t('Net Monthly Combined Salary'),
-        value: (goalTotals) => goalTotals.netMonthlySalary,
-      },
-      {
-        line: '1B',
-        category: t('Taxes, SECA, VTL, etc. %'),
-        value: (goalTotals) => goalTotals.taxesPercentage,
-        percentage: true,
-      },
-      {
-        line: '1C',
-        category: t('Taxes, SECA, VTL, etc.'),
-        value: (goalTotals) => goalTotals.taxes,
-      },
-      {
-        line: '1D',
-        category: t('Subtotal with Net, Taxes, and SECA'),
-        value: (goalTotals) => goalTotals.salaryPreIra,
-      },
-      {
-        line: '1E',
-        category: t('Roth 403(b) Contribution %'),
-        value: (goalTotals) => goalTotals.rothContributionPercentage,
-        percentage: true,
-      },
-      {
-        line: '1F',
-        category: t('Traditional 403(b) Contribution %'),
-        value: (goalTotals) => goalTotals.traditionalContributionPercentage,
-        percentage: true,
-      },
-      {
-        line: '1G',
-        category: t('100% - (Roth + Traditional 403(b)) %'),
-        value: (goalTotals) =>
-          1 -
-          goalTotals.rothContributionPercentage -
-          goalTotals.traditionalContributionPercentage,
-        percentage: true,
-      },
-      {
-        line: '1H',
-        category: t('Roth 403(b)'),
-        value: (goalTotals) => goalTotals.rothContribution,
-      },
-      {
-        line: '1I',
-        category: t('Traditional 403(b)'),
-        value: (goalTotals) => goalTotals.traditionalContribution,
-      },
-      {
-        line: '1J',
-        category: t('Gross Annual Salary'),
-        value: (goalTotals) => goalTotals.grossAnnualSalary,
-      },
-      {
-        line: '1',
-        category: t('Gross Monthly Salary'),
-        value: (goalTotals) => goalTotals.grossMonthlySalary,
-      },
-      {
-        line: '2',
-        category: t('Benefits'),
-        value: (goalTotals) => goalTotals.benefitsCharge,
-      },
-      ...ministryExpenseRows,
-      {
-        line: '3',
-        category: t('Ministry Expenses Subtotal'),
-        value: (goalTotals) =>
-          goalTotals.ministryExpensesTotal + goalTotals.benefitsCharge,
-      },
-      {
-        line: '4',
-        category: t('Subtotal'),
-        value: (goalTotals) => goalTotals.overallSubtotal,
-      },
-      {
-        line: '5',
-        category: t('Subtotal with {{admin}} admin charge', {
-          admin: percentageFormat(
-            goalMiscConstants.RATES?.ADMIN_RATE?.fee ?? 0,
-            locale,
-          ),
-        }),
-        value: (goalTotals) => goalTotals.overallSubtotalWithAdmin,
-      },
-      {
-        line: '6',
-        category: t('Total Goal (line 5 with {{attrition}} attrition)', {
-          attrition: percentageFormat(
-            goalMiscConstants.RATES?.ATTRITION_RATE?.fee ?? 0,
-            locale,
-          ),
-        }),
-        value: (goalTotals) => goalTotals.overallTotal,
-      },
-      {
-        line: '7',
-        category: t('Solid Monthly Support Developed'),
-        value: () => supportRaised,
-      },
-      {
-        line: '8',
-        category: t('Monthly Support to be Developed'),
-        value: (goalTotals) => goalTotals.overallTotal - supportRaised,
-      },
-      {
-        line: '9',
-        category: t('Support Goal Percentage Progress'),
-        value: (goalTotals) =>
-          safeProgressRatio(supportRaised, goalTotals.overallTotal),
-        percentage: true,
-      },
-    ];
-
-    return rows.map((row) => {
-      if ('value' in row) {
-        return {
-          ...row,
-          amount: row.value(goalTotals),
-          reference: row.value(newStaffReference),
-        };
-      }
-
-      return row;
-    });
-  }, [
-    t,
-    goalCalculation,
-    goalTotals,
-    goalMiscConstants,
-    newStaffReference,
-    supportRaised,
-  ]);
+  const { goalTotals } = useGoalCalculator();
+  const { rows, valueFormatter } = useMpdGoalRows(supportRaised);
 
   const columns = useMemo(
     (): GridColDef[] => [
@@ -357,57 +89,62 @@ export const MpdGoalTable: React.FC<MpdGoalTableProps> = ({
           goalTotals.overallTotal,
         )}
       />
-      <StyledDataGrid
-        label={t('MPD Goal')}
-        getRowId={(row) => row.line}
-        getRowClassName={(params) => {
-          const classes: string[] = [];
+      <SimpleScreenOnly>
+        <StyledDataGrid
+          label={t('MPD Goal')}
+          getRowId={(row) => row.line}
+          getRowClassName={(params) => {
+            const classes: string[] = [];
 
-          // Bold subtotal and total lines
-          if (
-            params.row.line === '1J' ||
-            params.row.line === '6' ||
-            params.row.line === '8'
-          ) {
-            classes.push('bold');
-          }
+            // Bold subtotal and total lines
+            if (
+              params.row.line === '1J' ||
+              params.row.line === '6' ||
+              params.row.line === '8'
+            ) {
+              classes.push('bold');
+            }
 
-          // Add a top border to some lines
-          if (params.row.line === '1' || params.row.line === '6') {
-            classes.push('top-border');
-          }
+            // Add a top border to some lines
+            if (params.row.line === '1' || params.row.line === '6') {
+              classes.push('top-border');
+            }
 
-          return classes.join(' ');
-        }}
-        getCellClassName={(params) => {
-          const classes: string[] = [];
+            return classes.join(' ');
+          }}
+          getCellClassName={(params) => {
+            const classes: string[] = [];
 
-          // Indent categories belonging to lines that contain a letter
-          if (
-            params.colDef.field === 'category' &&
-            typeof params.row.line === 'string' &&
-            /[a-z]/i.test(params.row.line)
-          ) {
-            classes.push('indent');
-          }
+            // Indent categories belonging to lines that contain a letter
+            if (
+              params.colDef.field === 'category' &&
+              typeof params.row.line === 'string' &&
+              /[a-z]/i.test(params.row.line)
+            ) {
+              classes.push('indent');
+            }
 
-          // Identify reference cells
-          if (params.colDef.field === 'reference') {
-            classes.push(params.colDef.field);
-          }
+            // Identify reference cells
+            if (params.colDef.field === 'reference') {
+              classes.push(params.colDef.field);
+            }
 
-          return classes.join(' ');
-        }}
-        rows={rows}
-        columns={columns}
-        disableColumnFilter
-        disableColumnMenu
-        disableRowSelectionOnClick
-        disableVirtualization
-        hideFooter
-        autoHeight
-        localeText={localeText}
-      />
+            return classes.join(' ');
+          }}
+          rows={rows}
+          columns={columns}
+          disableColumnFilter
+          disableColumnMenu
+          disableRowSelectionOnClick
+          disableVirtualization
+          hideFooter
+          autoHeight
+          localeText={localeText}
+        />
+      </SimpleScreenOnly>
+      <SimplePrintOnly>
+        <MpdGoalPrintTable supportRaised={supportRaised} />
+      </SimplePrintOnly>
     </>
   );
 };

--- a/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoal/MpdGoalTable.tsx
+++ b/src/components/HrTools/GoalCalculator/SummaryReport/MpdGoal/MpdGoalTable.tsx
@@ -6,7 +6,12 @@ import {
   SimplePrintOnly,
   SimpleScreenOnly,
 } from 'src/components/Reports/styledComponents';
-import { useMpdGoalRows } from 'src/hooks/useMpdGoalRows';
+import {
+  isBoldLine,
+  isIndentedLine,
+  isTopBorderLine,
+  useMpdGoalRows,
+} from 'src/hooks/useMpdGoalRows';
 import { useDataGridLocaleText } from 'src/hooks/useMuiLocaleText';
 import { safeProgressRatio } from '../../../Shared/helpers/safeProgressRatio';
 import { useGoalCalculator } from '../../Shared/GoalCalculatorContext';
@@ -97,16 +102,12 @@ export const MpdGoalTable: React.FC<MpdGoalTableProps> = ({
             const classes: string[] = [];
 
             // Bold subtotal and total lines
-            if (
-              params.row.line === '1J' ||
-              params.row.line === '6' ||
-              params.row.line === '8'
-            ) {
+            if (isBoldLine(params.row.line)) {
               classes.push('bold');
             }
 
             // Add a top border to some lines
-            if (params.row.line === '1' || params.row.line === '6') {
+            if (isTopBorderLine(params.row.line)) {
               classes.push('top-border');
             }
 
@@ -119,7 +120,7 @@ export const MpdGoalTable: React.FC<MpdGoalTableProps> = ({
             if (
               params.colDef.field === 'category' &&
               typeof params.row.line === 'string' &&
-              /[a-z]/i.test(params.row.line)
+              isIndentedLine(params.row.line)
             ) {
               classes.push('indent');
             }

--- a/src/hooks/useMpdGoalRows.test.ts
+++ b/src/hooks/useMpdGoalRows.test.ts
@@ -1,0 +1,129 @@
+import { waitFor } from '@testing-library/dom';
+import { renderHook } from '@testing-library/react-hooks';
+import { GoalCalculatorTestWrapper } from 'src/components/HrTools/GoalCalculator/GoalCalculatorTestWrapper';
+import { MpdGoalRow, useMpdGoalRows } from './useMpdGoalRows';
+
+const renderUseMpdGoalRows = (supportRaised = 1000) =>
+  renderHook(() => useMpdGoalRows(supportRaised), {
+    wrapper: GoalCalculatorTestWrapper,
+  });
+
+describe('useMpdGoalRows', () => {
+  it('returns a row for every goal line', () => {
+    const { result } = renderUseMpdGoalRows();
+
+    const lines = result.current.rows.map((row) => row.line);
+    expect(result.current.rows).toHaveLength(29);
+    expect(lines).toContain('1A');
+    expect(lines).toContain('3E');
+    expect(lines).toContain('9');
+  });
+
+  it('calculates the new staff reference amount for the net monthly salary line', async () => {
+    const { result } = renderUseMpdGoalRows();
+
+    await waitFor(() => {
+      const netMonthlySalary = result.current.rows.find(
+        (row) => row.line === '1A',
+      );
+      expect(netMonthlySalary).toBeDefined();
+      const formatted =
+        netMonthlySalary &&
+        result.current.valueFormatter(
+          netMonthlySalary.reference,
+          netMonthlySalary,
+        );
+      expect(formatted).toBe('$5,211');
+    });
+  });
+
+  it('sums a ministry-expense category from its sub-budget amounts', async () => {
+    const { result } = renderUseMpdGoalRows();
+
+    await waitFor(() => {
+      const ministryMiles = result.current.rows.find(
+        (row) => row.line === '3A',
+      );
+      expect(ministryMiles?.amount).toBe(1450);
+    });
+  });
+
+  describe('supportRaised parameter', () => {
+    it('renders supportRaised for solid support developed', () => {
+      const { result } = renderUseMpdGoalRows(1000);
+
+      const solidSupport = result.current.rows.find((row) => row.line === '7');
+      expect(solidSupport?.amount).toBe(1000);
+      expect(solidSupport?.reference).toBe(1000);
+    });
+
+    it('treats 0 support as 0% progress with the full goal still to develop', async () => {
+      const { result } = renderUseMpdGoalRows(0);
+
+      await waitFor(() => {
+        const totalGoal = result.current.rows.find((row) => row.line === '6');
+        const toBeDeveloped = result.current.rows.find(
+          (row) => row.line === '8',
+        );
+        const percentageProgress = result.current.rows.find(
+          (row) => row.line === '9',
+        );
+
+        expect(totalGoal?.amount).toBeGreaterThan(0);
+        expect(toBeDeveloped?.amount).toBe(totalGoal?.amount);
+        expect(percentageProgress?.amount).toBe(0);
+      });
+    });
+
+    it('clamps progress to 100% when support exceeds the goal', async () => {
+      const { result } = renderUseMpdGoalRows(1_000_000);
+
+      await waitFor(() => {
+        const totalGoal = result.current.rows.find((row) => row.line === '6');
+        const toBeDeveloped = result.current.rows.find(
+          (row) => row.line === '8',
+        );
+        const percentageProgress = result.current.rows.find(
+          (row) => row.line === '9',
+        );
+
+        expect(totalGoal?.amount).toBeGreaterThan(0);
+        expect(percentageProgress?.amount).toBe(1);
+        expect(toBeDeveloped?.amount).toBe(
+          (totalGoal?.amount ?? 0) - 1_000_000,
+        );
+        expect(toBeDeveloped?.amount).toBeLessThan(0);
+      });
+    });
+  });
+
+  describe('valueFormatter', () => {
+    const currencyRow: MpdGoalRow = {
+      line: '1',
+      category: 'Gross Monthly Salary',
+      amount: 0,
+      reference: 0,
+    };
+    const percentageRow: MpdGoalRow = {
+      line: '1B',
+      category: 'Taxes, SECA, VTL, etc. %',
+      amount: 0,
+      reference: 0,
+      percentage: true,
+    };
+
+    it('formats currency rows with no fraction digits', () => {
+      const { result } = renderUseMpdGoalRows();
+
+      expect(result.current.valueFormatter(1234.56, currencyRow)).toBe(
+        '$1,235',
+      );
+    });
+
+    it('formats percentage rows with two fraction digits', () => {
+      const { result } = renderUseMpdGoalRows();
+
+      expect(result.current.valueFormatter(0.15, percentageRow)).toBe('15.00%');
+    });
+  });
+});

--- a/src/hooks/useMpdGoalRows.ts
+++ b/src/hooks/useMpdGoalRows.ts
@@ -1,0 +1,286 @@
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useGoalCalculator } from 'src/components/HrTools/GoalCalculator/Shared/GoalCalculatorContext';
+import {
+  calculateNewStaffGoalTotals,
+  getNewStaffBudgetCategory,
+} from 'src/components/HrTools/GoalCalculator/Shared/calculateNewStaffTotals';
+import {
+  GoalTotals,
+  calculateCategoryEnumTotal,
+} from 'src/components/HrTools/GoalCalculator/Shared/calculateTotals';
+import { safeProgressRatio } from 'src/components/HrTools/Shared/helpers/safeProgressRatio';
+import { PrimaryBudgetCategoryEnum } from 'src/graphql/types.generated';
+import { currencyFormat, percentageFormat } from 'src/lib/intlFormat';
+import { useGoalCalculatorConstants } from './useGoalCalculatorConstants';
+import { useLocale } from './useLocale';
+
+export interface MpdGoalRow {
+  line: string;
+  category: string;
+  amount: number;
+  reference: number;
+  percentage?: boolean;
+}
+
+export const useMpdGoalRows = (supportRaised: number) => {
+  const { t } = useTranslation();
+  const locale = useLocale();
+  const { goalCalculationResult, goalTotals } = useGoalCalculator();
+  const constants = useGoalCalculatorConstants();
+  const { goalMiscConstants } = constants;
+
+  const valueFormatter = useCallback(
+    (value: number, row: MpdGoalRow) =>
+      row.percentage
+        ? percentageFormat(value, locale, { fractionDigits: 2 })
+        : currencyFormat(value, 'USD', locale, { fractionDigits: 0 }),
+    [locale],
+  );
+
+  const newStaffReference = useMemo(
+    () =>
+      calculateNewStaffGoalTotals(
+        goalCalculationResult.data?.goalCalculation ?? null,
+        constants,
+      ),
+    [goalCalculationResult, constants],
+  );
+
+  const goalCalculation = goalCalculationResult.data?.goalCalculation;
+  const rows = useMemo((): MpdGoalRow[] => {
+    const ministryExpenseCategories = [
+      {
+        line: '3A',
+        category: t('Ministry Miles'),
+        categories: [PrimaryBudgetCategoryEnum.MinistryAndMedicalMileage],
+      },
+      {
+        line: '3B',
+        category: t('Ministry Travel'),
+        categories: [PrimaryBudgetCategoryEnum.MinistryTravel],
+      },
+      {
+        line: '3C',
+        category: t('Meetings, Retreats, Conferences'),
+        categories: [
+          PrimaryBudgetCategoryEnum.MeetingsRetreatsConferences,
+          PrimaryBudgetCategoryEnum.UsStaffConference,
+        ],
+      },
+      {
+        line: '3D',
+        category: t('Meals and Per Diem'),
+        categories: [PrimaryBudgetCategoryEnum.MealsAndPerDiem],
+      },
+      {
+        line: '3E',
+        category: t('MPD'),
+        categories: [PrimaryBudgetCategoryEnum.MinistryPartnerDevelopment],
+      },
+      {
+        line: '3F',
+        category: t('Supplies and Materials'),
+        categories: [PrimaryBudgetCategoryEnum.SuppliesAndMaterials],
+      },
+      {
+        line: '3G',
+        category: t('Summer Assignment Expenses'),
+        categories: [PrimaryBudgetCategoryEnum.SummerAssignmentExpenses],
+      },
+      {
+        line: '3H',
+        category: t('Reimbursable Medical Expenses'),
+        categories: [PrimaryBudgetCategoryEnum.ReimbursableMedicalExpenses],
+      },
+      {
+        line: '3I',
+        category: t(
+          'Account transfers to staff members, ministries, projects, etc.',
+        ),
+        categories: [PrimaryBudgetCategoryEnum.AccountTransfers],
+      },
+      {
+        line: '3J',
+        category: t('Other (includes credit card charges)'),
+        categories: [
+          PrimaryBudgetCategoryEnum.InternetServiceProviderFee,
+          PrimaryBudgetCategoryEnum.CellPhoneWorkLine,
+          PrimaryBudgetCategoryEnum.CreditCardProcessingCharges,
+          PrimaryBudgetCategoryEnum.MinistryOther,
+        ],
+      },
+    ];
+    const ministryExpenseRows = ministryExpenseCategories.map(
+      ({ categories, ...rowFields }): MpdGoalRow => ({
+        ...rowFields,
+        amount: categories.reduce(
+          (sum, category) =>
+            sum +
+            calculateCategoryEnumTotal(
+              goalCalculation?.ministryFamily,
+              category,
+            ),
+          0,
+        ),
+        reference: categories.reduce(
+          (sum, category) =>
+            sum +
+            getNewStaffBudgetCategory(
+              goalCalculation,
+              category,
+              goalMiscConstants,
+            ),
+          0,
+        ),
+      }),
+    );
+
+    // The rows can have an amount and reference value, or a value function that calculates the
+    // amount and reference value from the goal total and new staff goal total
+    const rows: Array<
+      | MpdGoalRow
+      | (Omit<MpdGoalRow, 'amount' | 'reference'> & {
+          value: (goalTotals: GoalTotals) => number;
+        })
+    > = [
+      {
+        line: '1A',
+        category: t('Net Monthly Combined Salary'),
+        value: (goalTotals) => goalTotals.netMonthlySalary,
+      },
+      {
+        line: '1B',
+        category: t('Taxes, SECA, VTL, etc. %'),
+        value: (goalTotals) => goalTotals.taxesPercentage,
+        percentage: true,
+      },
+      {
+        line: '1C',
+        category: t('Taxes, SECA, VTL, etc.'),
+        value: (goalTotals) => goalTotals.taxes,
+      },
+      {
+        line: '1D',
+        category: t('Subtotal with Net, Taxes, and SECA'),
+        value: (goalTotals) => goalTotals.salaryPreIra,
+      },
+      {
+        line: '1E',
+        category: t('Roth 403(b) Contribution %'),
+        value: (goalTotals) => goalTotals.rothContributionPercentage,
+        percentage: true,
+      },
+      {
+        line: '1F',
+        category: t('Traditional 403(b) Contribution %'),
+        value: (goalTotals) => goalTotals.traditionalContributionPercentage,
+        percentage: true,
+      },
+      {
+        line: '1G',
+        category: t('100% - (Roth + Traditional 403(b)) %'),
+        value: (goalTotals) =>
+          1 -
+          goalTotals.rothContributionPercentage -
+          goalTotals.traditionalContributionPercentage,
+        percentage: true,
+      },
+      {
+        line: '1H',
+        category: t('Roth 403(b)'),
+        value: (goalTotals) => goalTotals.rothContribution,
+      },
+      {
+        line: '1I',
+        category: t('Traditional 403(b)'),
+        value: (goalTotals) => goalTotals.traditionalContribution,
+      },
+      {
+        line: '1J',
+        category: t('Gross Annual Salary'),
+        value: (goalTotals) => goalTotals.grossAnnualSalary,
+      },
+      {
+        line: '1',
+        category: t('Gross Monthly Salary'),
+        value: (goalTotals) => goalTotals.grossMonthlySalary,
+      },
+      {
+        line: '2',
+        category: t('Benefits'),
+        value: (goalTotals) => goalTotals.benefitsCharge,
+      },
+      ...ministryExpenseRows,
+      {
+        line: '3',
+        category: t('Ministry Expenses Subtotal'),
+        value: (goalTotals) =>
+          goalTotals.ministryExpensesTotal + goalTotals.benefitsCharge,
+      },
+      {
+        line: '4',
+        category: t('Subtotal'),
+        value: (goalTotals) => goalTotals.overallSubtotal,
+      },
+      {
+        line: '5',
+        category: t('Subtotal with {{admin}} admin charge', {
+          admin: percentageFormat(
+            goalMiscConstants.RATES?.ADMIN_RATE?.fee ?? 0,
+            locale,
+          ),
+        }),
+        value: (goalTotals) => goalTotals.overallSubtotalWithAdmin,
+      },
+      {
+        line: '6',
+        category: t('Total Goal (line 5 with {{attrition}} attrition)', {
+          attrition: percentageFormat(
+            goalMiscConstants.RATES?.ATTRITION_RATE?.fee ?? 0,
+            locale,
+          ),
+        }),
+        value: (goalTotals) => goalTotals.overallTotal,
+      },
+      {
+        line: '7',
+        category: t('Solid Monthly Support Developed'),
+        value: () => supportRaised,
+      },
+      {
+        line: '8',
+        category: t('Monthly Support to be Developed'),
+        value: (goalTotals) => goalTotals.overallTotal - supportRaised,
+      },
+      {
+        line: '9',
+        category: t('Support Goal Percentage Progress'),
+        value: (goalTotals) =>
+          safeProgressRatio(supportRaised, goalTotals.overallTotal),
+        percentage: true,
+      },
+    ];
+
+    return rows.map((row) => {
+      if ('value' in row) {
+        return {
+          ...row,
+          amount: row.value(goalTotals),
+          reference: row.value(newStaffReference),
+        };
+      }
+
+      return row;
+    });
+  }, [
+    t,
+    goalCalculation,
+    goalTotals,
+    goalMiscConstants,
+    newStaffReference,
+    supportRaised,
+  ]);
+
+  return { rows, valueFormatter };
+};

--- a/src/hooks/useMpdGoalRows.ts
+++ b/src/hooks/useMpdGoalRows.ts
@@ -15,6 +15,10 @@ import { currencyFormat, percentageFormat } from 'src/lib/intlFormat';
 import { useGoalCalculatorConstants } from './useGoalCalculatorConstants';
 import { useLocale } from './useLocale';
 
+export const isBoldLine = (line: string) => ['1J', '6', '8'].includes(line);
+export const isTopBorderLine = (line: string) => ['1', '6'].includes(line);
+export const isIndentedLine = (line: string) => /[a-z]/i.test(line);
+
 export interface MpdGoalRow {
   line: string;
   category: string;
@@ -275,6 +279,7 @@ export const useMpdGoalRows = (supportRaised: number) => {
     });
   }, [
     t,
+    locale,
     goalCalculation,
     goalTotals,
     goalMiscConstants,


### PR DESCRIPTION
## Description

On the Summary Report page (MPD Goal view), the print formatting is not functioning properly. The table cuts off the last few columns which prevent the users from seeing the calculated amounts.

Jira ticket: [MPDX-9835](https://jira.cru.org/browse/MPDX-9835)

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `/hrTools/goalCalculator` and select a goal
- Go to "Summary Report" step and click print on the MPD goal view tab
- Check that the table format is correct

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
