### PR TITLE
MPDX-9836 Preview changes to new staff goals before saving

### DIFF
--- a/.claude/rules/code-review.md
+++ b/.claude/rules/code-review.md
@@ -281,6 +281,7 @@ Project-specific testing conventions added to the Testing agent's universal chec
 
 - **`GqlMockedProvider` is the only GraphQL mock pattern.** All component tests that hit GraphQL must wrap in `<GqlMockedProvider<{ OperationName: OperationNameQuery }> mocks={...}>` with typed generics so mock shapes are type-checked at compile time
 - **`mutationSpy` + `toHaveGraphqlOperation(...)` pattern** is preferred over brittle snapshot-based assertions for verifying mutations
+- **Define the `onCall` / `mutationSpy` spy once at the top of the test file** and reference it directly — don't thread it through a test wrapper as a prop or redeclare `const onCall = jest.fn()` in each test.
 - **`toHaveTableStructure(...)` for full table contents** — when asserting more than a couple table cells, use `expect(getByRole('table')).toHaveTableStructure({ columnHeaders, rowHeaders, cells })` instead of ad-hoc `getByRole('cell')`
 - **`findBy*` for async assertions** — prefer `await findByText(...)` over `await waitFor(() => getByText(...))`
 - **`userEvent`, never `fireEvent`** — drive every user interaction (click, type, select, tab/blur, keyboard) through `@testing-library/user-event`, which dispatches the full event sequence a real user produces

