### PR TITLE
[MPDX-9858] Default the 403b contribution percentage to the server constant

### DIFF
--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.test.tsx
@@ -160,6 +160,48 @@ describe('GoalSettingsForm', () => {
     );
   });
 
+  it('prefills the 403(b) contribution with the default percentage when unset', async () => {
+    const { findByRole, getByRole } = render(
+      <TestComponent
+        goalCalculationMock={{
+          newStaffGoalCalculation: {
+            ...defaultMock.newStaffGoalCalculation,
+            contribution403bPercentage: null,
+            spouseContribution403bPercentage: null,
+            calculations: {
+              ...defaultGoalCalculation.calculations,
+              default403bFraction: 0.07,
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(
+      await findByRole('spinbutton', { name: '403(b) Contribution — John' }),
+    ).toHaveValue(7);
+    expect(
+      getByRole('spinbutton', { name: '403(b) Contribution — Jane' }),
+    ).toHaveValue(7);
+  });
+
+  it('keeps a saved 403(b) contribution instead of the default', async () => {
+    const { findByRole } = render(
+      <TestComponent
+        goalCalculationMock={{
+          newStaffGoalCalculation: {
+            ...defaultMock.newStaffGoalCalculation,
+            contribution403bPercentage: 12,
+          },
+        }}
+      />,
+    );
+
+    expect(
+      await findByRole('spinbutton', { name: '403(b) Contribution — John' }),
+    ).toHaveValue(12);
+  });
+
   it('hides the spouse 403(b) amount when there is no spouse', async () => {
     const { findByText, queryByText } = render(
       <TestComponent goalCalculationMock={singleMock} />,

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
@@ -82,7 +82,14 @@ export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = (props) => {
   // value (see `isMarried` below).
   const hasSavedSpouse = Boolean(calculation.spouseFirstName);
 
-  const initialValues = calculationToFormValues(calculation);
+  // Convert the fraction (0-1) to a percentage (0-100)
+  const default403bPercentage = Math.round(
+    calculation.calculations.default403bFraction * 100,
+  );
+
+  const initialValues = calculationToFormValues(calculation, {
+    default403bPercentage,
+  });
 
   const primaryPerson: GoalSettingsPerson = {
     firstName: calculation.firstName ?? '',

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
@@ -32,6 +32,7 @@ fragment NewStaffGoalCalculationFields on NewStaffGoalCalculation {
     secaRate
     adminRate
     attritionRate
+    default403bFraction
   }
 
   # Identity (read-only display in the header; prepopulated from HCM).

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.test.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.test.ts
@@ -104,6 +104,58 @@ describe('calculationToFormValues', () => {
     expect(values.geographicLocation).toBe('');
     expect(values.calculationsYear).toBe('');
   });
+
+  describe('403(b) contribution default', () => {
+    const noContribution = {
+      ...baseCalculation,
+      contribution403bPercentage: null,
+      spouseContribution403bPercentage: null,
+    };
+
+    it('prefills both people with the default when no value is saved', () => {
+      const values = calculationToFormValues(noContribution, {
+        default403bPercentage: 7,
+      });
+
+      expect(values.contribution403bPercentage).toBe(7);
+      expect(values.spouseContribution403bPercentage).toBe(7);
+    });
+
+    it('keeps a saved contribution instead of the default', () => {
+      const values = calculationToFormValues(
+        {
+          ...baseCalculation,
+          contribution403bPercentage: 10,
+          spouseContribution403bPercentage: 12,
+        },
+        { default403bPercentage: 7 },
+      );
+
+      expect(values.contribution403bPercentage).toBe(10);
+      expect(values.spouseContribution403bPercentage).toBe(12);
+    });
+
+    it('preserves an explicit 0% instead of applying the default', () => {
+      const values = calculationToFormValues(
+        {
+          ...baseCalculation,
+          contribution403bPercentage: 0,
+          spouseContribution403bPercentage: 0,
+        },
+        { default403bPercentage: 7 },
+      );
+
+      expect(values.contribution403bPercentage).toBe(0);
+      expect(values.spouseContribution403bPercentage).toBe(0);
+    });
+
+    it('leaves the fields blank when no default is provided', () => {
+      const values = calculationToFormValues(noContribution);
+
+      expect(values.contribution403bPercentage).toBe('');
+      expect(values.spouseContribution403bPercentage).toBe('');
+    });
+  });
 });
 
 describe('formValuesToAttributes', () => {

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
@@ -25,9 +25,19 @@ const toNumberOrNull = (value: number | ''): number | null =>
 const toEnumInput = <T>(value?: T | null): T | '' => value ?? '';
 const toEnumOrNull = <T>(value: T | ''): T | null => value || null;
 
+interface CalculationToFormValuesOptions {
+  /**
+   * Default 403(b) contribution as a whole percentage (e.g. `7`), prefilled for
+   * both people when the calculation has no saved value. Mirrors the server's
+   * calculation default.
+   */
+  default403bPercentage?: number | null;
+}
+
 /** Maps a loaded calculation onto the form's initial values. */
 export const calculationToFormValues = (
   calc: NewStaffGoalCalculationFieldsFragment,
+  { default403bPercentage }: CalculationToFormValuesOptions = {},
 ): GoalSettingsFormValues => ({
   calculationsYear:
     typeof calc.calculationsYear === 'number'
@@ -49,9 +59,11 @@ export const calculationToFormValues = (
 
   annualRequestedSalary: toNumberInput(calc.annualRequestedSalary),
   spouseRequestedAnnualSalary: toNumberInput(calc.spouseRequestedAnnualSalary),
-  contribution403bPercentage: toNumberInput(calc.contribution403bPercentage),
+  contribution403bPercentage: toNumberInput(
+    calc.contribution403bPercentage ?? default403bPercentage,
+  ),
   spouseContribution403bPercentage: toNumberInput(
-    calc.spouseContribution403bPercentage,
+    calc.spouseContribution403bPercentage ?? default403bPercentage,
   ),
   spouseMhaAmount: toNumberInput(calc.spouseMhaAmount),
   staffConferenceTransfer: toNumberInput(calc.staffConferenceTransfer),


### PR DESCRIPTION
## Description

When the 403b contribution amount isn't customized, show the server constant default instead of blank.

~~Depends on https://github.com/CruGlobal/mpdx_api/pull/3461~~ merged 🚀

MPDX-9858

## Testing

- Go to a new staff goal calculation without 403b contribution amounts, e.g. `accountLists/90935daa-0e49-4b31-a41b-d6b46854ebca/hrTools/nsGoalCalculator`
- Check that the 403b amounts are 7% and the totals are calculated
- Change the amounts to a different amount and save
- Reload and check that the changes are persisted

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
