### PR TITLE
[MPDX-9655] - Show future-dated one-time transfers as upcoming

### DIFF
--- a/src/components/HrTools/SavingsFundTransfer/Helper/filterTransfers.test.ts
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/filterTransfers.test.ts
@@ -160,6 +160,7 @@ describe('useFilteredTransfers', () => {
   it('should return the correct number of transfers', () => {
     const { filtered, upcoming } = filteredTransfers(mockTransactions);
     expect(filtered).toHaveLength(2);
+    // upcoming holds the future-dated recurring transfer and the scheduled transfer
     expect(upcoming).toHaveLength(2);
   });
 
@@ -170,7 +171,7 @@ describe('useFilteredTransfers', () => {
     expect(scheduled).toHaveLength(1);
     expect(scheduled[0].scheduledTransfer?.id).toBe('sched-1');
     expect(scheduled[0].summarizedTransfers).toBeUndefined();
-    expect(filtered.some((tx) => tx.scheduledTransfer)).toBe(false);
+    expect(filtered.every((tx) => !tx.scheduledTransfer)).toBe(true);
   });
 
   it('should correctly add amounts for recurring transfers', () => {

--- a/src/components/HrTools/SavingsFundTransfer/Helper/filterTransfers.test.ts
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/filterTransfers.test.ts
@@ -133,6 +133,23 @@ const mockTransactions: Transactions[] = [
     baseAmount: 10,
     failedCount: 0,
   },
+  {
+    transaction: null,
+    subCategory: null,
+    transfer: {
+      sourceFundTypeName: 'Primary',
+      destinationFundTypeName: 'Savings',
+    },
+    recurringTransfer: null,
+    scheduledTransfer: {
+      id: 'sched-1',
+      amount: 400,
+      transactedAt: DateTime.fromISO('2024-02-01'),
+      description: 'Conference fee',
+    },
+    baseAmount: 400,
+    failedCount: 0,
+  },
 ];
 
 describe('useFilteredTransfers', () => {
@@ -143,7 +160,17 @@ describe('useFilteredTransfers', () => {
   it('should return the correct number of transfers', () => {
     const { filtered, upcoming } = filteredTransfers(mockTransactions);
     expect(filtered).toHaveLength(2);
-    expect(upcoming).toHaveLength(1);
+    expect(upcoming).toHaveLength(2);
+  });
+
+  it('should route a pending scheduled transfer to upcoming without summarizing it', () => {
+    const { filtered, upcoming } = filteredTransfers(mockTransactions);
+
+    const scheduled = upcoming.filter((tx) => tx.scheduledTransfer);
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].scheduledTransfer?.id).toBe('sched-1');
+    expect(scheduled[0].summarizedTransfers).toBeUndefined();
+    expect(filtered.some((tx) => tx.scheduledTransfer)).toBe(false);
   });
 
   it('should correctly add amounts for recurring transfers', () => {

--- a/src/components/HrTools/SavingsFundTransfer/ReportsSavingsFund.graphql
+++ b/src/components/HrTools/SavingsFundTransfer/ReportsSavingsFund.graphql
@@ -31,6 +31,12 @@ query ReportsSavingsFundTransfer(
       recurringEnd
       active
     }
+    scheduledTransfer {
+      id
+      amount
+      transactedAt
+      description
+    }
   }
 }
 

--- a/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
@@ -46,6 +46,7 @@ const mock = {
           destinationFundTypeName: 'Savings',
         },
         recurringTransfer: null,
+        scheduledTransfer: null,
       },
       {
         transaction: {
@@ -69,6 +70,7 @@ const mock = {
           recurringEnd: '2025-09-30T00:00:00+00:00',
           active: true,
         },
+        scheduledTransfer: null,
       },
       {
         transaction: null,
@@ -83,6 +85,22 @@ const mock = {
           recurringStart: '2024-05-30T00:00:00+00:00',
           recurringEnd: '2025-05-30T00:00:00+00:00',
           active: true,
+        },
+        scheduledTransfer: null,
+      },
+      {
+        transaction: null,
+        subCategory: null,
+        transfer: {
+          sourceFundTypeName: 'Primary',
+          destinationFundTypeName: 'Savings',
+        },
+        recurringTransfer: null,
+        scheduledTransfer: {
+          id: 'sched-1',
+          amount: 400,
+          transactedAt: '2024-02-01T00:00:00+00:00',
+          description: 'Conference fee',
         },
       },
       {
@@ -300,6 +318,32 @@ describe('TransfersPage', () => {
     expect(
       within(stoppedRow!).queryByTitle('Edit End Date'),
     ).not.toBeInTheDocument();
+  });
+
+  it('shows a future-dated one-time transfer in the upcoming table', async () => {
+    const { findAllByRole } = render(<Components />);
+
+    // Upcoming is the first of the two grids; Transfer History is the second.
+    const [upcomingTable] = await findAllByRole('grid');
+    const row = within(upcomingTable).getByRole('row', {
+      name: /Conference fee/,
+    });
+
+    expect(within(row).getByText('One Time')).toBeInTheDocument();
+    expect(within(row).getByText('Feb 1, 2024')).toBeInTheDocument();
+    expect(within(row).getByText('$400.00')).toBeInTheDocument();
+  });
+
+  it('renders no edit or cancel actions on a scheduled transfer row', async () => {
+    const { findAllByRole } = render(<Components />);
+
+    const [upcomingTable] = await findAllByRole('grid');
+    const row = within(upcomingTable).getByRole('row', {
+      name: /Conference fee/,
+    });
+
+    expect(within(row).queryByTitle('Edit')).not.toBeInTheDocument();
+    expect(within(row).queryByTitle('Cancel Transfer')).not.toBeInTheDocument();
   });
 
   it('should show empty state when no transfer history', async () => {

--- a/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
@@ -346,6 +346,34 @@ describe('TransfersPage', () => {
     expect(within(row).queryByTitle('Cancel Transfer')).not.toBeInTheDocument();
   });
 
+  it('still shows a pending recurring transfer as an editable monthly row', async () => {
+    const { findAllByRole } = render(<Components />);
+
+    const [upcomingTable] = await findAllByRole('grid');
+    const row = within(upcomingTable).getByRole('row', {
+      name: /May 30, 2024/,
+    });
+
+    expect(within(row).getByText('Monthly')).toBeInTheDocument();
+    expect(within(row).getByText('$100.00')).toBeInTheDocument();
+    expect(within(row).getByText('May 30, 2025')).toBeInTheDocument();
+    expect(within(row).getByTitle('Edit')).toBeInTheDocument();
+    expect(within(row).getByTitle('Cancel Transfer')).toBeInTheDocument();
+  });
+
+  it('keys upcoming rows off the scheduled/recurring id, not a fresh uuid', async () => {
+    const { findAllByRole } = render(<Components />);
+
+    const [upcomingTable] = await findAllByRole('grid');
+    const ids = within(upcomingTable)
+      .getAllByRole('row')
+      .map((row) => row.dataset.id)
+      .filter(Boolean);
+
+    // Namespaced so a scheduled and a recurring transfer sharing a primary key cannot collide.
+    expect(ids).toEqual(['recurring-2', 'scheduled-sched-1']);
+  });
+
   it('should show empty state when no transfer history', async () => {
     const { findByText } = render(
       <SnackbarProvider>

--- a/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
@@ -125,6 +125,7 @@ const mock = {
           recurringEnd: null,
           active: false,
         },
+        scheduledTransfer: null,
       },
     ],
   },

--- a/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
@@ -200,7 +200,15 @@ export const TransfersPage: React.FC<TransfersPageProps> = ({ title }) => {
         const scheduled = tx.scheduledTransfer;
 
         return {
-          id: scheduled?.id ?? tx.recurringTransfer?.id ?? crypto.randomUUID(),
+          // Scheduled and recurring ids are per-table primary keys from two different
+          // SAA tables, so they can collide (both '2'). Namespace them to keep the
+          // DataGrid and print table row keys unique. `recurringId` below stays raw:
+          // it is what the edit/cancel mutations send.
+          id: scheduled
+            ? `scheduled-${scheduled.id}`
+            : tx.recurringTransfer
+              ? `recurring-${tx.recurringTransfer.id}`
+              : crypto.randomUUID(),
           transferFrom: tx.transfer.sourceFundTypeName,
           transferTo: tx.transfer.destinationFundTypeName,
           amount: scheduled?.amount ?? tx.recurringTransfer?.amount ?? 0,

--- a/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
@@ -135,11 +135,22 @@ export const TransfersPage: React.FC<TransfersPageProps> = ({ title }) => {
                   : null,
               }
             : null,
-          baseAmount: tx.transaction
-            ? tx.transaction.amount
-            : tx.recurringTransfer
-              ? tx.recurringTransfer.amount
-              : 0,
+          scheduledTransfer: tx.scheduledTransfer
+            ? {
+                ...tx.scheduledTransfer,
+                transactedAt: DateTime.fromISO(
+                  tx.scheduledTransfer.transactedAt,
+                  {
+                    setZone: true,
+                  },
+                ),
+              }
+            : null,
+          baseAmount:
+            tx.transaction?.amount ??
+            tx.recurringTransfer?.amount ??
+            tx.scheduledTransfer?.amount ??
+            0,
           failedCount: 0,
           summarizedTransfers: null,
           missingMonths: null,
@@ -184,17 +195,25 @@ export const TransfersPage: React.FC<TransfersPageProps> = ({ title }) => {
   const upcomingTransfers: Transfers[] = useMemo(
     () =>
       upcoming.map((tx) => {
+        // A pending one-time transfer carries its own amount/date; a recurring one has not fired yet,
+        // so its details come from the recurring schedule instead.
+        const scheduled = tx.scheduledTransfer;
+
         return {
-          id: tx.transaction?.id ?? crypto.randomUUID(),
+          id: scheduled?.id ?? tx.recurringTransfer?.id ?? crypto.randomUUID(),
           transferFrom: tx.transfer.sourceFundTypeName,
           transferTo: tx.transfer.destinationFundTypeName,
-          amount: tx.recurringTransfer?.amount ?? 0,
-          schedule: ScheduleEnum.Monthly,
+          amount: scheduled?.amount ?? tx.recurringTransfer?.amount ?? 0,
+          schedule: scheduled ? ScheduleEnum.OneTime : ScheduleEnum.Monthly,
           status: StatusEnum.Pending,
-          transferDate: tx.recurringTransfer?.recurringStart,
-          endDate: tx.recurringTransfer?.recurringEnd ?? null,
-          note: tx.subCategory?.name ?? '',
-          actions: 'edit-delete',
+          transferDate:
+            scheduled?.transactedAt ?? tx.recurringTransfer?.recurringStart,
+          endDate: scheduled
+            ? null
+            : (tx.recurringTransfer?.recurringEnd ?? null),
+          note: scheduled?.description ?? tx.subCategory?.name ?? '',
+          // Scheduled transfers cannot be edited or cancelled: SAA has no endpoint for it yet.
+          actions: scheduled ? '' : 'edit-delete',
           recurringId: tx.recurringTransfer?.id ?? null,
         };
       }),

--- a/src/components/HrTools/SavingsFundTransfer/mockData.ts
+++ b/src/components/HrTools/SavingsFundTransfer/mockData.ts
@@ -55,6 +55,13 @@ export interface RecurringTransfer {
   active: boolean;
 }
 
+export interface ScheduledTransfer {
+  id: string;
+  amount: number;
+  transactedAt: DateTime;
+  description?: string | null;
+}
+
 export interface Transfer {
   sourceFundTypeName: string;
   destinationFundTypeName: string;
@@ -72,6 +79,7 @@ export interface Transactions {
   subCategory: SubCategory | null;
   transfer: Transfer;
   recurringTransfer?: RecurringTransfer | null;
+  scheduledTransfer?: ScheduledTransfer | null;
   baseAmount: number;
   failedCount?: number;
   summarizedTransfers?: Map<string, Transactions> | null;


### PR DESCRIPTION
## Business Requirements

A staff member reported that a future-dated one-time Savings Fund transfer **never appeared in the Upcoming Transfers list**. It stayed invisible until its run date, then silently appeared in Transfer History as Complete.

This is the frontend third of a three-repo fix, and follows #1909 (merged), which let users pick the date in the first place.

## Technical Solution

SAA stores a future-dated one-time transfer as a `ScheduledTransfer` that deliberately creates **no transactions** until its run date, so it was invisible in every MPDX layer. SAA now emits it as a synthetic row and mpdx_api exposes a nullable `scheduledTransfer` field.

This PR consumes it:

- Adds `scheduledTransfer { id amount transactedAt description }` to `ReportsSavingsFundTransfer`, plus the `ScheduledTransfer` type in `mockData.ts`.
- Re-maps `transactedAt` through Luxon in the `transactions` memo, mirroring the existing `recurringTransfer` handling. (Not optional — `TransfersPage.tsx` spreads `...tx`, so the raw ISO string reaches the `Transactions[]`-typed memo implicitly whether or not the field is read.)
- Branches `upcomingTransfers` on whichever carrier is present: a scheduled row renders as `One Time` with its own amount/date/description; a recurring row maps exactly as before.
- Flattens `baseAmount`'s nested ternary to a `??` chain (equivalent — `amount` is `Float!` on both types, so it can't be null and `??` won't swallow `0`).

Scheduled rows deliberately render **no edit/cancel actions** — SAA has no cancel endpoint for a `ScheduledTransfer` yet (follow-up ticket).

`filterTransfers.ts` needs **no change**: scheduled rows arrive with `transaction: null` and are already routed to `upcoming` by the existing rule. A test now pins that, since the whole design rests on it. (Verified this still holds against MPDX-9654/#1908, which changed `filterTransfers.ts` while this branch was in flight — its changes are confined to the summary loop, which scheduled rows never reach.)

### Drive-by bugfix

`upcomingTransfers` used `id: tx.transaction?.id ?? crypto.randomUUID()`, but upcoming rows **always** have a null transaction — so every row got a fresh random id on each render, an unstable React/DataGrid key. Now keyed off the scheduled/recurring id, namespaced `scheduled-${id}` / `recurring-${id}`: the two ids come from different SAA tables and can collide otherwise (reproduced as real React duplicate-key warnings). `recurringId` stays raw — every mutation uses it, not `id`.

## Testing

`13 suites / 106 tests` passing; `yarn lint:ts` and `yarn lint` clean.

New coverage: a scheduled row renders in Upcoming with its date/amount/note and no actions; a recurring upcoming row still renders `Monthly` with its Edit/Cancel actions (pinning both branches of the new fork); upcoming row ids are stable and namespaced; `filterTransfers` routes a scheduled row to `upcoming` without summarizing it. Each new test was verified load-bearing by mutation — the id test in particular, because the fix's lack of coverage had already let it be silently reverted with a green suite.

## Related Links

- Jira: [MPDX-9655](https://jira.cru.org/browse/MPDX-9655), [SAA-652](https://jira.cru.org/browse/SAA-652)
- SAA: CruGlobal/staff_accounting_app#598
- API: CruGlobal/mpdx_api#3457
- Prior frontend work: #1909 (merged)

> [!IMPORTANT]
> **Deploy order: this PR must NOT reach staging before mpdx_api#3457.** Querying `scheduledTransfer` against a schema without it fails document validation and takes down the entire savings fund report. SAA#598 and mpdx_api#3457 are both additive and safe to land first.
>
> Until #3457 deploys, local codegen needs the field grafted onto a cached staging SDL snapshot — plain `yarn gql` will fail on this branch. Do **not** use mpdx_api's own schema dump as the base: mpdx_api's `staging` branch runs ahead of `master`, so that dump is missing fields `main` already depends on (e.g. `UserTypeEnum.HYBRID_STAFF`).

## UI Testing

**This cannot be tested against `saa-stage.cru.org` as it stands.** SAA is the root-cause fix: staging has the `ScheduledTransfer` model (from staff_accounting_app#573) but not #598's `TransferList` change, so it emits no scheduled row and nothing reaches the UI. All three layers must be present.

**Recommended — via staging:** land staff_accounting_app#598 on SAA's `staging` branch and mpdx_api#3457 on mpdx_api's `staging` branch, then run this branch locally against `api.stage.mpdx.org` (plain `yarn gql` works once #3457 is on staging).

**Alternative — full local stack:** SAA on `SAA-652-scheduled-transfers-in-transfer-list` (`PORT=3001 bin/dev`), mpdx_api on `MPDX-9655-scheduled-transfer` with `SAA_URL=http://localhost:3001` (`PORT=3002 bin/rails s`), and this branch with `API_URL=http://localhost:3002/graphql yarn gql && yarn start`. Requires local SAA data (staff account, funds, doorkeeper app for `SAA_UID`/`SAA_SECRET`).

Then:

1. Open Savings Fund Transfers, create a one-time transfer dated ~10 days out.
2. It appears in **Upcoming Transfers** as `One Time` with the chosen date, amount and note, and no edit/cancel icons.
3. It does **not** appear in Transfer History.
4. Existing recurring upcoming rows still show `Monthly` with their edit/cancel icons.

## Checklist

- [x] PR title prefixed with Jira ticket number
- [x] Assign myself to the PR
- [x] Tests are passing
- [x] Perform AI code review (multi-pass: spec-compliance + code-quality, each finding verified by mutation testing)
- [ ] Human code review requested
- [ ] Passes QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
