### PR TITLE
MPDX-9851 - Add success toast notification on questionnaire submission

### DIFF
--- a/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.test.tsx
@@ -174,4 +174,16 @@ describe('Summary', () => {
       expect(mutationSpy).toHaveBeenCalledWith('/accountLists/account-list-1'),
     );
   });
+
+  it('shows a success toast when submitting', async () => {
+    const { findByRole, getByRole, findByText } = render(<TestComponent />);
+    userEvent.click(await findByRole('button', { name: 'Submit' }));
+    userEvent.click(
+      within(getByRole('dialog')).getByRole('button', { name: 'Submit' }),
+    );
+
+    expect(
+      await findByText('Questionnaire submitted successfully.'),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import { Box, Divider, Stack, Typography } from '@mui/material';
+import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { Confirmation } from 'src/components/Shared/Modal/Confirmation/Confirmation';
 import { useAccountListId } from 'src/hooks/useAccountListId';
@@ -14,6 +15,7 @@ import { useSummarySections } from './useSummarySections';
 export const Summary: React.FC = () => {
   const { t } = useTranslation();
   const router = useRouter();
+  const { enqueueSnackbar } = useSnackbar();
   const accountListId = useAccountListId();
   const { handleStepChange, handleBack, completeQuestionnaire } =
     useNsoMpdQuestionnaire();
@@ -24,6 +26,9 @@ export const Summary: React.FC = () => {
   // Complete the questionnaire, then redirect to the dashboard on success.
   const handleSubmit = async () => {
     await completeQuestionnaire();
+    enqueueSnackbar(t('Questionnaire submitted successfully.'), {
+      variant: 'success',
+    });
     await router.push(`/accountLists/${accountListId}`);
   };
 


### PR DESCRIPTION
## Description

- Notify the user that their request submitted successfully upon rerouting the user to the dashboard.
- https://jira.cru.org/browse/MPDX-9851

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to the NSO MPD Questionnaire
- Submit the questionnaire
- Check that the snackbar displays

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