--- a/src/components/Coaching/CoachingDetail/CoachingDetail.test.tsx
+++ b/src/components/Coaching/CoachingDetail/CoachingDetail.test.tsx
@@ -168,6 +168,9 @@ describe('LoadCoachingDetail', () => {
         <TestComponent accountListType={AccountListTypeEnum.Coaching} />,
       );
 
+      expect(
+        await findByRole('heading', { name: 'John Doe Account' }),
+      ).toBeInTheDocument();
       const link = await findByRole('link', {
         name: 'View New Staff Goal',
       });

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
@@ -82,6 +82,10 @@ export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = (props) => {
     save,
   } = useNewStaffGoalCalculation(props);
 
+  // The header and preview need the account list explicitly; a scenario goal
+  // has none, so pass null — the preview then omits it from the request.
+  const accountListId = 'accountListId' in props ? props.accountListId : null;
+
   if (!calculation) {
     return <ScrollContainer>{fallback}</ScrollContainer>;
   }
@@ -160,6 +164,8 @@ export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = (props) => {
           return (
             <Form>
               <GoalSettingsHeader
+                accountListId={accountListId}
+                calculationId={calculation.id}
                 primaryPerson={primaryPerson}
                 spousePerson={spousePerson}
                 mpdGoal={mpdGoal}

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
@@ -82,10 +82,6 @@ export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = (props) => {
     save,
   } = useNewStaffGoalCalculation(props);
 
-  // The header and preview need the account list explicitly; a scenario goal
-  // has none, so pass null — the preview then omits it from the request.
-  const accountListId = 'accountListId' in props ? props.accountListId : null;
-
   if (!calculation) {
     return <ScrollContainer>{fallback}</ScrollContainer>;
   }
@@ -164,7 +160,10 @@ export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = (props) => {
           return (
             <Form>
               <GoalSettingsHeader
-                accountListId={accountListId}
+                accountListId={
+                  // Scenario goals have no account list
+                  'accountListId' in props ? props.accountListId : null
+                }
                 calculationId={calculation.id}
                 primaryPerson={primaryPerson}
                 spousePerson={spousePerson}

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.test.tsx
@@ -3,6 +3,8 @@ import { ThemeProvider } from '@mui/material';
 import { render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Form, Formik } from 'formik';
+import { SnackbarProvider } from 'notistack';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from 'src/theme';
 import { GoalSettingsHeader } from './GoalSettingsHeader';
 import { GoalSettingsPerson } from './goalSettingsFormValues';
@@ -39,17 +41,26 @@ const TestComponent: React.FC<TestComponentProps> = ({
   isScenario = false,
 }) => (
   <ThemeProvider theme={theme}>
-    <Formik initialValues={{ calculationsYear: '2020' }} onSubmit={jest.fn()}>
-      <Form>
-        <GoalSettingsHeader
-          primaryPerson={primaryPerson}
-          spousePerson={spouse}
-          mpdGoal={mpdGoal}
-          joinedStaffYear={joinedStaffYear}
-          isScenario={isScenario}
-        />
-      </Form>
-    </Formik>
+    <SnackbarProvider>
+      <GqlMockedProvider>
+        <Formik
+          initialValues={{ calculationsYear: '2020' }}
+          onSubmit={jest.fn()}
+        >
+          <Form>
+            <GoalSettingsHeader
+              accountListId="account-list-1"
+              calculationId="goal-calculation-1"
+              primaryPerson={primaryPerson}
+              spousePerson={spouse}
+              mpdGoal={mpdGoal}
+              joinedStaffYear={joinedStaffYear}
+              isScenario={isScenario}
+            />
+          </Form>
+        </Formik>
+      </GqlMockedProvider>
+    </SnackbarProvider>
   </ThemeProvider>
 );
 

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.tsx
@@ -14,10 +14,9 @@ import {
 } from '@mui/material';
 import { DateTime } from 'luxon';
 import { useTranslation } from 'react-i18next';
-import { useLocale } from 'src/hooks/useLocale';
-import { currencyFormat } from 'src/lib/intlFormat';
 import { GoalSettingsPlaceholder } from './Fields/GoalSettingsPlaceholder';
 import { GoalSettingsSelect, SelectOption } from './Fields/GoalSettingsSelect';
+import { MpdGoalPreview } from './MpdGoalPreview';
 import { GoalSettingsPerson } from './goalSettingsFormValues';
 
 interface ContactLineProps {
@@ -67,8 +66,13 @@ const PersonInfoCard: React.FC<PersonInfoCardProps> = ({ person }) => {
 };
 
 interface GoalSettingsHeaderProps {
+  /** Account list the goal belongs to, or `null` for a scenario goal. */
+  accountListId: string | null;
+  /** Id of the calculation to preview unsaved changes against. */
+  calculationId: string;
   primaryPerson: GoalSettingsPerson;
   spousePerson: GoalSettingsPerson | null;
+  /** The saved goal total, shown when there are no goal-affecting edits. */
   mpdGoal: number;
   /**
    * Year the staff member joined staff. The calculation year options span from
@@ -82,6 +86,8 @@ interface GoalSettingsHeaderProps {
 }
 
 export const GoalSettingsHeader: React.FC<GoalSettingsHeaderProps> = ({
+  accountListId,
+  calculationId,
   primaryPerson,
   spousePerson,
   mpdGoal,
@@ -89,7 +95,6 @@ export const GoalSettingsHeader: React.FC<GoalSettingsHeaderProps> = ({
   isScenario = false,
 }) => {
   const { t } = useTranslation();
-  const locale = useLocale();
   const yearLabelId = useId();
 
   // Years from joinedStaffYear to the current year, newest first. Falls back to
@@ -161,13 +166,11 @@ export const GoalSettingsHeader: React.FC<GoalSettingsHeaderProps> = ({
             <InfoOutlined fontSize="small" />
           </IconButton>
         </Tooltip>
-        <Typography variant="h6" sx={{ ml: 3 }}>
-          {t('MPD Goal: {{amount}}', {
-            amount: currencyFormat(mpdGoal, 'USD', locale, {
-              showTrailingZeros: true,
-            }),
-          })}
-        </Typography>
+        <MpdGoalPreview
+          accountListId={accountListId}
+          calculationId={calculationId}
+          savedMonthlyGoal={mpdGoal}
+        />
       </Stack>
 
       {!isScenario && (

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.test.tsx
@@ -1,0 +1,265 @@
+import React from 'react';
+import { ThemeProvider } from '@mui/material';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Field, Form, Formik } from 'formik';
+import { ApolloErgonoMockMap } from 'graphql-ergonomock';
+import { SnackbarProvider } from 'notistack';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import theme from 'src/theme';
+import { defaultGoalCalculation } from '../NsGoalCalculatorTestWrapper';
+import { MpdGoalPreview } from './MpdGoalPreview';
+import { PreviewNewStaffGoalCalculationMutation } from './NewStaffGoalCalculation.generated';
+import { calculationToFormValues } from './goalSettingsApiMapping';
+
+const accountListId = 'account-list-1';
+const calculationId = 'goal-calculation-1';
+
+const previewGoalMock = (
+  monthlyGoal: number,
+): {
+  PreviewNewStaffGoalCalculation: PreviewNewStaffGoalCalculationMutation;
+} => ({
+  PreviewNewStaffGoalCalculation: {
+    previewNewStaffGoalCalculation: {
+      newStaffGoalCalculation: {
+        id: calculationId,
+        calculations: { monthlyGoal },
+      },
+    },
+  },
+});
+
+interface TestComponentProps {
+  accountListId?: string | null;
+  savedMonthlyGoal?: number;
+  mocks?: ApolloErgonoMockMap;
+  onCall?: jest.Mock;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({
+  accountListId: accountListIdProp = accountListId,
+  savedMonthlyGoal = 5000,
+  mocks,
+  onCall,
+}) => (
+  <ThemeProvider theme={theme}>
+    <SnackbarProvider>
+      <GqlMockedProvider<{
+        PreviewNewStaffGoalCalculation: PreviewNewStaffGoalCalculationMutation;
+      }>
+        mocks={mocks}
+        onCall={onCall}
+      >
+        <Formik
+          initialValues={calculationToFormValues(defaultGoalCalculation)}
+          onSubmit={jest.fn()}
+        >
+          <Form>
+            {/* Two fields so tabbing off the first blurs it (focusout). */}
+            <Field
+              name="annualRequestedSalary"
+              type="number"
+              aria-label="Salary"
+            />
+            <Field name="tenure" type="number" aria-label="Tenure" />
+            <MpdGoalPreview
+              accountListId={accountListIdProp}
+              calculationId={calculationId}
+              savedMonthlyGoal={savedMonthlyGoal}
+            />
+          </Form>
+        </Formik>
+      </GqlMockedProvider>
+    </SnackbarProvider>
+  </ThemeProvider>
+);
+
+/** Edit the salary field and blur it (tab away) to commit a preview. */
+const editSalaryAndBlur = (field: HTMLElement, value: string) => {
+  userEvent.clear(field);
+  userEvent.type(field, value);
+  userEvent.tab();
+};
+
+describe('MpdGoalPreview', () => {
+  it('shows the saved goal total when there are no unsaved changes', async () => {
+    const onCall = jest.fn();
+    const { findByText, queryByText } = render(
+      <TestComponent onCall={onCall} />,
+    );
+
+    expect(await findByText('MPD Goal: $5,000.00')).toBeInTheDocument();
+    // No signed difference is shown while the form is untouched.
+    expect(queryByText(/[+-]\$/)).not.toBeInTheDocument();
+    expect(onCall).not.toHaveGraphqlOperation('PreviewNewStaffGoalCalculation');
+  });
+
+  it('does not preview while typing, before the field is blurred', () => {
+    jest.useFakeTimers();
+    try {
+      const onCall = jest.fn();
+      const { getByRole } = render(
+        <TestComponent mocks={previewGoalMock(5200)} onCall={onCall} />,
+      );
+
+      const salary = getByRole('spinbutton', { name: 'Salary' });
+      userEvent.clear(salary);
+      userEvent.type(salary, '80000');
+      // No blur yet: even past the debounce window, typing triggers no preview.
+      jest.advanceTimersByTime(1000);
+
+      expect(onCall).not.toHaveGraphqlOperation(
+        'PreviewNewStaffGoalCalculation',
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('previews the new goal total and a positive difference when an edit raises the goal', async () => {
+    const { findByText, getByRole } = render(
+      <TestComponent mocks={previewGoalMock(5200)} />,
+    );
+
+    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+
+    expect(await findByText('MPD Goal: $5,200.00')).toBeInTheDocument();
+    expect(await findByText('+$200.00')).toBeInTheDocument();
+  });
+
+  it('shows a negative difference when an edit lowers the goal', async () => {
+    const { findByText, getByRole } = render(
+      <TestComponent mocks={previewGoalMock(4925)} />,
+    );
+
+    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '40000');
+
+    expect(await findByText('MPD Goal: $4,925.00')).toBeInTheDocument();
+    expect(await findByText('-$75.00')).toBeInTheDocument();
+  });
+
+  it('hides the goal total and difference while recalculating after another edit', async () => {
+    const { findByText, getByRole, getByText, getByLabelText, queryByText } =
+      render(<TestComponent mocks={previewGoalMock(5200)} />);
+
+    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    expect(await findByText('MPD Goal: $5,200.00')).toBeInTheDocument();
+
+    // A further edit starts a new preview. Until it returns, the "MPD Goal:"
+    // label stays but the amount is replaced by a spinner and the difference is
+    // hidden — no stale number on screen.
+    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '70000');
+
+    expect(getByLabelText('Calculating new goal total')).toBeInTheDocument();
+    expect(getByText('MPD Goal:')).toBeInTheDocument();
+    expect(queryByText(/MPD Goal: \$/)).not.toBeInTheDocument();
+    expect(queryByText(/[+-]\$/)).not.toBeInTheDocument();
+  });
+
+  it('shows no difference when the change does not affect the goal', async () => {
+    const onCall = jest.fn();
+    const { findByText, queryByText, getByRole } = render(
+      <TestComponent mocks={previewGoalMock(5000)} onCall={onCall} />,
+    );
+
+    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+
+    // Wait for the preview to run, then confirm the goal is unchanged and no
+    // signed difference is rendered.
+    await waitFor(() =>
+      expect(onCall).toHaveGraphqlOperation('PreviewNewStaffGoalCalculation'),
+    );
+    expect(await findByText('MPD Goal: $5,000.00')).toBeInTheDocument();
+    expect(queryByText(/[+-]\$/)).not.toBeInTheDocument();
+  });
+
+  it('requests a preview with the edited attributes', async () => {
+    const onCall = jest.fn();
+    const { getByRole } = render(
+      <TestComponent mocks={previewGoalMock(5200)} onCall={onCall} />,
+    );
+
+    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '99999');
+
+    await waitFor(() =>
+      expect(onCall).toHaveGraphqlOperation('PreviewNewStaffGoalCalculation', {
+        input: {
+          accountListId,
+          id: calculationId,
+          attributes: { annualRequestedSalary: 99999 },
+        },
+      }),
+    );
+  });
+
+  it('previews a scenario goal, omitting the account list', async () => {
+    const onCall = jest.fn();
+    const { findByText, getByRole } = render(
+      <TestComponent
+        accountListId={null}
+        mocks={previewGoalMock(5200)}
+        onCall={onCall}
+      />,
+    );
+
+    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+
+    // A scenario goal has no account list; the API previews it all the same,
+    // with the account list left out of the request.
+    await waitFor(() =>
+      expect(onCall).toHaveGraphqlOperation('PreviewNewStaffGoalCalculation', {
+        input: {
+          id: calculationId,
+          attributes: { annualRequestedSalary: 80000 },
+        },
+      }),
+    );
+    const previewCall = onCall.mock.calls.find(
+      ([{ operation }]) =>
+        operation.operationName === 'PreviewNewStaffGoalCalculation',
+    );
+    expect(
+      previewCall?.[0].operation.variables.input.accountListId,
+    ).toBeUndefined();
+    expect(await findByText('MPD Goal: $5,200.00')).toBeInTheDocument();
+  });
+
+  it('shows a spinner while the preview is loading', async () => {
+    const { findByLabelText, getByRole } = render(
+      <TestComponent mocks={previewGoalMock(5200)} />,
+    );
+
+    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+
+    expect(
+      await findByLabelText('Calculating new goal total'),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the saved goal when the preview request fails', async () => {
+    const onCall = jest.fn();
+    const { findByText, queryByText, getByRole } = render(
+      <TestComponent
+        onCall={onCall}
+        mocks={
+          {
+            PreviewNewStaffGoalCalculation: {
+              previewNewStaffGoalCalculation: () => {
+                throw new Error('Preview failed');
+              },
+            },
+          } as ApolloErgonoMockMap
+        }
+      />,
+    );
+
+    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+
+    await waitFor(() =>
+      expect(onCall).toHaveGraphqlOperation('PreviewNewStaffGoalCalculation'),
+    );
+    expect(await findByText('MPD Goal: $5,000.00')).toBeInTheDocument();
+    expect(queryByText(/[+-]\$/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.test.tsx
@@ -75,8 +75,8 @@ const TestComponent: React.FC<TestComponentProps> = ({
   </ThemeProvider>
 );
 
-/** Edit the salary field and blur it (tab away) to commit a preview. */
-const editSalaryAndBlur = (field: HTMLElement, value: string) => {
+/** Edit a field and blur it (tab away) to commit a preview. */
+const editAndBlur = (field: HTMLElement, value: string) => {
   userEvent.clear(field);
   userEvent.type(field, value);
   userEvent.tab();
@@ -96,25 +96,38 @@ describe('MpdGoalPreview', () => {
   });
 
   it('does not preview while typing, before the field is blurred', () => {
-    jest.useFakeTimers();
-    try {
-      const onCall = jest.fn();
-      const { getByRole } = render(
-        <TestComponent mocks={previewGoalMock(5200)} onCall={onCall} />,
-      );
+    const onCall = jest.fn();
+    const { getByRole } = render(
+      <TestComponent mocks={previewGoalMock(5200)} onCall={onCall} />,
+    );
 
-      const salary = getByRole('spinbutton', { name: 'Salary' });
-      userEvent.clear(salary);
-      userEvent.type(salary, '80000');
-      // No blur yet: even past the debounce window, typing triggers no preview.
-      jest.advanceTimersByTime(1000);
+    const salary = getByRole('spinbutton', { name: 'Salary' });
+    userEvent.clear(salary);
+    userEvent.type(salary, '80000');
 
-      expect(onCall).not.toHaveGraphqlOperation(
-        'PreviewNewStaffGoalCalculation',
-      );
-    } finally {
-      jest.useRealTimers();
-    }
+    // Nothing is committed until a field blurs, so no preview is scheduled — the
+    // preview is gated on blur, not on keystrokes.
+    expect(onCall).not.toHaveGraphqlOperation('PreviewNewStaffGoalCalculation');
+  });
+
+  it('coalesces rapid blurs across fields into a single preview request', async () => {
+    const onCall = jest.fn();
+    const { getByRole } = render(
+      <TestComponent mocks={previewGoalMock(5200)} onCall={onCall} />,
+    );
+
+    // Tab quickly through two fields within the debounce window.
+    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editAndBlur(getByRole('spinbutton', { name: 'Tenure' }), '5');
+
+    await waitFor(() =>
+      expect(onCall).toHaveGraphqlOperation('PreviewNewStaffGoalCalculation'),
+    );
+    const previewCalls = onCall.mock.calls.filter(
+      ([{ operation }]) =>
+        operation.operationName === 'PreviewNewStaffGoalCalculation',
+    );
+    expect(previewCalls).toHaveLength(1);
   });
 
   it('previews the new goal total and a positive difference when an edit raises the goal', async () => {
@@ -122,7 +135,7 @@ describe('MpdGoalPreview', () => {
       <TestComponent mocks={previewGoalMock(5200)} />,
     );
 
-    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
 
     expect(await findByText('MPD Goal: $5,200.00')).toBeInTheDocument();
     expect(await findByText('+$200.00')).toBeInTheDocument();
@@ -133,7 +146,7 @@ describe('MpdGoalPreview', () => {
       <TestComponent mocks={previewGoalMock(4925)} />,
     );
 
-    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '40000');
+    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '40000');
 
     expect(await findByText('MPD Goal: $4,925.00')).toBeInTheDocument();
     expect(await findByText('-$75.00')).toBeInTheDocument();
@@ -143,18 +156,64 @@ describe('MpdGoalPreview', () => {
     const { findByText, getByRole, getByText, getByLabelText, queryByText } =
       render(<TestComponent mocks={previewGoalMock(5200)} />);
 
-    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
     expect(await findByText('MPD Goal: $5,200.00')).toBeInTheDocument();
 
     // A further edit starts a new preview. Until it returns, the "MPD Goal:"
     // label stays but the amount is replaced by a spinner and the difference is
     // hidden — no stale number on screen.
-    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '70000');
+    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '70000');
 
     expect(getByLabelText('Calculating new goal total')).toBeInTheDocument();
     expect(getByText('MPD Goal:')).toBeInTheDocument();
     expect(queryByText(/MPD Goal: \$/)).not.toBeInTheDocument();
     expect(queryByText(/[+-]\$/)).not.toBeInTheDocument();
+  });
+
+  it('settles again after a further edit while recalculating', async () => {
+    const { findByText, getByRole, getByLabelText } = render(
+      <TestComponent mocks={previewGoalMock(5200)} />,
+    );
+
+    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    expect(await findByText('MPD Goal: $5,200.00')).toBeInTheDocument();
+
+    // A second edit supersedes the first; only its result (matched by key)
+    // should replace the spinner once it settles.
+    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '70000');
+    expect(getByLabelText('Calculating new goal total')).toBeInTheDocument();
+
+    expect(await findByText('MPD Goal: $5,200.00')).toBeInTheDocument();
+  });
+
+  it('drops the preview and reverts to the saved goal when edits are undone', async () => {
+    const { findByText, queryByText, getByRole } = render(
+      <TestComponent mocks={previewGoalMock(5200)} savedMonthlyGoal={5000} />,
+    );
+
+    const salary = getByRole('spinbutton', {
+      name: 'Salary',
+    }) as HTMLInputElement;
+    const original = salary.value;
+
+    editAndBlur(salary, '80000');
+    expect(await findByText('+$200.00')).toBeInTheDocument();
+
+    // Undo the edit → the form is pristine again → the preview is dropped and
+    // the header returns to the saved goal with no stale difference.
+    editAndBlur(salary, original);
+
+    expect(await findByText('MPD Goal: $5,000.00')).toBeInTheDocument();
+    expect(queryByText(/[+-]\$/)).not.toBeInTheDocument();
+  });
+
+  it('previews a raise from a zero saved goal', async () => {
+    const { findByText } = render(
+      <TestComponent mocks={previewGoalMock(200)} savedMonthlyGoal={0} />,
+    );
+
+    // Zero renders as a real total, not a blank.
+    expect(await findByText('MPD Goal: $0.00')).toBeInTheDocument();
   });
 
   it('shows no difference when the change does not affect the goal', async () => {
@@ -163,7 +222,7 @@ describe('MpdGoalPreview', () => {
       <TestComponent mocks={previewGoalMock(5000)} onCall={onCall} />,
     );
 
-    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
 
     // Wait for the preview to run, then confirm the goal is unchanged and no
     // signed difference is rendered.
@@ -180,7 +239,7 @@ describe('MpdGoalPreview', () => {
       <TestComponent mocks={previewGoalMock(5200)} onCall={onCall} />,
     );
 
-    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '99999');
+    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '99999');
 
     await waitFor(() =>
       expect(onCall).toHaveGraphqlOperation('PreviewNewStaffGoalCalculation', {
@@ -203,7 +262,7 @@ describe('MpdGoalPreview', () => {
       />,
     );
 
-    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
 
     // A scenario goal has no account list; the API previews it all the same,
     // with the account list left out of the request.
@@ -230,7 +289,7 @@ describe('MpdGoalPreview', () => {
       <TestComponent mocks={previewGoalMock(5200)} />,
     );
 
-    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
 
     expect(
       await findByLabelText('Calculating new goal total'),
@@ -254,11 +313,14 @@ describe('MpdGoalPreview', () => {
       />,
     );
 
-    editSalaryAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
 
     await waitFor(() =>
       expect(onCall).toHaveGraphqlOperation('PreviewNewStaffGoalCalculation'),
     );
+    // The failure is surfaced (rather than looking like a zero-impact edit) and
+    // the header falls back to the saved goal with no stale difference.
+    expect(await findByText('Preview unavailable')).toBeInTheDocument();
     expect(await findByText('MPD Goal: $5,000.00')).toBeInTheDocument();
     expect(queryByText(/[+-]\$/)).not.toBeInTheDocument();
   });

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.test.tsx
@@ -208,12 +208,18 @@ describe('MpdGoalPreview', () => {
   });
 
   it('previews a raise from a zero saved goal', async () => {
-    const { findByText } = render(
+    const { findByText, getByRole } = render(
       <TestComponent mocks={previewGoalMock(200)} savedMonthlyGoal={0} />,
     );
 
     // Zero renders as a real total, not a blank.
     expect(await findByText('MPD Goal: $0.00')).toBeInTheDocument();
+
+    // An edit raises the goal off zero; the diff is measured against $0.00.
+    editField(getByRole('spinbutton', { name: 'Salary' }), '80000');
+
+    expect(await findByText('MPD Goal: $200.00')).toBeInTheDocument();
+    expect(await findByText('+$200.00')).toBeInTheDocument();
   });
 
   it('shows no difference when the change does not affect the goal', async () => {

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.test.tsx
@@ -56,7 +56,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
           onSubmit={jest.fn()}
         >
           <Form>
-            {/* Two fields so tabbing off the first blurs it (focusout). */}
+            {/* Two fields so the coalescing test can edit across both. */}
             <Field
               name="annualRequestedSalary"
               type="number"
@@ -75,11 +75,10 @@ const TestComponent: React.FC<TestComponentProps> = ({
   </ThemeProvider>
 );
 
-/** Edit a field and blur it (tab away) to commit a preview. */
-const editAndBlur = (field: HTMLElement, value: string) => {
+/** Edit a field; the preview keys off the value change, no blur needed. */
+const editField = (field: HTMLElement, value: string) => {
   userEvent.clear(field);
   userEvent.type(field, value);
-  userEvent.tab();
 };
 
 describe('MpdGoalPreview', () => {
@@ -95,30 +94,15 @@ describe('MpdGoalPreview', () => {
     expect(onCall).not.toHaveGraphqlOperation('PreviewNewStaffGoalCalculation');
   });
 
-  it('does not preview while typing, before the field is blurred', () => {
+  it('coalesces rapid edits across fields into a single preview request', async () => {
     const onCall = jest.fn();
     const { getByRole } = render(
       <TestComponent mocks={previewGoalMock(5200)} onCall={onCall} />,
     );
 
-    const salary = getByRole('spinbutton', { name: 'Salary' });
-    userEvent.clear(salary);
-    userEvent.type(salary, '80000');
-
-    // Nothing is committed until a field blurs, so no preview is scheduled — the
-    // preview is gated on blur, not on keystrokes.
-    expect(onCall).not.toHaveGraphqlOperation('PreviewNewStaffGoalCalculation');
-  });
-
-  it('coalesces rapid blurs across fields into a single preview request', async () => {
-    const onCall = jest.fn();
-    const { getByRole } = render(
-      <TestComponent mocks={previewGoalMock(5200)} onCall={onCall} />,
-    );
-
-    // Tab quickly through two fields within the debounce window.
-    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
-    editAndBlur(getByRole('spinbutton', { name: 'Tenure' }), '5');
+    // Edit two fields within the debounce window.
+    editField(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editField(getByRole('spinbutton', { name: 'Tenure' }), '5');
 
     await waitFor(() =>
       expect(onCall).toHaveGraphqlOperation('PreviewNewStaffGoalCalculation'),
@@ -135,7 +119,7 @@ describe('MpdGoalPreview', () => {
       <TestComponent mocks={previewGoalMock(5200)} />,
     );
 
-    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editField(getByRole('spinbutton', { name: 'Salary' }), '80000');
 
     expect(await findByText('MPD Goal: $5,200.00')).toBeInTheDocument();
     expect(await findByText('+$200.00')).toBeInTheDocument();
@@ -146,7 +130,7 @@ describe('MpdGoalPreview', () => {
       <TestComponent mocks={previewGoalMock(4925)} />,
     );
 
-    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '40000');
+    editField(getByRole('spinbutton', { name: 'Salary' }), '40000');
 
     expect(await findByText('MPD Goal: $4,925.00')).toBeInTheDocument();
     expect(await findByText('-$75.00')).toBeInTheDocument();
@@ -156,13 +140,13 @@ describe('MpdGoalPreview', () => {
     const { findByText, getByRole, getByText, getByLabelText, queryByText } =
       render(<TestComponent mocks={previewGoalMock(5200)} />);
 
-    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editField(getByRole('spinbutton', { name: 'Salary' }), '80000');
     expect(await findByText('MPD Goal: $5,200.00')).toBeInTheDocument();
 
     // A further edit starts a new preview. Until it returns, the "MPD Goal:"
     // label stays but the amount is replaced by a spinner and the difference is
     // hidden — no stale number on screen.
-    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '70000');
+    editField(getByRole('spinbutton', { name: 'Salary' }), '70000');
 
     expect(getByLabelText('Calculating new goal total')).toBeInTheDocument();
     expect(getByText('MPD Goal:')).toBeInTheDocument();
@@ -175,12 +159,12 @@ describe('MpdGoalPreview', () => {
       <TestComponent mocks={previewGoalMock(5200)} />,
     );
 
-    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editField(getByRole('spinbutton', { name: 'Salary' }), '80000');
     expect(await findByText('MPD Goal: $5,200.00')).toBeInTheDocument();
 
     // A second edit supersedes the first; only its result (matched by key)
     // should replace the spinner once it settles.
-    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '70000');
+    editField(getByRole('spinbutton', { name: 'Salary' }), '70000');
     expect(getByLabelText('Calculating new goal total')).toBeInTheDocument();
 
     expect(await findByText('MPD Goal: $5,200.00')).toBeInTheDocument();
@@ -196,12 +180,12 @@ describe('MpdGoalPreview', () => {
     }) as HTMLInputElement;
     const original = salary.value;
 
-    editAndBlur(salary, '80000');
+    editField(salary, '80000');
     expect(await findByText('+$200.00')).toBeInTheDocument();
 
     // Undo the edit → the form is pristine again → the preview is dropped and
     // the header returns to the saved goal with no stale difference.
-    editAndBlur(salary, original);
+    editField(salary, original);
 
     expect(await findByText('MPD Goal: $5,000.00')).toBeInTheDocument();
     expect(queryByText(/[+-]\$/)).not.toBeInTheDocument();
@@ -222,7 +206,7 @@ describe('MpdGoalPreview', () => {
       <TestComponent mocks={previewGoalMock(5000)} onCall={onCall} />,
     );
 
-    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editField(getByRole('spinbutton', { name: 'Salary' }), '80000');
 
     // Wait for the preview to run, then confirm the goal is unchanged and no
     // signed difference is rendered.
@@ -239,7 +223,7 @@ describe('MpdGoalPreview', () => {
       <TestComponent mocks={previewGoalMock(5200)} onCall={onCall} />,
     );
 
-    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '99999');
+    editField(getByRole('spinbutton', { name: 'Salary' }), '99999');
 
     await waitFor(() =>
       expect(onCall).toHaveGraphqlOperation('PreviewNewStaffGoalCalculation', {
@@ -262,7 +246,7 @@ describe('MpdGoalPreview', () => {
       />,
     );
 
-    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editField(getByRole('spinbutton', { name: 'Salary' }), '80000');
 
     // A scenario goal has no account list; the API previews it all the same,
     // with the account list left out of the request.
@@ -289,7 +273,7 @@ describe('MpdGoalPreview', () => {
       <TestComponent mocks={previewGoalMock(5200)} />,
     );
 
-    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editField(getByRole('spinbutton', { name: 'Salary' }), '80000');
 
     expect(
       await findByLabelText('Calculating new goal total'),
@@ -313,7 +297,7 @@ describe('MpdGoalPreview', () => {
       />,
     );
 
-    editAndBlur(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    editField(getByRole('spinbutton', { name: 'Salary' }), '80000');
 
     await waitFor(() =>
       expect(onCall).toHaveGraphqlOperation('PreviewNewStaffGoalCalculation'),

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.test.tsx
@@ -5,12 +5,22 @@ import userEvent from '@testing-library/user-event';
 import { Field, Form, Formik } from 'formik';
 import { ApolloErgonoMockMap } from 'graphql-ergonomock';
 import { SnackbarProvider } from 'notistack';
+import * as yup from 'yup';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import theme from 'src/theme';
 import { defaultGoalCalculation } from '../NsGoalCalculatorTestWrapper';
 import { MpdGoalPreview } from './MpdGoalPreview';
 import { PreviewNewStaffGoalCalculationMutation } from './NewStaffGoalCalculation.generated';
 import { calculationToFormValues } from './goalSettingsApiMapping';
+import { PREVIEW_DEBOUNCE_MS } from './useMpdGoalPreview';
+
+/**
+ * A schema that rejects a negative salary, so a field can be edited into an
+ * invalid state to exercise the `dirty && isValid` preview gate.
+ */
+const invalidatingSchema = yup.object({
+  annualRequestedSalary: yup.number().min(0),
+});
 
 const accountListId = 'account-list-1';
 const calculationId = 'goal-calculation-1';
@@ -35,6 +45,7 @@ interface TestComponentProps {
   savedMonthlyGoal?: number;
   mocks?: ApolloErgonoMockMap;
   onCall?: jest.Mock;
+  validationSchema?: yup.AnyObjectSchema;
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({
@@ -42,6 +53,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
   savedMonthlyGoal = 5000,
   mocks,
   onCall,
+  validationSchema,
 }) => (
   <ThemeProvider theme={theme}>
     <SnackbarProvider>
@@ -53,6 +65,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
       >
         <Formik
           initialValues={calculationToFormValues(defaultGoalCalculation)}
+          validationSchema={validationSchema}
           onSubmit={jest.fn()}
         >
           <Form>
@@ -82,6 +95,14 @@ const editField = (field: HTMLElement, value: string) => {
 };
 
 describe('MpdGoalPreview', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('shows the saved goal total when there are no unsaved changes', async () => {
     const onCall = jest.fn();
     const { findByText, queryByText } = render(
@@ -305,6 +326,44 @@ describe('MpdGoalPreview', () => {
     // The failure is surfaced (rather than looking like a zero-impact edit) and
     // the header falls back to the saved goal with no stale difference.
     expect(await findByText('Preview unavailable')).toBeInTheDocument();
+    expect(await findByText('MPD Goal: $5,000.00')).toBeInTheDocument();
+    expect(queryByText(/[+-]\$/)).not.toBeInTheDocument();
+  });
+
+  it('does not preview while the form is dirty but invalid', async () => {
+    const onCall = jest.fn();
+    const { getByRole } = render(
+      <TestComponent
+        validationSchema={invalidatingSchema}
+        mocks={previewGoalMock(5200)}
+        onCall={onCall}
+      />,
+    );
+
+    // A negative salary is a real edit but fails validation, so no preview
+    // request should be sent with the invalid attributes.
+    editField(getByRole('spinbutton', { name: 'Salary' }), '-100');
+    jest.advanceTimersByTime(PREVIEW_DEBOUNCE_MS);
+
+    expect(onCall).not.toHaveGraphqlOperation('PreviewNewStaffGoalCalculation');
+  });
+
+  it('drops the preview when a previewed edit is then made invalid', async () => {
+    const { findByText, queryByText, getByRole } = render(
+      <TestComponent
+        validationSchema={invalidatingSchema}
+        mocks={previewGoalMock(5200)}
+        savedMonthlyGoal={5000}
+      />,
+    );
+
+    editField(getByRole('spinbutton', { name: 'Salary' }), '80000');
+    expect(await findByText('+$200.00')).toBeInTheDocument();
+
+    // Making the edit invalid clears the preview: the header reverts to the
+    // saved goal with no stale difference.
+    editField(getByRole('spinbutton', { name: 'Salary' }), '-100');
+
     expect(await findByText('MPD Goal: $5,000.00')).toBeInTheDocument();
     expect(queryByText(/[+-]\$/)).not.toBeInTheDocument();
   });

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.test.tsx
@@ -24,6 +24,7 @@ const invalidatingSchema = yup.object({
 
 const accountListId = 'account-list-1';
 const calculationId = 'goal-calculation-1';
+const onCall = jest.fn();
 
 const previewGoalMock = (
   monthlyGoal: number,
@@ -44,7 +45,6 @@ interface TestComponentProps {
   accountListId?: string | null;
   savedMonthlyGoal?: number;
   mocks?: ApolloErgonoMockMap;
-  onCall?: jest.Mock;
   validationSchema?: yup.AnyObjectSchema;
 }
 
@@ -52,7 +52,6 @@ const TestComponent: React.FC<TestComponentProps> = ({
   accountListId: accountListIdProp = accountListId,
   savedMonthlyGoal = 5000,
   mocks,
-  onCall,
   validationSchema,
 }) => (
   <ThemeProvider theme={theme}>
@@ -104,10 +103,7 @@ describe('MpdGoalPreview', () => {
   });
 
   it('shows the saved goal total when there are no unsaved changes', async () => {
-    const onCall = jest.fn();
-    const { findByText, queryByText } = render(
-      <TestComponent onCall={onCall} />,
-    );
+    const { findByText, queryByText } = render(<TestComponent />);
 
     expect(await findByText('MPD Goal: $5,000.00')).toBeInTheDocument();
     // No signed difference is shown while the form is untouched.
@@ -116,9 +112,8 @@ describe('MpdGoalPreview', () => {
   });
 
   it('coalesces rapid edits across fields into a single preview request', async () => {
-    const onCall = jest.fn();
     const { getByRole } = render(
-      <TestComponent mocks={previewGoalMock(5200)} onCall={onCall} />,
+      <TestComponent mocks={previewGoalMock(5200)} />,
     );
 
     // Edit two fields within the debounce window.
@@ -222,9 +217,8 @@ describe('MpdGoalPreview', () => {
   });
 
   it('shows no difference when the change does not affect the goal', async () => {
-    const onCall = jest.fn();
     const { findByText, queryByText, getByRole } = render(
-      <TestComponent mocks={previewGoalMock(5000)} onCall={onCall} />,
+      <TestComponent mocks={previewGoalMock(5000)} />,
     );
 
     editField(getByRole('spinbutton', { name: 'Salary' }), '80000');
@@ -239,9 +233,8 @@ describe('MpdGoalPreview', () => {
   });
 
   it('requests a preview with the edited attributes', async () => {
-    const onCall = jest.fn();
     const { getByRole } = render(
-      <TestComponent mocks={previewGoalMock(5200)} onCall={onCall} />,
+      <TestComponent mocks={previewGoalMock(5200)} />,
     );
 
     editField(getByRole('spinbutton', { name: 'Salary' }), '99999');
@@ -258,13 +251,8 @@ describe('MpdGoalPreview', () => {
   });
 
   it('previews a scenario goal, omitting the account list', async () => {
-    const onCall = jest.fn();
     const { findByText, getByRole } = render(
-      <TestComponent
-        accountListId={null}
-        mocks={previewGoalMock(5200)}
-        onCall={onCall}
-      />,
+      <TestComponent accountListId={null} mocks={previewGoalMock(5200)} />,
     );
 
     editField(getByRole('spinbutton', { name: 'Salary' }), '80000');
@@ -302,10 +290,8 @@ describe('MpdGoalPreview', () => {
   });
 
   it('falls back to the saved goal when the preview request fails', async () => {
-    const onCall = jest.fn();
     const { findByText, queryByText, getByRole } = render(
       <TestComponent
-        onCall={onCall}
         mocks={
           {
             PreviewNewStaffGoalCalculation: {
@@ -331,12 +317,10 @@ describe('MpdGoalPreview', () => {
   });
 
   it('does not preview while the form is dirty but invalid', async () => {
-    const onCall = jest.fn();
     const { getByRole } = render(
       <TestComponent
         validationSchema={invalidatingSchema}
         mocks={previewGoalMock(5200)}
-        onCall={onCall}
       />,
     );
 

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.tsx
@@ -30,8 +30,9 @@ export const MpdGoalPreview: React.FC<MpdGoalPreviewProps> = ({
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
-  const { containerRef, calculating, displayGoal, diff, changed, failed } =
-    useMpdGoalPreview({ accountListId, calculationId, savedMonthlyGoal });
+  const { calculating, displayGoal, diff, changed, failed } = useMpdGoalPreview(
+    { accountListId, calculationId, savedMonthlyGoal },
+  );
 
   const diffLabel =
     (diff > 0 ? '+' : '-') +
@@ -40,13 +41,7 @@ export const MpdGoalPreview: React.FC<MpdGoalPreviewProps> = ({
     });
 
   return (
-    <Stack
-      ref={containerRef}
-      direction="row"
-      spacing={1}
-      alignItems="center"
-      sx={{ ml: 3 }}
-    >
+    <Stack direction="row" spacing={1} alignItems="center" sx={{ ml: 3 }}>
       <Typography
         variant="h6"
         component="span"

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.tsx
@@ -1,0 +1,185 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { CircularProgress, Stack, Typography } from '@mui/material';
+import { useFormikContext } from 'formik';
+import { useTranslation } from 'react-i18next';
+import { NewStaffGoalCalculationAttributesInput } from 'src/graphql/types.generated';
+import { useDebouncedValue } from 'src/hooks/useDebounce';
+import { useLocale } from 'src/hooks/useLocale';
+import { currencyFormat } from 'src/lib/intlFormat';
+import { usePreviewNewStaffGoalCalculationMutation } from './NewStaffGoalCalculation.generated';
+import { formValuesToAttributes } from './goalSettingsApiMapping';
+import { GoalSettingsFormValues } from './goalSettingsFormValues';
+
+/** Coalesce blurs from tabbing quickly through several fields into one request. */
+export const PREVIEW_DEBOUNCE_MS = 500;
+
+/** The previewed goal keyed by the attributes it was computed for. */
+interface PreviewState {
+  attributesKey: string;
+  /** Computed goal, or `null` if the preview request failed. */
+  monthlyGoal: number | null;
+}
+
+interface MpdGoalPreviewProps {
+  /**
+   * Account list the goal belongs to, or `null` for a scenario goal that has no
+   * account list. Omitted from the preview request when null — the API previews
+   * a scenario goal without it.
+   */
+  accountListId: string | null;
+  calculationId: string;
+  /** The saved goal total; shown when there are no goal-affecting edits. */
+  savedMonthlyGoal: number;
+}
+
+/**
+ * MPD Goal figure in the header. When a field is blurred with unsaved, valid
+ * edits it asks the API to recompute the goal (`previewNewStaffGoalCalculation`)
+ * and shows the new total plus the signed difference from the saved goal
+ * (e.g. `+$200.00` / `-$75.00`) so coaches and admins can see the impact of a
+ * change before saving. Preview runs on blur, not on every keystroke.
+ */
+export const MpdGoalPreview: React.FC<MpdGoalPreviewProps> = ({
+  accountListId,
+  calculationId,
+  savedMonthlyGoal,
+}) => {
+  const { t } = useTranslation();
+  const locale = useLocale();
+  const { values, dirty, isValid } = useFormikContext<GoalSettingsFormValues>();
+
+  const [preview, setPreview] = useState<PreviewState | null>(null);
+  const [previewMutation] = usePreviewNewStaffGoalCalculationMutation();
+
+  const liveAttributesKey = useMemo(
+    () => JSON.stringify(formValuesToAttributes(values)),
+    [values],
+  );
+  // The attributes key to commit when a field blurs, or `null` when the form
+  // isn't previewable. Held in a ref so the blur listener reads the latest
+  // without re-subscribing.
+  const committableKeyRef = useRef<string | null>(null);
+  committableKeyRef.current = dirty && isValid ? liveAttributesKey : null;
+
+  // Attributes committed for preview — updated only when a field blurs, so the
+  // preview reflects the last-blurred state rather than every keystroke.
+  const [committedKey, setCommittedKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    // The editable fields are siblings of this component, not descendants, so
+    // React's `onBlur` can't see them. `focusout` bubbles to the document, so
+    // listen there.
+    const handleFocusOut = () => {
+      setCommittedKey(committableKeyRef.current);
+    };
+    document.addEventListener('focusout', handleFocusOut);
+    return () => document.removeEventListener('focusout', handleFocusOut);
+  }, []);
+
+  // Drop the preview once the form is clean again (saved or cancelled).
+  useEffect(() => {
+    if (!dirty) {
+      setCommittedKey(null);
+    }
+  }, [dirty]);
+
+  const debouncedKey = useDebouncedValue(committedKey, PREVIEW_DEBOUNCE_MS);
+
+  useEffect(() => {
+    if (debouncedKey === null) {
+      return;
+    }
+
+    let active = true;
+    previewMutation({
+      variables: {
+        input: {
+          // Omitted for a scenario goal that has no account list.
+          accountListId: accountListId ?? undefined,
+          id: calculationId,
+          attributes: JSON.parse(
+            debouncedKey,
+          ) as NewStaffGoalCalculationAttributesInput,
+        },
+      },
+      context: { suppressErrors: true },
+    })
+      .then(({ data }) => {
+        if (active) {
+          setPreview({
+            attributesKey: debouncedKey,
+            monthlyGoal:
+              data?.previewNewStaffGoalCalculation?.newStaffGoalCalculation
+                .calculations.monthlyGoal ?? null,
+          });
+        }
+      })
+      .catch(() => {
+        // Record the failed key so the spinner stops and we fall back to the saved goal.
+        if (active) {
+          setPreview({ attributesKey: debouncedKey, monthlyGoal: null });
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [debouncedKey, accountListId, calculationId, previewMutation]);
+
+  // The preview matches the committed edits once their request has settled.
+  const settledPreview =
+    committedKey !== null && preview?.attributesKey === committedKey
+      ? preview
+      : null;
+  // A blur committed new edits but their preview hasn't arrived yet.
+  const calculating = committedKey !== null && !settledPreview;
+
+  const previewGoal = settledPreview?.monthlyGoal ?? null;
+  const displayGoal = previewGoal ?? savedMonthlyGoal;
+  const diff =
+    previewGoal === null
+      ? 0
+      : Math.round((previewGoal - savedMonthlyGoal) * 100) / 100;
+  const changed = Math.abs(diff) >= 0.005;
+  const sign = diff > 0 ? '+' : '-';
+  const diffLabel =
+    sign +
+    currencyFormat(Math.abs(diff), 'USD', locale, {
+      showTrailingZeros: true,
+    });
+
+  // While recalculating, swap the amount for a spinner and hide the difference,
+  // so no stale number is on screen mid-update.
+  return (
+    <Stack direction="row" spacing={1} alignItems="center" sx={{ ml: 3 }}>
+      <Typography variant="h6">
+        {calculating
+          ? t('MPD Goal:')
+          : t('MPD Goal: {{amount}}', {
+              amount: currencyFormat(displayGoal, 'USD', locale, {
+                showTrailingZeros: true,
+              }),
+            })}
+      </Typography>
+      {calculating ? (
+        <CircularProgress
+          size={16}
+          aria-label={t('Calculating new goal total')}
+        />
+      ) : (
+        changed && (
+          <Typography
+            variant="h6"
+            component="span"
+            sx={{ color: 'text.secondary' }}
+            aria-label={t('Unsaved changes will adjust goal by {{diff}}', {
+              diff: diffLabel,
+            })}
+          >
+            {diffLabel}
+          </Typography>
+        )
+      )}
+    </Stack>
+  );
+};

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.tsx
@@ -17,10 +17,10 @@ interface MpdGoalPreviewProps {
 }
 
 /**
- * MPD Goal figure in the header. When a field is blurred with unsaved, valid
- * edits it shows the recomputed goal total plus the signed difference from the
- * saved goal (e.g. `+$200.00` / `-$75.00`) so coaches and admins can see the
- * impact of a change before saving. All the preview orchestration lives in
+ * MPD Goal figure in the header. While the form has unsaved, valid edits it
+ * shows the recomputed goal total plus the signed difference from the saved
+ * goal (e.g. `+$200.00` / `-$75.00`) so coaches and admins can see the impact
+ * of a change before saving. All the preview orchestration lives in
  * {@link useMpdGoalPreview}; this component only renders its result.
  */
 export const MpdGoalPreview: React.FC<MpdGoalPreviewProps> = ({

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.tsx
@@ -1,30 +1,14 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React from 'react';
 import { CircularProgress, Stack, Typography } from '@mui/material';
-import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
-import { NewStaffGoalCalculationAttributesInput } from 'src/graphql/types.generated';
-import { useDebouncedValue } from 'src/hooks/useDebounce';
 import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat } from 'src/lib/intlFormat';
-import { usePreviewNewStaffGoalCalculationMutation } from './NewStaffGoalCalculation.generated';
-import { formValuesToAttributes } from './goalSettingsApiMapping';
-import { GoalSettingsFormValues } from './goalSettingsFormValues';
-
-/** Coalesce blurs from tabbing quickly through several fields into one request. */
-export const PREVIEW_DEBOUNCE_MS = 500;
-
-/** The previewed goal keyed by the attributes it was computed for. */
-interface PreviewState {
-  attributesKey: string;
-  /** Computed goal, or `null` if the preview request failed. */
-  monthlyGoal: number | null;
-}
+import { useMpdGoalPreview } from './useMpdGoalPreview';
 
 interface MpdGoalPreviewProps {
   /**
    * Account list the goal belongs to, or `null` for a scenario goal that has no
-   * account list. Omitted from the preview request when null — the API previews
-   * a scenario goal without it.
+   * account list.
    */
   accountListId: string | null;
   calculationId: string;
@@ -34,10 +18,10 @@ interface MpdGoalPreviewProps {
 
 /**
  * MPD Goal figure in the header. When a field is blurred with unsaved, valid
- * edits it asks the API to recompute the goal (`previewNewStaffGoalCalculation`)
- * and shows the new total plus the signed difference from the saved goal
- * (e.g. `+$200.00` / `-$75.00`) so coaches and admins can see the impact of a
- * change before saving. Preview runs on blur, not on every keystroke.
+ * edits it shows the recomputed goal total plus the signed difference from the
+ * saved goal (e.g. `+$200.00` / `-$75.00`) so coaches and admins can see the
+ * impact of a change before saving. All the preview orchestration lives in
+ * {@link useMpdGoalPreview}; this component only renders its result.
  */
 export const MpdGoalPreview: React.FC<MpdGoalPreviewProps> = ({
   accountListId,
@@ -46,139 +30,60 @@ export const MpdGoalPreview: React.FC<MpdGoalPreviewProps> = ({
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
-  const { values, dirty, isValid } = useFormikContext<GoalSettingsFormValues>();
+  const { containerRef, calculating, displayGoal, diff, changed, failed } =
+    useMpdGoalPreview({ accountListId, calculationId, savedMonthlyGoal });
 
-  const [preview, setPreview] = useState<PreviewState | null>(null);
-  const [previewMutation] = usePreviewNewStaffGoalCalculationMutation();
-
-  const liveAttributesKey = useMemo(
-    () => JSON.stringify(formValuesToAttributes(values)),
-    [values],
-  );
-  // The attributes key to commit when a field blurs, or `null` when the form
-  // isn't previewable. Held in a ref so the blur listener reads the latest
-  // without re-subscribing.
-  const committableKeyRef = useRef<string | null>(null);
-  committableKeyRef.current = dirty && isValid ? liveAttributesKey : null;
-
-  // Attributes committed for preview — updated only when a field blurs, so the
-  // preview reflects the last-blurred state rather than every keystroke.
-  const [committedKey, setCommittedKey] = useState<string | null>(null);
-
-  useEffect(() => {
-    // The editable fields are siblings of this component, not descendants, so
-    // React's `onBlur` can't see them. `focusout` bubbles to the document, so
-    // listen there.
-    const handleFocusOut = () => {
-      setCommittedKey(committableKeyRef.current);
-    };
-    document.addEventListener('focusout', handleFocusOut);
-    return () => document.removeEventListener('focusout', handleFocusOut);
-  }, []);
-
-  // Drop the preview once the form is clean again (saved or cancelled).
-  useEffect(() => {
-    if (!dirty) {
-      setCommittedKey(null);
-    }
-  }, [dirty]);
-
-  const debouncedKey = useDebouncedValue(committedKey, PREVIEW_DEBOUNCE_MS);
-
-  useEffect(() => {
-    if (debouncedKey === null) {
-      return;
-    }
-
-    let active = true;
-    previewMutation({
-      variables: {
-        input: {
-          // Omitted for a scenario goal that has no account list.
-          accountListId: accountListId ?? undefined,
-          id: calculationId,
-          attributes: JSON.parse(
-            debouncedKey,
-          ) as NewStaffGoalCalculationAttributesInput,
-        },
-      },
-      context: { suppressErrors: true },
-    })
-      .then(({ data }) => {
-        if (active) {
-          setPreview({
-            attributesKey: debouncedKey,
-            monthlyGoal:
-              data?.previewNewStaffGoalCalculation?.newStaffGoalCalculation
-                .calculations.monthlyGoal ?? null,
-          });
-        }
-      })
-      .catch(() => {
-        // Record the failed key so the spinner stops and we fall back to the saved goal.
-        if (active) {
-          setPreview({ attributesKey: debouncedKey, monthlyGoal: null });
-        }
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [debouncedKey, accountListId, calculationId, previewMutation]);
-
-  // The preview matches the committed edits once their request has settled.
-  const settledPreview =
-    committedKey !== null && preview?.attributesKey === committedKey
-      ? preview
-      : null;
-  // A blur committed new edits but their preview hasn't arrived yet.
-  const calculating = committedKey !== null && !settledPreview;
-
-  const previewGoal = settledPreview?.monthlyGoal ?? null;
-  const displayGoal = previewGoal ?? savedMonthlyGoal;
-  const diff =
-    previewGoal === null
-      ? 0
-      : Math.round((previewGoal - savedMonthlyGoal) * 100) / 100;
-  const changed = Math.abs(diff) >= 0.005;
-  const sign = diff > 0 ? '+' : '-';
   const diffLabel =
-    sign +
+    (diff > 0 ? '+' : '-') +
     currencyFormat(Math.abs(diff), 'USD', locale, {
       showTrailingZeros: true,
     });
 
-  // While recalculating, swap the amount for a spinner and hide the difference,
-  // so no stale number is on screen mid-update.
   return (
-    <Stack direction="row" spacing={1} alignItems="center" sx={{ ml: 3 }}>
-      <Typography variant="h6">
-        {calculating
-          ? t('MPD Goal:')
-          : t('MPD Goal: {{amount}}', {
-              amount: currencyFormat(displayGoal, 'USD', locale, {
-                showTrailingZeros: true,
-              }),
-            })}
+    <Stack
+      ref={containerRef}
+      direction="row"
+      spacing={1}
+      alignItems="center"
+      sx={{ ml: 3 }}
+    >
+      <Typography
+        variant="h6"
+        component="span"
+        sx={{ minWidth: (theme) => theme.spacing(20) }}
+      >
+        {t('MPD Goal:')}{' '}
+        {!calculating &&
+          currencyFormat(displayGoal, 'USD', locale, {
+            showTrailingZeros: true,
+          })}
       </Typography>
-      {calculating ? (
+      {calculating && (
         <CircularProgress
           size={16}
           aria-label={t('Calculating new goal total')}
         />
-      ) : (
-        changed && (
-          <Typography
-            variant="h6"
-            component="span"
-            sx={{ color: 'text.secondary' }}
-            aria-label={t('Unsaved changes will adjust goal by {{diff}}', {
-              diff: diffLabel,
-            })}
-          >
-            {diffLabel}
-          </Typography>
-        )
+      )}
+      {!calculating && changed && (
+        <Typography
+          variant="h6"
+          component="span"
+          sx={{ color: 'text.secondary' }}
+          aria-label={t('Unsaved changes will adjust goal by {{diff}}', {
+            diff: diffLabel,
+          })}
+        >
+          {diffLabel}
+        </Typography>
+      )}
+      {!calculating && failed && (
+        <Typography
+          variant="body2"
+          component="span"
+          sx={{ color: 'text.secondary' }}
+        >
+          {t('Preview unavailable')}
+        </Typography>
       )}
     </Stack>
   );

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/MpdGoalPreview.tsx
@@ -42,11 +42,7 @@ export const MpdGoalPreview: React.FC<MpdGoalPreviewProps> = ({
 
   return (
     <Stack direction="row" spacing={1} alignItems="center" sx={{ ml: 3 }}>
-      <Typography
-        variant="h6"
-        component="span"
-        sx={{ minWidth: (theme) => theme.spacing(20) }}
-      >
+      <Typography variant="h6" component="span">
         {t('MPD Goal:')}{' '}
         {!calculating &&
           currencyFormat(displayGoal, 'USD', locale, {

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
@@ -114,3 +114,17 @@ mutation UpdateNewStaffGoalCalculation(
     }
   }
 }
+
+# Recalculate the goal for a set of unsaved changes
+mutation PreviewNewStaffGoalCalculation(
+  $input: NewStaffGoalCalculationPreviewMutationInput!
+) {
+  previewNewStaffGoalCalculation(input: $input) {
+    newStaffGoalCalculation {
+      id
+      calculations {
+        monthlyGoal
+      }
+    }
+  }
+}

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/useMpdGoalPreview.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/useMpdGoalPreview.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useFormikContext } from 'formik';
+import { NewStaffGoalCalculationAttributesInput } from 'src/graphql/types.generated';
 import { useDebouncedValue } from 'src/hooks/useDebounce';
 import { usePreviewNewStaffGoalCalculationMutation } from './NewStaffGoalCalculation.generated';
 import { formValuesToAttributes } from './goalSettingsApiMapping';
@@ -11,9 +12,9 @@ export const PREVIEW_DEBOUNCE_MS = 500;
 /** Diffs smaller than half a cent are treated as no change. */
 const CENT_EPSILON = 0.005;
 
-/** The previewed goal keyed by the attributes it was computed for. */
+/** The previewed goal, tagged with the attributes it was computed for. */
 interface PreviewState {
-  key: string;
+  attributes: NewStaffGoalCalculationAttributesInput;
   /** Computed goal, or `null` if the preview request failed. */
   monthlyGoal: number | null;
 }
@@ -62,16 +63,14 @@ export const useMpdGoalPreview = ({
     fetchPolicy: 'no-cache',
   });
 
+  // Formik keeps `values` referentially stable until a real edit (tabbing/blur
+  // only touches `touched`), so this memoized object is stable too — its
+  // identity doubles as the debounce key and the settled-preview match, no
+  // serialization needed.
   const attributes = useMemo(() => formValuesToAttributes(values), [values]);
-  const attributesKey = useMemo(() => JSON.stringify(attributes), [attributes]);
-
   // The attributes to preview, or `null` while the form is clean or invalid
-  // (which also clears any prior preview). Memoized so its identity is stable
-  // across unrelated re-renders and the debounce only restarts on a real edit.
-  const previewable = useMemo(
-    () => (dirty && isValid ? { key: attributesKey, attributes } : null),
-    [dirty, isValid, attributesKey, attributes],
-  );
+  // (which also clears any prior preview).
+  const previewable = dirty && isValid ? attributes : null;
 
   // Debounced so we preview the settled values, not every keystroke.
   const debounced = useDebouncedValue(previewable, PREVIEW_DEBOUNCE_MS);
@@ -88,7 +87,7 @@ export const useMpdGoalPreview = ({
           // Omitted for a scenario goal that has no account list.
           accountListId: accountListId ?? undefined,
           id: calculationId,
-          attributes: debounced.attributes,
+          attributes: debounced,
         },
       },
       context: { suppressErrors: true },
@@ -96,7 +95,7 @@ export const useMpdGoalPreview = ({
       .then(({ data }) => {
         if (active) {
           setPreview({
-            key: debounced.key,
+            attributes: debounced,
             monthlyGoal:
               data?.previewNewStaffGoalCalculation?.newStaffGoalCalculation
                 ?.calculations?.monthlyGoal ?? null,
@@ -104,10 +103,10 @@ export const useMpdGoalPreview = ({
         }
       })
       .catch(() => {
-        // Record the failed key so the spinner stops and we fall back to the
-        // saved goal.
+        // Record the failed attributes so the spinner stops and we fall back to
+        // the saved goal.
         if (active) {
-          setPreview({ key: debounced.key, monthlyGoal: null });
+          setPreview({ attributes: debounced, monthlyGoal: null });
         }
       });
 
@@ -118,7 +117,9 @@ export const useMpdGoalPreview = ({
 
   // The preview matches the current edits once their request has settled.
   const settledPreview =
-    previewable !== null && preview?.key === previewable.key ? preview : null;
+    previewable !== null && preview?.attributes === previewable
+      ? preview
+      : null;
   // Edits are pending but their preview hasn't arrived yet.
   const calculating = previewable !== null && settledPreview === null;
   const failed = settledPreview !== null && settledPreview.monthlyGoal === null;

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/useMpdGoalPreview.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/useMpdGoalPreview.ts
@@ -1,22 +1,15 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useFormikContext } from 'formik';
-import { NewStaffGoalCalculationAttributesInput } from 'src/graphql/types.generated';
 import { useDebouncedValue } from 'src/hooks/useDebounce';
 import { usePreviewNewStaffGoalCalculationMutation } from './NewStaffGoalCalculation.generated';
 import { formValuesToAttributes } from './goalSettingsApiMapping';
 import { GoalSettingsFormValues } from './goalSettingsFormValues';
 
-/** Coalesce blurs from tabbing quickly through several fields into one request. */
+/** Coalesce a burst of edits (e.g. picking through selects) into one request. */
 export const PREVIEW_DEBOUNCE_MS = 500;
 
 /** Diffs smaller than half a cent are treated as no change. */
 const CENT_EPSILON = 0.005;
-
-/** Attributes committed for preview, plus a stable key for deduping/debouncing. */
-interface CommittedAttributes {
-  key: string;
-  attributes: NewStaffGoalCalculationAttributesInput;
-}
 
 /** The previewed goal keyed by the attributes it was computed for. */
 interface PreviewState {
@@ -33,12 +26,7 @@ interface UseMpdGoalPreviewArgs {
 }
 
 interface UseMpdGoalPreviewResult {
-  /**
-   * Attach to the element wrapping the preview. Used to find the enclosing form
-   * so blur detection is scoped to it rather than the whole document.
-   */
-  containerRef: React.RefObject<HTMLDivElement>;
-  /** True while a committed edit's preview request is in flight. */
+  /** True while a debounced edit's preview request is in flight. */
   calculating: boolean;
   /** Goal to display: the previewed total when settled, else the saved goal. */
   displayGoal: number;
@@ -51,11 +39,13 @@ interface UseMpdGoalPreviewResult {
 }
 
 /**
- * Orchestrates the on-blur goal preview for {@link MpdGoalPreview}: watches the
- * Goal Settings form, and when a field is blurred with unsaved, valid edits it
- * asks the API to recompute the goal (`previewNewStaffGoalCalculation`) and
- * exposes the new total plus the signed difference from the saved goal. Preview
- * runs on blur (debounced), not on every keystroke.
+ * Orchestrates the goal preview for {@link MpdGoalPreview}: watches the Goal
+ * Settings form and, whenever the unsaved, valid form values change, debounces
+ * a call to the API to recompute the goal (`previewNewStaffGoalCalculation`),
+ * exposing the new total plus the signed difference from the saved goal.
+ *
+ * Previewing keys off the Formik values directly rather than field blur, since
+ * some inputs (selects) don't produce a usable blur.
  */
 export const useMpdGoalPreview = ({
   accountListId,
@@ -75,38 +65,16 @@ export const useMpdGoalPreview = ({
   const attributes = useMemo(() => formValuesToAttributes(values), [values]);
   const attributesKey = useMemo(() => JSON.stringify(attributes), [attributes]);
 
-  // The attributes to commit when a field blurs, or `null` when the form isn't
-  // previewable. Held in a ref (mirrored in an effect) so the blur listener
-  // reads the latest without re-subscribing.
-  const committableRef = useRef<CommittedAttributes | null>(null);
-  useEffect(() => {
-    committableRef.current =
-      dirty && isValid ? { key: attributesKey, attributes } : null;
-  }, [dirty, isValid, attributesKey, attributes]);
+  // The attributes to preview, or `null` while the form is clean or invalid
+  // (which also clears any prior preview). Memoized so its identity is stable
+  // across unrelated re-renders and the debounce only restarts on a real edit.
+  const previewable = useMemo(
+    () => (dirty && isValid ? { key: attributesKey, attributes } : null),
+    [dirty, isValid, attributesKey, attributes],
+  );
 
-  // Attributes committed for preview — updated only when a field blurs, so the
-  // preview reflects the last-blurred state rather than every keystroke.
-  const [committed, setCommitted] = useState<CommittedAttributes | null>(null);
-
-  const containerRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    // The editable fields are siblings of this component, not descendants, so
-    // React's `onBlur` can't see them. `focusout` bubbles, so listen on the
-    // enclosing form (falling back to the document) — scoped, not global.
-    const target = containerRef.current?.closest('form') ?? document;
-    const handleFocusOut = () => setCommitted(committableRef.current);
-    target.addEventListener('focusout', handleFocusOut);
-    return () => target.removeEventListener('focusout', handleFocusOut);
-  }, []);
-
-  // Drop the preview once the form is clean again (saved or cancelled).
-  useEffect(() => {
-    if (!dirty) {
-      setCommitted(null);
-    }
-  }, [dirty]);
-
-  const debounced = useDebouncedValue(committed, PREVIEW_DEBOUNCE_MS);
+  // Debounced so we preview the settled values, not every keystroke.
+  const debounced = useDebouncedValue(previewable, PREVIEW_DEBOUNCE_MS);
 
   useEffect(() => {
     if (debounced === null) {
@@ -148,11 +116,11 @@ export const useMpdGoalPreview = ({
     };
   }, [debounced, accountListId, calculationId, previewMutation]);
 
-  // The preview matches the committed edits once their request has settled.
+  // The preview matches the current edits once their request has settled.
   const settledPreview =
-    committed !== null && preview?.key === committed.key ? preview : null;
-  // A blur committed new edits but their preview hasn't arrived yet.
-  const calculating = committed !== null && settledPreview === null;
+    previewable !== null && preview?.key === previewable.key ? preview : null;
+  // Edits are pending but their preview hasn't arrived yet.
+  const calculating = previewable !== null && settledPreview === null;
   const failed = settledPreview !== null && settledPreview.monthlyGoal === null;
 
   const previewGoal = settledPreview?.monthlyGoal ?? null;
@@ -163,5 +131,5 @@ export const useMpdGoalPreview = ({
       : Math.round((previewGoal - savedMonthlyGoal) * 100) / 100;
   const changed = Math.abs(diff) >= CENT_EPSILON;
 
-  return { containerRef, calculating, displayGoal, diff, changed, failed };
+  return { calculating, displayGoal, diff, changed, failed };
 };

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/useMpdGoalPreview.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/useMpdGoalPreview.ts
@@ -1,0 +1,167 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useFormikContext } from 'formik';
+import { NewStaffGoalCalculationAttributesInput } from 'src/graphql/types.generated';
+import { useDebouncedValue } from 'src/hooks/useDebounce';
+import { usePreviewNewStaffGoalCalculationMutation } from './NewStaffGoalCalculation.generated';
+import { formValuesToAttributes } from './goalSettingsApiMapping';
+import { GoalSettingsFormValues } from './goalSettingsFormValues';
+
+/** Coalesce blurs from tabbing quickly through several fields into one request. */
+export const PREVIEW_DEBOUNCE_MS = 500;
+
+/** Diffs smaller than half a cent are treated as no change. */
+const CENT_EPSILON = 0.005;
+
+/** Attributes committed for preview, plus a stable key for deduping/debouncing. */
+interface CommittedAttributes {
+  key: string;
+  attributes: NewStaffGoalCalculationAttributesInput;
+}
+
+/** The previewed goal keyed by the attributes it was computed for. */
+interface PreviewState {
+  key: string;
+  /** Computed goal, or `null` if the preview request failed. */
+  monthlyGoal: number | null;
+}
+
+interface UseMpdGoalPreviewArgs {
+  /** Account list the goal belongs to, or `null` for a scenario goal. */
+  accountListId: string | null;
+  calculationId: string;
+  savedMonthlyGoal: number;
+}
+
+interface UseMpdGoalPreviewResult {
+  /**
+   * Attach to the element wrapping the preview. Used to find the enclosing form
+   * so blur detection is scoped to it rather than the whole document.
+   */
+  containerRef: React.RefObject<HTMLDivElement>;
+  /** True while a committed edit's preview request is in flight. */
+  calculating: boolean;
+  /** Goal to display: the previewed total when settled, else the saved goal. */
+  displayGoal: number;
+  /** Signed difference from the saved goal, rounded to cents (0 when unchanged). */
+  diff: number;
+  /** Whether the preview differs from the saved goal by at least a cent. */
+  changed: boolean;
+  /** True when the settled preview request failed (and fell back to the saved goal). */
+  failed: boolean;
+}
+
+/**
+ * Orchestrates the on-blur goal preview for {@link MpdGoalPreview}: watches the
+ * Goal Settings form, and when a field is blurred with unsaved, valid edits it
+ * asks the API to recompute the goal (`previewNewStaffGoalCalculation`) and
+ * exposes the new total plus the signed difference from the saved goal. Preview
+ * runs on blur (debounced), not on every keystroke.
+ */
+export const useMpdGoalPreview = ({
+  accountListId,
+  calculationId,
+  savedMonthlyGoal,
+}: UseMpdGoalPreviewArgs): UseMpdGoalPreviewResult => {
+  const { values, dirty, isValid } = useFormikContext<GoalSettingsFormValues>();
+
+  const [preview, setPreview] = useState<PreviewState | null>(null);
+  // `no-cache`: the preview returns a partial calculation under a throwaway
+  // `NewStaffGoalCalculationPreview` type; keeping it out of the cache avoids
+  // persisting an entity nothing else reads.
+  const [previewMutation] = usePreviewNewStaffGoalCalculationMutation({
+    fetchPolicy: 'no-cache',
+  });
+
+  const attributes = useMemo(() => formValuesToAttributes(values), [values]);
+  const attributesKey = useMemo(() => JSON.stringify(attributes), [attributes]);
+
+  // The attributes to commit when a field blurs, or `null` when the form isn't
+  // previewable. Held in a ref (mirrored in an effect) so the blur listener
+  // reads the latest without re-subscribing.
+  const committableRef = useRef<CommittedAttributes | null>(null);
+  useEffect(() => {
+    committableRef.current =
+      dirty && isValid ? { key: attributesKey, attributes } : null;
+  }, [dirty, isValid, attributesKey, attributes]);
+
+  // Attributes committed for preview — updated only when a field blurs, so the
+  // preview reflects the last-blurred state rather than every keystroke.
+  const [committed, setCommitted] = useState<CommittedAttributes | null>(null);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    // The editable fields are siblings of this component, not descendants, so
+    // React's `onBlur` can't see them. `focusout` bubbles, so listen on the
+    // enclosing form (falling back to the document) — scoped, not global.
+    const target = containerRef.current?.closest('form') ?? document;
+    const handleFocusOut = () => setCommitted(committableRef.current);
+    target.addEventListener('focusout', handleFocusOut);
+    return () => target.removeEventListener('focusout', handleFocusOut);
+  }, []);
+
+  // Drop the preview once the form is clean again (saved or cancelled).
+  useEffect(() => {
+    if (!dirty) {
+      setCommitted(null);
+    }
+  }, [dirty]);
+
+  const debounced = useDebouncedValue(committed, PREVIEW_DEBOUNCE_MS);
+
+  useEffect(() => {
+    if (debounced === null) {
+      return;
+    }
+
+    let active = true;
+    previewMutation({
+      variables: {
+        input: {
+          // Omitted for a scenario goal that has no account list.
+          accountListId: accountListId ?? undefined,
+          id: calculationId,
+          attributes: debounced.attributes,
+        },
+      },
+      context: { suppressErrors: true },
+    })
+      .then(({ data }) => {
+        if (active) {
+          setPreview({
+            key: debounced.key,
+            monthlyGoal:
+              data?.previewNewStaffGoalCalculation?.newStaffGoalCalculation
+                ?.calculations?.monthlyGoal ?? null,
+          });
+        }
+      })
+      .catch(() => {
+        // Record the failed key so the spinner stops and we fall back to the
+        // saved goal.
+        if (active) {
+          setPreview({ key: debounced.key, monthlyGoal: null });
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [debounced, accountListId, calculationId, previewMutation]);
+
+  // The preview matches the committed edits once their request has settled.
+  const settledPreview =
+    committed !== null && preview?.key === committed.key ? preview : null;
+  // A blur committed new edits but their preview hasn't arrived yet.
+  const calculating = committed !== null && settledPreview === null;
+  const failed = settledPreview !== null && settledPreview.monthlyGoal === null;
+
+  const previewGoal = settledPreview?.monthlyGoal ?? null;
+  const displayGoal = previewGoal ?? savedMonthlyGoal;
+  const diff =
+    previewGoal === null
+      ? 0
+      : Math.round((previewGoal - savedMonthlyGoal) * 100) / 100;
+  const changed = Math.abs(diff) >= CENT_EPSILON;
+
+  return { containerRef, calculating, displayGoal, diff, changed, failed };
+};


### PR DESCRIPTION
## Description

Previews the recalculated MPD goal in the New Staff Goal Calculator header so coaches and admins can see the impact of unsaved edits before saving.

- Add `MpdGoalPreview` component that renders the `MPD Goal:` figure in the header. On field blur, if the form is dirty and valid, it calls the new `previewNewStaffGoalCalculation` mutation and shows the recalculated total plus the signed difference from the saved goal (e.g. `+$200.00` / `-$75.00`).
- Preview runs on blur (via a document `focusout` listener, since the edited fields are siblings of the header), not on every keystroke, and coalesces rapid blurs with a 500ms debounce.
- While recalculating, the amount is replaced by a spinner and the difference is hidden so no stale number is shown mid-update.
- Falls back to the saved goal (no difference) when the preview request fails; errors are suppressed so a failed preview doesn't surface a snackbar.
- Scenario goals have no account list, so `accountListId` is passed as `null` from `GoalSettingsForm` and omitted from the preview request; the API previews the scenario goal without it.
- Add the `PreviewNewStaffGoalCalculation` mutation to `NewStaffGoalCalculation.graphql`.

Jira: MPDX-9836

## Testing

- Open the New Staff Goal Calculator for a staff goal (HR Tools → Goal Calculator).
- Note the `MPD Goal:` total in the header.
- Edit a goal-affecting field (e.g. requested salary) and tab/click away to blur it.
- Check that the header briefly shows a spinner, then updates to the recalculated total with a signed difference (e.g. `+$200.00`) next to it.
- Make a change that doesn't affect the goal and confirm no difference is shown.
- Save (or cancel) and confirm the difference clears and the header shows the saved goal.
- Repeat for a scenario goal (no account list) and confirm the preview still updates.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
