### PR TITLE
[No Jira] - Apply developer bypass to HR Tools nav tab visibility

### DIFF
--- a/src/hooks/useNavPages.test.tsx
+++ b/src/hooks/useNavPages.test.tsx
@@ -31,6 +31,22 @@ const Wrapper = ({ children }: { children: ReactElement }) => (
   </TestRouter>
 );
 
+// Reports are disabled when the user_type_verified option is not 'true'
+const ReportsDisabledWrapper = ({ children }: { children: ReactElement }) => (
+  <TestRouter>
+    <GqlMockedProvider<{ GetUser: GetUserQuery; UserOption: UserOptionQuery }>
+      mocks={{
+        GetUser: { user: nonUsStaffUser },
+        UserOption: {
+          userOption: { key: 'user_type_verified', value: 'false' },
+        },
+      }}
+    >
+      {children}
+    </GqlMockedProvider>
+  </TestRouter>
+);
+
 describe('useNavPages', () => {
   afterEach(() => {
     process.env.DEVELOPMENT_ENV = 'false';
@@ -73,6 +89,20 @@ describe('useNavPages', () => {
     await waitForNextUpdate();
 
     expect(result.current.navPages.map((page) => page.id)).toContain(
+      'hr-tools-page',
+    );
+  });
+
+  it('keeps the HR Tools tab hidden for a developer when reports are disabled', async () => {
+    process.env.DEVELOPMENT_ENV = 'true';
+    mockSession({ developer: true });
+
+    const { result, waitForNextUpdate } = renderHook(() => useNavPages(false), {
+      wrapper: ReportsDisabledWrapper,
+    });
+    await waitForNextUpdate();
+
+    expect(result.current.navPages.map((page) => page.id)).not.toContain(
       'hr-tools-page',
     );
   });

--- a/src/hooks/useNavPages.test.tsx
+++ b/src/hooks/useNavPages.test.tsx
@@ -1,0 +1,79 @@
+import { ReactElement } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import TestRouter from '__tests__/util/TestRouter';
+import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
+import { mockSession } from '__tests__/util/mockSession';
+import { GetUserQuery } from 'src/components/User/GetUser.generated';
+import { UserTypeEnum } from 'src/graphql/types.generated';
+import { UserOptionQuery } from './UserPreference.generated';
+import { useNavPages } from './useNavPages';
+
+// A user without the US Staff user type, ineligible for every HR Tool
+const nonUsStaffUser = {
+  userType: UserTypeEnum.GlobalStaff,
+  usStaffGroup: null,
+  spouseUsStaffGroup: null,
+  staffAccountId: null,
+};
+
+const Wrapper = ({ children }: { children: ReactElement }) => (
+  <TestRouter>
+    <GqlMockedProvider<{ GetUser: GetUserQuery; UserOption: UserOptionQuery }>
+      mocks={{
+        GetUser: { user: nonUsStaffUser },
+        UserOption: {
+          userOption: { key: 'user_type_verified', value: 'true' },
+        },
+      }}
+    >
+      {children}
+    </GqlMockedProvider>
+  </TestRouter>
+);
+
+describe('useNavPages', () => {
+  afterEach(() => {
+    process.env.DEVELOPMENT_ENV = 'false';
+  });
+
+  it('hides the HR Tools tab for a non-US Staff user when not in a development env', async () => {
+    mockSession({ developer: false });
+
+    const { result, waitForNextUpdate } = renderHook(() => useNavPages(false), {
+      wrapper: Wrapper,
+    });
+    await waitForNextUpdate();
+
+    expect(result.current.navPages.map((page) => page.id)).not.toContain(
+      'hr-tools-page',
+    );
+  });
+
+  it('hides the HR Tools tab for a non-US Staff non-developer in a development env', async () => {
+    process.env.DEVELOPMENT_ENV = 'true';
+    mockSession({ developer: false });
+
+    const { result, waitForNextUpdate } = renderHook(() => useNavPages(false), {
+      wrapper: Wrapper,
+    });
+    await waitForNextUpdate();
+
+    expect(result.current.navPages.map((page) => page.id)).not.toContain(
+      'hr-tools-page',
+    );
+  });
+
+  it('shows the HR Tools tab for a non-US Staff developer in a development env', async () => {
+    process.env.DEVELOPMENT_ENV = 'true';
+    mockSession({ developer: true });
+
+    const { result, waitForNextUpdate } = renderHook(() => useNavPages(false), {
+      wrapper: Wrapper,
+    });
+    await waitForNextUpdate();
+
+    expect(result.current.navPages.map((page) => page.id)).toContain(
+      'hr-tools-page',
+    );
+  });
+});

--- a/src/hooks/useNavPages.tsx
+++ b/src/hooks/useNavPages.tsx
@@ -57,7 +57,7 @@ export function useNavPages(coachingAccountCount: boolean, isSearch = false) {
 
   const userType = data?.user.userType;
   const developerBypass = useDeveloperBypass();
-  const showTab = userType === UserTypeEnum.UsStaff || developerBypass;
+  const canSeeHrTools = userType === UserTypeEnum.UsStaff || developerBypass;
 
   const reportItems = useReportNavItems();
   const toolsItems = useToolsNavItems();
@@ -123,7 +123,7 @@ export function useNavPages(coachingAccountCount: boolean, isSearch = false) {
               })),
               showInNav: true,
               hideTab:
-                (!!data && !showTab) ||
+                (!!data && !canSeeHrTools) ||
                 hrToolsLoading ||
                 hrToolsItems.length === 0,
             },
@@ -194,7 +194,7 @@ export function useNavPages(coachingAccountCount: boolean, isSearch = false) {
     settingsItems,
     hrToolsItems,
     hrToolsLoading,
-    showTab,
+    canSeeHrTools,
     reportsDisabled,
     data,
   ]);

--- a/src/hooks/useNavPages.tsx
+++ b/src/hooks/useNavPages.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import { UserTypeEnum } from 'src/graphql/types.generated';
 import { useAccountListId } from 'src/hooks/useAccountListId';
+import { useDeveloperBypass } from './useDeveloperBypass';
 import { useHrToolsNavItems } from './useHrToolsNavItems';
 import { useReportNavItems } from './useReportNavItems';
 import { useReportsDisabled } from './useReportsDisabled';
@@ -55,7 +56,8 @@ export function useNavPages(coachingAccountCount: boolean, isSearch = false) {
   const { reportsDisabled } = useReportsDisabled();
 
   const userType = data?.user.userType;
-  const showTab = userType === UserTypeEnum.UsStaff;
+  const developerBypass = useDeveloperBypass();
+  const showTab = userType === UserTypeEnum.UsStaff || developerBypass;
 
   const reportItems = useReportNavItems();
   const toolsItems = useToolsNavItems();


### PR DESCRIPTION
## Description

- The `DEVELOPMENT_ENV` developer bypass (added in #1830) lets developers reach all HR Tools pages and see all HR Tools menu items, but the tab-level gate in `useNavPages` still hid the entire HR Tools dropdown for any user whose `userType` is not `US_STAFF`. A non-US Staff developer could visit every HR page directly by URL but never saw the menu tab.
- Folds `useDeveloperBypass()` into the `showTab` check in `useNavPages` so the tab-level gate follows the same pattern as `useHrToolsNavItems`, `useReportNavItems`, and `UserTypeAccess`.
- Adds a `useNavPages` test covering the three cases: non-US Staff developer in a development env sees the tab; non-developers and non-development envs still hide it.

No dependent PRs and no Jira ticket — this fixes a developer-experience inconsistency found while debugging why `DEVELOPMENT_ENV=true` stopped surfacing the HR menu.

## Testing

- Add `DEVELOPMENT_ENV=true` to your `.env.local` and restart the dev server
- Sign in with a developer account (`user.developer` is `true` in `/api/auth/session`) whose `userType` is **not** `US_STAFF`
- Check that the **HR Tools** dropdown now appears in the top nav and lists all HR tools
- Sign in with a non-developer, non-US Staff account and check that the HR Tools tab is still hidden
- Run `yarn test useNavPages.test.tsx`

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)
