### PR TITLE
[no-Jira] Make account list id required

### DIFF
--- a/pages/acceptInvite.test.tsx
+++ b/pages/acceptInvite.test.tsx
@@ -4,7 +4,6 @@ import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import AcceptInvitePage from './acceptInvite.page';
 
-jest.mock('src/hooks/useAccountListId');
 const mockPush = jest.fn();
 const dashboardLink = '/accountLists/_/';
 

--- a/pages/accountLists/[accountListId]/reports/partnerGivingAnalysis/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/reports/partnerGivingAnalysis/[[...contactId]].page.tsx
@@ -48,8 +48,7 @@ const PageContent: React.FC = () => {
   };
 
   const { data: filterData, loading: filtersLoading } = useContactFiltersQuery({
-    variables: { accountListId: accountListId ?? '' },
-    skip: !accountListId,
+    variables: { accountListId },
     context: {
       doNotBatch: true,
     },

--- a/pages/accountLists/[accountListId]/settings/manageAccounts.page.test.tsx
+++ b/pages/accountLists/[accountListId]/settings/manageAccounts.page.test.tsx
@@ -24,7 +24,9 @@ interface ComponentsProps {
 
 const Components: React.FC<ComponentsProps> = ({ selectedTab }) => (
   <ThemeProvider theme={theme}>
-    <TestRouter router={{ query: { selectedTab } }}>
+    <TestRouter
+      router={{ query: { selectedTab, accountListId: 'account-list-1' } }}
+    >
       <GqlMockedProvider>
         <SnackbarProvider>
           <ManageAccounts />

--- a/pages/accountLists/[accountListId]/settings/manageCoaches.page.test.tsx
+++ b/pages/accountLists/[accountListId]/settings/manageCoaches.page.test.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import { SnackbarProvider } from 'notistack';
@@ -7,9 +6,6 @@ import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from 'src/theme';
 import ManageCoaching from './manageCoaches.page';
 
-jest.mock('next/router', () => ({
-  useRouter: jest.fn(),
-}));
 jest.mock('notistack', () => ({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -34,13 +30,6 @@ const Components = () => (
 );
 
 describe('ManageCoaching', () => {
-  beforeEach(() => {
-    (useRouter as jest.Mock).mockReturnValue({
-      query: {},
-      isReady: true,
-    });
-  });
-
   it('should open Coaching Access accordion', async () => {
     const { getAllByText } = render(<Components />);
     await waitFor(() => {

--- a/pages/accountLists/[accountListId]/settings/preferences.page.tsx
+++ b/pages/accountLists/[accountListId]/settings/preferences.page.tsx
@@ -87,19 +87,19 @@ const Preferences: React.FC = () => {
   const { data: personalPreferencesData, loading: personalPreferencesLoading } =
     useGetPersonalPreferencesQuery({
       variables: {
-        accountListId: accountListId ?? '',
+        accountListId,
       },
     });
 
   const { data: accountPreferencesData, loading: accountPreferencesLoading } =
     useGetAccountPreferencesQuery({
       variables: {
-        accountListId: accountListId ?? '',
+        accountListId,
       },
     });
   const { data: canUserExportData } = useCanUserExportDataQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
     },
   });
 

--- a/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tasks/[[...contactId]].page.tsx
@@ -106,7 +106,7 @@ export const tasksSavedFilters = (
 
 const PageContent: React.FC = () => {
   const { t } = useTranslation();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const { isOpen, openContact: setContactFocus } = useContactPanel();
   const { openTaskModal, preloadTaskModal } = useTaskModal();
   const appName = getAppName();
@@ -141,10 +141,9 @@ const PageContent: React.FC = () => {
 
   const { data, loading, fetchMore } = useTasksQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
       tasksFilter,
     },
-    skip: !accountListId,
     context: {
       doNotBatch: true,
     },
@@ -167,8 +166,7 @@ const PageContent: React.FC = () => {
   }, [activeFilters]);
 
   const { data: filterData, loading: filtersLoading } = useTaskFiltersQuery({
-    variables: { accountListId: accountListId ?? '' },
-    skip: !accountListId,
+    variables: { accountListId },
   });
 
   const toggleFilterPanel = () => {

--- a/pages/accountLists/[accountListId]/tools/fix/commitmentInfo/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/commitmentInfo/[[...contactId]].page.tsx
@@ -14,7 +14,7 @@ const FixCommitmentInfoPage: React.FC = () => {
       pageTitle={t('Fix Commitment Info')}
       selectedMenuId="fixCommitmentInfo"
     >
-      <FixCommitmentInfo accountListId={accountListId || ''} />
+      <FixCommitmentInfo accountListId={accountListId} />
     </ToolsWrapper>
   );
 };

--- a/pages/accountLists/[accountListId]/tools/fix/emailAddresses/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/emailAddresses/[[...contactId]].page.tsx
@@ -14,7 +14,7 @@ const FixEmailAddressesPage: React.FC = () => {
       pageTitle={t('Fix Email Addresses')}
       selectedMenuId="fixEmailAddresses"
     >
-      <FixEmailAddresses accountListId={accountListId || ''} />
+      <FixEmailAddresses accountListId={accountListId} />
     </ToolsWrapper>
   );
 };

--- a/pages/accountLists/[accountListId]/tools/fix/mailingAddresses/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/mailingAddresses/[[...contactId]].page.tsx
@@ -14,7 +14,7 @@ const FixMailingAddressesPage: React.FC = () => {
       pageTitle={t('Fix Mailing Addresses')}
       selectedMenuId="fixMailingAddresses"
     >
-      <FixMailingAddresses accountListId={accountListId || ''} />
+      <FixMailingAddresses accountListId={accountListId} />
     </ToolsWrapper>
   );
 };

--- a/pages/accountLists/[accountListId]/tools/fix/phoneNumbers/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/phoneNumbers/[[...contactId]].page.tsx
@@ -14,7 +14,7 @@ const FixPhoneNumbersPage: React.FC = () => {
       pageTitle={t('Fix Phone Numbers')}
       selectedMenuId="fixPhoneNumbers"
     >
-      <FixPhoneNumbers accountListId={accountListId || ''} />
+      <FixPhoneNumbers accountListId={accountListId} />
     </ToolsWrapper>
   );
 };

--- a/pages/accountLists/[accountListId]/tools/fix/sendNewsletter/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/fix/sendNewsletter/[[...contactId]].page.tsx
@@ -14,7 +14,7 @@ const FixSendNewsletterPage: React.FC = () => {
       pageTitle={t('Fix Send Newsletter')}
       selectedMenuId="fixSendNewsletter'"
     >
-      <FixSendNewsletter accountListId={accountListId || ''} />
+      <FixSendNewsletter accountListId={accountListId} />
     </ToolsWrapper>
   );
 };

--- a/pages/accountLists/[accountListId]/tools/import/csv.page.test.tsx
+++ b/pages/accountLists/[accountListId]/tools/import/csv.page.test.tsx
@@ -5,11 +5,9 @@ import TestRouter from '__tests__/util/TestRouter';
 import TestWrapper from '__tests__/util/TestWrapper';
 import { CsvImportViewStepEnum } from 'src/components/Tool/Import/Csv/CsvImportContext';
 import { get } from 'src/components/Tool/Import/Csv/csvImportService';
-import { useAccountListId } from 'src/hooks/useAccountListId';
 import theme from 'src/theme';
 import CsvHome from './csv.page';
 
-jest.mock('src/hooks/useAccountListId');
 jest.mock('src/components/Tool/Import/Csv/csvImportService');
 
 const accountListId = 'accountListId';
@@ -19,6 +17,7 @@ const buildRouter = (tab) => {
   return {
     isReady: true,
     query: {
+      accountListId,
       tab: tab,
       id: csvFileId,
     },
@@ -39,7 +38,6 @@ const renderCsvHome = (router) =>
 
 describe('CSV wrapper page', () => {
   beforeEach(() => {
-    (useAccountListId as jest.Mock).mockReturnValue(accountListId);
     (get as jest.Mock).mockReturnValue(Promise.resolve({ id: 'from-get' }));
   });
 
@@ -47,7 +45,7 @@ describe('CSV wrapper page', () => {
     it('should show the upload tab if none specified in the URL', async () => {
       const router = {
         isReady: true,
-        query: {},
+        query: { accountListId },
       };
 
       const { findByTestId } = renderCsvHome(router);

--- a/pages/accountLists/[accountListId]/tools/merge/contacts/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/merge/contacts/[[...contactId]].page.tsx
@@ -17,7 +17,7 @@ const MergeContactsPage: React.FC = () => {
       selectedMenuId="mergeContacts"
     >
       <MergeContacts
-        accountListId={accountListId || ''}
+        accountListId={accountListId}
         contactId={
           typeof query.duplicateId === 'string' ? query.duplicateId : undefined
         }

--- a/pages/accountLists/[accountListId]/tools/merge/people/[[...contactId]].page.tsx
+++ b/pages/accountLists/[accountListId]/tools/merge/people/[[...contactId]].page.tsx
@@ -11,7 +11,7 @@ const MergePeoplePage: React.FC = () => {
 
   return (
     <ToolsWrapper pageTitle={t('Merge People')} selectedMenuId="mergePeople">
-      <MergePeople accountListId={accountListId || ''} />
+      <MergePeople accountListId={accountListId} />
     </ToolsWrapper>
   );
 };

--- a/src/components/Announcements/Announcements.tsx
+++ b/src/components/Announcements/Announcements.tsx
@@ -14,7 +14,7 @@ import {
   ContactFilterStatusEnum,
   DisplayMethodEnum,
 } from 'src/graphql/types.generated';
-import { useAccountListId } from 'src/hooks/useAccountListId';
+import { useOptionalAccountListId } from 'src/hooks/useAccountListId';
 import { useContactPartnershipStatuses } from 'src/hooks/useContactPartnershipStatuses';
 import { dispatch } from 'src/lib/analytics';
 import i18n from 'src/lib/i18n';
@@ -43,7 +43,7 @@ export const Announcements: React.FC = () => {
 
 const Announcement: React.FC = () => {
   const { push } = useRouter();
-  const accountListId = useAccountListId();
+  const accountListId = useOptionalAccountListId();
   const [showAppealModal, setShowAppealModal] = useState(false);
   const [hideAnnouncement, setHideAnnouncement] = useState(false);
   const { contactStatuses } = useContactPartnershipStatuses();

--- a/src/components/Coaching/CoachingList.test.tsx
+++ b/src/components/Coaching/CoachingList.test.tsx
@@ -23,7 +23,7 @@ const coachingAccountListsMock = [
   },
 ];
 const router = {
-  query: { accountListId: accountListId },
+  query: { accountListId },
   push: jest.fn(),
 };
 

--- a/src/components/Coaching/CoachingRow/CoachingRow.tsx
+++ b/src/components/Coaching/CoachingRow/CoachingRow.tsx
@@ -75,7 +75,7 @@ export const CoachingRow: React.FC<Props> = ({
                 href={{
                   pathname:
                     '/accountLists/[accountListId]/coaching/[coachingId]',
-                  query: { accountListId: accountListId, coachingId: id },
+                  query: { accountListId, coachingId: id },
                 }}
               >
                 {name}

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/ContactDetailsMoreActions/ContactDetailsMoreActions.tsx
@@ -98,7 +98,7 @@ export const ContactDetailsMoreActions: React.FC<
     };
     await updateContactOther({
       variables: {
-        accountListId: accountListId ?? '',
+        accountListId,
         attributes,
       },
       refetchQueries: [
@@ -117,7 +117,7 @@ export const ContactDetailsMoreActions: React.FC<
   const handleDeleteContact = () => {
     deleteContact({
       variables: {
-        accountListId: accountListId ?? '',
+        accountListId,
         contactId,
       },
       update: (cache) => {
@@ -234,7 +234,7 @@ export const ContactDetailsMoreActions: React.FC<
         size={'xl'} // TODO: Expand logic as more menu modals are added
       >
         <DynamicCreateMultipleContacts
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           handleClose={handleModalClose}
           referredById={contactId}
         />

--- a/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/DeleteContactModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsHeader/DeleteContactModal/DeleteContactModal.tsx
@@ -63,7 +63,7 @@ export const DeleteContactModal: React.FC<DeleteContactModalProps> = ({
   contactId,
 }) => {
   const { t } = useTranslation();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
 
   const { data } = useContactSourceQuery({
     variables: { accountListId, contactId },

--- a/src/components/Contacts/ContactDetails/ContactDetailsTab/PartnerAccounts/ContactDetailsPartnerAccounts.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDetailsTab/PartnerAccounts/ContactDetailsPartnerAccounts.tsx
@@ -69,7 +69,7 @@ export const ContactDetailsPartnerAccounts: React.FC<
     useUpdateContactOtherMutation();
   const [showForm, setShowForm] = useState(false);
   const { data: accountListData } = useGetAccountListSalaryOrganizationQuery({
-    variables: { accountListId: accountListId },
+    variables: { accountListId },
   });
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/ContactDonationsTab.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/ContactDonationsTab.tsx
@@ -69,7 +69,7 @@ export const ContactDonationsTab: React.FC<ContactDonationsProp> = ({
 }) => {
   const { data } = useGetContactDonationsQuery({
     variables: {
-      accountListId: accountListId,
+      accountListId,
       contactId: contactId,
     },
   });

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/DonationsGraph/DonationsGraph.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/DonationsGraph/DonationsGraph.test.tsx
@@ -101,7 +101,7 @@ describe('Donations Graph', () => {
       () =>
         useGetDonationsGraphQuery({
           variables: {
-            accountListId: accountListId,
+            accountListId,
             donorAccountIds: donorAccountIds,
           },
         }),

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/DonationsGraph/DonationsGraph.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/DonationsGraph/DonationsGraph.tsx
@@ -41,7 +41,7 @@ export const DonationsGraph: React.FC<DonationsGraphProps> = ({
   const locale = useLocale();
   const { data } = useGetDonationsGraphQuery({
     variables: {
-      accountListId: accountListId,
+      accountListId,
       donorAccountIds: donorAccountIds,
     },
     skip: !donorAccountIds,

--- a/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
+++ b/src/components/Contacts/ContactDetails/ContactDonationsTab/PartnershipInfo/EditPartnershipInfoModal/EditPartnershipInfoModal.tsx
@@ -40,6 +40,7 @@ import {
   SendNewsletterEnum,
   StatusEnum,
 } from 'src/graphql/types.generated';
+import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useLocale } from 'src/hooks/useLocale';
 import { useLocalizedConstants } from 'src/hooks/useLocalizedConstants';
 import { getAppName } from 'src/lib/getAppName';
@@ -48,7 +49,6 @@ import {
   parseNumberFromCurrencyString,
 } from 'src/lib/intlFormat';
 import { nullableDateTime } from 'src/lib/yupHelpers';
-import { useAccountListId } from '../../../../../../hooks/useAccountListId';
 import { useApiConstants } from '../../../../../Constants/UseApiConstants';
 import Modal from '../../../../../Shared/Modal/Modal';
 import { ContactDonorAccountsFragment } from '../../ContactDonationsTab.generated';
@@ -151,7 +151,7 @@ export const EditPartnershipInfoModal: React.FC<
 
     await updateContactPartnership({
       variables: {
-        accountListId: accountListId ?? '',
+        accountListId,
         attributes: {
           ...attributes,
           pledgeStartDate: attributes.pledgeStartDate?.toISODate() ?? null,

--- a/src/components/Contacts/ContactDetails/ContactReferralTab/ContactReferralTab.tsx
+++ b/src/components/Contacts/ContactDetails/ContactReferralTab/ContactReferralTab.tsx
@@ -75,7 +75,7 @@ export const ContactReferralTab: React.FC<ContactReferralTabProps> = ({
 
   const { data, error, fetchMore } = useContactReferralTabQuery({
     variables: {
-      accountListId: accountListId,
+      accountListId,
       contactId: contactId,
     },
   });
@@ -220,7 +220,7 @@ export const ContactReferralTab: React.FC<ContactReferralTabProps> = ({
             size={'xl'} // TODO: Expand logic as more menu modals are added
           >
             <DynamicCreateMultipleContacts
-              accountListId={accountListId ?? ''}
+              accountListId={accountListId}
               handleClose={handleModalClose}
               referredById={contactId}
             />

--- a/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTasksTab.test.tsx
+++ b/src/components/Contacts/ContactDetails/ContactTasksTab/ContactTasksTab.test.tsx
@@ -3,10 +3,10 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DateTime } from 'luxon';
 import { VirtuosoMockContext } from 'react-virtuoso';
+import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { TaskModalEnum } from 'src/components/Task/Modal/TaskModal';
 import { PhaseEnum } from 'src/graphql/types.generated';
-import { useAccountListId } from 'src/hooks/useAccountListId';
 import useTaskModal from '../../../../hooks/useTaskModal';
 import theme from '../../../../theme';
 import { TasksMassActionsDropdown } from '../../../Shared/MassActions/TasksMassActionsDropdown';
@@ -17,7 +17,6 @@ import {
 } from './ContactTasksTab.generated';
 
 jest.mock('../../../../hooks/useTaskModal');
-jest.mock('../../../../hooks/useAccountListId');
 
 jest.mock('../../../Shared/MassActions/TasksMassActionsDropdown', () => ({
   TasksMassActionsDropdown: jest.fn(
@@ -38,7 +37,6 @@ beforeEach(() => {
     openTaskModal,
     preloadTaskModal: jest.fn(),
   });
-  (useAccountListId as jest.Mock).mockReturnValue(router);
 });
 
 const mockEnqueue = jest.fn();
@@ -65,19 +63,21 @@ describe('ContactTasksTab', () => {
   it('default', async () => {
     const querySpy = jest.fn();
     const { getByText, queryByTestId } = render(
-      <ThemeProvider theme={theme}>
-        <GqlMockedProvider onCall={querySpy}>
-          <VirtuosoMockContext.Provider
-            value={{ viewportHeight: 300, itemHeight: 100 }}
-          >
-            <ContactTasksTab
-              accountListId={accountListId}
-              contactId={contactId}
-              contactDetailsLoaded={false}
-            />
-          </VirtuosoMockContext.Provider>
-        </GqlMockedProvider>
-      </ThemeProvider>,
+      <TestRouter router={router}>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider onCall={querySpy}>
+            <VirtuosoMockContext.Provider
+              value={{ viewportHeight: 300, itemHeight: 100 }}
+            >
+              <ContactTasksTab
+                accountListId={accountListId}
+                contactId={contactId}
+                contactDetailsLoaded={false}
+              />
+            </VirtuosoMockContext.Provider>
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </TestRouter>,
     );
     await waitFor(() =>
       expect(
@@ -96,19 +96,21 @@ describe('ContactTasksTab', () => {
 
   it('loading', async () => {
     const { getAllByTestId } = render(
-      <ThemeProvider theme={theme}>
-        <GqlMockedProvider>
-          <VirtuosoMockContext.Provider
-            value={{ viewportHeight: 300, itemHeight: 100 }}
-          >
-            <ContactTasksTab
-              accountListId={accountListId}
-              contactId={contactId}
-              contactDetailsLoaded={false}
-            />
-          </VirtuosoMockContext.Provider>
-        </GqlMockedProvider>
-      </ThemeProvider>,
+      <TestRouter router={router}>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider>
+            <VirtuosoMockContext.Provider
+              value={{ viewportHeight: 300, itemHeight: 100 }}
+            >
+              <ContactTasksTab
+                accountListId={accountListId}
+                contactId={contactId}
+                contactDetailsLoaded={false}
+              />
+            </VirtuosoMockContext.Provider>
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </TestRouter>,
     );
     expect(
       getAllByTestId('infinite-list-skeleton-loading')[0],
@@ -118,24 +120,26 @@ describe('ContactTasksTab', () => {
   it('handles add task click', async () => {
     const querySpy = jest.fn();
     const { getByText, queryByTestId } = render(
-      <ThemeProvider theme={theme}>
-        <GqlMockedProvider<{
-          ContactPhase: ContactPhaseQuery;
-        }>
-          mocks={contactPhaseMock}
-          onCall={querySpy}
-        >
-          <VirtuosoMockContext.Provider
-            value={{ viewportHeight: 300, itemHeight: 100 }}
+      <TestRouter router={router}>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider<{
+            ContactPhase: ContactPhaseQuery;
+          }>
+            mocks={contactPhaseMock}
+            onCall={querySpy}
           >
-            <ContactTasksTab
-              accountListId={accountListId}
-              contactId={contactId}
-              contactDetailsLoaded={false}
-            />
-          </VirtuosoMockContext.Provider>
-        </GqlMockedProvider>
-      </ThemeProvider>,
+            <VirtuosoMockContext.Provider
+              value={{ viewportHeight: 300, itemHeight: 100 }}
+            >
+              <ContactTasksTab
+                accountListId={accountListId}
+                contactId={contactId}
+                contactDetailsLoaded={false}
+              />
+            </VirtuosoMockContext.Provider>
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </TestRouter>,
     );
     await waitFor(() =>
       expect(
@@ -164,24 +168,26 @@ describe('ContactTasksTab', () => {
   it('handles log task click', async () => {
     const querySpy = jest.fn();
     const { getByText, queryByTestId } = render(
-      <ThemeProvider theme={theme}>
-        <GqlMockedProvider<{
-          ContactPhase: ContactPhaseQuery;
-        }>
-          mocks={contactPhaseMock}
-          onCall={querySpy}
-        >
-          <VirtuosoMockContext.Provider
-            value={{ viewportHeight: 300, itemHeight: 100 }}
+      <TestRouter router={router}>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider<{
+            ContactPhase: ContactPhaseQuery;
+          }>
+            mocks={contactPhaseMock}
+            onCall={querySpy}
           >
-            <ContactTasksTab
-              accountListId={accountListId}
-              contactId={contactId}
-              contactDetailsLoaded={false}
-            />
-          </VirtuosoMockContext.Provider>
-        </GqlMockedProvider>
-      </ThemeProvider>,
+            <VirtuosoMockContext.Provider
+              value={{ viewportHeight: 300, itemHeight: 100 }}
+            >
+              <ContactTasksTab
+                accountListId={accountListId}
+                contactId={contactId}
+                contactDetailsLoaded={false}
+              />
+            </VirtuosoMockContext.Provider>
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </TestRouter>,
     );
     await waitFor(() =>
       expect(
@@ -209,28 +215,30 @@ describe('ContactTasksTab', () => {
 
   it('load null state', async () => {
     const { getByText, queryByTestId } = render(
-      <ThemeProvider theme={theme}>
-        <GqlMockedProvider<{ ContactTasksTab: ContactTasksTabQuery }>
-          mocks={{
-            ContactTasksTab: {
-              tasks: {
-                nodes: [],
-                pageInfo: {
-                  endCursor: 'MjU',
-                  hasNextPage: false,
+      <TestRouter router={router}>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider<{ ContactTasksTab: ContactTasksTabQuery }>
+            mocks={{
+              ContactTasksTab: {
+                tasks: {
+                  nodes: [],
+                  pageInfo: {
+                    endCursor: 'MjU',
+                    hasNextPage: false,
+                  },
+                  totalCount: 0,
                 },
-                totalCount: 0,
               },
-            },
-          }}
-        >
-          <ContactTasksTab
-            accountListId={accountListId}
-            contactId={contactId}
-            contactDetailsLoaded={false}
-          />
-        </GqlMockedProvider>
-      </ThemeProvider>,
+            }}
+          >
+            <ContactTasksTab
+              accountListId={accountListId}
+              contactId={contactId}
+              contactDetailsLoaded={false}
+            />
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </TestRouter>,
     );
     await waitFor(() =>
       expect(
@@ -246,24 +254,26 @@ describe('ContactTasksTab', () => {
 
   it('counts total tasks when all are selected', async () => {
     const { getAllByRole, queryByTestId } = render(
-      <ThemeProvider theme={theme}>
-        <GqlMockedProvider<{ ContactTasksTab: ContactTasksTabQuery }>
-          mocks={{
-            ContactTasksTab: {
-              tasks: {
-                nodes: [],
-                totalCount: 100,
+      <TestRouter router={router}>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider<{ ContactTasksTab: ContactTasksTabQuery }>
+            mocks={{
+              ContactTasksTab: {
+                tasks: {
+                  nodes: [],
+                  totalCount: 100,
+                },
               },
-            },
-          }}
-        >
-          <ContactTasksTab
-            accountListId={accountListId}
-            contactId={contactId}
-            contactDetailsLoaded={false}
-          />
-        </GqlMockedProvider>
-      </ThemeProvider>,
+            }}
+          >
+            <ContactTasksTab
+              accountListId={accountListId}
+              contactId={contactId}
+              contactDetailsLoaded={false}
+            />
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </TestRouter>,
     );
     await waitFor(() =>
       expect(
@@ -285,35 +295,37 @@ describe('ContactTasksTab', () => {
   it('reached end of list and fetched more', async () => {
     const querySpy = jest.fn();
     const { queryByTestId } = render(
-      <ThemeProvider theme={theme}>
-        <GqlMockedProvider<{
-          ContactTasksTabQuery: ContactTasksTabQuery;
-        }>
-          mocks={{
-            ContactTasksTab: {
-              tasks: {
-                nodes: [{}, {}, {}],
-                pageInfo: {
-                  endCursor: 'MjU',
-                  hasNextPage: true,
+      <TestRouter router={router}>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider<{
+            ContactTasksTabQuery: ContactTasksTabQuery;
+          }>
+            mocks={{
+              ContactTasksTab: {
+                tasks: {
+                  nodes: [{}, {}, {}],
+                  pageInfo: {
+                    endCursor: 'MjU',
+                    hasNextPage: true,
+                  },
+                  totalCount: 10,
                 },
-                totalCount: 10,
               },
-            },
-          }}
-          onCall={querySpy}
-        >
-          <VirtuosoMockContext.Provider
-            value={{ viewportHeight: 400, itemHeight: 100 }}
+            }}
+            onCall={querySpy}
           >
-            <ContactTasksTab
-              accountListId={accountListId}
-              contactId={contactId}
-              contactDetailsLoaded={false}
-            />
-          </VirtuosoMockContext.Provider>
-        </GqlMockedProvider>
-      </ThemeProvider>,
+            <VirtuosoMockContext.Provider
+              value={{ viewportHeight: 400, itemHeight: 100 }}
+            >
+              <ContactTasksTab
+                accountListId={accountListId}
+                contactId={contactId}
+                contactDetailsLoaded={false}
+              />
+            </VirtuosoMockContext.Provider>
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </TestRouter>,
     );
     await waitFor(() =>
       expect(

--- a/src/components/Contacts/ContactFlow/ContactFlowColumn/ContactFlowColumn.tsx
+++ b/src/components/Contacts/ContactFlow/ContactFlowColumn/ContactFlowColumn.tsx
@@ -84,13 +84,13 @@ export const ContactFlowColumn: React.FC<ContactFlowColumnProps> = ({
 
   const { data, loading, fetchMore } = useContactsQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
       contactsFilters: {
         ...combinedFilters,
         status: statuses as string[] as ContactFilterStatusEnum[],
       },
     },
-    skip: !accountListId || statuses.length === 0,
+    skip: statuses.length === 0,
   });
 
   const cardContentRef = useRef<HTMLDivElement>();

--- a/src/components/Contacts/ContactRow/ContactRow.tsx
+++ b/src/components/Contacts/ContactRow/ContactRow.tsx
@@ -170,7 +170,7 @@ export const ContactRow: React.FC<Props> = ({ contact, useTopMargin }) => {
           style={{ position: 'static', top: 0, transform: 'none' }}
         >
           <StarContactIconButton
-            accountListId={accountListId ?? ''}
+            accountListId={accountListId}
             contactId={contactId}
             isStarred={starred || false}
           />

--- a/src/components/Contacts/ContactsContext/ContactsContext.tsx
+++ b/src/components/Contacts/ContactsContext/ContactsContext.tsx
@@ -26,7 +26,7 @@ import {
 import { Coordinates } from '../ContactsMap/coordinates';
 
 export type ContactsType = {
-  accountListId: string | undefined;
+  accountListId: string;
   contactsQueryResult: ReturnType<typeof useContactsQuery>;
   selectionType: ListHeaderCheckBoxState;
   isRowChecked: (id: string) => boolean;
@@ -94,7 +94,7 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
   userOptionsLoading,
 }) => {
   const locale = useLocale();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
 
   const { combinedFilters: contactsFilters } = useUrlFilters();
 
@@ -129,7 +129,7 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
 
   const contactsQueryResult = useContactsQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
       contactsFilters:
         // In the map view, ignore all filters and only show the selected contacts
         // If no contacts were selected, show all contacts
@@ -138,7 +138,6 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
           : contactsFilters,
       first: viewMode === TableViewModeEnum.Map ? 20000 : 25,
     },
-    skip: !accountListId,
   });
   const { data, fetchMore } = contactsQueryResult;
 
@@ -157,8 +156,7 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
   }, [data, viewMode]);
 
   const { data: filterData, loading: filtersLoading } = useContactFiltersQuery({
-    variables: { accountListId: accountListId ?? '' },
-    skip: !accountListId,
+    variables: { accountListId },
     context: {
       doNotBatch: true,
     },
@@ -196,7 +194,7 @@ export const ContactsProvider: React.FC<ContactsContextProps> = ({
 
   const contextValue = useMemo(
     () => ({
-      accountListId: accountListId ?? '',
+      accountListId,
       contactsQueryResult,
       selectionType,
       isRowChecked,

--- a/src/components/Contacts/ContactsMainPanel/ContactsMainPanel.tsx
+++ b/src/components/Contacts/ContactsMainPanel/ContactsMainPanel.tsx
@@ -21,7 +21,7 @@ export const ContactsMainPanel: React.FC = () => {
         (viewMode === TableViewModeEnum.List ? (
           <DynamicContactsList />
         ) : viewMode === TableViewModeEnum.Flows ? (
-          <DynamicContactFlow accountListId={accountListId ?? ''} />
+          <DynamicContactFlow accountListId={accountListId} />
         ) : (
           <DynamicContactsMap />
         ))}

--- a/src/components/EditDonationModal/EditDonationModal.tsx
+++ b/src/components/EditDonationModal/EditDonationModal.tsx
@@ -70,7 +70,7 @@ export const EditDonationModal: React.FC<EditDonationModalProps> = ({
 }) => {
   const { t } = useTranslation();
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
 
   const {
     data: appeals,

--- a/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/Autosave/useSaveField.ts
+++ b/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/Autosave/useSaveField.ts
@@ -5,7 +5,7 @@ import { useGoalCalculator } from '../../../Shared/GoalCalculatorContext';
 import { useUpdateGoalCalculationMutation } from '../SettingsCategory/GoalCalculation.generated';
 
 export const useSaveField = () => {
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const {
     goalCalculationResult: { data },
     trackMutation,

--- a/src/components/HrTools/GoalCalculator/GoalCard/MpdGoalCard.tsx
+++ b/src/components/HrTools/GoalCalculator/GoalCard/MpdGoalCard.tsx
@@ -13,7 +13,7 @@ export interface MpdGoalCardProps {
 }
 
 export const MpdGoalCard: React.FC<MpdGoalCardProps> = ({ goal }) => {
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const constants = useGoalCalculatorConstants();
   const [deleteGoalCalculation] = useDeleteGoalCalculationMutation();
 

--- a/src/components/HrTools/GoalCalculator/GoalsList/GoalsList.tsx
+++ b/src/components/HrTools/GoalCalculator/GoalsList/GoalsList.tsx
@@ -26,7 +26,7 @@ const PlaceholderImage = styled('img')(({ theme }) => ({
 export const GoalsList: React.FC = () => {
   const { t } = useTranslation();
   const router = useRouter();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const { data, error, fetchMore } = useGoalCalculationsQuery({
     variables: { accountListId },
   });

--- a/src/components/HrTools/GoalCalculator/HouseholdExpenses/HouseholdExpensesHeader.tsx
+++ b/src/components/HrTools/GoalCalculator/HouseholdExpenses/HouseholdExpensesHeader.tsx
@@ -44,7 +44,7 @@ const AmountTypography = styled(Typography)(({ theme }) => ({
 }));
 
 export const HouseholdExpensesHeader: React.FC = () => {
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const {
     goalCalculationResult: { data, loading },
     goalTotals: { monthlyBudget },

--- a/src/components/HrTools/GoalCalculator/MinistryExpenses/MinistryExpensesStep.tsx
+++ b/src/components/HrTools/GoalCalculator/MinistryExpenses/MinistryExpensesStep.tsx
@@ -14,7 +14,7 @@ const InstructionsWrapper = styled('div')(({ theme }) => ({
 
 const Instructions: React.FC = () => {
   const { t } = useTranslation();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
 
   return (
     <InstructionsWrapper>

--- a/src/components/HrTools/GoalCalculator/Shared/GoalCalculatorContext.tsx
+++ b/src/components/HrTools/GoalCalculator/Shared/GoalCalculatorContext.tsx
@@ -80,7 +80,7 @@ interface Props {
 export const GoalCalculatorProvider: React.FC<Props> = ({ children }) => {
   const { enqueueSnackbar } = useSnackbar();
   const { t } = useTranslation();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const { query } = useRouter();
   const goalCalculationId = getQueryParam(query, 'goalCalculationId') ?? '';
 

--- a/src/components/HrTools/GoalCalculator/SharedComponents/GoalCalculatorGrid/GoalCalculatorGrid.tsx
+++ b/src/components/HrTools/GoalCalculator/SharedComponents/GoalCalculatorGrid/GoalCalculatorGrid.tsx
@@ -86,7 +86,7 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
   const { t } = useTranslation();
   const locale = useLocale();
   const { label: categoryName } = category;
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const {
     setRightPanelContent,
     trackMutation,

--- a/src/components/HrTools/GoalCalculator/SummaryReport/SummaryReport.tsx
+++ b/src/components/HrTools/GoalCalculator/SummaryReport/SummaryReport.tsx
@@ -14,7 +14,7 @@ import { PresentingYourGoalStepRightPanel } from './Steps/PresentingYourGoalStep
 
 export const SummaryReport: React.FC = () => {
   const { t } = useTranslation();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const { selectedReport, goalCalculationResult } = useGoalCalculator();
   const { data } = useAccountListSupportRaisedQuery({
     variables: { accountListId },

--- a/src/components/HrTools/MinistryPartnerReminders/PartnerRemindersReport.tsx
+++ b/src/components/HrTools/MinistryPartnerReminders/PartnerRemindersReport.tsx
@@ -77,7 +77,7 @@ export const PartnerRemindersReport: React.FC<MPRemindersReportProps> = ({
 
   const { data, loading, error } = useMinistryPartnerRemindersQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
       designationNumber,
     },
     skip: !designationNumber,
@@ -140,7 +140,7 @@ export const PartnerRemindersReport: React.FC<MPRemindersReportProps> = ({
     await updateMutation({
       variables: {
         input: {
-          accountListId: accountListId ?? '',
+          accountListId,
           designationNumber,
           updates: getUpdates(values),
         },

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/useNewStaffGoalCalculation.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/useNewStaffGoalCalculation.tsx
@@ -23,7 +23,7 @@ interface UseNewStaffGoalCalculationResult {
  * loading skeleton, error alert, and empty-state.
  */
 export const useNewStaffGoalCalculation = (
-  accountListId: string | null | undefined,
+  accountListId: string,
 ): UseNewStaffGoalCalculationResult => {
   const { t } = useTranslation();
 

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/useNewStaffGoalCalculation.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/useNewStaffGoalCalculation.tsx
@@ -28,8 +28,7 @@ export const useNewStaffGoalCalculation = (
   const { t } = useTranslation();
 
   const { data, loading, error } = useNewStaffGoalCalculationQuery({
-    variables: { accountListId: accountListId ?? '' },
-    skip: !accountListId,
+    variables: { accountListId },
   });
   const goalCalculation = data?.newStaffGoalCalculation ?? null;
 

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NsoMpdQuestionnaireContext.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NsoMpdQuestionnaireContext.tsx
@@ -67,8 +67,7 @@ export const NsoMpdQuestionnaireProvider: React.FC<Props> = ({ children }) => {
   const accountListId = useAccountListId();
 
   const { data: questionnaireData, loading } = useNewStaffQuestionnaireQuery({
-    variables: { accountListId: accountListId ?? '' },
-    skip: !accountListId,
+    variables: { accountListId },
   });
   const questionnaire = questionnaireData?.newStaffQuestionnaire ?? null;
 

--- a/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalCard/PdsGoalCard.tsx
@@ -17,7 +17,7 @@ export interface PdsGoalCardProps {
 
 export const PdsGoalCard: React.FC<PdsGoalCardProps> = ({ goal }) => {
   const { t } = useTranslation();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const [deletePdsGoalCalculation] = useDeletePdsGoalCalculationMutation();
 
   const { data: hcmData, loading: hcmLoading } = useHcmUserQuery();

--- a/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/GoalsList/PdsGoalsList.tsx
@@ -30,7 +30,7 @@ export const PdsGoalsList: React.FC = () => {
   const { t } = useTranslation();
   const router = useRouter();
   const { enqueueSnackbar } = useSnackbar();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
 
   const { data: userData } = useGetUserQuery();
   const defaultName = t('User');

--- a/src/components/HrTools/PdsGoalCalculator/SummaryReport/SummaryReportStep.tsx
+++ b/src/components/HrTools/PdsGoalCalculator/SummaryReport/SummaryReportStep.tsx
@@ -9,7 +9,7 @@ import { PdsSummaryTable } from './PdsSummaryTable';
 
 export const SummaryReportStep: React.FC = () => {
   const { t } = useTranslation();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const { calculationLoading } = usePdsGoalCalculator();
   const { data } = useAccountListSupportRaisedQuery({
     variables: { accountListId },

--- a/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.test.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.test.tsx
@@ -13,7 +13,6 @@ import { DirectionButtons } from './DirectionButtons';
 const title = 'Submit this form';
 
 const submit = jest.fn();
-const pushMock = jest.fn();
 const handleNextStep = jest.fn();
 const handlePreviousStep = jest.fn();
 const handleDiscard = jest.fn();
@@ -76,14 +75,6 @@ const TestComponent: React.FC<TestComponentProps> = ({
     </TestRouter>
   </ThemeProvider>
 );
-
-jest.mock('src/hooks/useAccountListId', () => ({
-  useAccountListId: () => 'account-list-1',
-}));
-
-jest.mock('next/router', () => ({
-  useRouter: () => ({ push: pushMock }),
-}));
 
 describe('DirectionButtons', () => {
   it('renders Back and Submit buttons', async () => {

--- a/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.test.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.test.tsx
@@ -6,12 +6,12 @@ import { signOut } from 'next-auth/react';
 import TestRouter from '__tests__/util/TestRouter';
 import TestWrapper from '__tests__/util/TestWrapper';
 import { TestSetupProvider } from 'src/components/Setup/SetupProvider';
-import theme from '../../../../../../theme';
+import theme from 'src/theme';
 import { getTopBarMock } from '../../../TopBar/TopBar.mock';
 import { ProfileMenuPanel } from './ProfileMenuPanel';
 
 const router = {
-  isReady: false,
+  isReady: true,
   pathname: '/accountLists/[accountListId]/test',
   query: { accountListId: '1' },
   push: jest.fn(),
@@ -50,7 +50,7 @@ describe('ProfileMenuPanelForNavBar', () => {
     userEvent.click(await findByTestId('accountListSelectorButton'));
     expect(getByTestId('accountListButton-1')).toBeInTheDocument();
     expect(getByTestId('accountListButton-1')).toHaveStyle(
-      'backgroundColor: #383F43;',
+      'backgroundColor: #9C9FA1;',
     );
     expect(getByText('Preferences')).toBeInTheDocument();
   });
@@ -75,7 +75,7 @@ describe('ProfileMenuPanelForNavBar', () => {
     userEvent.click(getByTestId('accountListButton-1'));
     await waitFor(() =>
       expect(router.push).toHaveBeenCalledWith({
-        pathname: '/accountLists/[accountListId]/',
+        pathname: '/accountLists/[accountListId]/test',
         query: { accountListId: '1' },
       }),
     );

--- a/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.tsx
@@ -14,10 +14,10 @@ import {
   PrivacyPolicyLink,
   TermsOfUseLink,
 } from 'src/components/Shared/Links/Links';
+import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useNavPages } from 'src/hooks/useNavPages';
 import { clearDataDogUser } from 'src/lib/dataDog';
-import { useAccountListId } from '../../../../../../hooks/useAccountListId';
-import theme from '../../../../../../theme';
+import theme from 'src/theme';
 import { useGetTopBarQuery } from '../../../TopBar/GetTopBar.generated';
 import { LeafListItem, Title } from '../../StyledComponents';
 

--- a/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.tsx
+++ b/src/components/Layouts/Primary/NavBar/NavTools/ProfileMenuPanel/ProfileMenuPanel.tsx
@@ -66,7 +66,7 @@ export const ProfileMenuPanel: React.FC = () => {
   const changeAccountListId = (id: string): void => {
     setAccountsDrawerOpen(false);
     push({
-      pathname: accountListId ? pathname : '/accountLists/[accountListId]/',
+      pathname,
       query: { accountListId: id },
     });
   };

--- a/src/components/Layouts/Primary/Primary.tsx
+++ b/src/components/Layouts/Primary/Primary.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, ReactNode, useState } from 'react';
 import { Box } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { NavBar } from 'src/components/Layouts/Primary/NavBar/NavBar';
-import { useAccountListId } from 'src/hooks/useAccountListId';
+import { useOptionalAccountListId } from 'src/hooks/useAccountListId';
 import TopBar from './TopBar/TopBar';
 
 export const navBarHeight = '64px';
@@ -29,7 +29,7 @@ interface Props {
 }
 
 const Primary = ({ children }: Props): ReactElement => {
-  const accountListId = useAccountListId();
+  const accountListId = useOptionalAccountListId();
   const [isMobileNavOpen, setMobileNavOpen] = useState<boolean>(false);
 
   return (

--- a/src/components/Layouts/Primary/TopBar/Items/AddMenu/AddMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/AddMenu/AddMenu.tsx
@@ -114,21 +114,21 @@ export const renderDialog = (
       case AddMenuItemsEnum.NewContact:
         return (
           <DynamicCreateContact
-            accountListId={accountListId ?? ''}
+            accountListId={accountListId}
             handleClose={handleDialogClose}
           />
         );
       case AddMenuItemsEnum.MultipleContacts:
         return (
           <DynamicCreateMultipleContacts
-            accountListId={accountListId ?? ''}
+            accountListId={accountListId}
             handleClose={handleDialogClose}
           />
         );
       case AddMenuItemsEnum.AddDonation:
         return (
           <DynamicAddDonation
-            accountListId={accountListId ?? ''}
+            accountListId={accountListId}
             handleClose={handleDialogClose}
           />
         );

--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
@@ -237,13 +237,6 @@ describe('NavMenu', () => {
     );
   });
 
-  it('hidden', () => {
-    const { queryByRole } = render(
-      <TestComponent router={{ query: { accountListId: '' } }} />,
-    );
-    expect(queryByRole('menuitem')).toBeNull();
-  });
-
   it('test current tool id hook', () => {
     const { getByTestId } = render(
       <TestComponent

--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.tsx
@@ -169,7 +169,7 @@ const NavMenu: React.FC = () => {
     (page) => page.id === 'coaching-page',
   );
 
-  return accountListId ? (
+  return (
     <Grid container alignItems="center" size="auto">
       {navPages.map(
         (page) =>
@@ -244,7 +244,7 @@ const NavMenu: React.FC = () => {
         </Grid>
       )}
     </Grid>
-  ) : null;
+  );
 };
 
 export default NavMenu;

--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.tsx
@@ -4,9 +4,9 @@ import React, { useMemo, useState } from 'react';
 import { Grid, ListItemText, MenuItem } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
 import { useLoadCoachingListQuery } from 'src/components/Coaching/LoadCoachingList.generated';
+import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useNavPages } from 'src/hooks/useNavPages';
-import { useAccountListId } from '../../../../../../hooks/useAccountListId';
-import theme from '../../../../../../theme';
+import theme from 'src/theme';
 import { useGetToolNotificationsQuery } from './GetToolNotifcations.generated';
 import { NavMenuDropdown } from './NavMenuDropdown';
 
@@ -90,8 +90,7 @@ const NavMenu: React.FC = () => {
 
   const { classes } = useStyles();
   const { data, loading } = useGetToolNotificationsQuery({
-    variables: { accountListId: accountListId ?? '' },
-    skip: !accountListId,
+    variables: { accountListId },
   });
   const { data: coachingData } = useLoadCoachingListQuery();
 

--- a/src/components/Layouts/Primary/TopBar/Items/NotificationMenu/Item/Item.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NotificationMenu/Item/Item.tsx
@@ -84,7 +84,7 @@ const NotificationMenuItem = ({
           const query = {
             query: GetNotificationsDocument,
             variables: {
-              accountListId: accountListId,
+              accountListId,
               after: null,
             },
           };

--- a/src/components/Layouts/Primary/TopBar/Items/NotificationMenu/NotificationMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NotificationMenu/NotificationMenu.tsx
@@ -13,8 +13,8 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { makeStyles } from 'tss-react/mui';
+import { useAccountListId } from 'src/hooks/useAccountListId';
 import theme from 'src/theme';
-import { useAccountListId } from '../../../../../../hooks/useAccountListId';
 import illustration13 from '../../../../../../images/drawkit/grape/drawkit-grape-pack-illustration-13.svg';
 import { useAcknowledgeAllUserNotificationsMutation } from './AcknowledgeAllUserNotifications.generated';
 import {
@@ -158,10 +158,9 @@ const NotificationMenu = ({
 
   const { data, loading, fetchMore } = useGetNotificationsQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
       after: null,
     },
-    skip: !accountListId,
     notifyOnNetworkStatusChange: true,
   });
 
@@ -170,7 +169,7 @@ const NotificationMenu = ({
 
   const handleAcknowledgeAllClick = () => {
     acknoweldgeAllUserNotifications({
-      variables: { accountListId: accountListId ?? '' },
+      variables: { accountListId },
       optimisticResponse: {
         acknowledgeAllUserNotifications: {
           notificationIds: [],
@@ -180,7 +179,7 @@ const NotificationMenu = ({
         const query = {
           query: GetNotificationsDocument,
           variables: {
-            accountListId: accountListId,
+            accountListId,
             after: null,
           },
         };

--- a/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/ProfileMenu/ProfileMenu.tsx
@@ -28,10 +28,10 @@ import {
   TermsOfUseLink,
 } from 'src/components/Shared/Links/Links';
 import { AccountList } from 'src/graphql/types.generated';
+import { useOptionalAccountListId } from 'src/hooks/useAccountListId';
 import { useRequiredSession } from 'src/hooks/useRequiredSession';
 import { clearDataDogUser } from 'src/lib/dataDog';
-import { useAccountListId } from '../../../../../../hooks/useAccountListId';
-import theme from '../../../../../../theme';
+import theme from 'src/theme';
 import { useGetTopBarQuery } from '../../GetTopBar.generated';
 import ProfileName from './ProfileName';
 
@@ -133,7 +133,7 @@ const ProfileMenu = (): ReactElement => {
   const client = useApolloClient();
   const { enqueueSnackbar } = useSnackbar();
   const { contactId: _, ...queryWithoutContactId } = router.query;
-  const accountListId = useAccountListId();
+  const accountListId = useOptionalAccountListId();
   const { data, loading } = useGetTopBarQuery();
   const { onSetupTour } = useSetupContext();
   const [profileMenuAnchorEl, setProfileMenuAnchorEl] =

--- a/src/components/Layouts/Primary/TopBar/Items/SearchMenu/SearchDialog.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/SearchMenu/SearchDialog.tsx
@@ -24,9 +24,9 @@ import {
   ContactFilterStatusEnum,
   StatusEnum,
 } from 'src/graphql/types.generated';
+import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useLocalizedConstants } from 'src/hooks/useLocalizedConstants';
 import { NavPage, useNavPages } from 'src/hooks/useNavPages';
-import { useAccountListId } from '../../../../../../hooks/useAccountListId';
 import { useCreateContactMutation } from '../AddMenu/Items/CreateContact/CreateContact.generated';
 import { useGetSearchMenuContactsLazyQuery } from './SearchMenu.generated';
 
@@ -80,7 +80,7 @@ export const SearchDialog: React.FC<SearchDialogProps> = ({ handleClose }) => {
       (wildcardSearch: string) =>
         searchForContacts({
           variables: {
-            accountListId: accountListId ?? '',
+            accountListId,
             contactsFilter: {
               status: [
                 ContactFilterStatusEnum.Active,
@@ -112,7 +112,7 @@ export const SearchDialog: React.FC<SearchDialogProps> = ({ handleClose }) => {
   const handleCreateContact = async () => {
     const { data } = await createContact({
       variables: {
-        accountListId: accountListId ?? '',
+        accountListId,
         attributes: {
           name: wildcardSearch,
         },

--- a/src/components/Layouts/Primary/TopBar/TopBar.tsx
+++ b/src/components/Layouts/Primary/TopBar/TopBar.tsx
@@ -18,7 +18,7 @@ import ProfileMenu from './Items/ProfileMenu/ProfileMenu';
 import SearchMenu from './Items/SearchMenu/SearchMenu';
 
 interface TopBarProps {
-  accountListId: string | undefined;
+  accountListId: string | null;
   onMobileNavOpen?: () => void;
 }
 

--- a/src/components/Reports/AccountsListLayout/List/ListItem/ListItem.tsx
+++ b/src/components/Reports/AccountsListLayout/List/ListItem/ListItem.tsx
@@ -54,7 +54,7 @@ export const AccountListItem: FC<AccountListItemProps> = ({
   onCheckToggle,
 }) => {
   const { t } = useTranslation();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const locale = useLocale();
 
   const average = useMemo(() => {

--- a/src/components/Reports/EmptyReport/EmptyReport.tsx
+++ b/src/components/Reports/EmptyReport/EmptyReport.tsx
@@ -62,7 +62,7 @@ export const EmptyReport: React.FC<Props> = ({
         size="sm"
       >
         <DynamicAddDonation
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           handleClose={handleCloseAddDonation}
         />
       </Modal>

--- a/src/components/Reports/FinancialAccountsReport/AccountSummary/AccountSummary.tsx
+++ b/src/components/Reports/FinancialAccountsReport/AccountSummary/AccountSummary.tsx
@@ -98,7 +98,7 @@ export const AccountSummary: React.FC<AccountSummaryProps> = ({
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const router = useRouter();
   const { query } = router;
 

--- a/src/components/Reports/FinancialAccountsReport/Context/FinancialAccountsContext.tsx
+++ b/src/components/Reports/FinancialAccountsReport/Context/FinancialAccountsContext.tsx
@@ -33,7 +33,7 @@ interface FinancialAccountProviderProps {
 export const FinancialAccountProvider: React.FC<
   FinancialAccountProviderProps
 > = ({ children, financialAccountId }) => {
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
 
   const [designationAccounts, setDesignationAccounts] = useState<string[]>([]);
   const [panelOpen, setPanelOpen] = useState<Panel | null>(null);
@@ -58,7 +58,7 @@ export const FinancialAccountProvider: React.FC<
 
   const contextValue = useMemo(
     () => ({
-      accountListId: accountListId ?? '',
+      accountListId,
       financialAccountId,
       financialAccountQuery,
       isNavListOpen,

--- a/src/components/Settings/Organization/AccountLists/AccountListRow/AccountListRow.tsx
+++ b/src/components/Settings/Organization/AccountLists/AccountListRow/AccountListRow.tsx
@@ -177,7 +177,7 @@ export const AccountListRow: React.FC<AccountListRowProps> = ({
     await deleteAccountList({
       variables: {
         input: {
-          accountListId: accountListId,
+          accountListId,
           reason: reason,
         },
       },
@@ -219,7 +219,7 @@ export const AccountListRow: React.FC<AccountListRowProps> = ({
     await adminDeleteOrganizationCoach({
       variables: {
         input: {
-          accountListId: accountListId,
+          accountListId,
           coachId: item.id,
         },
       },
@@ -262,7 +262,7 @@ export const AccountListRow: React.FC<AccountListRowProps> = ({
     await removeAccountListUser({
       variables: {
         input: {
-          accountListId: accountListId,
+          accountListId,
           userId: item.userId,
         },
       },

--- a/src/components/Settings/integrations/Chalkline/ChalklineAccordion.test.tsx
+++ b/src/components/Settings/integrations/Chalkline/ChalklineAccordion.test.tsx
@@ -108,7 +108,7 @@ describe('PrayerlettersAccount', () => {
         'SendToChalkline',
       );
       expect(mutationSpy.mock.calls[0][0].operation.variables.input).toEqual({
-        accountListId: accountListId,
+        accountListId,
       });
     });
 

--- a/src/components/Settings/integrations/Chalkline/ChalklineAccordion.tsx
+++ b/src/components/Settings/integrations/Chalkline/ChalklineAccordion.tsx
@@ -33,7 +33,7 @@ export const ChalklineAccordion: React.FC<AccordionProps> = ({
     await sendToChalkline({
       variables: {
         input: {
-          accountListId: accountListId ?? '',
+          accountListId,
         },
       },
       onCompleted: () => {

--- a/src/components/Settings/integrations/Google/GoogleAccordion.test.tsx
+++ b/src/components/Settings/integrations/Google/GoogleAccordion.test.tsx
@@ -123,7 +123,7 @@ describe('GoogleAccordion', () => {
 
       expect(getByText(/continue/i)).toHaveAttribute(
         'href',
-        `https://auth.mpdx.org/auth/user/google?account_list_id=account-list-1&redirect_to=${encodeURIComponent(
+        `https://auth.mpdx.org/auth/user/google?redirect_to=${encodeURIComponent(
           `${window.location.origin}/accountLists/account-list-1/settings/integrations?selectedTab=google`,
         )}&access_token=apiToken`,
       );
@@ -224,7 +224,7 @@ describe('GoogleAccordion', () => {
 
         expect(getByText(/continue/i)).toHaveAttribute(
           'href',
-          `https://auth.mpdx.org/auth/user/google?account_list_id=account-list-1&redirect_to=${encodeURIComponent(
+          `https://auth.mpdx.org/auth/user/google?redirect_to=${encodeURIComponent(
             `${window.location.origin}/accountLists/account-list-1/settings/integrations?selectedTab=google`,
           )}&access_token=apiToken`,
         );

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.test.tsx
@@ -419,7 +419,7 @@ describe('EditGoogleAccountModal', () => {
       );
       expect(mutationSpy.mock.calls[1][0].operation.variables.input).toEqual({
         googleAccountId: googleAccount.id,
-        accountListId: accountListId,
+        accountListId,
         googleIntegration: {
           calendarIntegration: true,
         },

--- a/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.tsx
+++ b/src/components/Settings/integrations/Google/Modals/EditGoogleAccountModal.tsx
@@ -65,10 +65,9 @@ export const EditGoogleAccountModal: React.FC<EditGoogleAccountModalProps> = ({
     variables: {
       input: {
         googleAccountId: account.id,
-        accountListId: accountListId ?? '',
+        accountListId,
       },
     },
-    skip: !accountListId,
   });
 
   const googleAccountDetails = data?.googleAccountIntegrations[0];
@@ -91,7 +90,7 @@ export const EditGoogleAccountModal: React.FC<EditGoogleAccountModalProps> = ({
         variables: {
           input: {
             googleAccountId: account.id,
-            accountListId: accountListId ?? '',
+            accountListId,
             googleIntegration: {
               [`${tabSelected}Integration`]: enableIntegration,
             },

--- a/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.tsx
+++ b/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.tsx
@@ -400,7 +400,7 @@ export const MailchimpAccordion: React.FC<AccordionProps> = ({
       )}
       {showDeleteModal && (
         <DeleteMailchimpAccountModal
-          accountListId={accountListId || ''}
+          accountListId={accountListId}
           handleClose={handleDeleteModalClose}
           refetchMailchimpAccount={refetchMailchimpAccount}
           appName={appName || ''}

--- a/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.tsx
+++ b/src/components/Settings/integrations/Mailchimp/MailchimpAccordion.tsx
@@ -80,10 +80,9 @@ export const MailchimpAccordion: React.FC<AccordionProps> = ({
   } = useMailchimpAccountQuery({
     variables: {
       input: {
-        accountListId: accountListId ?? '',
+        accountListId,
       },
     },
-    skip: !accountListId,
   });
 
   const mailchimpAccount = data?.mailchimpAccount
@@ -96,7 +95,7 @@ export const MailchimpAccordion: React.FC<AccordionProps> = ({
     await updateMailchimpAccount({
       variables: {
         input: {
-          accountListId: accountListId ?? '',
+          accountListId,
           mailchimpAccount: attributes,
           mailchimpAccountId: mailchimpAccount?.id ?? '',
         },
@@ -136,7 +135,7 @@ export const MailchimpAccordion: React.FC<AccordionProps> = ({
     await syncMailchimpAccount({
       variables: {
         input: {
-          accountListId: accountListId ?? '',
+          accountListId,
         },
       },
     });

--- a/src/components/Settings/integrations/Mailchimp/Modals/DeleteMailchimpModal.tsx
+++ b/src/components/Settings/integrations/Mailchimp/Modals/DeleteMailchimpModal.tsx
@@ -32,7 +32,7 @@ export const DeleteMailchimpAccountModal: React.FC<
     await deleteMailchimpAccount({
       variables: {
         input: {
-          accountListId: accountListId,
+          accountListId,
         },
       },
       update: () => refetchMailchimpAccount(),

--- a/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
+++ b/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
@@ -331,7 +331,7 @@ describe('OrganizationAccordion', () => {
       });
 
       expect(window.location.assign).toHaveBeenCalledWith(
-        `https://auth.mpdx.org/auth/user/donorhub?account_list_id=account-list-1&redirect_to=${encodeURIComponent(
+        `https://auth.mpdx.org/auth/user/donorhub?redirect_to=${encodeURIComponent(
           `${window.location.origin}/accountLists/account-list-1/settings/integrations?selectedTab=organization`,
         )}&access_token=apiToken&organization_id=organizationId`,
       );

--- a/src/components/Settings/integrations/Organization/OrganizationAccordion.tsx
+++ b/src/components/Settings/integrations/Organization/OrganizationAccordion.tsx
@@ -345,7 +345,7 @@ export const OrganizationAccordion: React.FC<AccordionProps> = ({
           handleClose={() => setImportDataSyncModal(null)}
           organizationId={importDataSyncModal.id}
           organizationName={importDataSyncModal.organization.name}
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
         />
       )}
       {editOrganizationModal && (

--- a/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.test.tsx
+++ b/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.test.tsx
@@ -189,7 +189,7 @@ describe('PrayerlettersAccount', () => {
           'DeletePrayerlettersAccount',
         );
         expect(mutationSpy.mock.calls[1][0].operation.variables.input).toEqual({
-          accountListId: accountListId,
+          accountListId,
         });
       });
     });
@@ -252,7 +252,7 @@ describe('PrayerlettersAccount', () => {
           'DeletePrayerlettersAccount',
         );
         expect(mutationSpy.mock.calls[1][0].operation.variables.input).toEqual({
-          accountListId: accountListId,
+          accountListId,
         });
       });
     });
@@ -302,7 +302,7 @@ describe('PrayerlettersAccount', () => {
           'SyncPrayerlettersAccount',
         );
         expect(mutationSpy.mock.calls[1][0].operation.variables.input).toEqual({
-          accountListId: accountListId,
+          accountListId,
         });
       });
     });

--- a/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.tsx
+++ b/src/components/Settings/integrations/Prayerletters/PrayerlettersAccordion.tsx
@@ -37,7 +37,7 @@ export const PrayerlettersAccordion: React.FC<AccordionProps> = ({
   } = usePrayerlettersAccountQuery({
     variables: {
       input: {
-        accountListId: accountListId ?? '',
+        accountListId,
       },
     },
     skip: expandedAccordion !== IntegrationAccordion.Prayerletters,
@@ -53,7 +53,7 @@ export const PrayerlettersAccordion: React.FC<AccordionProps> = ({
     await syncPrayerlettersAccount({
       variables: {
         input: {
-          accountListId: accountListId ?? '',
+          accountListId,
         },
       },
       onError: () => {
@@ -199,7 +199,7 @@ export const PrayerlettersAccordion: React.FC<AccordionProps> = ({
       )}
       {showDeleteModal && (
         <DeletePrayerlettersAccountModal
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           handleClose={handleDeleteModal}
           refetchPrayerlettersAccount={refetchPrayerlettersAccount}
         />

--- a/src/components/Settings/integrations/useOauthUrl.test.tsx
+++ b/src/components/Settings/integrations/useOauthUrl.test.tsx
@@ -24,18 +24,54 @@ describe('useOauthUrl', () => {
     const { result } = renderUseOauthUrl();
 
     expect(result.current.getGoogleOauthUrl()).toBe(
-      `https://auth.mpdx.org/auth/user/google?account_list_id=${accountListId}&redirect_to=${encodeURIComponent(
+      `https://auth.mpdx.org/auth/user/google?redirect_to=${encodeURIComponent(
         `http://localhost/accountLists/${accountListId}/settings/integrations?selectedTab=${IntegrationAccordion.Google}`,
       )}&access_token=${apiToken}`,
     );
   });
 
-  it('includes the organization id in the DonorHub OAuth url', () => {
+  it('builds the Mailchimp OAuth url with the account list id and redirect', () => {
+    const { result } = renderUseOauthUrl();
+
+    expect(result.current.getMailChimpOauthUrl()).toBe(
+      `https://auth.mpdx.org/auth/user/mailchimp?account_list_id=${accountListId}&redirect_to=${encodeURIComponent(
+        `http://localhost/accountLists/${accountListId}/settings/integrations?selectedTab=${IntegrationAccordion.Mailchimp}`,
+      )}&access_token=${apiToken}`,
+    );
+  });
+
+  it('builds the organization OAuth url with the the organization, account list id, and redirect', () => {
     const { result } = renderUseOauthUrl();
 
     expect(result.current.getOrganizationOauthUrl('org-1')).toBe(
-      `https://auth.mpdx.org/auth/user/donorhub?account_list_id=${accountListId}&redirect_to=${encodeURIComponent(
+      `https://auth.mpdx.org/auth/user/donorhub?redirect_to=${encodeURIComponent(
         `http://localhost/accountLists/${accountListId}/settings/integrations?selectedTab=${IntegrationAccordion.Organization}`,
+      )}&access_token=${apiToken}&organization_id=org-1`,
+    );
+  });
+
+  it('builds the Prayer Letters OAuth url with the account list id and redirect', () => {
+    const { result } = renderUseOauthUrl();
+
+    expect(result.current.getPrayerlettersOauthUrl()).toBe(
+      `https://auth.mpdx.org/auth/user/prayer_letters?account_list_id=${accountListId}&redirect_to=${encodeURIComponent(
+        `http://localhost/accountLists/${accountListId}/settings/integrations?selectedTab=${IntegrationAccordion.Prayerletters}`,
+      )}&access_token=${apiToken}`,
+    );
+  });
+
+  it('redirects to the setup Connect page without an accountListId', () => {
+    const NoAccountListWrapper = ({ children }: PropsWithChildren) => (
+      <TestRouter router={{ query: {}, isReady: true }}>{children}</TestRouter>
+    );
+
+    const { result } = renderHook(() => useOauthUrl(), {
+      wrapper: NoAccountListWrapper,
+    });
+
+    expect(result.current.getOrganizationOauthUrl('org-1')).toBe(
+      `https://auth.mpdx.org/auth/user/donorhub?redirect_to=${encodeURIComponent(
+        'http://localhost/setup/connect',
       )}&access_token=${apiToken}&organization_id=org-1`,
     );
   });

--- a/src/components/Settings/integrations/useOauthUrl.ts
+++ b/src/components/Settings/integrations/useOauthUrl.ts
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 import { IntegrationAccordion } from 'src/components/Shared/Forms/Accordions/AccordionEnum';
-import { useAccountListId } from 'src/hooks/useAccountListId';
+import { useOptionalAccountListId } from 'src/hooks/useAccountListId';
 import { useRequiredSession } from 'src/hooks/useRequiredSession';
 
 export const useOauthUrl = () => {
   const { apiToken } = useRequiredSession();
-  const accountListId = useAccountListId();
+  // Optional because the setup Connect flow reuses ConnectOrganization on
+  // /setup/connect, which has no accountListId in the route.
+  const accountListId = useOptionalAccountListId();
 
   const [origin, setOrigin] = useState('');
   useEffect(() => {
@@ -14,13 +16,15 @@ export const useOauthUrl = () => {
 
   const getRedirectUrl = (accordion: IntegrationAccordion) =>
     encodeURIComponent(
-      `${origin}/accountLists/${accountListId}/settings/integrations?selectedTab=${accordion}`,
+      accountListId
+        ? `${origin}/accountLists/${accountListId}/settings/integrations?selectedTab=${accordion}`
+        : `${origin}/setup/connect`,
     );
 
   return {
     getGoogleOauthUrl: () =>
-      `${process.env.OAUTH_URL}/auth/user/google?account_list_id=${accountListId}` +
-      `&redirect_to=${getRedirectUrl(IntegrationAccordion.Google)}` +
+      `${process.env.OAUTH_URL}/auth/user/google` +
+      `?redirect_to=${getRedirectUrl(IntegrationAccordion.Google)}` +
       `&access_token=${apiToken}`,
 
     getMailChimpOauthUrl: () =>
@@ -29,8 +33,8 @@ export const useOauthUrl = () => {
       `&access_token=${apiToken}`,
 
     getOrganizationOauthUrl: (organizationId: string) =>
-      `${process.env.OAUTH_URL}/auth/user/donorhub?account_list_id=${accountListId}` +
-      `&redirect_to=${getRedirectUrl(IntegrationAccordion.Organization)}` +
+      `${process.env.OAUTH_URL}/auth/user/donorhub` +
+      `?redirect_to=${getRedirectUrl(IntegrationAccordion.Organization)}` +
       `&access_token=${apiToken}` +
       `&organization_id=${organizationId}`,
 

--- a/src/components/Settings/notifications/NotificationsTable.test.tsx
+++ b/src/components/Settings/notifications/NotificationsTable.test.tsx
@@ -171,7 +171,7 @@ describe('NotificationsTable', () => {
       );
 
       expect(mutationSpy.mock.calls[2][0].operation.variables.input).toEqual({
-        accountListId: accountListId,
+        accountListId,
         attributes: [
           {
             app: true,

--- a/src/components/Settings/notifications/NotificationsTable.tsx
+++ b/src/components/Settings/notifications/NotificationsTable.tsx
@@ -98,7 +98,7 @@ export const NotificationsTable: React.FC<NotificationsTableProps> = ({
   const { data: notificationsPreferences, loading } =
     useNotificationsPreferencesQuery({
       variables: {
-        accountListId: accountListId ?? '',
+        accountListId,
       },
     });
   const { data: notificationTypes } = useNotificationTypesQuery({
@@ -162,7 +162,7 @@ export const NotificationsTable: React.FC<NotificationsTableProps> = ({
     await updateNotifications({
       variables: {
         input: {
-          accountListId: accountListId ?? '',
+          accountListId,
           attributes,
         },
       },

--- a/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.test.tsx
+++ b/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.test.tsx
@@ -135,7 +135,7 @@ describe('Export All Data Accordion', () => {
             operationName: 'ExportData',
             variables: {
               input: {
-                accountListId: accountListId,
+                accountListId,
               },
             },
           },

--- a/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.tsx
+++ b/src/components/Settings/preferences/accordions/ExportAllDataAccordion/ExportAllDataAccordion.tsx
@@ -56,7 +56,7 @@ export const ExportAllDataAccordion: React.FC<ExportAllDataAccordionProps> = ({
     await exportData({
       variables: {
         input: {
-          accountListId: accountListId,
+          accountListId,
         },
       },
       onCompleted: () => {

--- a/src/components/Shared/EmptyDonationsTable/EmptyDonationsTable.tsx
+++ b/src/components/Shared/EmptyDonationsTable/EmptyDonationsTable.tsx
@@ -62,7 +62,7 @@ export const EmptyDonationsTable: React.FC<Props> = ({ title }) => {
         size="sm"
       >
         <DynamicAddDonation
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           handleClose={handleCloseAddDonation}
         />
       </Modal>

--- a/src/components/Shared/Filters/NullState/NullState.test.tsx
+++ b/src/components/Shared/Filters/NullState/NullState.test.tsx
@@ -35,6 +35,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
     router={{
       ...defaultRouter,
       query: {
+        accountListId: 'account-list-1',
         filters,
       },
     }}

--- a/src/components/Shared/Filters/SaveFilterModal/SaveFilterModal.test.tsx
+++ b/src/components/Shared/Filters/SaveFilterModal/SaveFilterModal.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider, gqlMock } from '__tests__/util/graphqlMocking';
 import theme from '../../../../theme';
 import {
@@ -24,8 +25,7 @@ jest.mock('notistack', () => ({
   },
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const useRouter = jest.spyOn(require('next/router'), 'useRouter');
+const accountListId = 'account-list-1';
 
 const handleClose = jest.fn();
 
@@ -79,23 +79,23 @@ const savedFiltersMock = gqlMock<UserOptionFragment>(UserOptionFragmentDoc, {
 describe('SaveFilterModal', () => {
   //#region SaveFilterModal | Contacts
   describe('Contacts', () => {
-    beforeEach(() => {
-      useRouter.mockReturnValue({
-        route: '/contacts',
-      });
-    });
     it('renders modal', () => {
       const { getByText } = render(
-        <ThemeProvider theme={theme}>
-          <GqlMockedProvider>
-            <SaveFilterModal
-              isOpen={true}
-              handleClose={handleClose}
-              currentFilters={currentFilters}
-              currentSavedFilters={[savedGraphQLContactMock, savedFiltersMock]}
-            />
-          </GqlMockedProvider>
-        </ThemeProvider>,
+        <TestRouter router={{ route: '/contacts' }}>
+          <ThemeProvider theme={theme}>
+            <GqlMockedProvider>
+              <SaveFilterModal
+                isOpen={true}
+                handleClose={handleClose}
+                currentFilters={currentFilters}
+                currentSavedFilters={[
+                  savedGraphQLContactMock,
+                  savedFiltersMock,
+                ]}
+              />
+            </GqlMockedProvider>
+          </ThemeProvider>
+        </TestRouter>,
       );
 
       expect(getByText('Save Filter')).toBeVisible();
@@ -103,16 +103,21 @@ describe('SaveFilterModal', () => {
 
     it('closes modal', () => {
       const { getByText, getByLabelText } = render(
-        <ThemeProvider theme={theme}>
-          <GqlMockedProvider>
-            <SaveFilterModal
-              isOpen={true}
-              handleClose={handleClose}
-              currentFilters={currentFilters}
-              currentSavedFilters={[savedGraphQLContactMock, savedFiltersMock]}
-            />
-          </GqlMockedProvider>
-        </ThemeProvider>,
+        <TestRouter router={{ route: '/contacts' }}>
+          <ThemeProvider theme={theme}>
+            <GqlMockedProvider>
+              <SaveFilterModal
+                isOpen={true}
+                handleClose={handleClose}
+                currentFilters={currentFilters}
+                currentSavedFilters={[
+                  savedGraphQLContactMock,
+                  savedFiltersMock,
+                ]}
+              />
+            </GqlMockedProvider>
+          </ThemeProvider>
+        </TestRouter>,
       );
 
       expect(getByText('Save Filter')).toBeVisible();
@@ -123,16 +128,21 @@ describe('SaveFilterModal', () => {
     it('saves filter', async () => {
       const mutationSpy = jest.fn();
       const { getByText, getByRole } = render(
-        <ThemeProvider theme={theme}>
-          <GqlMockedProvider onCall={mutationSpy}>
-            <SaveFilterModal
-              isOpen={true}
-              handleClose={handleClose}
-              currentFilters={currentFilters}
-              currentSavedFilters={[savedGraphQLContactMock, savedFiltersMock]}
-            />
-          </GqlMockedProvider>
-        </ThemeProvider>,
+        <TestRouter router={{ route: '/contacts' }}>
+          <ThemeProvider theme={theme}>
+            <GqlMockedProvider onCall={mutationSpy}>
+              <SaveFilterModal
+                isOpen={true}
+                handleClose={handleClose}
+                currentFilters={currentFilters}
+                currentSavedFilters={[
+                  savedGraphQLContactMock,
+                  savedFiltersMock,
+                ]}
+              />
+            </GqlMockedProvider>
+          </ThemeProvider>
+        </TestRouter>,
       );
 
       expect(getByText('Save Filter')).toBeVisible();
@@ -152,7 +162,7 @@ describe('SaveFilterModal', () => {
         'graphql_saved_contacts_filter_My_Cool_Filter_2',
       );
       expect(operation.variables.input.value).toEqual(
-        JSON.stringify(currentFilters),
+        JSON.stringify({ ...currentFilters, accountListId }),
       );
       expect(handleClose).toHaveBeenCalled();
     });
@@ -160,16 +170,21 @@ describe('SaveFilterModal', () => {
     it('asks if you want save filter when filter with same name already exists', async () => {
       const mutationSpy = jest.fn();
       const { getByText, getByRole } = render(
-        <ThemeProvider theme={theme}>
-          <GqlMockedProvider onCall={mutationSpy}>
-            <SaveFilterModal
-              isOpen={true}
-              handleClose={handleClose}
-              currentFilters={currentFilters}
-              currentSavedFilters={[savedGraphQLContactMock, savedFiltersMock]}
-            />
-          </GqlMockedProvider>
-        </ThemeProvider>,
+        <TestRouter router={{ route: '/contacts' }}>
+          <ThemeProvider theme={theme}>
+            <GqlMockedProvider onCall={mutationSpy}>
+              <SaveFilterModal
+                isOpen={true}
+                handleClose={handleClose}
+                currentFilters={currentFilters}
+                currentSavedFilters={[
+                  savedGraphQLContactMock,
+                  savedFiltersMock,
+                ]}
+              />
+            </GqlMockedProvider>
+          </ThemeProvider>
+        </TestRouter>,
       );
 
       expect(getByText('Save Filter')).toBeVisible();
@@ -197,7 +212,7 @@ describe('SaveFilterModal', () => {
         'graphql_saved_contacts_filter_My_Cool_Filter',
       );
       expect(operation.variables.input.value).toEqual(
-        JSON.stringify(currentFilters),
+        JSON.stringify({ ...currentFilters, accountListId }),
       );
       expect(handleClose).toHaveBeenCalled();
     });
@@ -206,24 +221,21 @@ describe('SaveFilterModal', () => {
 
   //#region SaveFilterModal | Tasks
   describe('Tasks', () => {
-    beforeEach(() => {
-      useRouter.mockReturnValue({
-        route: '/tasks',
-      });
-    });
     it('saves filter', async () => {
       const mutationSpy = jest.fn();
       const { getByText, getByRole } = render(
-        <ThemeProvider theme={theme}>
-          <GqlMockedProvider onCall={mutationSpy}>
-            <SaveFilterModal
-              isOpen={true}
-              handleClose={handleClose}
-              currentFilters={currentFilters}
-              currentSavedFilters={[savedGraphQLTaskMock, savedFiltersMock]}
-            />
-          </GqlMockedProvider>
-        </ThemeProvider>,
+        <TestRouter router={{ route: '/tasks' }}>
+          <ThemeProvider theme={theme}>
+            <GqlMockedProvider onCall={mutationSpy}>
+              <SaveFilterModal
+                isOpen={true}
+                handleClose={handleClose}
+                currentFilters={currentFilters}
+                currentSavedFilters={[savedGraphQLTaskMock, savedFiltersMock]}
+              />
+            </GqlMockedProvider>
+          </ThemeProvider>
+        </TestRouter>,
       );
 
       expect(getByText('Save Filter')).toBeVisible();
@@ -243,7 +255,7 @@ describe('SaveFilterModal', () => {
         'graphql_saved_tasks_filter_My_Cool_Filter_2',
       );
       expect(operation.variables.input.value).toEqual(
-        JSON.stringify(currentFilters),
+        JSON.stringify({ ...currentFilters, accountListId }),
       );
       expect(handleClose).toHaveBeenCalled();
     });
@@ -251,16 +263,18 @@ describe('SaveFilterModal', () => {
     it('asks if you want save filter when filter with same name already exists', async () => {
       const mutationSpy = jest.fn();
       const { getByText, getByRole } = render(
-        <ThemeProvider theme={theme}>
-          <GqlMockedProvider onCall={mutationSpy}>
-            <SaveFilterModal
-              isOpen={true}
-              handleClose={handleClose}
-              currentFilters={currentFilters}
-              currentSavedFilters={[savedGraphQLTaskMock, savedFiltersMock]}
-            />
-          </GqlMockedProvider>
-        </ThemeProvider>,
+        <TestRouter router={{ route: '/tasks' }}>
+          <ThemeProvider theme={theme}>
+            <GqlMockedProvider onCall={mutationSpy}>
+              <SaveFilterModal
+                isOpen={true}
+                handleClose={handleClose}
+                currentFilters={currentFilters}
+                currentSavedFilters={[savedGraphQLTaskMock, savedFiltersMock]}
+              />
+            </GqlMockedProvider>
+          </ThemeProvider>
+        </TestRouter>,
       );
 
       expect(getByText('Save Filter')).toBeVisible();
@@ -288,7 +302,7 @@ describe('SaveFilterModal', () => {
         'graphql_saved_tasks_filter_My_Cool_Filter',
       );
       expect(operation.variables.input.value).toEqual(
-        JSON.stringify(currentFilters),
+        JSON.stringify({ ...currentFilters, accountListId }),
       );
       expect(handleClose).toHaveBeenCalled();
     });

--- a/src/components/Shared/Header/ListHeader.test.tsx
+++ b/src/components/Shared/Header/ListHeader.test.tsx
@@ -32,7 +32,6 @@ const push = jest.fn();
 const replace = jest.fn();
 const mockEnqueue = jest.fn();
 
-jest.mock('src/hooks/useAccountListId');
 jest.mock('notistack', () => ({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore

--- a/src/components/Shared/MassActions/ContactsMassActionsDropdown.test.tsx
+++ b/src/components/Shared/MassActions/ContactsMassActionsDropdown.test.tsx
@@ -10,7 +10,6 @@ import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { ContactsWrapper } from 'pages/accountLists/[accountListId]/contacts/ContactsWrapper';
 import { AppealsWrapper } from 'pages/accountLists/[accountListId]/tools/appeals/AppealsWrapper';
 import { TaskModalEnum } from 'src/components/Task/Modal/TaskModal';
-import { useAccountListId } from 'src/hooks/useAccountListId';
 import theme from 'src/theme';
 import useTaskModal from '../../../hooks/useTaskModal';
 import { PageEnum, TableViewModeEnum } from '../Header/ListHeader';
@@ -22,7 +21,6 @@ const mockEnqueue = jest.fn();
 const openTaskModal = jest.fn();
 
 jest.mock('../../../hooks/useTaskModal');
-jest.mock('src/hooks/useAccountListId');
 
 jest.mock('notistack', () => ({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -62,7 +60,6 @@ describe('ContactsMassActionsDropdown', () => {
       openTaskModal,
       preloadTaskModal: jest.fn(),
     });
-    (useAccountListId as jest.Mock).mockReturnValue('123456789');
 
     massDeselectAll.mockClear();
   });

--- a/src/components/Shared/MassActions/ContactsMassActionsDropdown.tsx
+++ b/src/components/Shared/MassActions/ContactsMassActionsDropdown.tsx
@@ -75,7 +75,7 @@ export const ContactsMassActionsDropdown: React.FC<
 }) => {
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const { isOpen: contactPanelOpen } = useContactPanel();
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -108,7 +108,7 @@ export const ContactsMassActionsDropdown: React.FC<
   const hideContacts = async () => {
     await updateContacts({
       variables: {
-        accountListId: accountListId ?? '',
+        accountListId,
         attributes: selectedIds.map((id) => ({
           id,
           status: StatusEnum.NeverAsk,
@@ -297,14 +297,14 @@ export const ContactsMassActionsDropdown: React.FC<
 
       {openRemoveTagsModal && (
         <DynamicMassActionsRemoveTagsModal
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           ids={selectedIds}
           handleClose={() => setOpenRemoveTagsModal(false)}
         />
       )}
       {openAddTagsModal && (
         <DynamicMassActionsAddTagsModal
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           ids={selectedIds}
           handleClose={() => setOpenAddTagsModal(false)}
         />
@@ -312,21 +312,21 @@ export const ContactsMassActionsDropdown: React.FC<
       {addToAppealModalOpen && (
         <DynamicMassActionsAddToAppealModal
           ids={selectedIds}
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           handleClose={() => setAddToAppealModalOpen(false)}
         />
       )}
       {createAppealModalOpen && (
         <DynamicMassActionsCreateAppealModal
           ids={selectedIds}
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           handleClose={() => setCreateAppealModalOpen(false)}
         />
       )}
       {editFieldsModalOpen && (
         <DynamicMassActionsEditFieldsModal
           ids={selectedIds}
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           handleClose={() => setEditFieldsModalOpen(false)}
         />
       )}
@@ -341,14 +341,14 @@ export const ContactsMassActionsDropdown: React.FC<
       {exportsModalOpen && (
         <DynamicExportsModal
           ids={selectedIds}
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           handleClose={() => setExportsModalOpen(false)}
           openMailMergedLabelModal={() => setLabelModalOpen(true)}
         />
       )}
       {labelModalOpen && (
         <DynamicMailMergedLabelModal
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           ids={selectedIds}
           handleClose={() => setLabelModalOpen(false)}
         />
@@ -356,14 +356,14 @@ export const ContactsMassActionsDropdown: React.FC<
       {exportEmailsModalOpen && (
         <DynamicMassActionsExportEmailsModal
           ids={selectedIds}
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           handleClose={() => setExportEmailsModalOpen(false)}
         />
       )}
       {mergeModalOpen && (
         <DynamicMassActionsMergeModal
           ids={selectedIds}
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           handleClose={() => setMergeModalOpen(false)}
         />
       )}

--- a/src/components/Shared/MassActions/TasksMassActionsDropdown.test.tsx
+++ b/src/components/Shared/MassActions/TasksMassActionsDropdown.test.tsx
@@ -36,7 +36,6 @@ const mocks = {
   },
 };
 
-jest.mock('src/hooks/useAccountListId');
 jest.mock('notistack', () => ({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -205,24 +204,26 @@ describe('TasksMassActionsDropdown', () => {
   it('opens the more actions menu and clicks the add tags (tasks) action', async () => {
     const mutationSpy = jest.fn();
     const { queryByTestId, getByText, queryByText, getByRole } = render(
-      <ThemeProvider theme={theme}>
-        <GqlMockedProvider<{
-          GetTasksForAddingTags: GetTasksForAddingTagsQuery;
-        }>
-          mocks={mocks}
-          onCall={mutationSpy}
-        >
-          <LocalizationProvider dateAdapter={AdapterLuxon}>
-            <SnackbarProvider>
-              <TasksMassActionsDropdown
-                selectedIdCount={selectedIds?.length ?? 0}
-                selectedIds={selectedIds}
-                massDeselectAll={massDeselectAll}
-              />
-            </SnackbarProvider>
-          </LocalizationProvider>
-        </GqlMockedProvider>
-      </ThemeProvider>,
+      <TestRouter>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider<{
+            GetTasksForAddingTags: GetTasksForAddingTagsQuery;
+          }>
+            mocks={mocks}
+            onCall={mutationSpy}
+          >
+            <LocalizationProvider dateAdapter={AdapterLuxon}>
+              <SnackbarProvider>
+                <TasksMassActionsDropdown
+                  selectedIdCount={selectedIds?.length ?? 0}
+                  selectedIds={selectedIds}
+                  massDeselectAll={massDeselectAll}
+                />
+              </SnackbarProvider>
+            </LocalizationProvider>
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </TestRouter>,
     );
 
     expect(queryByText('Add Tag(s)')).not.toBeInTheDocument();
@@ -254,24 +255,26 @@ describe('TasksMassActionsDropdown', () => {
   it('opens the more actions menu and clicks the remove tags (tasks) action', async () => {
     const mutationSpy = jest.fn();
     const { queryByTestId, getByText, queryByText } = render(
-      <ThemeProvider theme={theme}>
-        <GqlMockedProvider<{
-          GetTasksForAddingTags: GetTasksForAddingTagsQuery;
-        }>
-          mocks={mocks}
-          onCall={mutationSpy}
-        >
-          <LocalizationProvider dateAdapter={AdapterLuxon}>
-            <SnackbarProvider>
-              <TasksMassActionsDropdown
-                selectedIdCount={selectedIds?.length ?? 0}
-                selectedIds={selectedIds}
-                massDeselectAll={massDeselectAll}
-              />
-            </SnackbarProvider>
-          </LocalizationProvider>
-        </GqlMockedProvider>
-      </ThemeProvider>,
+      <TestRouter>
+        <ThemeProvider theme={theme}>
+          <GqlMockedProvider<{
+            GetTasksForAddingTags: GetTasksForAddingTagsQuery;
+          }>
+            mocks={mocks}
+            onCall={mutationSpy}
+          >
+            <LocalizationProvider dateAdapter={AdapterLuxon}>
+              <SnackbarProvider>
+                <TasksMassActionsDropdown
+                  selectedIdCount={selectedIds?.length ?? 0}
+                  selectedIds={selectedIds}
+                  massDeselectAll={massDeselectAll}
+                />
+              </SnackbarProvider>
+            </LocalizationProvider>
+          </GqlMockedProvider>
+        </ThemeProvider>
+      </TestRouter>,
     );
 
     expect(queryByText('Remove Tag(s)')).not.toBeInTheDocument();

--- a/src/components/Shared/MassActions/TasksMassActionsDropdown.tsx
+++ b/src/components/Shared/MassActions/TasksMassActionsDropdown.tsx
@@ -43,7 +43,7 @@ export const TasksMassActionsDropdown: React.FC<
 > = ({ buttonGroup, selectedIdCount, massDeselectAll, selectedIds }) => {
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
@@ -70,7 +70,7 @@ export const TasksMassActionsDropdown: React.FC<
     const completedAt = DateTime.local().toISO();
     await updateTasksMutation({
       variables: {
-        accountListId: accountListId ?? '',
+        accountListId,
         attributes: selectedIds.map((id) => ({
           id,
           completedAt,
@@ -96,7 +96,7 @@ export const TasksMassActionsDropdown: React.FC<
     setDeleteTasksModalOpen(false);
     await deleteTasksMutation({
       variables: {
-        accountListId: accountListId ?? '',
+        accountListId,
         ids: selectedIds,
       },
       update: (cache) => {

--- a/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.tsx
@@ -124,7 +124,7 @@ export const MultiPageMenu: React.FC<Props & BoxProps> = ({
 
   const { data } = useGetDesignationAccountsQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
     },
     skip: !designationAccounts && !setDesignationAccounts,
   });

--- a/src/components/Task/Modal/Comments/Item/TaskModalCommentListItem.tsx
+++ b/src/components/Task/Modal/Comments/Item/TaskModalCommentListItem.tsx
@@ -66,7 +66,7 @@ const TaskModalCommentsListItem: React.FC<Props> = ({
   taskId,
 }: Props) => {
   const { t } = useTranslation();
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
   const [deleteComment] = useDeleteCommentMutation();
   const [updateComment] = useUpdateCommentMutation();
   const [editing, setEditing] = useState<boolean>(false);

--- a/src/components/Task/Modal/Form/Inputs/SuggestedContactStatus/SuggestedContactStatus.test.tsx
+++ b/src/components/Task/Modal/Form/Inputs/SuggestedContactStatus/SuggestedContactStatus.test.tsx
@@ -110,7 +110,7 @@ describe('SuggestedContactStatus', () => {
 
     await waitFor(() =>
       expect(mutationSpy).toHaveGraphqlOperation('ContactStatus', {
-        accountListId: accountListId,
+        accountListId,
         contactId: 'contact-1',
       }),
     );

--- a/src/components/Task/Modal/TaskModal.tsx
+++ b/src/components/Task/Modal/TaskModal.tsx
@@ -68,7 +68,7 @@ const TaskModal = ({
   const { t } = useTranslation();
   const { data, loading } = useGetTaskForTaskModalQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
       taskId: taskId ?? '',
       includeComments: view === TaskModalEnum.Comments,
     },

--- a/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanel.tsx
+++ b/src/components/Tool/Appeal/AppealDetails/AppealsMainPanel/AppealsMainPanel.tsx
@@ -16,10 +16,10 @@ export const AppealsMainPanel: React.FC = () => {
 
   const { data: appealInfo, loading: appealInfoLoading } = useAppealQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
       appealId: appealId ?? '',
     },
-    skip: !accountListId || !appealId,
+    skip: !appealId,
   });
 
   return (
@@ -32,7 +32,7 @@ export const AppealsMainPanel: React.FC = () => {
         />
       ) : viewMode === TableViewModeEnum.Flows ? (
         <DynamicContactFlow
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           appealInfo={appealInfo}
           appealInfoLoading={appealInfoLoading}
         />

--- a/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
+++ b/src/components/Tool/Appeal/AppealsContext/AppealsContext.tsx
@@ -110,7 +110,7 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
   tour,
   setTour,
 }) => {
-  const accountListId = useAccountListId() ?? '';
+  const accountListId = useAccountListId();
 
   const [listAppealStatus, setListAppealStatus] = useState<AppealStatusEnum>(
     AppealStatusEnum.Asked,
@@ -147,11 +147,10 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
 
   const contactsQueryResult = useAppealsContactsQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
       contactsFilters,
       first: 25,
     },
-    skip: !accountListId,
   });
 
   //#region Mass Actions
@@ -211,8 +210,7 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
   //#endregion
 
   const { data: filterData, loading: filtersLoading } = useContactFiltersQuery({
-    variables: { accountListId: accountListId ?? '' },
-    skip: !accountListId,
+    variables: { accountListId },
     context: {
       doNotBatch: true,
     },
@@ -222,7 +220,7 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
 
   const askedCountQueryResult = useContactsCountQuery({
     variables: {
-      accountListId: accountListId || '',
+      accountListId,
       contactsFilter: {
         ...defaultFilters,
         appealStatus: AppealStatusEnum.Asked,
@@ -233,7 +231,7 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
 
   const excludedCountQueryResult = useContactsCountQuery({
     variables: {
-      accountListId: accountListId || '',
+      accountListId,
       contactsFilter: {
         ...defaultFilters,
         appealStatus: AppealStatusEnum.Excluded,
@@ -244,7 +242,7 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
 
   const committedCountQueryResult = useContactsCountQuery({
     variables: {
-      accountListId: accountListId || '',
+      accountListId,
       contactsFilter: {
         ...defaultFilters,
         appealStatus: AppealStatusEnum.NotReceived,
@@ -255,7 +253,7 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
 
   const givenCountQueryResult = useContactsCountQuery({
     variables: {
-      accountListId: accountListId || '',
+      accountListId,
       contactsFilter: {
         ...defaultFilters,
         appealStatus: AppealStatusEnum.Processed,
@@ -266,7 +264,7 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
 
   const receivedCountQueryResult = useContactsCountQuery({
     variables: {
-      accountListId: accountListId || '',
+      accountListId,
       contactsFilter: {
         ...defaultFilters,
         appealStatus: AppealStatusEnum.ReceivedNotProcessed,
@@ -319,7 +317,7 @@ export const AppealsProvider: React.FC<AppealsContextProps> = ({
 
   const contextValue = useMemo(
     () => ({
-      accountListId: accountListId ?? '',
+      accountListId,
       contactsQueryResult,
       selectionType,
       isRowChecked,

--- a/src/components/Tool/Appeal/Flow/ContactFlowColumn/ContactFlowColumn.tsx
+++ b/src/components/Tool/Appeal/Flow/ContactFlowColumn/ContactFlowColumn.tsx
@@ -90,10 +90,10 @@ export const ContactFlowColumn: React.FC<Props> = ({
 
   const { data, loading, fetchMore } = useAppealsContactsQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
       contactsFilters,
     },
-    skip: !accountListId || !appealStatus,
+    skip: !appealStatus,
   });
 
   const { data: allContacts, previousData: allContactsPrevious } =
@@ -116,7 +116,7 @@ export const ContactFlowColumn: React.FC<Props> = ({
   const { data: excludedContacts } = useExcludedAppealContactsQuery({
     variables: {
       appealId: appealId ?? '',
-      accountListId: accountListId ?? '',
+      accountListId,
     },
     skip: appealStatus !== AppealStatusEnum.Excluded,
   });

--- a/src/components/Tool/Appeal/InitialPage/AppealsInitialPage.tsx
+++ b/src/components/Tool/Appeal/InitialPage/AppealsInitialPage.tsx
@@ -64,7 +64,7 @@ const AppealsInitialPage: React.FC = () => {
             md: 6,
           }}
         >
-          <Appeals accountListId={accountListId || ''} />
+          <Appeals accountListId={accountListId} />
         </Grid>
         <Grid
           size={{
@@ -83,7 +83,7 @@ const AppealsInitialPage: React.FC = () => {
                   })}
                 />
                 <CardContent>
-                  <AddAppealForm accountListId={accountListId || ''} />
+                  <AddAppealForm accountListId={accountListId} />
                 </CardContent>
               </Card>
             </Box>

--- a/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
+++ b/src/components/Tool/Appeal/List/AppealsListFilterPanel/AppealsListFilterPanel.tsx
@@ -228,14 +228,14 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
       {exportsModalOpen && (
         <DynamicExportsModal
           ids={selectedIds}
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           handleClose={handleExportModalClose}
           openMailMergedLabelModal={() => setLabelModalOpen(true)}
         />
       )}
       {labelModalOpen && (
         <DynamicMailMergedLabelModal
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           ids={selectedIds}
           handleClose={() => setLabelModalOpen(false)}
         />
@@ -243,7 +243,7 @@ export const AppealsListFilterPanel: React.FC<FilterPanelProps & BoxProps> = ({
       {exportEmailsModalOpen && (
         <DynamicMassActionsExportEmailsModal
           ids={selectedIds}
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           handleClose={() => setExportEmailsModalOpen(false)}
         />
       )}

--- a/src/components/Tool/Appeal/List/ContactsList/ContactsList.tsx
+++ b/src/components/Tool/Appeal/List/ContactsList/ContactsList.tsx
@@ -67,7 +67,7 @@ export const ContactsList: React.FC<ContactsListProps> = ({
   const { data: excludedContacts } = useExcludedAppealContactsQuery({
     variables: {
       appealId: appealId ?? '',
-      accountListId: accountListId ?? '',
+      accountListId,
     },
     skip: appealStatus !== AppealStatusEnum.Excluded,
   });

--- a/src/components/Tool/Appeal/Modals/AddAppealModal/AddAppealModal.tsx
+++ b/src/components/Tool/Appeal/Modals/AddAppealModal/AddAppealModal.tsx
@@ -75,7 +75,7 @@ export const AddAppealModal: React.FC<AddAppealModalProps> = ({
     <Modal isOpen={true} title={t('Add Appeal')} handleClose={handleClose}>
       <DialogContent dividers>
         <AddAppealForm
-          accountListId={accountListId ?? ''}
+          accountListId={accountListId}
           appealName={appealName}
           appealGoal={appealGoal}
           appealStatuses={appealStatuses}

--- a/src/components/Tool/Appeal/Modals/AddContactToAppealModal/AddContactToAppealModal.tsx
+++ b/src/components/Tool/Appeal/Modals/AddContactToAppealModal/AddContactToAppealModal.tsx
@@ -42,7 +42,7 @@ export const AddContactToAppealModal: React.FC<
 
   const { data } = useAppealContactsQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
       appealId: appealId ?? '',
     },
   });
@@ -61,7 +61,7 @@ export const AddContactToAppealModal: React.FC<
     await assignContactsToAppeal({
       variables: {
         input: {
-          accountListId: accountListId ?? '',
+          accountListId,
           attributes: {
             id: appealId,
             contactIds: [...existingContactIds, ...contactIds],
@@ -143,7 +143,7 @@ export const AddContactToAppealModal: React.FC<
                     </Alert>
                   )}
                   <ContactsAutocomplete
-                    accountListId={accountListId ?? ''}
+                    accountListId={accountListId}
                     value={contactIds}
                     onChange={(contactIds) => {
                       setFieldValue('contactIds', contactIds);

--- a/src/components/Tool/Appeal/Modals/AddExcludedContactModal/AddExcludedContactModal.tsx
+++ b/src/components/Tool/Appeal/Modals/AddExcludedContactModal/AddExcludedContactModal.tsx
@@ -36,7 +36,7 @@ export const AddExcludedContactModal: React.FC<
 
   const { data, loading } = useAppealContactsQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
       appealId: appealId ?? '',
     },
   });
@@ -54,7 +54,7 @@ export const AddExcludedContactModal: React.FC<
     await assignContactsToAppeal({
       variables: {
         input: {
-          accountListId: accountListId ?? '',
+          accountListId,
           attributes: {
             id: appealId,
             contactIds: [...existingContactIds, ...contactIds],

--- a/src/components/Tool/Appeal/Modals/DeleteAppealModal/DeleteAppealModal.tsx
+++ b/src/components/Tool/Appeal/Modals/DeleteAppealModal/DeleteAppealModal.tsx
@@ -49,7 +49,7 @@ export const DeleteAppealModal: React.FC<DeleteAppealModalProps> = ({
     await deleteAppeal({
       variables: {
         input: {
-          accountListId: accountListId,
+          accountListId,
           id: appealId,
         },
       },

--- a/src/components/Tool/Appeal/Modals/EditAppealHeaderInfoModal/EditAppealHeaderInfoModal.tsx
+++ b/src/components/Tool/Appeal/Modals/EditAppealHeaderInfoModal/EditAppealHeaderInfoModal.tsx
@@ -56,7 +56,7 @@ export const EditAppealHeaderInfoModal: React.FC<
     await UpdateAppeal({
       variables: {
         input: {
-          accountListId: accountListId ?? '',
+          accountListId,
           attributes: {
             id: appealInfo.id,
             name: attributes.name,

--- a/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
+++ b/src/components/Tool/Appeal/Modals/PledgeModal/PledgeModal.tsx
@@ -104,7 +104,7 @@ export const PledgeModal: React.FC<PledgeModalProps> = ({
       await createAccountListPledge({
         variables: {
           input: {
-            accountListId: accountListId ?? '',
+            accountListId,
             attributes: {
               appealId: appealId,
               contactId: contact.id,

--- a/src/components/Tool/Appeal/Modals/UpdateDonationsModal/UpdateDonationsModal.tsx
+++ b/src/components/Tool/Appeal/Modals/UpdateDonationsModal/UpdateDonationsModal.tsx
@@ -68,13 +68,13 @@ export const UpdateDonationsModal: React.FC<UpdateDonationsModalProps> = ({
 
   const { data: accountListData, loading: loadingAccountListData } =
     useAccountListCurrencyQuery({
-      variables: { accountListId: accountListId ?? '' },
+      variables: { accountListId },
     });
   const accountCurrency = accountListData?.accountList.currency || 'USD';
 
   const { data } = useGetContactDonationsQuery({
     variables: {
-      accountListId: accountListId ?? '',
+      accountListId,
       contactId: contact.id,
     },
   });
@@ -100,7 +100,7 @@ export const UpdateDonationsModal: React.FC<UpdateDonationsModalProps> = ({
   // TODO: sort donations on the server after https://jira.cru.org/browse/MPDX-7634 is implemented
   const variables: DonationTableQueryVariables = useMemo(
     () => ({
-      accountListId: accountListId ?? '',
+      accountListId,
       pageSize: paginationModel.pageSize,
       donorAccountIds,
     }),
@@ -206,7 +206,7 @@ export const UpdateDonationsModal: React.FC<UpdateDonationsModalProps> = ({
       await updateDonations({
         variables: {
           input: {
-            accountListId: accountListId ?? '',
+            accountListId,
             attributes: donationsAttributes,
           },
         },
@@ -259,7 +259,7 @@ export const UpdateDonationsModal: React.FC<UpdateDonationsModalProps> = ({
       await createAccountListPledge({
         variables: {
           input: {
-            accountListId: accountListId ?? '',
+            accountListId,
             attributes: {
               appealId: appealId,
               contactId: contact.id,

--- a/src/components/Tool/FixCommitmentInfo/Contact.test.tsx
+++ b/src/components/Tool/FixCommitmentInfo/Contact.test.tsx
@@ -6,11 +6,9 @@ import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { fireEvent, render } from '__tests__/util/testingLibraryReactMock';
 import { ContactPanelProvider } from 'src/components/Shared/ContactPanelProvider/ContactPanelProvider';
 import { PledgeFrequencyEnum, StatusEnum } from 'src/graphql/types.generated';
-import { useAccountListId } from 'src/hooks/useAccountListId';
 import theme from '../../../theme';
 import Contact from './Contact';
 
-jest.mock('src/hooks/useAccountListId');
 let testData = {
   id: 'tester-1',
   name: 'Tester 1',
@@ -74,7 +72,6 @@ const TestComponent = ({
 describe('FixCommitmentContact', () => {
   beforeEach(() => {
     handleShowModal.mockClear();
-    (useAccountListId as jest.Mock).mockReturnValue(accountListId);
   });
 
   it('default', async () => {

--- a/src/components/Tool/FixCommitmentInfo/Contact.test.tsx
+++ b/src/components/Tool/FixCommitmentInfo/Contact.test.tsx
@@ -38,7 +38,7 @@ const accountListId = 'accountListId';
 const router = {
   pathname:
     '/accountLists/[accountListId]/tools/fix/commitmentInfo/[[...contactId]]',
-  query: { accountListId: accountListId },
+  query: { accountListId },
   push: jest.fn(),
 };
 

--- a/src/components/Tool/FixEmailAddresses/EmailValidationForm.tsx
+++ b/src/components/Tool/FixEmailAddresses/EmailValidationForm.tsx
@@ -99,7 +99,7 @@ const EmailValidationForm = ({
     emailAddressesMutation({
       variables: {
         input: {
-          accountListId: accountListId ?? '',
+          accountListId,
           attributes: {
             id: personId,
             emailAddresses: [
@@ -115,7 +115,7 @@ const EmailValidationForm = ({
         const query = {
           query: GetInvalidEmailAddressesDocument,
           variables: {
-            accountListId: accountListId,
+            accountListId,
           },
         };
         const dataFromCache =

--- a/src/components/Tool/FixEmailAddresses/FixEmailAddresses.test.tsx
+++ b/src/components/Tool/FixEmailAddresses/FixEmailAddresses.test.tsx
@@ -203,7 +203,7 @@ describe('FixEmailAddresses-Home', () => {
     );
     expect(mutationSpy).toHaveGraphqlOperation('EmailAddresses', {
       input: {
-        accountListId: accountListId,
+        accountListId,
         attributes: {
           id: 'testid',
           emailAddresses: [{ email: newEmail.email }],

--- a/src/components/Tool/FixPhoneNumbers/Contact.tsx
+++ b/src/components/Tool/FixPhoneNumbers/Contact.tsx
@@ -190,7 +190,7 @@ const Contact: React.FC<Props> = ({ person, submitAll, accountListId }) => {
     await updatePhoneNumber({
       variables: {
         input: {
-          accountListId: accountListId ?? '',
+          accountListId,
           attributes: {
             id: personId,
             phoneNumbers: [

--- a/src/components/Tool/FixPhoneNumbers/PhoneNumberValidationForm.tsx
+++ b/src/components/Tool/FixPhoneNumbers/PhoneNumberValidationForm.tsx
@@ -97,7 +97,7 @@ const PhoneValidationForm = ({
     UpdatePhoneNumber({
       variables: {
         input: {
-          accountListId: accountListId ?? '',
+          accountListId,
           attributes: {
             id: personId,
             phoneNumbers: [
@@ -113,7 +113,7 @@ const PhoneValidationForm = ({
         const query = {
           query: GetInvalidPhoneNumbersDocument,
           variables: {
-            accountListId: accountListId,
+            accountListId,
           },
         };
         const dataFromCache =

--- a/src/components/Tool/FixSendNewsletter/FixSendNewsletter.tsx
+++ b/src/components/Tool/FixSendNewsletter/FixSendNewsletter.tsx
@@ -99,7 +99,7 @@ const FixSendNewsletter: React.FC<Props> = ({ accountListId }: Props) => {
     }
     await updateContacts({
       variables: {
-        accountListId: accountListId ?? '',
+        accountListId,
         attributes: contactUpdates.map((contact) => ({
           id: contact.id,
           sendNewsletter: contact.sendNewsletter,

--- a/src/components/Tool/Home/ToolsHome.tsx
+++ b/src/components/Tool/Home/ToolsHome.tsx
@@ -44,8 +44,7 @@ const ToolsHome: React.FC<ToolHomeProps> = ({ onSetupTour }): ReactElement => {
   const accountListId = useAccountListId();
 
   const { data, loading } = useGetToolNotificationsQuery({
-    variables: { accountListId: accountListId ?? '' },
-    skip: !accountListId,
+    variables: { accountListId },
   });
 
   const toolDataTotalCount: { [key: string]: number } = {

--- a/src/components/Tool/Import/Csv/CsvImportWrapper.test.tsx
+++ b/src/components/Tool/Import/Csv/CsvImportWrapper.test.tsx
@@ -11,10 +11,8 @@ import {
 } from 'src/components/Tool/Import/Csv/CsvImportContext';
 import { CsvImportWrapper } from 'src/components/Tool/Import/Csv/CsvImportWrapper';
 import { get } from 'src/components/Tool/Import/Csv/csvImportService';
-import { useAccountListId } from 'src/hooks/useAccountListId';
 import theme from 'src/theme';
 
-jest.mock('src/hooks/useAccountListId');
 jest.mock('src/components/Constants/UseApiConstants');
 jest.mock('src/components/Tool/Import/Csv/csvImportService');
 
@@ -45,7 +43,6 @@ const t = (message: string) => message;
 
 describe('CsvImportWrapper', () => {
   beforeEach(() => {
-    (useAccountListId as jest.Mock).mockReturnValue(accountListId);
     (useApiConstants as jest.Mock).mockReturnValue(constants);
     (get as jest.Mock).mockReturnValue(Promise.resolve({ id: 'from-get' }));
   });

--- a/src/components/Tool/MergePeople/MergePeople.test.tsx
+++ b/src/components/Tool/MergePeople/MergePeople.test.tsx
@@ -8,7 +8,6 @@ import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { ContactPanelProvider } from 'src/components/Shared/ContactPanelProvider/ContactPanelProvider';
 import { TypeEnum } from 'src/graphql/types.generated';
-import { useAccountListId } from 'src/hooks/useAccountListId';
 import theme from 'src/theme';
 import { GetPersonDuplicatesQuery } from './GetPersonDuplicates.generated';
 import MergePeople from './MergePeople';
@@ -22,7 +21,6 @@ const router = {
 
 const mockEnqueue = jest.fn();
 
-jest.mock('src/hooks/useAccountListId');
 jest.mock('notistack', () => ({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -221,8 +219,6 @@ describe('Tools - MergePeople', () => {
   });
 
   it('should render link with correct href', async () => {
-    (useAccountListId as jest.Mock).mockReturnValue(accountListId);
-
     const { findByRole } = render(<MergePeopleWrapper />);
 
     const contactName = await findByRole('link', {

--- a/src/components/Tool/NavToolList/NavToolList.tsx
+++ b/src/components/Tool/NavToolList/NavToolList.tsx
@@ -54,8 +54,7 @@ const NavToolList = ({ selectedId, isOpen, toggle }: Props): ReactElement => {
   const { t } = useTranslation();
   const accountListId = useAccountListId();
   const { data, loading } = useGetToolNotificationsQuery({
-    variables: { accountListId: accountListId ?? '' },
-    skip: !accountListId,
+    variables: { accountListId },
   });
 
   const toolsItems = useToolsNavItems();

--- a/src/hooks/useAccountListId.test.tsx
+++ b/src/hooks/useAccountListId.test.tsx
@@ -17,7 +17,7 @@ describe('useOptionalAccountListId', () => {
       wrapper: makeWrapper({ isReady: false, query: {} }),
     });
 
-    expect(result.current).toBeFalsy();
+    expect(result.current).toBeNull();
   });
 
   it('returns null when the route has no accountListId', () => {
@@ -25,7 +25,7 @@ describe('useOptionalAccountListId', () => {
       wrapper: makeWrapper({ isReady: true, query: {} }),
     });
 
-    expect(result.current).toBeFalsy();
+    expect(result.current).toBeNull();
   });
 
   it('returns the accountListId from the route', () => {

--- a/src/hooks/useAccountListId.test.tsx
+++ b/src/hooks/useAccountListId.test.tsx
@@ -60,7 +60,7 @@ describe('useAccountListId', () => {
     ).toThrow(/accountListId/);
   });
 
-  it('throws when the route has no blank accountListId', () => {
+  it('throws when the route has a blank accountListId', () => {
     expect(() =>
       renderHook(() => useAccountListId(), {
         wrapper: makeWrapper({ isReady: true, query: { accountListId: '' } }),

--- a/src/hooks/useAccountListId.test.tsx
+++ b/src/hooks/useAccountListId.test.tsx
@@ -1,0 +1,70 @@
+import { NextRouter } from 'next/router';
+import React, { ReactNode } from 'react';
+import { renderHook } from '@testing-library/react';
+import TestRouter from '__tests__/util/TestRouter';
+import { useAccountListId, useOptionalAccountListId } from './useAccountListId';
+
+const makeWrapper = (router: Partial<NextRouter>) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <TestRouter router={router}>{children}</TestRouter>
+  );
+  return Wrapper;
+};
+
+describe('useOptionalAccountListId', () => {
+  it('returns null while the router is not ready', () => {
+    const { result } = renderHook(() => useOptionalAccountListId(), {
+      wrapper: makeWrapper({ isReady: false, query: {} }),
+    });
+
+    expect(result.current).toBeFalsy();
+  });
+
+  it('returns null when the route has no accountListId', () => {
+    const { result } = renderHook(() => useOptionalAccountListId(), {
+      wrapper: makeWrapper({ isReady: true, query: {} }),
+    });
+
+    expect(result.current).toBeFalsy();
+  });
+
+  it('returns the accountListId from the route', () => {
+    const { result } = renderHook(() => useOptionalAccountListId(), {
+      wrapper: makeWrapper({
+        isReady: true,
+        query: { accountListId: 'account-list-1' },
+      }),
+    });
+
+    expect(result.current).toBe('account-list-1');
+  });
+});
+
+describe('useAccountListId', () => {
+  it('returns the accountListId from the route', () => {
+    const { result } = renderHook(() => useAccountListId(), {
+      wrapper: makeWrapper({
+        isReady: true,
+        query: { accountListId: 'account-list-1' },
+      }),
+    });
+
+    expect(result.current).toBe('account-list-1');
+  });
+
+  it('throws when the route has no accountListId', () => {
+    expect(() =>
+      renderHook(() => useAccountListId(), {
+        wrapper: makeWrapper({ isReady: true, query: {} }),
+      }),
+    ).toThrow(/accountListId/);
+  });
+
+  it('throws while the router is not ready', () => {
+    expect(() =>
+      renderHook(() => useAccountListId(), {
+        wrapper: makeWrapper({ isReady: false, query: {} }),
+      }),
+    ).toThrow(/accountListId/);
+  });
+});

--- a/src/hooks/useAccountListId.test.tsx
+++ b/src/hooks/useAccountListId.test.tsx
@@ -60,6 +60,14 @@ describe('useAccountListId', () => {
     ).toThrow(/accountListId/);
   });
 
+  it('throws when the route has no blank accountListId', () => {
+    expect(() =>
+      renderHook(() => useAccountListId(), {
+        wrapper: makeWrapper({ isReady: true, query: { accountListId: '' } }),
+      }),
+    ).toThrow(/accountListId/);
+  });
+
   it('throws while the router is not ready', () => {
     expect(() =>
       renderHook(() => useAccountListId(), {

--- a/src/hooks/useAccountListId.ts
+++ b/src/hooks/useAccountListId.ts
@@ -1,12 +1,37 @@
 import { useRouter } from 'next/router';
 import { getQueryParam } from 'src/lib/queryParam';
 
-export const useAccountListId = (): string | undefined => {
+/**
+ * Read the accountListId from the route. Returns null until the router is
+ * ready or when the current route has no accountListId param (e.g. the account
+ * list chooser or the setup flow). Only use this on pages that may render
+ * without an accountListId; everywhere else prefer useAccountListId.
+ */
+export const useOptionalAccountListId = (): string | null => {
   const router = useRouter();
 
   if (!router.isReady) {
-    return undefined;
+    return null;
   }
 
-  return getQueryParam(router.query, 'accountListId');
+  return getQueryParam(router.query, 'accountListId') ?? null;
+};
+
+/**
+ * Read the accountListId from the route, throwing if it is missing. Use this on
+ * pages nested under an [accountListId] route (all of which use
+ * getServerSideProps, so the router is ready on the first render and the param
+ * is always present). On pages that may render without an accountListId, use
+ * useOptionalAccountListId instead.
+ */
+export const useAccountListId = (): string => {
+  const accountListId = useOptionalAccountListId();
+
+  if (accountListId === null) {
+    throw new Error(
+      'useAccountListId was called on a route without an accountListId param. Use useOptionalAccountListId for pages that can render without one.',
+    );
+  }
+
+  return accountListId;
 };

--- a/src/hooks/useAccountListId.ts
+++ b/src/hooks/useAccountListId.ts
@@ -27,7 +27,7 @@ export const useOptionalAccountListId = (): string | null => {
 export const useAccountListId = (): string => {
   const accountListId = useOptionalAccountListId();
 
-  if (accountListId === null) {
+  if (!accountListId) {
     throw new Error(
       'useAccountListId was called on a route without an accountListId param. Use useOptionalAccountListId for pages that can render without one.',
     );


### PR DESCRIPTION
## Description

Make `useAccountListId` hook return `string` instead of `string | undefined` since most pages have an account list id. Have special logic guards for setup pages with an account list id.

Removing `account_list_id` from Google and organization OAuth URLs is intentional because the API doesn't use them.

## Testing

- Go to `/setup/connect`
- Add a new organization
- Check that there are no errors

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
