### PR TITLE
[No Jira] - Bump GitHub Actions: checkout and setup-node to v7, retry to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
           ]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
@@ -52,7 +52,7 @@ jobs:
         run: yarn cache clean && yarn install
 
       - name: 📈 Run GraphQL Codegen
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           command: yarn gql
           timeout_minutes: 1
@@ -69,8 +69,8 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
@@ -78,7 +78,7 @@ jobs:
         run: yarn cache clean && yarn install
 
       - name: 📈 Run GraphQL Codegen
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           command: yarn gql
           timeout_minutes: 1
@@ -90,8 +90,8 @@ jobs:
   typescript:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
@@ -99,7 +99,7 @@ jobs:
         run: yarn cache clean && yarn install
 
       - name: 📈 Run GraphQL Codegen
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           command: yarn gql
           timeout_minutes: 1
@@ -111,8 +111,8 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
@@ -125,10 +125,10 @@ jobs:
   yarn-check-cache:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           lfs: true
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 🔍 Check Yarn Cache
@@ -137,8 +137,8 @@ jobs:
   translations:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
@@ -164,8 +164,8 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
@@ -173,7 +173,7 @@ jobs:
         run: yarn cache clean && yarn install
 
       - name: 📈 Run GraphQL Codegen
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           command: yarn gql
           timeout_minutes: 1

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -16,8 +16,8 @@ jobs:
   download:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies

--- a/.github/workflows/preview-close.yml
+++ b/.github/workflows/preview-close.yml
@@ -10,7 +10,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'Preview Environment')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: configure AWS credentials
         id: creds
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: configure AWS credentials
         id: creds
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/run-lighthouse.yml
+++ b/.github/workflows/run-lighthouse.yml
@@ -15,8 +15,8 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies

--- a/.github/workflows/update-staging.yml
+++ b/.github/workflows/update-staging.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'On Staging')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: 🖇️ Merge current branch into staging
         uses: devmasx/merge-branch@1.4.0
         with:


### PR DESCRIPTION
## Description

- Bumps `nick-fields/retry` from v3 to v4 (4 usages in `ci.yml`)
- Bumps `actions/checkout` from v4 to v7 (12 usages across all workflows)
- Bumps `actions/setup-node` from v4 to v7 (9 usages across all workflows)

No Jira ticket — routine CI dependency maintenance; no dependent PRs.

Breaking changes across the skipped majors were reviewed and none apply to this repo:

- `setup-node` v6 removed automatic yarn/pnpm caching, but our workflows never use the `cache:` input (they intentionally run `yarn cache clean && yarn install`), so behavior is unchanged.
- `checkout` v7 blocks checking out fork PR head refs in `pull_request_target` workflows. `preview-close.yml` uses `pull_request_target` but checks out the default (base) ref, so it is unaffected.
- `checkout` v5+ and `setup-node` v5+ require runner v2.327.1+, which GitHub-hosted `ubuntu-latest` runners already satisfy.

## Testing

- Check that all CI jobs on this PR (lint, type check, tests, yarn-check-cache) pass using the bumped actions
- Add the "Preview Environment" label and check that the Amplify preview deploy workflow still runs
- Close/reopen behavior of the preview cleanup workflow (`pull_request_target`) can be verified when this PR is closed

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)