### PR TITLE
MPDX-9850 - Remove 'solidSupportRaised' field from NSO Questionnaire and New Staff Goal Calculation

### DIFF
--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
@@ -69,7 +69,6 @@ fragment NewStaffGoalCalculationFields on NewStaffGoalCalculation {
   studentLoanMonthlyPayment
   carLoanMonthlyPayment
   creditCardDebtMonthlyPayment
-  solidSupportRaised
 
   # Healthcare
   benefitsPlan

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/FinancialInformationSection.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/FinancialInformationSection.tsx
@@ -167,14 +167,6 @@ export const FinancialInformationSection: React.FC<
           adornment="currency"
         />
       </FieldRow>
-
-      <FieldRow label={t('Solid Support Raised')}>
-        <GoalSettingsNumberField
-          name="solidSupportRaised"
-          label={t('Solid Support Raised')}
-          adornment="currency"
-        />
-      </FieldRow>
     </Section>
   );
 };

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.test.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.test.ts
@@ -210,13 +210,11 @@ describe('formValuesToAttributes', () => {
     const attributes = formValuesToAttributes({
       ...coupleValues,
       annualRequestedSalary: 0,
-      solidSupportRaised: 0,
       tenure: 0,
       childcareChildrenCount: 0,
     });
 
     expect(attributes.annualRequestedSalary).toBe(0);
-    expect(attributes.solidSupportRaised).toBe(0);
     expect(attributes.tenure).toBe(0);
     expect(attributes.childcareChildrenCount).toBe(0);
   });

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
@@ -63,7 +63,6 @@ export const calculationToFormValues = (
   creditCardDebtMonthlyPayment: toNumberInput(
     calc.creditCardDebtMonthlyPayment,
   ),
-  solidSupportRaised: toNumberInput(calc.solidSupportRaised),
 
   benefitsPlan: calc.benefitsPlan ?? '',
   reimbursableExpenses: toNumberInput(calc.reimbursableExpenses),
@@ -158,8 +157,6 @@ export const formValuesToAttributes = (
     creditCardDebtMonthlyPayment: toNumberOrNull(
       values.creditCardDebtMonthlyPayment,
     ),
-
-    solidSupportRaised: toNumberOrNull(values.solidSupportRaised),
 
     // Healthcare
     benefitsPlan: values.benefitsPlan || null,

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsFormValues.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsFormValues.ts
@@ -65,7 +65,6 @@ export interface GoalSettingsFormValues {
   studentLoanMonthlyPayment: number | '';
   carLoanMonthlyPayment: number | '';
   creditCardDebtMonthlyPayment: number | '';
-  solidSupportRaised: number | '';
 
   // --- 3. Healthcare Information (shared) ---
   benefitsPlan: MpdGoalBenefitsConstantPlanEnum | '';

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsSchema.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsSchema.ts
@@ -52,7 +52,6 @@ export const getGoalSettingsSchema = (t: TFunction) =>
       t('Credit Card Debt Payment'),
       t,
     ),
-    solidSupportRaised: optionalAmount(t('Solid Support Raised'), t),
 
     // Healthcare
     reimbursableExpenses: optionalAmount(t('Reimbursable Expenses'), t),

--- a/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/VariantQuestions.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/VariantQuestions.test.tsx
@@ -108,11 +108,6 @@ describe('VariantQuestions', () => {
         }),
       ).toBeInTheDocument();
       expect(
-        getByRole('spinbutton', {
-          name: 'How much do you have raised in Solid Support?',
-        }),
-      ).toBeInTheDocument();
-      expect(
         queryByRole('spinbutton', {
           name: 'How many total dependents would you like to cover by your Cru healthcare?',
         }),

--- a/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/VariantQuestions.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/VariantQuestions.tsx
@@ -26,7 +26,6 @@ export const getVariantQuestionsSchema = (t: TFunction) =>
     spouseMhaAmount: getAmountSchema(t),
     staffConferenceTransfer: getAmountSchema(t),
     accountTransfers: getAmountSchema(t),
-    solidSupportRaised: getAmountSchema(t),
   });
 
 export const VariantQuestions: React.FC = () => {
@@ -108,13 +107,6 @@ export const VariantQuestions: React.FC = () => {
             helperText={t(
               'Please enter zero if you do not transfer money from your staff account each month as giving to other staff.',
             )}
-            startAdornment={<CurrencyAdornment />}
-          />
-          <NumberQuestion
-            fieldName="solidSupportRaised"
-            schema={schema}
-            question={t('How much do you have raised in Solid Support?')}
-            helperText={t('Please enter as a monthly amount.')}
             startAdornment={<CurrencyAdornment />}
           />
         </>

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NewStaffQuestionnaire.graphql
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NewStaffQuestionnaire.graphql
@@ -31,7 +31,6 @@ fragment NewStaffQuestionnaireFields on NewStaffQuestionnaire {
   nsoSessions
   nsoSpecialNeedsSupportReceived
   phoneNumber
-  solidSupportRaised
   spouseContribution403bPercentage
   spouseMhaAmount
   spousePhoneNumber

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NsoMpdQuestionnaireLayout.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NsoMpdQuestionnaireLayout.test.tsx
@@ -203,7 +203,6 @@ describe('NsoMpdQuestionnaireLayout', () => {
           spouseMhaAmount: 0,
           staffConferenceTransfer: 0,
           accountTransfers: 0,
-          solidSupportRaised: 1000,
           ...filledDebtFields,
         }}
       />,

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.ts
@@ -48,7 +48,6 @@ const variantRequiredFields: Partial<
     'spouseMhaAmount',
     'staffConferenceTransfer',
     'accountTransfers',
-    'solidSupportRaised',
   ],
 };
 

--- a/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.test.tsx
@@ -119,15 +119,12 @@ describe('Summary', () => {
     );
     await findByRole('heading', { level: 6, name: 'Financial Information' });
     expect(
-      queryByRole('rowheader', { name: 'Solid support raised' }),
-    ).not.toBeInTheDocument();
-    expect(
       queryByRole('rowheader', { name: 'Healthcare dependents' }),
     ).not.toBeInTheDocument();
   });
 
   it('shows the healthcare dependents row only for the sosa variant', async () => {
-    const { findByRole, queryByRole } = render(
+    const { findByRole } = render(
       <TestComponent
         newStaffQuestionnaire={{
           variant: NewStaffQuestionnaireVariantEnum.Sosa,
@@ -137,9 +134,6 @@ describe('Summary', () => {
     expect(
       await findByRole('rowheader', { name: 'Healthcare dependents' }),
     ).toBeInTheDocument();
-    expect(
-      queryByRole('rowheader', { name: 'Solid support raised' }),
-    ).not.toBeInTheDocument();
   });
 
   it('renders a Back button', async () => {

--- a/src/components/HrTools/NsoMpdQuestionnaire/Summary/useSummarySections.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Summary/useSummarySections.ts
@@ -62,7 +62,6 @@ export const useSummarySections = (): SummarySectionData[] => {
       spouseMhaAmount,
       staffConferenceTransfer,
       accountTransfers,
-      solidSupportRaised,
       nsoHousing,
       nsoSessions,
       nsoSpecialNeedsSupportReceived,
@@ -177,10 +176,6 @@ export const useSummarySections = (): SummarySectionData[] => {
                 {
                   label: t('Monthly account transfers'),
                   value: formatMoney(accountTransfers),
-                },
-                {
-                  label: t('Solid support raised'),
-                  value: formatMoney(solidSupportRaised),
                 },
               ]
             : []),


### PR DESCRIPTION
## Description

We no longer need this field.
https://jira.cru.org/browse/MPDX-9850

Related followup backend PR: https://github.com/CruGlobal/mpdx_api/pull/3463

## Testing

- Go to the NSO MPD Questionnaire
- Test that the form still works and behaves as expected.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
