### PR TITLE
[MPDX-9655] - Allow one time Savings Fund Transfers to be future dated

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3069,6 +3069,7 @@
     "Transfer created successfully": "Transfer created successfully",
     "Transfer Date": "Transfer Date",
     "Transfer date cannot be earlier than {{date}}": "Transfer date cannot be earlier than {{date}}",
+    "Transfer date cannot be in the past": "Transfer date cannot be in the past",
     "Transfer date is required": "Transfer date is required",
     "TRANSFER FROM": "TRANSFER FROM",
     "Transfer History": "Transfer History",

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -469,6 +469,56 @@ describe('TransferModal', () => {
       ).toBeInTheDocument();
     });
 
+    it('should require a transfer date for one-time transfers when cleared', async () => {
+      const { getByRole, getByLabelText, findByText } = render(<Components />);
+
+      expect(getByRole('radio', { name: /one time/i })).toBeChecked();
+
+      const transferDate = getByLabelText(/transfer date/i);
+
+      userEvent.clear(transferDate);
+      expect(transferDate).toHaveValue('');
+      userEvent.tab();
+
+      expect(await findByText('Transfer date is required')).toBeInTheDocument();
+
+      await waitFor(() =>
+        expect(getByRole('button', { name: /submit/i })).toBeDisabled(),
+      );
+    });
+
+    it('should not submit a one-time transfer with an unparseable transfer date', async () => {
+      const { getByRole, getByLabelText, findByText } = render(<Components />);
+
+      const amountField = getByRole('spinbutton', { name: /amount/i });
+      const noteField = getByRole('textbox', { name: /note/i });
+
+      userEvent.click(getByRole('combobox', { name: /to account/i }));
+      userEvent.click(getByRole('option', { name: /staff savings/i }));
+
+      userEvent.clear(amountField);
+      userEvent.type(amountField, '100');
+
+      userEvent.type(noteField, 'Test note');
+
+      const transferDate = getByLabelText(/transfer date/i);
+
+      userEvent.clear(transferDate);
+      userEvent.type(transferDate, '99/99/9999');
+      expect(transferDate).toHaveValue('99/99/9999');
+      userEvent.tab();
+
+      expect(
+        await findByText('Transfer date cannot be in the past'),
+      ).toBeInTheDocument();
+
+      await waitFor(() =>
+        expect(getByRole('button', { name: /submit/i })).toBeDisabled(),
+      );
+
+      expect(mutationSpy).not.toHaveGraphqlOperation('CreateTransfer');
+    });
+
     it('should show error message when monthly schedule is selected', async () => {
       const { getByRole, getByLabelText, findByText } = render(<Components />);
 

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.test.tsx
@@ -431,6 +431,44 @@ describe('TransferModal', () => {
       ).toBeInTheDocument();
     });
 
+    it('should allow editing the transfer date for one-time transfers', async () => {
+      const { getByRole, getByLabelText, queryByText } = render(<Components />);
+
+      expect(getByRole('radio', { name: /one time/i })).toBeChecked();
+
+      const transferDate = getByLabelText(/transfer date/i);
+      expect(transferDate).toBeEnabled();
+      expect(transferDate).toHaveValue('1/1/2020');
+
+      userEvent.clear(transferDate);
+      userEvent.type(transferDate, '02/15/2020');
+      expect(transferDate).toHaveValue('02/15/2020');
+      userEvent.tab();
+
+      await waitFor(() =>
+        expect(
+          queryByText('Transfer date cannot be in the past'),
+        ).not.toBeInTheDocument(),
+      );
+    });
+
+    it('should show error message when one-time transfer date is in the past', async () => {
+      const { getByRole, getByLabelText, findByText } = render(<Components />);
+
+      expect(getByRole('radio', { name: /one time/i })).toBeChecked();
+
+      const transferDate = getByLabelText(/transfer date/i);
+
+      userEvent.clear(transferDate);
+      userEvent.type(transferDate, '12/31/2019');
+      expect(transferDate).toHaveValue('12/31/2019');
+      userEvent.tab();
+
+      expect(
+        await findByText('Transfer date cannot be in the past'),
+      ).toBeInTheDocument();
+    });
+
     it('should show error message when monthly schedule is selected', async () => {
       const { getByRole, getByLabelText, findByText } = render(<Components />);
 
@@ -542,6 +580,48 @@ describe('TransferModal', () => {
                 sourceFundTypeName: 'Staff Account',
                 destinationFundTypeName: 'Staff Savings',
                 description: 'Test note',
+                transactedAt: '2020-01-01T00:00:00.000+00:00',
+              }),
+            }),
+          }),
+        );
+      });
+    });
+
+    it('should create a future-dated one-time transfer', async () => {
+      const { getByRole, getByLabelText } = render(<Components />);
+
+      const amountField = getByRole('spinbutton', { name: /amount/i });
+      const noteField = getByRole('textbox', { name: /note/i });
+
+      userEvent.click(getByRole('combobox', { name: /to account/i }));
+      userEvent.click(getByRole('option', { name: /staff savings/i }));
+
+      userEvent.clear(amountField);
+      userEvent.type(amountField, '100');
+
+      const transferDate = getByLabelText(/transfer date/i);
+
+      userEvent.clear(transferDate);
+      userEvent.type(transferDate, '02/15/2020');
+      expect(transferDate).toHaveValue('02/15/2020');
+      userEvent.tab();
+
+      userEvent.type(noteField, 'Future transfer');
+
+      userEvent.click(getByRole('button', { name: /submit/i }));
+
+      await waitFor(() => {
+        expect(mutationSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            operation: expect.objectContaining({
+              operationName: 'CreateTransfer',
+              variables: expect.objectContaining({
+                amount: 100,
+                sourceFundTypeName: 'Staff Account',
+                destinationFundTypeName: 'Staff Savings',
+                description: 'Future transfer',
+                transactedAt: '2020-02-15T00:00:00.000+00:00',
               }),
             }),
           }),

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -44,7 +44,7 @@ interface TransferFormValues {
   transferFrom: string;
   transferTo: string;
   schedule: ScheduleEnum;
-  transferDate: DateTime<boolean>;
+  transferDate: DateTime<boolean> | null;
   endDate: DateTime<boolean> | null;
   amount: number;
   note: string;
@@ -190,7 +190,8 @@ export const TransferModal: React.FC<TransferModalProps> = ({
       note,
     } = values;
 
-    const convertedTransferDate = transferDate.toISO() ?? '';
+    const convertedTransferDate =
+      transferDate && transferDate.isValid ? (transferDate.toISO() ?? '') : '';
     const convertedEndDate = endDate?.toISO() ?? null;
 
     const successMessage =

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -58,6 +58,14 @@ const getTomorrow = (): DateTime => {
   return getToday().plus({ days: 1 });
 };
 
+const minimumTransferDate = (schedule: ScheduleEnum): DateTime =>
+  schedule === ScheduleEnum.OneTime ? getToday() : getTomorrow();
+
+const pastDateMessage = (schedule: ScheduleEnum): string =>
+  schedule === ScheduleEnum.OneTime
+    ? i18n.t('Transfer date cannot be in the past')
+    : i18n.t('Recurring transfers must start at least one day in the future');
+
 const transferSchema = (locale: string) =>
   yup.object({
     transferFrom: yup.string().required(i18n.t('From account is required')),
@@ -79,9 +87,6 @@ const transferSchema = (locale: string) =>
           originalStart?: DateTime<boolean> | null;
           isEditing?: boolean;
         };
-        if (!value) {
-          return false;
-        }
         if (isEditing) {
           const baseline = originalStart
             ? originalStart.startOf('day')
@@ -97,20 +102,11 @@ const transferSchema = (locale: string) =>
           });
         }
 
-        const minimum =
-          schedule === ScheduleEnum.OneTime ? getToday() : getTomorrow();
-        if (selected >= minimum) {
+        if (selected >= minimumTransferDate(schedule)) {
           return true;
         }
 
-        return this.createError({
-          message:
-            schedule === ScheduleEnum.OneTime
-              ? i18n.t('Transfer date cannot be in the past')
-              : i18n.t(
-                  'Recurring transfers must start at least one day in the future',
-                ),
-        });
+        return this.createError({ message: pastDateMessage(schedule) });
       }),
     endDate: yup
       .mixed<DateTime>()

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -104,9 +104,12 @@ const transferSchema = (locale: string) =>
         }
 
         return this.createError({
-          message: i18n.t(
-            'Recurring transfers must start at least one day in the future',
-          ),
+          message:
+            schedule === ScheduleEnum.OneTime
+              ? i18n.t('Transfer date cannot be in the past')
+              : i18n.t(
+                  'Recurring transfers must start at least one day in the future',
+                ),
         });
       }),
     endDate: yup
