### PR TITLE
MPDX-9838 Add HR Tools and partner reminders to prod

### DIFF
--- a/pages/accountLists/[accountListId]/hrTools/partnerReminders/index.page.test.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/partnerReminders/index.page.test.tsx
@@ -18,7 +18,7 @@ const mutationSpy = jest.fn();
 
 interface ComponentProps {
   userType?: UserTypeEnum;
-  staffAccountId?: string;
+  staffAccountId?: string | null;
 }
 
 const Components: React.FC<ComponentProps> = ({
@@ -76,33 +76,25 @@ describe('Partner Reminders Report Page', () => {
   });
 
   it('renders even though there is no staff account', async () => {
-    const mockNoStaffAccount = {
-      GetUser: {
-        user: {
-          staffAccountId: null,
-        },
-      },
-    };
-
     const { findByRole } = render(
-      <ThemeProvider theme={theme}>
-        <SnackbarProvider>
-          <TestRouter>
-            <GqlMockedProvider<{
-              GetUser: GetUserQuery;
-            }>
-              mocks={mockNoStaffAccount}
-              onCall={mutationSpy}
-            >
-              <PartnerRemindersReportPage />
-            </GqlMockedProvider>
-          </TestRouter>
-        </SnackbarProvider>
-      </ThemeProvider>,
+      <Components userType={UserTypeEnum.UsStaff} staffAccountId={null} />,
     );
 
     expect(
       await findByRole('heading', { name: /online reminder system/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders limited access page when user group is not US or hybrid staff', async () => {
+    const { findByText, getByText } = render(
+      <Components userType={UserTypeEnum.GlobalStaff} staffAccountId={null} />,
+    );
+
+    expect(
+      await findByText(/access to this feature is limited/i),
+    ).toBeInTheDocument();
+    expect(
+      getByText(/our records show that you are not part of the user group/i),
     ).toBeInTheDocument();
   });
 

--- a/pages/accountLists/[accountListId]/hrTools/partnerReminders/index.page.tsx
+++ b/pages/accountLists/[accountListId]/hrTools/partnerReminders/index.page.tsx
@@ -10,6 +10,7 @@ import {
   MultiPageMenu,
   NavTypeEnum,
 } from 'src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu';
+import { UserTypeAccess } from 'src/components/Shared/UserTypeAccess/UserTypeAccess';
 import { getAppName } from 'src/lib/getAppName';
 
 const PartnerRemindersReportPageWrapper = styled(Box)(({ theme }) => ({
@@ -31,28 +32,30 @@ const PartnerRemindersReportPage: React.FC = () => {
       <Head>
         <title>{`${appName} | ${t('HR Tools | Ministry Partner Reminders')}`}</title>
       </Head>
-      <PartnerRemindersReportPageWrapper>
-        <SidePanelsLayout
-          isScrollBox={false}
-          leftPanel={
-            <MultiPageMenu
-              isOpen={isNavListOpen}
-              selectedId="partnerReminders"
-              onClose={handleNavListToggle}
-              navType={NavTypeEnum.HrTools}
-            />
-          }
-          leftOpen={isNavListOpen}
-          leftWidth="290px"
-          mainContent={
-            <PartnerRemindersReport
-              isNavListOpen={isNavListOpen}
-              onNavListToggle={handleNavListToggle}
-              title={t('Ministry Partner Reminders')}
-            />
-          }
-        />
-      </PartnerRemindersReportPageWrapper>
+      <UserTypeAccess>
+        <PartnerRemindersReportPageWrapper>
+          <SidePanelsLayout
+            isScrollBox={false}
+            leftPanel={
+              <MultiPageMenu
+                isOpen={isNavListOpen}
+                selectedId="partnerReminders"
+                onClose={handleNavListToggle}
+                navType={NavTypeEnum.HrTools}
+              />
+            }
+            leftOpen={isNavListOpen}
+            leftWidth="290px"
+            mainContent={
+              <PartnerRemindersReport
+                isNavListOpen={isNavListOpen}
+                onNavListToggle={handleNavListToggle}
+                title={t('Ministry Partner Reminders')}
+              />
+            }
+          />
+        </PartnerRemindersReportPageWrapper>
+      </UserTypeAccess>
     </>
   );
 };

--- a/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
+++ b/src/components/Layouts/Primary/TopBar/Items/NavMenu/NavMenu.test.tsx
@@ -123,7 +123,7 @@ describe('NavMenu', () => {
   });
 
   it('renders HR Tools submenu items', async () => {
-    const { findByRole, getByRole, getByTestId, queryByRole } = render(
+    const { findByRole, getByRole, getByTestId } = render(
       <TestComponent
         mocks={{
           ...defaultMocks,
@@ -154,8 +154,8 @@ describe('NavMenu', () => {
       getByRole('menuitem', { name: 'Additional Salary Request' }),
     ).toBeInTheDocument();
     expect(
-      queryByRole('menuitem', { name: 'Ministry Partner Reminders' }),
-    ).not.toBeInTheDocument();
+      getByRole('menuitem', { name: 'Ministry Partner Reminders' }),
+    ).toBeInTheDocument();
   });
 
   it('renders MPDX Tools submenu items', async () => {
@@ -196,11 +196,17 @@ describe('NavMenu', () => {
     expect(getByTestId('appeals-false')).toBeInTheDocument();
   });
 
-  it('does not render new reports when user type not verified', async () => {
-    const { queryByRole } = render(
+  it('shows only Partner Reminders in HR Tools when user type not verified', async () => {
+    const { findByRole, getByRole, getByTestId, queryByRole } = render(
       <TestComponent
         mocks={{
           ...defaultMocks,
+          GetUser: {
+            user: {
+              userType: UserTypeEnum.UsStaff,
+              usStaffGroup: UsStaffGroupEnum.SeniorStaff,
+            },
+          },
           UserOption: {
             userOption: {
               value: '',
@@ -210,11 +216,20 @@ describe('NavMenu', () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(
-        queryByRole('menuitem', { name: 'HR Tools' }),
-      ).not.toBeInTheDocument();
-    });
+    await findByRole('menuitem', { name: 'HR Tools' });
+    userEvent.click(getByTestId('HrToolsMenuToggle'));
+
+    // Partner Reminders is live regardless of verification, so the tab still shows
+    expect(
+      getByRole('menuitem', { name: 'Ministry Partner Reminders' }),
+    ).toBeInTheDocument();
+
+    expect(
+      queryByRole('menuitem', { name: 'Salary Calculation Form' }),
+    ).not.toBeInTheDocument();
+    expect(
+      queryByRole('menuitem', { name: 'MPD Goal Calculator' }),
+    ).not.toBeInTheDocument();
   });
 
   it('does not show coaching link if there are no coaching accounts', async () => {

--- a/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
+++ b/src/components/Shared/MultiPageLayout/MultiPageMenu/MultiPageMenu.test.tsx
@@ -513,13 +513,21 @@ describe('MultiPageMenu', () => {
       const { findByText, getByText, queryByText } = render(
         <ThemeProvider theme={theme}>
           <TestRouter router={router}>
-            <GqlMockedProvider<{ GetUser: GetUserQuery }>
+            <GqlMockedProvider<{
+              GetUser: GetUserQuery;
+              UserOption: UserOptionQuery;
+            }>
               mocks={{
                 GetUser: {
                   user: {
                     userType: UserTypeEnum.UsStaff,
                     usStaffGroup: UsStaffGroupEnum.SeniorStaff,
                     staffAccountId: '12345',
+                  },
+                },
+                UserOption: {
+                  userOption: {
+                    value: 'true',
                   },
                 },
               }}
@@ -542,25 +550,32 @@ describe('MultiPageMenu', () => {
       expect(getByText('MPD Goal Calculator')).toBeInTheDocument();
       expect(getByText('MHA Calculation Tool')).toBeInTheDocument();
       expect(getByText('Additional Salary Request')).toBeInTheDocument();
+      expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
       expect(
         queryByText('Paid with Designation Support Goal Calculator'),
       ).not.toBeInTheDocument();
       expect(queryByText('New Staff Goal Calculator')).not.toBeInTheDocument();
-
-      expect(queryByText('Ministry Partner Reminders')).not.toBeInTheDocument();
     });
 
     it('shows hr tools for new staff', async () => {
       const { findByText, getByText, queryByText } = render(
         <ThemeProvider theme={theme}>
           <TestRouter router={router}>
-            <GqlMockedProvider<{ GetUser: GetUserQuery }>
+            <GqlMockedProvider<{
+              GetUser: GetUserQuery;
+              UserOption: UserOptionQuery;
+            }>
               mocks={{
                 GetUser: {
                   user: {
                     userType: UserTypeEnum.UsStaff,
                     usStaffGroup: UsStaffGroupEnum.NewStaff,
                     staffAccountId: '12345',
+                  },
+                },
+                UserOption: {
+                  userOption: {
+                    value: 'true',
                   },
                 },
               }}
@@ -584,24 +599,31 @@ describe('MultiPageMenu', () => {
       expect(getByText('New Staff Goal Calculator')).toBeInTheDocument();
       expect(queryByText('MPD Goal Calculator')).not.toBeInTheDocument();
       expect(queryByText('MHA Calculation Tool')).not.toBeInTheDocument();
+      expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
       expect(
         queryByText('Paid with Designation Support Goal Calculator'),
       ).not.toBeInTheDocument();
-
-      expect(queryByText('Ministry Partner Reminders')).not.toBeInTheDocument();
     });
 
     it('shows hr tools for national expat staff', async () => {
       const { findByText, getByText, queryByText } = render(
         <ThemeProvider theme={theme}>
           <TestRouter router={router}>
-            <GqlMockedProvider<{ GetUser: GetUserQuery }>
+            <GqlMockedProvider<{
+              GetUser: GetUserQuery;
+              UserOption: UserOptionQuery;
+            }>
               mocks={{
                 GetUser: {
                   user: {
                     userType: UserTypeEnum.UsStaff,
                     usStaffGroup: UsStaffGroupEnum.NationalExpat,
                     staffAccountId: '12345',
+                  },
+                },
+                UserOption: {
+                  userOption: {
+                    value: 'true',
                   },
                 },
               }}
@@ -624,25 +646,32 @@ describe('MultiPageMenu', () => {
       expect(queryByText('MPD Goal Calculator')).not.toBeInTheDocument();
       expect(getByText('MHA Calculation Tool')).toBeInTheDocument();
       expect(getByText('Additional Salary Request')).toBeInTheDocument();
+      expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
       expect(
         queryByText('Paid with Designation Support Goal Calculator'),
       ).not.toBeInTheDocument();
       expect(queryByText('New Staff Goal Calculator')).not.toBeInTheDocument();
-
-      expect(queryByText('Ministry Partner Reminders')).not.toBeInTheDocument();
     });
 
     it('shows hr tools for paid with designation', async () => {
-      const { findByText, queryByText } = render(
+      const { findByText, queryByText, getByText } = render(
         <ThemeProvider theme={theme}>
           <TestRouter router={router}>
-            <GqlMockedProvider<{ GetUser: GetUserQuery }>
+            <GqlMockedProvider<{
+              GetUser: GetUserQuery;
+              UserOption: UserOptionQuery;
+            }>
               mocks={{
                 GetUser: {
                   user: {
                     userType: UserTypeEnum.UsStaff,
                     usStaffGroup: UsStaffGroupEnum.PaidWithDesignation,
                     staffAccountId: null,
+                  },
+                },
+                UserOption: {
+                  userOption: {
+                    value: 'true',
                   },
                 },
               }}
@@ -663,26 +692,34 @@ describe('MultiPageMenu', () => {
       expect(
         await findByText('Paid with Designation Support Goal Calculator'),
       ).toBeInTheDocument();
+      expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
       expect(queryByText('Salary Calculation Form')).not.toBeInTheDocument();
       expect(queryByText('Additional Salary Request')).not.toBeInTheDocument();
       expect(queryByText('Savings Fund Transfer')).not.toBeInTheDocument();
       expect(queryByText('MPD Goal Calculator')).not.toBeInTheDocument();
       expect(queryByText('MHA Calculation Tool')).not.toBeInTheDocument();
       expect(queryByText('New Staff Goal Calculator')).not.toBeInTheDocument();
-      expect(queryByText('Ministry Partner Reminders')).not.toBeInTheDocument();
     });
 
     it('shows hr tools for part time field staff', async () => {
-      const { findByText, queryByText } = render(
+      const { findByText, queryByText, getByText } = render(
         <ThemeProvider theme={theme}>
           <TestRouter router={router}>
-            <GqlMockedProvider<{ GetUser: GetUserQuery }>
+            <GqlMockedProvider<{
+              GetUser: GetUserQuery;
+              UserOption: UserOptionQuery;
+            }>
               mocks={{
                 GetUser: {
                   user: {
                     userType: UserTypeEnum.UsStaff,
                     usStaffGroup: UsStaffGroupEnum.PartTimeFieldStaff,
                     staffAccountId: '12345',
+                  },
+                },
+                UserOption: {
+                  userOption: {
+                    value: 'true',
                   },
                 },
               }}
@@ -701,7 +738,7 @@ describe('MultiPageMenu', () => {
       );
 
       expect(await findByText('Savings Fund Transfer')).toBeInTheDocument();
-      expect(queryByText('Ministry Partner Reminders')).not.toBeInTheDocument();
+      expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
       expect(
         queryByText('Paid with Designation Support Goal Calculator'),
       ).not.toBeInTheDocument();
@@ -713,16 +750,24 @@ describe('MultiPageMenu', () => {
     });
 
     it('shows hr tools for interns', async () => {
-      const { findByText, queryByText } = render(
+      const { findByText, queryByText, getByText } = render(
         <ThemeProvider theme={theme}>
           <TestRouter router={router}>
-            <GqlMockedProvider<{ GetUser: GetUserQuery }>
+            <GqlMockedProvider<{
+              GetUser: GetUserQuery;
+              UserOption: UserOptionQuery;
+            }>
               mocks={{
                 GetUser: {
                   user: {
                     userType: UserTypeEnum.UsStaff,
                     usStaffGroup: UsStaffGroupEnum.Intern,
                     staffAccountId: '12345',
+                  },
+                },
+                UserOption: {
+                  userOption: {
+                    value: 'true',
                   },
                 },
               }}
@@ -741,7 +786,7 @@ describe('MultiPageMenu', () => {
       );
 
       expect(await findByText('Savings Fund Transfer')).toBeInTheDocument();
-      expect(queryByText('Ministry Partner Reminders')).not.toBeInTheDocument();
+      expect(getByText('Ministry Partner Reminders')).toBeInTheDocument();
       expect(
         queryByText('Paid with Designation Support Goal Calculator'),
       ).not.toBeInTheDocument();

--- a/src/hooks/useHrToolsNavItems.test.tsx
+++ b/src/hooks/useHrToolsNavItems.test.tsx
@@ -4,6 +4,7 @@ import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { mockSession } from '__tests__/util/mockSession';
 import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import { UsStaffGroupEnum, UserTypeEnum } from 'src/graphql/types.generated';
+import { UserOptionQuery } from './UserPreference.generated';
 import { useHrToolsNavItems } from './useHrToolsNavItems';
 
 // A user in a group that is ineligible for every HR Tool and with no staff account
@@ -31,8 +32,11 @@ const Wrapper = ({ children }: { children: ReactElement }) => (
 );
 
 const MpdGoalEligibleWrapper = ({ children }: { children: ReactElement }) => (
-  <GqlMockedProvider<{ GetUser: GetUserQuery }>
-    mocks={{ GetUser: { user: mpdGoalEligibleUser } }}
+  <GqlMockedProvider<{ GetUser: GetUserQuery; UserOption: UserOptionQuery }>
+    mocks={{
+      GetUser: { user: mpdGoalEligibleUser },
+      UserOption: { userOption: { key: 'user_type_verified', value: 'true' } },
+    }}
   >
     {children}
   </GqlMockedProvider>
@@ -42,16 +46,33 @@ describe('useHrToolsNavItems', () => {
   afterEach(() => {
     process.env.DEVELOPMENT_ENV = 'false';
     process.env.DISABLE_MPD_GOAL_ADMIN = 'false';
+    process.env.DISABLE_NEW_REPORTS = 'false';
   });
 
-  it('hides all items for an ineligible user when not in a development env', async () => {
+  it('hides all items, except partner reminders, for an ineligible user when not in a development env', async () => {
     const { result, waitForNextUpdate } = renderHook(
       () => useHrToolsNavItems(),
       { wrapper: Wrapper },
     );
     await waitForNextUpdate();
 
-    expect(result.current.items).toHaveLength(0);
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].id).toBe('partnerReminders');
+  });
+
+  it('hides every eligible item except partner reminders when DISABLE_NEW_REPORTS is on', async () => {
+    process.env.DISABLE_NEW_REPORTS = 'true';
+    mockSession({ developer: false });
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useHrToolsNavItems(),
+      { wrapper: MpdGoalEligibleWrapper },
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.items.map((item) => item.id)).toEqual([
+      'partnerReminders',
+    ]);
   });
 
   it('shows all items for an ineligible developer in a development env', async () => {
@@ -111,7 +132,7 @@ describe('useHrToolsNavItems', () => {
     );
   });
 
-  it('hides all items for an ineligible non-developer in a development env', async () => {
+  it('hides all items, except partner reminders, for an ineligible non-developer in a development env', async () => {
     process.env.DEVELOPMENT_ENV = 'true';
     mockSession({ developer: false });
 
@@ -121,10 +142,11 @@ describe('useHrToolsNavItems', () => {
     );
     await waitForNextUpdate();
 
-    expect(result.current.items).toHaveLength(0);
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].id).toBe('partnerReminders');
   });
 
-  it('hides all items for an ineligible developer outside a development env', async () => {
+  it('hides all items, except partner reminders, for an ineligible developer outside a development env', async () => {
     process.env.DEVELOPMENT_ENV = 'false';
     mockSession({ developer: true });
 
@@ -134,6 +156,7 @@ describe('useHrToolsNavItems', () => {
     );
     await waitForNextUpdate();
 
-    expect(result.current.items).toHaveLength(0);
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].id).toBe('partnerReminders');
   });
 });

--- a/src/hooks/useHrToolsNavItems.ts
+++ b/src/hooks/useHrToolsNavItems.ts
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useDeveloperBypass } from './useDeveloperBypass';
 import { useIneligibleByGroup } from './useIneligibleByGroup';
 import { NavItems } from './useReportNavItems';
+import { useReportsDisabled } from './useReportsDisabled';
 
 export function useHrToolsNavItems(): {
   items: NavItems[];
@@ -20,6 +21,8 @@ export function useHrToolsNavItems(): {
     userLoading,
   } = useIneligibleByGroup();
   const developerBypass = useDeveloperBypass();
+  // Partner Reminders is live in production; every other HR Tool is still disabled
+  const { reportsDisabled } = useReportsDisabled();
 
   const items = useMemo(() => {
     if (userLoading) {
@@ -30,17 +33,18 @@ export function useHrToolsNavItems(): {
       {
         id: 'salaryCalculator',
         title: t('Salary Calculation Form'),
-        hideItem: inSalaryCalcIneligibleGroup,
+        hideItem: reportsDisabled || inSalaryCalcIneligibleGroup,
       },
       {
         id: 'staffSavingFund',
         title: t('Savings Fund Transfer'),
-        hideItem: hasNoStaffAccount,
+        hideItem: reportsDisabled || hasNoStaffAccount,
       },
       {
         id: 'nsGoalCalculator',
         title: t('New Staff Goal Calculator'),
         hideItem:
+          reportsDisabled ||
           process.env.DISABLE_NS_GOAL_CALCULATOR === 'true' ||
           inNsGoalCalcIneligibleGroup,
       },
@@ -48,45 +52,48 @@ export function useHrToolsNavItems(): {
         id: 'nsoMpdQuestionnaire',
         title: t('NSO MPD Questionnaire'),
         hideItem:
+          reportsDisabled ||
           process.env.DISABLE_NS_GOAL_CALCULATOR === 'true' ||
           inNsGoalCalcIneligibleGroup,
       },
       {
         id: 'goalCalculator',
         title: t('MPD Goal Calculator'),
-        hideItem: inMpdGoalCalcIneligibleGroup,
+        hideItem: reportsDisabled || inMpdGoalCalcIneligibleGroup,
       },
       {
         id: 'mpdGoalAdmin',
         title: t('MPD Goal Calculator Admin Table'),
         hideItem:
+          reportsDisabled ||
           process.env.DISABLE_MPD_GOAL_ADMIN === 'true' ||
           inMpdGoalCalcIneligibleGroup,
       },
       {
         id: 'mhaCalculator',
         title: t('MHA Calculation Tool'),
-        hideItem: inMhaIneligibleGroup,
+        hideItem: reportsDisabled || inMhaIneligibleGroup,
       },
       {
         id: 'additionalSalaryRequest',
         title: t('Additional Salary Request'),
-        hideItem: inAsrIneligibleGroup,
+        hideItem: reportsDisabled || inAsrIneligibleGroup,
       },
       {
         id: 'pdsGoalCalculator',
         title: t('Paid with Designation Support Goal Calculator'),
-        hideItem: inPdsGoalCalcIneligibleGroup,
+        hideItem: reportsDisabled || inPdsGoalCalcIneligibleGroup,
       },
       {
         id: 'partnerReminders',
         title: t('Ministry Partner Reminders'),
-        hideItem: !developerBypass,
+        // TODO (MPDX-9822): Once HCM goes live, add has no staff account gate back
+        hideItem: false,
       },
       {
         id: 'mpdSupervisorReport',
         title: t('MPD Supervisor Report'),
-        hideItem: hasNoStaffAccount,
+        hideItem: reportsDisabled || hasNoStaffAccount,
       },
     ].filter((item) => developerBypass || !item.hideItem);
   }, [
@@ -100,6 +107,7 @@ export function useHrToolsNavItems(): {
     userLoading,
     hasNoStaffAccount,
     developerBypass,
+    reportsDisabled,
   ]);
 
   return { items, loading: userLoading };

--- a/src/hooks/useNavPages.test.tsx
+++ b/src/hooks/useNavPages.test.tsx
@@ -11,14 +11,14 @@ import { useNavPages } from './useNavPages';
 const accountListId = 'account-list-1';
 
 // Wrapper for asserting HR Tools visibility by user type (verified, reports enabled)
-const makeWrapper = (userType: UserTypeEnum) => {
+const makeWrapper = (userType: UserTypeEnum, userTypeVerified = 'true') => {
   const wrapper = ({ children }: { children: ReactElement }) => (
     <TestRouter router={{ query: { accountListId }, isReady: true }}>
       <GqlMockedProvider<{ GetUser: GetUserQuery; UserOption: UserOptionQuery }>
         mocks={{
           GetUser: { user: { userType } },
           UserOption: {
-            userOption: { key: 'user_type_verified', value: 'true' },
+            userOption: { key: 'user_type_verified', value: userTypeVerified },
           },
         }}
       >
@@ -137,17 +137,39 @@ describe('useNavPages', () => {
     );
   });
 
-  it('keeps the HR Tools tab hidden for a developer when reports are disabled', async () => {
+  it('shows the HR Tools tab for a developer when reports are disabled', async () => {
     process.env.DEVELOPMENT_ENV = 'true';
     mockSession({ developer: true });
 
-    const { result, waitForNextUpdate } = renderHook(() => useNavPages(false), {
+    const { result, waitFor } = renderHook(() => useNavPages(false), {
       wrapper: ReportsDisabledWrapper,
     });
-    await waitForNextUpdate();
 
-    expect(result.current.navPages.map((page) => page.id)).not.toContain(
-      'hr-tools-page',
+    await waitFor(() =>
+      expect(result.current.navPages.map((page) => page.id)).toContain(
+        'hr-tools-page',
+      ),
     );
+  });
+
+  it('shows only Partner Reminders in the HR Tools tab when reports are disabled', async () => {
+    mockSession({ developer: false });
+
+    const { result, waitFor } = renderHook(() => useNavPages(false), {
+      wrapper: makeWrapper(UserTypeEnum.UsStaff, 'false'),
+    });
+
+    await waitFor(() =>
+      expect(result.current.navPages.map((page) => page.id)).toContain(
+        'hr-tools-page',
+      ),
+    );
+
+    const hrToolsPage = result.current.navPages.find(
+      (page) => page.id === 'hr-tools-page',
+    );
+    expect(hrToolsPage?.items?.map((item) => item.id)).toEqual([
+      'partnerReminders',
+    ]);
   });
 });

--- a/src/hooks/useNavPages.tsx
+++ b/src/hooks/useNavPages.tsx
@@ -8,7 +8,6 @@ import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useDeveloperBypass } from './useDeveloperBypass';
 import { useHrToolsNavItems } from './useHrToolsNavItems';
 import { useReportNavItems } from './useReportNavItems';
-import { useReportsDisabled } from './useReportsDisabled';
 import { useSettingsNavItems } from './useSettingsNavItems';
 import { useToolsNavItems } from './useToolsNavItems';
 
@@ -53,7 +52,6 @@ export function useNavPages(coachingAccountCount: boolean, isSearch = false) {
   const accountListId = useAccountListId();
   const { t } = useTranslation();
   const { data } = useGetUserQuery();
-  const { reportsDisabled } = useReportsDisabled();
 
   const userType = data?.user.userType;
   const developerBypass = useDeveloperBypass();
@@ -110,27 +108,23 @@ export function useNavPages(coachingAccountCount: boolean, isSearch = false) {
         })),
         showInNav: true,
       },
-      ...(reportsDisabled
-        ? []
-        : [
-            {
-              id: 'hr-tools-page',
-              title: t('HR Tools'),
-              pathname: '/accountLists/[accountListId]/hrTools',
-              items: hrToolsItems.map((item) => ({
-                ...item,
-                href: `/accountLists/${accountListId}/hrTools/${item.id}`,
-                searchIcon: <CompassIcon />,
-                searchName: t(`HR Tools - {{ title }}`, { title: item.title }),
-                showInSearchDialog: true,
-              })),
-              showInNav: true,
-              hideTab:
-                (!!data && !canSeeHrTools) ||
-                hrToolsLoading ||
-                hrToolsItems.length === 0,
-            },
-          ]),
+      {
+        id: 'hr-tools-page',
+        title: t('HR Tools'),
+        pathname: '/accountLists/[accountListId]/hrTools',
+        items: hrToolsItems.map((item) => ({
+          ...item,
+          href: `/accountLists/${accountListId}/hrTools/${item.id}`,
+          searchIcon: <CompassIcon />,
+          searchName: t(`HR Tools - {{ title }}`, { title: item.title }),
+          showInSearchDialog: true,
+        })),
+        showInNav: true,
+        hideTab:
+          (!!data && !canSeeHrTools) ||
+          hrToolsLoading ||
+          hrToolsItems.length === 0,
+      },
       {
         id: 'mpdx-tools-page',
         title: t('MPDX Tools'),
@@ -198,7 +192,6 @@ export function useNavPages(coachingAccountCount: boolean, isSearch = false) {
     hrToolsItems,
     hrToolsLoading,
     canSeeHrTools,
-    reportsDisabled,
     data,
   ]);
 


### PR DESCRIPTION
## Description

**_Set to merge on Monday, July 27th, 2026_**

Since Ministry Partner Reminders broke in staff web, we want to release this report before HCM go-live. We need to add HR Tools and partner reminders to production.

Production: `DISABLE_NEW_REPORTS=true`, `DEVELOPMENT_ENV=false`, `user_type_verified="false"` (no modal), and `us_staff_group=null` (no HCM data)

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->
User type has NOT been verified in the modal (this is what will happen in production)
```
user_type_verified: 'false'
```

US staff production test: ✅
- Set `DISABLE_NEW_REPORTS` to `true` in your local
- Impersonate: dave.cook@crumilitary.org
- Verify that "HR Tools" is present with only Ministry Partner Reminders
- Go to `/hrTools/partnerReminders`
- Check that the page is accessible

Non-US staff production test: ✅
- Set `DISABLE_NEW_REPORTS` to `true` in your local
- Log in to the test account (it is seen as Global right now)
- Verify that "HR Tools" is NOT present

US staff non-production test: ✅
- Set `DISABLE_NEW_REPORTS` to `false` in your local
- Impersonate: dave.cook@crumilitary.org
- Verify that "HR Tools" is present with only Ministry Partner Reminders (user group is `null` and user type verified is false - no HCM data and no modal)
- Go to `/hrTools/partnerReminders`
- Check that the page is accessible


User type has been verified in the modal...
```
user_type_verified: 'true'
```
... AND HCM data exists (this is similar to what devs should see locally)

US staff non-production test: ✅
- Set `DISABLE_NEW_REPORTS` to `false` in your local
- Impersonate: courtney.campbell@cru.org
- Verify that "HR Tools" is present with all eligible reports
- Go to `/hrTools/partnerReminders`
- Check that the page is accessible

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
