### PR TITLE
[MPDX-9654] - Show stopped recurring transfers in Transfer History

### DIFF
--- a/src/components/HrTools/MpdGoalAdmin/EditTrainingCostsModal/EditTrainingCostsModal.test.tsx
+++ b/src/components/HrTools/MpdGoalAdmin/EditTrainingCostsModal/EditTrainingCostsModal.test.tsx
@@ -208,7 +208,9 @@ describe('EditTrainingCostsModal', () => {
     await userEvent.click(apply);
 
     await waitFor(() => expect(onSave).toHaveBeenCalledWith(filledCosts));
-  });
+    // Typing into all eleven fields exceeds the default 5s timeout when the
+    // full suite runs in parallel, so give this test extra headroom.
+  }, 15000);
 
   it('closes via the Cancel button', async () => {
     const { getByRole } = render(<TestComponent />);

--- a/src/components/HrTools/SavingsFundTransfer/Helper/filterTransfers.test.ts
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/filterTransfers.test.ts
@@ -188,4 +188,74 @@ describe('useFilteredTransfers', () => {
       recurringTransfer?.missingMonths?.map((month) => month.toISODate()),
     ).toEqual(['2023-11-15']);
   });
+
+  describe('stopped recurring transfers', () => {
+    const makeStoppedTransactions = (
+      recurringEnd: DateTime | null,
+    ): Transactions[] => {
+      const recurringTransfer = {
+        id: '3',
+        amount: 20,
+        recurringStart: DateTime.fromISO('2023-09-15'),
+        recurringEnd,
+        active: false,
+      };
+      return ['2023-09-15', '2023-11-15'].map((date, index) => ({
+        transaction: {
+          id: `stopped-${index}`,
+          amount: 20,
+          description: null,
+          transactedAt: DateTime.fromISO(date),
+        },
+        subCategory: {
+          id: '1',
+          name: 'deposit',
+        },
+        transfer: {
+          sourceFundTypeName: 'Primary',
+          destinationFundTypeName: 'Savings',
+        },
+        recurringTransfer,
+        baseAmount: 20,
+        failedCount: 0,
+      }));
+    };
+
+    it('should not count months after the last transaction as missing when stopped with no end date', () => {
+      const { filtered } = filteredTransfers(makeStoppedTransactions(null));
+      const stoppedTransfer = filtered.find(
+        (tx) => tx.recurringTransfer?.id === '3',
+      );
+      expect(
+        stoppedTransfer?.missingMonths?.map((month) => month.toISODate()),
+      ).toEqual(['2023-10-15']);
+      expect(stoppedTransfer?.failedCount).toBe(1);
+    });
+
+    it('should not count months after the last transaction as missing when stopped before a future end date', () => {
+      const { filtered } = filteredTransfers(
+        makeStoppedTransactions(DateTime.fromISO('2024-06-15')),
+      );
+      const stoppedTransfer = filtered.find(
+        (tx) => tx.recurringTransfer?.id === '3',
+      );
+      expect(
+        stoppedTransfer?.missingMonths?.map((month) => month.toISODate()),
+      ).toEqual(['2023-10-15']);
+      expect(stoppedTransfer?.failedCount).toBe(1);
+    });
+
+    it('should scan through the end date for inactive transfers that ended naturally', () => {
+      const { filtered } = filteredTransfers(
+        makeStoppedTransactions(DateTime.fromISO('2023-12-15')),
+      );
+      const endedTransfer = filtered.find(
+        (tx) => tx.recurringTransfer?.id === '3',
+      );
+      expect(
+        endedTransfer?.missingMonths?.map((month) => month.toISODate()),
+      ).toEqual(['2023-10-15', '2023-12-15']);
+      expect(endedTransfer?.failedCount).toBe(2);
+    });
+  });
 });

--- a/src/components/HrTools/SavingsFundTransfer/Helper/filterTransfers.test.ts
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/filterTransfers.test.ts
@@ -257,5 +257,18 @@ describe('useFilteredTransfers', () => {
       ).toEqual(['2023-10-15', '2023-12-15']);
       expect(endedTransfer?.failedCount).toBe(2);
     });
+
+    it('should scan through the end date when a stopped transfer ends today', () => {
+      const { filtered } = filteredTransfers(
+        makeStoppedTransactions(DateTime.fromISO('2024-01-15')),
+      );
+      const endedTransfer = filtered.find(
+        (tx) => tx.recurringTransfer?.id === '3',
+      );
+      expect(
+        endedTransfer?.missingMonths?.map((month) => month.toISODate()),
+      ).toEqual(['2023-10-15', '2023-12-15', '2024-01-15']);
+      expect(endedTransfer?.failedCount).toBe(3);
+    });
   });
 });