@@ -219,6 +222,7 @@ export const TransferModal: React.FC<TransferModalProps> = ({
             sourceFundTypeName: transferFrom,
             destinationFundTypeName: transferTo,
             description: note.trim(),
+            transactedAt: convertedTransferDate,
           },
         });
       } else {
@@ -455,11 +459,21 @@ export const TransferModal: React.FC<TransferModalProps> = ({
                   <Grid container spacing={2}>
                     {schedule === ScheduleEnum.OneTime ? (
                       <Grid size={12}>
-                        <TextField
-                          fullWidth
+                        <CustomDateField
                           label={t('Transfer Date')}
-                          value={transferDate.toFormat('MM/dd/yyyy')}
-                          disabled={true}
+                          value={transferDate}
+                          onChange={(date) => {
+                            setFieldValue('transferDate', date);
+                            setFieldTouched('transferDate', true, false);
+                          }}
+                          error={
+                            touched.transferDate && Boolean(errors.transferDate)
+                          }
+                          helperText={
+                            touched.transferDate &&
+                            (errors.transferDate as string)
+                          }
+                          required
                         />
                       </Grid>
                     ) : (

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/TransferModal.tsx
@@ -454,66 +454,44 @@ export const TransferModal: React.FC<TransferModalProps> = ({
 
                 <Box sx={{ mb: 3 }}>
                   <Grid container spacing={2}>
-                    {schedule === ScheduleEnum.OneTime ? (
-                      <Grid size={12}>
+                    <Grid size={schedule === ScheduleEnum.OneTime ? 12 : 6}>
+                      <CustomDateField
+                        label={t('Transfer Date')}
+                        value={transferDate}
+                        onChange={(date) => {
+                          setFieldValue('transferDate', date);
+                          setFieldTouched('transferDate', true, false);
+                        }}
+                        error={
+                          touched.transferDate && Boolean(errors.transferDate)
+                        }
+                        helperText={
+                          touched.transferDate &&
+                          (errors.transferDate as string)
+                        }
+                        required
+                      />
+                    </Grid>
+
+                    {schedule !== ScheduleEnum.OneTime && (
+                      <Grid size={6}>
                         <CustomDateField
-                          label={t('Transfer Date')}
-                          value={transferDate}
+                          label={t('End Date (Optional)')}
+                          value={endDate}
                           onChange={(date) => {
-                            setFieldValue('transferDate', date);
-                            setFieldTouched('transferDate', true, false);
+                            setFieldValue('endDate', date);
+                            setFieldTouched('endDate', true, false);
                           }}
-                          error={
-                            touched.transferDate && Boolean(errors.transferDate)
-                          }
+                          error={touched.endDate && Boolean(errors.endDate)}
                           helperText={
-                            touched.transferDate &&
-                            (errors.transferDate as string)
+                            touched.endDate && errors.endDate
+                              ? errors.endDate
+                              : t(
+                                  'The transfer will no longer recur after this date. If left blank, the transfer will recur indefinitely until manually stopped.',
+                                )
                           }
-                          required
                         />
                       </Grid>
-                    ) : (
-                      <>
-                        <Grid size={6}>
-                          <CustomDateField
-                            label={t('Transfer Date')}
-                            value={transferDate}
-                            onChange={(date) => {
-                              setFieldValue('transferDate', date);
-                              setFieldTouched('transferDate', true, false);
-                            }}
-                            error={
-                              touched.transferDate &&
-                              Boolean(errors.transferDate)
-                            }
-                            helperText={
-                              touched.transferDate &&
-                              (errors.transferDate as string)
-                            }
-                            required
-                          />
-                        </Grid>
-
-                        <Grid size={6}>
-                          <CustomDateField
-                            label={t('End Date (Optional)')}
-                            value={endDate}
-                            onChange={(date) => {
-                              setFieldValue('endDate', date);
-                              setFieldTouched('endDate', true, false);
-                            }}
-                            error={touched.endDate && Boolean(errors.endDate)}
-                            helperText={
-                              touched.endDate && errors.endDate
-                                ? errors.endDate
-                                : t(
-                                    'The transfer will no longer recur after this date. If left blank, the transfer will recur indefinitely until manually stopped.',
-                                  )
-                            }
-                          />
-                        </Grid>
-                      </>
                     )}
                   </Grid>
                 </Box>

--- a/src/components/HrTools/SavingsFundTransfer/TransferMutations.graphql
+++ b/src/components/HrTools/SavingsFundTransfer/TransferMutations.graphql
@@ -47,6 +47,7 @@ mutation CreateTransfer(
   $destinationFundTypeName: String!
   $description: String!
   $amount: Float!
+  $transactedAt: ISO8601DateTime!
 ) {
   createTransfer(
     input: {
@@ -54,6 +55,7 @@ mutation CreateTransfer(
       destinationFundTypeName: $destinationFundTypeName
       description: $description
       amount: $amount
+      transactedAt: $transactedAt
     }
   ) {
     message


### PR DESCRIPTION
## Description

- Replaces the disabled (grayed-out) Transfer Date field on one-time Savings Fund Transfers with an editable date picker, so users can schedule a one-time transfer for today or a future date
- Sends the selected date to the API via the new required `transactedAt` argument on the `CreateTransfer` mutation
- Adds a one-time-specific validation message ("Transfer date cannot be in the past") — previously a past date showed the recurring-transfer error message
- Adds tests covering the enabled date field, future-date submission (including `transactedAt` in the mutation variables), and past-date validation

**Dependent on:** CruGlobal/mpdx_api#3342 (adds the required `transactedAt` argument to `TransferCreateMutation`). GraphQL codegen in CI will fail until that PR is deployed to the staging API. Note also that since `transacted_at` is required on the API side, deploying the API change before this PR would break one-time transfers on the current UI — release order needs coordination.

Jira: [MPDX-9655](https://jira.cru.org/browse/MPDX-9655)

## Testing

- Go to HR Tools → Staff Saving Fund → Transfers
- Click a balance card to open the New Fund Transfer modal
- With the "One Time" schedule selected, check that the Transfer Date field is enabled (no longer grayed out) and defaults to today
- Pick a future date, fill in To Account, Amount, and Note, and submit — check that the transfer is created with the selected date
- Pick a past date and check that the "Transfer date cannot be in the past" validation error appears and Submit is disabled
- Switch to "Monthly" and check that the recurring transfer date/end date behavior is unchanged

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)