--- a/src/components/HrTools/SavingsFundTransfer/Helper/filterTransfers.ts
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/filterTransfers.ts
@@ -62,13 +62,22 @@ export function filteredTransfers(transfers: Transactions[]) {
     const transferRow = filtered[index];
 
     const currentDate = DateTime.local().startOf('day');
-    const start = transferRow.recurringTransfer?.recurringStart.startOf('day');
-    const end = DateTime.min(
-      (transferRow.recurringTransfer?.recurringEnd ?? currentDate).startOf(
-        'day',
-      ),
-      currentDate,
-    );
+    const recurring = transferRow.recurringTransfer;
+    const start = recurring?.recurringStart.startOf('day');
+    const recurringEnd = recurring?.recurringEnd?.startOf('day') ?? null;
+    let end: DateTime = DateTime.min(recurringEnd ?? currentDate, currentDate);
+
+    // A transfer stopped before its end date creates no transactions after the
+    // stop, so only look for missed months through its last actual transaction.
+    const stoppedEarly =
+      recurring?.active === false &&
+      (!recurringEnd || recurringEnd > currentDate);
+    if (stoppedEarly) {
+      const lastTransactedAt = DateTime.max(
+        ...[...transactions.values()].map((tx) => tx.transaction!.transactedAt),
+      ).startOf('day');
+      end = DateTime.min(end, lastTransactedAt);
+    }
 
     if (!start) {
       continue;

--- a/src/components/HrTools/SavingsFundTransfer/Helper/getStatus.test.ts
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/getStatus.test.ts
@@ -112,4 +112,40 @@ describe('createTable', () => {
     const status = mockData[3];
     expect(getStatusLabel(status)).toBe('ongoing');
   });
+
+  it('should return stopped status if inactive with no end date', () => {
+    const transfer: Transactions = {
+      ...mockData[2],
+      recurringTransfer: {
+        ...mockData[2].recurringTransfer!,
+        recurringEnd: null,
+        active: false,
+      },
+    };
+    expect(getStatusLabel(transfer)).toBe('stopped');
+  });
+
+  it('should return stopped status if inactive with a future end date', () => {
+    const transfer: Transactions = {
+      ...mockData[3],
+      recurringTransfer: {
+        ...mockData[3].recurringTransfer!,
+        recurringEnd: DateTime.fromISO('2024-12-31'),
+        active: false,
+      },
+    };
+    expect(getStatusLabel(transfer)).toBe('stopped');
+  });
+
+  it('should return ended status if inactive with an end date in the past', () => {
+    const transfer: Transactions = {
+      ...mockData[1],
+      recurringTransfer: {
+        ...mockData[1].recurringTransfer!,
+        recurringEnd: DateTime.fromISO('2023-01-01'),
+        active: false,
+      },
+    };
+    expect(getStatusLabel(transfer)).toBe('ended');
+  });
 });

--- a/src/components/HrTools/SavingsFundTransfer/Helper/getStatus.test.ts
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/getStatus.test.ts
@@ -148,4 +148,16 @@ describe('createTable', () => {
     };
     expect(getStatusLabel(transfer)).toBe('ended');
   });
+
+  it('should return ended status if inactive with an end date of today', () => {
+    const transfer: Transactions = {
+      ...mockData[1],
+      recurringTransfer: {
+        ...mockData[1].recurringTransfer!,
+        recurringEnd: DateTime.fromISO('2023-12-15'),
+        active: false,
+      },
+    };
+    expect(getStatusLabel(transfer)).toBe('ended');
+  });
 });

--- a/src/components/HrTools/SavingsFundTransfer/Helper/getStatus.test.ts
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/getStatus.test.ts
@@ -137,7 +137,7 @@ describe('createTable', () => {
     expect(getStatusLabel(transfer)).toBe('stopped');
   });
 
-  it('should return ended status if inactive with an end date in the past', () => {
+  it('should return ended status when the end date is in the past, even if inactive', () => {
     const transfer: Transactions = {
       ...mockData[1],
       recurringTransfer: {

--- a/src/components/HrTools/SavingsFundTransfer/Helper/getStatus.ts
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/getStatus.ts
@@ -6,12 +6,14 @@ export function getStatusLabel(history: Transactions): StatusEnum {
     return StatusEnum.Complete;
   }
 
-  const endDate = history.recurringTransfer.recurringEnd;
+  const { recurringEnd, active } = history.recurringTransfer;
   const today = DateTime.now().endOf('day');
 
-  if (!endDate) {
-    return StatusEnum.Ongoing;
+  if (recurringEnd && recurringEnd <= today) {
+    return StatusEnum.Ended;
   }
 
-  return endDate > today ? StatusEnum.Ongoing : StatusEnum.Ended;
+  // An inactive recurring transfer that hasn't reached its end date was
+  // stopped manually rather than running its course.
+  return active ? StatusEnum.Ongoing : StatusEnum.Stopped;
 }

--- a/src/components/HrTools/SavingsFundTransfer/Table/Row/createTableRowHelper.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/Table/Row/createTableRowHelper.tsx
@@ -32,6 +32,10 @@ export const chipStyle: Record<
     avatarColor: theme.palette.chipGrayDark.main,
     chipColor: theme.palette.chipGrayLight.main,
   },
+  [StatusEnum.Stopped]: {
+    avatarColor: theme.palette.chipGrayDark.main,
+    chipColor: theme.palette.chipGrayLight.main,
+  },
   [StatusEnum.Failed]: {
     avatarColor: theme.palette.chipRedDark.main,
     chipColor: theme.palette.chipRedLight.main,

--- a/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
@@ -288,6 +288,9 @@ describe('TransfersPage', () => {
       .find((row) => within(row).queryByText('stopped'));
     expect(stoppedRow).toBeDefined();
 
+    expect(within(stoppedRow!).getByText('$300.00')).toBeInTheDocument();
+    expect(within(stoppedRow!).getByText('Oct 5, 2023')).toBeInTheDocument();
+
     expect(
       within(stoppedRow!).queryByTitle('Stop Transfer'),
     ).not.toBeInTheDocument();

--- a/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
@@ -85,6 +85,29 @@ const mock = {
           active: true,
         },
       },
+      {
+        transaction: {
+          id: 'stopped-transaction-1',
+          amount: 300,
+          description: null,
+          transactedAt: '2023-10-05T00:00:00+00:00',
+        },
+        subCategory: {
+          id: '1',
+          name: 'deposit',
+        },
+        transfer: {
+          sourceFundTypeName: 'Savings',
+          destinationFundTypeName: 'Primary',
+        },
+        recurringTransfer: {
+          id: '3',
+          amount: 300,
+          recurringStart: '2023-10-05T00:00:00+00:00',
+          recurringEnd: null,
+          active: false,
+        },
+      },
     ],
   },
   FundBalances: {
@@ -252,6 +275,28 @@ describe('TransfersPage', () => {
     expect(tables.length).toBe(2);
 
     expect(within(tables[0]).getAllByRole('columnheader')).toHaveLength(8);
+  });
+
+  it('should display stopped recurring transfers in history with a stopped status and no actions', async () => {
+    const { findAllByRole } = render(<Components />);
+
+    const tables = await findAllByRole('grid');
+    const historyGrid = tables[1];
+
+    const stoppedRow = within(historyGrid)
+      .getAllByRole('row')
+      .find((row) => within(row).queryByText('stopped'));
+    expect(stoppedRow).toBeDefined();
+
+    expect(
+      within(stoppedRow!).queryByTitle('Stop Transfer'),
+    ).not.toBeInTheDocument();
+    expect(
+      within(stoppedRow!).queryByTitle('Add End Date'),
+    ).not.toBeInTheDocument();
+    expect(
+      within(stoppedRow!).queryByTitle('Edit End Date'),
+    ).not.toBeInTheDocument();
   });
 
   it('should show empty state when no transfer history', async () => {

--- a/src/components/HrTools/SavingsFundTransfer/mockData.ts
+++ b/src/components/HrTools/SavingsFundTransfer/mockData.ts
@@ -11,6 +11,7 @@ export enum StatusEnum {
   Ongoing = 'ongoing',
   Complete = 'complete',
   Ended = 'ended',
+  Stopped = 'stopped',
   Failed = 'failed',
 }
 


### PR DESCRIPTION
## Description

- Jira: [MPDX-9654](https://jira.cru.org/browse/MPDX-9654) — stopped recurring fund transfers were disappearing from the Transfer History section; they need to remain visible with a stopped status
- Stopping a recurring transfer soft-deletes it in SAA (`active: false`). The SAA report endpoint now returns stopped recurring transfers in history (SAA-646), but the frontend never used the `active` flag, so a stopped transfer was labeled "Ongoing" with live stop/edit actions
- Adds a `Stopped` status to `StatusEnum`, derived in `getStatusLabel`: a recurring transfer whose end date has passed is still "Ended"; otherwise inactive means "Stopped" and active means "Ongoing"
- Renders the Stopped status as a gray chip (same terminal-state styling as Ended); row actions were already hidden for non-Pending/non-Ongoing statuses, so Stopped rows get no stop/edit buttons
- Bounds the missed-month scan in `filterTransfers` at the last real transaction for transfers stopped before their end date, so months after the stop don't accumulate as false "failed" transfers. Transfers that ended naturally keep the old scan window (regression-tested)
- Note: the API doesn't expose *when* a transfer was stopped, so a month that genuinely failed between the last successful transaction and the stop won't be flagged — chose no-false-positives over that edge case

## Testing

- Go to the Staff Savings Fund Transfer screen (impersonate a staff member who has a recurring transfer that has already fired at least once)
- Confirm the recurring transfer's past transactions show in Transfer History with status "ongoing"
- Stop the recurring transfer via the stop action on the history row
- Check that the transfer remains in Transfer History with a gray "stopped" chip
- Check that the stopped row has no stop or edit-end-date actions
- Check that the failed-transfers badge on the row does not count months after the stop
- Unit coverage: `yarn test getStatus.test.ts filterTransfers.test.ts TransfersPage.test.tsx`

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)