### PR TITLE
MPDX-9862 - Change NSO Questionnaire to non-linear form

### DIFF
--- a/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/DebtQuestions.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/DebtQuestions.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import CreditCard from '@mui/icons-material/CreditCard';
 import DirectionsCar from '@mui/icons-material/DirectionsCar';
 import School from '@mui/icons-material/School';
@@ -10,7 +10,6 @@ import {
 } from '@mui/material';
 import { TFunction, useTranslation } from 'react-i18next';
 import * as yup from 'yup';
-import { useOptionalAutosaveForm } from 'src/components/Shared/Autosave/AutosaveForm';
 import { useSyncedState } from 'src/hooks/useSyncedState';
 import { LabeledField } from '../Shared/LabeledField';
 import { useNsoMpdQuestionnaire } from '../Shared/NsoMpdQuestionnaireContext';
@@ -71,16 +70,6 @@ export const DebtQuestions: React.FC = () => {
       });
     }
   };
-
-  const { markValid, markInvalid } = useOptionalAutosaveForm() ?? {};
-  useEffect(() => {
-    if (hasDebtError) {
-      markInvalid?.('hasDebt');
-    } else {
-      markValid?.('hasDebt');
-    }
-    return () => markValid?.('hasDebt');
-  }, [hasDebtError, markValid, markInvalid]);
 
   const debtFields: {
     fieldName: QuestionnaireField;

--- a/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/FinancialInformation.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/FinancialInformation.test.tsx
@@ -28,33 +28,29 @@ describe('FinancialInformation', () => {
     ).toBeInTheDocument();
   });
 
-  it('keeps Continue disabled until the debt question is answered', () => {
+  it('keeps Continue enabled even before the debt question is answered', () => {
     const { getByRole } = render(<TestComponent />);
 
-    const continueButton = getByRole('button', { name: 'Continue' });
-    expect(continueButton).toBeDisabled();
-
-    userEvent.click(getByRole('radio', { name: 'No' }));
-
-    expect(continueButton).toBeEnabled();
+    // Gating moved to the Summary step, so Continue is never disabled here.
+    expect(getByRole('button', { name: 'Continue' })).toBeEnabled();
   });
 
-  it('requires all three payment amounts when Yes is selected', () => {
-    const { getByRole } = render(<TestComponent />);
+  it('reveals the three payment questions when Yes is selected', async () => {
+    const { getByRole, findByRole, queryByRole } = render(<TestComponent />);
 
-    const continueButton = getByRole('button', { name: 'Continue' });
+    // The payment questions are hidden until the debt question is answered Yes.
+    expect(
+      queryByRole('spinbutton', { name: studentLoanQuestion }),
+    ).not.toBeInTheDocument();
 
     userEvent.click(getByRole('radio', { name: 'Yes' }));
-    expect(continueButton).toBeDisabled();
 
-    userEvent.type(
-      getByRole('spinbutton', { name: studentLoanQuestion }),
-      '500',
-    );
-    userEvent.type(getByRole('spinbutton', { name: carQuestion }), '0');
-    expect(continueButton).toBeDisabled();
-
-    userEvent.type(getByRole('spinbutton', { name: creditCardQuestion }), '0');
-    expect(continueButton).toBeEnabled();
+    expect(
+      await findByRole('spinbutton', { name: studentLoanQuestion }),
+    ).toBeInTheDocument();
+    expect(getByRole('spinbutton', { name: carQuestion })).toBeInTheDocument();
+    expect(
+      getByRole('spinbutton', { name: creditCardQuestion }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryInformation.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/MinistryInformation/MinistryInformation.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 import { NsoMpdQuestionnaireTestWrapper } from '../NsoMpdQuestionnaireTestWrapper';
 import { MinistryInformation } from './MinistryInformation';
 
@@ -11,39 +10,10 @@ const TestComponent: React.FC = () => (
 );
 
 describe('MinistryInformation', () => {
-  it('keeps Continue disabled until all four fields are answered', async () => {
-    const { getByRole, findByRole } = render(<TestComponent />);
+  it('keeps Continue enabled even before the fields are answered', () => {
+    const { getByRole } = render(<TestComponent />);
 
-    const continueButton = getByRole('button', { name: 'Continue' });
-    expect(continueButton).toBeDisabled();
-
-    const ministryCombobox = getByRole('combobox', {
-      name: 'What ministry are you expecting to serve with?',
-    });
-    await waitFor(() =>
-      expect(ministryCombobox).not.toHaveAttribute('aria-disabled', 'true'),
-    );
-    userEvent.click(ministryCombobox);
-    userEvent.click(await findByRole('option', { name: 'University' }));
-
-    userEvent.type(
-      getByRole('textbox', {
-        name: 'What is your expected ministry assignment location?',
-      }),
-      'Orlando, FL',
-    );
-
-    const cityCombobox = await findByRole('combobox', {
-      name: 'Is your ministry assignment location within 50 miles of one of these cities?',
-    });
-    await waitFor(() =>
-      expect(cityCombobox).not.toHaveAttribute('aria-disabled', 'true'),
-    );
-    userEvent.click(cityCombobox);
-    userEvent.click(await findByRole('option', { name: 'Atlanta, GA' }));
-
-    userEvent.click(getByRole('radio', { name: 'Field' }));
-
-    expect(continueButton).toBeEnabled();
+    // Gating moved to the Summary step, so Continue is never disabled here.
+    expect(getByRole('button', { name: 'Continue' })).toBeEnabled();
   });
 });

--- a/src/components/HrTools/NsoMpdQuestionnaire/NsoInformation/NsoInformation.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/NsoInformation/NsoInformation.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { NsoMpdQuestionnaireTestWrapper } from '../NsoMpdQuestionnaireTestWrapper';
 import { NsoInformation } from './NsoInformation';
 
@@ -19,32 +18,9 @@ describe('NsoInformation', () => {
     ).toBeInTheDocument();
   });
 
-  it('keeps Continue disabled until all four questions are answered', () => {
+  it('keeps Continue enabled even before the questions are answered', () => {
     const { getByRole } = render(<TestComponent />);
 
-    const continueButton = getByRole('button', { name: 'Continue' });
-    expect(continueButton).toBeDisabled();
-
-    userEvent.click(getByRole('radio', { name: 'Single in hotel/dorm room' }));
-    expect(continueButton).toBeDisabled();
-
-    userEvent.click(getByRole('radio', { name: 'NSO' }));
-    expect(continueButton).toBeDisabled();
-
-    userEvent.type(
-      getByRole('spinbutton', {
-        name: 'How much special needs support have you already received for NSO?',
-      }),
-      '500',
-    );
-    expect(continueButton).toBeDisabled();
-
-    userEvent.type(
-      getByRole('spinbutton', {
-        name: 'If you are a parent with children in Childcare, please enter how many.',
-      }),
-      '0',
-    );
-    expect(continueButton).toBeEnabled();
+    expect(getByRole('button', { name: 'Continue' })).toBeEnabled();
   });
 });

--- a/src/components/HrTools/NsoMpdQuestionnaire/NsoMpdQuestionnaire.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/NsoMpdQuestionnaire.test.tsx
@@ -65,4 +65,20 @@ describe('NsoMpdQuestionnaire', () => {
       queryByRole('heading', { name: 'Staff Information' }),
     ).not.toBeInTheDocument();
   });
+
+  it('jumps to an incomplete section from the Summary warning', async () => {
+    const { findByRole, getByText, getByRole } = render(<TestComponent />);
+
+    // Jump straight to the Summary step via the rail.
+    userEvent.click(await findByRole('button', { name: 'Summary' }));
+
+    // The default mock leaves the debt fields empty, so Financial is flagged.
+    userEvent.click(getByRole('button', { name: 'Financial Information' }));
+
+    // Assert on copy unique to the Financial step (absent from the Summary page),
+    // so a broken warning link that never navigates would fail this test.
+    expect(
+      getByText('Tell us about your financial situation.'),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/HrTools/NsoMpdQuestionnaire/NsoMpdQuestionnaire.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/NsoMpdQuestionnaire.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NsoMpdQuestionnaire } from './NsoMpdQuestionnaire';
 import {
@@ -27,17 +27,14 @@ describe('NsoMpdQuestionnaire', () => {
   it('renders the matching step page after continuing to the next step', async () => {
     const { findByRole } = render(<TestComponent />);
 
-    // Personal Information is a review-only step, so Continue enables once it registers.
-    const continueButton = await findByRole('button', { name: 'Continue' });
-    await waitFor(() => expect(continueButton).toBeEnabled());
-    userEvent.click(continueButton);
+    userEvent.click(await findByRole('button', { name: 'Continue' }));
 
     expect(
       await findByRole('heading', { name: 'Ministry Information' }),
     ).toBeInTheDocument();
   });
 
-  it('enables Continue on the review-only first step and gates it on the next', async () => {
+  it('keeps Continue enabled even when the current step has missing fields', async () => {
     const { findByRole, getByRole } = render(
       <TestComponent
         newStaffQuestionnaire={{
@@ -49,17 +46,13 @@ describe('NsoMpdQuestionnaire', () => {
       />,
     );
 
-    // Personal Information has nothing to fill in, so Continue enables.
     const continueButton = await findByRole('button', { name: 'Continue' });
-    await waitFor(() => expect(continueButton).toBeEnabled());
     userEvent.click(continueButton);
 
     expect(
       await findByRole('heading', { name: 'Ministry Information' }),
     ).toBeInTheDocument();
-    await waitFor(() =>
-      expect(getByRole('button', { name: 'Continue' })).toBeDisabled(),
-    );
+    expect(getByRole('button', { name: 'Continue' })).toBeEnabled();
   });
 
   it('shows the informational view when there is no open questionnaire', async () => {

--- a/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/PersonalInformation.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/PersonalInformation/PersonalInformation.tsx
@@ -1,29 +1,13 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Box, Divider } from '@mui/material';
-import { useOptionalAutosaveForm } from 'src/components/Shared/Autosave/AutosaveForm';
 import { NsoMpdQuestionnaireLayout } from '../Shared/NsoMpdQuestionnaireLayout';
 import { Settings } from './Settings';
 import { StaffInformation } from './StaffInformation';
-
-/**
- * Review-only step: staff data is shown for verification, with nothing to fill in.
- */
-const RegisterReviewStepValid: React.FC = () => {
-  const { markValid } = useOptionalAutosaveForm() ?? {};
-
-  useEffect(() => {
-    markValid?.('personal-information');
-    return () => markValid?.('personal-information');
-  }, [markValid]);
-
-  return null;
-};
 
 export const PersonalInformation: React.FC = () => {
   return (
     <NsoMpdQuestionnaireLayout>
       <Box mx={4} my={2}>
-        <RegisterReviewStepValid />
         <Settings />
         <Divider sx={{ mx: -4, my: 4 }} />
         <StaffInformation />

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/ContinueButton.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/ContinueButton.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useOptionalAutosaveForm } from 'src/components/Shared/Autosave/AutosaveForm';
 import { QuestionnaireActionButton } from './QuestionnaireActionButton';
 
 interface ContinueButtonProps {
@@ -10,10 +9,8 @@ interface ContinueButtonProps {
 export const ContinueButton: React.FC<ContinueButtonProps> = ({ onClick }) => {
   const { t } = useTranslation();
 
-  const allValid = useOptionalAutosaveForm()?.allValid ?? true;
-
   return (
-    <QuestionnaireActionButton onClick={onClick} disabled={!allValid}>
+    <QuestionnaireActionButton onClick={onClick}>
       {t('Continue')}
     </QuestionnaireActionButton>
   );

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/LabeledField.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/LabeledField.tsx
@@ -34,7 +34,7 @@ export const LabeledField: React.FC<LabeledFieldProps> = ({
     <FormControl
       error={error}
       required={required}
-      sx={{ '.MuiTextField-root': { maxWidth: { xs: '100%', sm: '40%' } } }}
+      sx={{ '.MuiTextField-root': { maxWidth: { xs: '100%', md: '50%' } } }}
     >
       <FormLabel component="span" id={labelId} sx={{ color: 'text.primary' }}>
         {label}

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NsoMpdQuestionnaireLayout.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NsoMpdQuestionnaireLayout.test.tsx
@@ -92,18 +92,23 @@ describe('NsoMpdQuestionnaireLayout', () => {
     expect(getByText('Main panel content')).toBeInTheDocument();
   });
 
-  it('disables the non-current step icons so users cannot jump between steps', () => {
+  it('enables every step icon in the rail', () => {
     const { getByRole } = render(<TestComponent />);
 
-    expect(
-      getByRole('button', { name: 'Questionnaire Step 2' }),
-    ).toBeDisabled();
+    expect(getByRole('button', { name: 'Questionnaire Step 2' })).toBeEnabled();
+    expect(getByRole('button', { name: 'Questionnaire Step 3' })).toBeEnabled();
+    expect(getByRole('button', { name: 'Questionnaire Step 4' })).toBeEnabled();
+    expect(getByRole('button', { name: 'Summary' })).toBeEnabled();
+  });
+
+  it('jumps to another step when its rail icon is clicked', () => {
+    const { getByRole } = render(<TestComponent />);
+
+    userEvent.click(getByRole('button', { name: 'Questionnaire Step 3' }));
+
     expect(
       getByRole('button', { name: 'Questionnaire Step 3' }),
-    ).toBeDisabled();
-    expect(
-      getByRole('button', { name: 'Questionnaire Step 4' }),
-    ).toBeDisabled();
+    ).toHaveAttribute('aria-current', 'step');
   });
 
   it('keeps the current step icon interactive', () => {

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/NsoMpdQuestionnaireLayout.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/NsoMpdQuestionnaireLayout.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Stack } from '@mui/material';
-import { AutosaveForm } from 'src/components/Shared/Autosave/AutosaveForm';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import {
   IconPanelItem,
@@ -17,9 +16,9 @@ interface NsoMpdQuestionnaireLayoutProps {
 
 /**
  * Layout shared by all NSO MPD Questionnaire pages. The icon rail holds a completion progress ring
- * and one icon per view step; the content has Back and Continue buttons below it on every step
- * except the last, which supplies its own Back and Submit buttons. Each step has a single section,
- * so there is no sub-step sidebar.
+ * and one navigable icon per view step, so users can jump directly to any step; the content has Back
+ * and Continue buttons below it on every step except the last, which supplies its own Back and Submit
+ * buttons. Each step has a single section, so there is no sub-step sidebar.
  */
 export const NsoMpdQuestionnaireLayout: React.FC<
   NsoMpdQuestionnaireLayoutProps
@@ -31,6 +30,7 @@ export const NsoMpdQuestionnaireLayout: React.FC<
     currentIndex,
     isLastStep,
     percentComplete,
+    handleStepChange,
     handleContinue,
     handleBack,
     loading,
@@ -38,18 +38,13 @@ export const NsoMpdQuestionnaireLayout: React.FC<
 
   const isFirstStep = currentIndex === 0;
 
-  const stepIcons: IconPanelItem[] = steps.map((step) => {
-    const isActive = currentStep.step === step.step;
-    return {
-      key: step.step,
-      icon: step.icon,
-      label: step.title,
-      isActive,
-      // Only the current step's icon is highlighted; the other steps are disabled so users move
-      // through the questionnaire with the Continue and Back buttons.
-      disabled: !isActive,
-    };
-  });
+  const stepIcons: IconPanelItem[] = steps.map((step) => ({
+    key: step.step,
+    icon: step.icon,
+    label: step.title,
+    isActive: currentStep.step === step.step,
+    onClick: () => handleStepChange(step.step),
+  }));
 
   return (
     <PanelLayout
@@ -61,17 +56,15 @@ export const NsoMpdQuestionnaireLayout: React.FC<
       backHref={`/accountLists/${accountListId}`}
       hideSidebar
       mainContent={
-        <AutosaveForm>
-          <Stack spacing={4}>
-            {children}
-            {!isLastStep && (
-              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} mx={4}>
-                {!isFirstStep && <BackButton onClick={handleBack} />}
-                <ContinueButton onClick={handleContinue} />
-              </Stack>
-            )}
-          </Stack>
-        </AutosaveForm>
+        <Stack spacing={4}>
+          {children}
+          {!isLastStep && (
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} mx={4}>
+              {!isFirstStep && <BackButton onClick={handleBack} />}
+              <ContinueButton onClick={handleContinue} />
+            </Stack>
+          )}
+        </Stack>
       }
     />
   );

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.test.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.test.ts
@@ -7,7 +7,11 @@ import {
 } from 'src/graphql/types.generated';
 import { NsoMpdQuestionnaireStepEnum } from '../NsoMpdQuestionnaireHelper';
 import { NewStaffQuestionnaireQuery } from './NewStaffQuestionnaire.generated';
-import { getCompletionPercentage, isStepComplete } from './stepCompletion';
+import {
+  getCompletionPercentage,
+  getIncompleteSteps,
+  isStepComplete,
+} from './stepCompletion';
 
 type Questionnaire = NonNullable<
   NewStaffQuestionnaireQuery['newStaffQuestionnaire']
@@ -132,5 +136,51 @@ describe('isStepComplete', () => {
         marriedNoPhones,
       ),
     ).toBe(true);
+  });
+});
+
+describe('getIncompleteSteps', () => {
+  it('returns every data-entry step for a missing questionnaire', () => {
+    expect(getIncompleteSteps(null)).toEqual([
+      NsoMpdQuestionnaireStepEnum.PersonalInformation,
+      NsoMpdQuestionnaireStepEnum.MinistryInformation,
+      NsoMpdQuestionnaireStepEnum.FinancialInformation,
+      NsoMpdQuestionnaireStepEnum.NsoInformation,
+    ]);
+  });
+
+  it('returns an empty array when every data-entry step is complete', () => {
+    expect(getIncompleteSteps(completeSingle)).toEqual([]);
+  });
+
+  it('returns only the steps missing a required field', () => {
+    expect(
+      getIncompleteSteps({ ...completeSingle, ministryLocation: null }),
+    ).toEqual([NsoMpdQuestionnaireStepEnum.MinistryInformation]);
+  });
+
+  it('flags the financial step for the Sosa variant healthcare dependents field', () => {
+    const sosa: Questionnaire = {
+      ...completeSingle,
+      variant: NewStaffQuestionnaireVariantEnum.Sosa,
+      healthcareDependentsCount: null,
+    };
+
+    expect(getIncompleteSteps(sosa)).toEqual([
+      NsoMpdQuestionnaireStepEnum.FinancialInformation,
+    ]);
+    expect(
+      getIncompleteSteps({ ...sosa, healthcareDependentsCount: 2 }),
+    ).toEqual([]);
+  });
+
+  it('ignores the Sosa-only healthcare dependents field for non-Sosa variants', () => {
+    expect(
+      getIncompleteSteps({
+        ...completeSingle,
+        variant: NewStaffQuestionnaireVariantEnum.SingleMarried,
+        healthcareDependentsCount: null,
+      }),
+    ).toEqual([]);
   });
 });

--- a/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Shared/stepCompletion.ts
@@ -77,6 +77,11 @@ export const isStepComplete = (
     isFieldFilled(questionnaire[field]),
   );
 
+export const getIncompleteSteps = (
+  questionnaire: NewStaffQuestionnaire,
+): NsoMpdQuestionnaireStepEnum[] =>
+  steps.filter((step) => !isStepComplete(step, questionnaire));
+
 export const getCompletionPercentage = (
   questionnaire: NewStaffQuestionnaire,
 ): number => {

--- a/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.test.tsx
@@ -13,6 +13,12 @@ import { Summary } from './Summary';
 
 const mutationSpy = jest.fn();
 
+const filledDebtFields = {
+  studentLoanMonthlyPayment: 0,
+  carLoanMonthlyPayment: 0,
+  creditCardDebtMonthlyPayment: 0,
+};
+
 const TestComponent: React.FC<
   Omit<NsoMpdQuestionnaireTestWrapperProps, 'children'>
 > = (props) => (
@@ -144,9 +150,14 @@ describe('Summary', () => {
 
   it('submits via the confirmation modal', async () => {
     const { findByRole, getByRole } = render(
-      <TestComponent onCall={mutationSpy} />,
+      <TestComponent
+        onCall={mutationSpy}
+        newStaffQuestionnaire={filledDebtFields}
+      />,
     );
-    userEvent.click(await findByRole('button', { name: 'Submit' }));
+    const submitButton = await findByRole('button', { name: 'Submit' });
+    await waitFor(() => expect(submitButton).toBeEnabled());
+    userEvent.click(submitButton);
     const dialog = getByRole('dialog');
     userEvent.click(within(dialog).getByRole('button', { name: 'Submit' }));
     await waitFor(() =>
@@ -159,9 +170,14 @@ describe('Summary', () => {
 
   it('redirects to the dashboard after submitting', async () => {
     const { findByRole, getByRole } = render(
-      <TestComponent mockPush={mutationSpy} />,
+      <TestComponent
+        mockPush={mutationSpy}
+        newStaffQuestionnaire={filledDebtFields}
+      />,
     );
-    userEvent.click(await findByRole('button', { name: 'Submit' }));
+    const submitButton = await findByRole('button', { name: 'Submit' });
+    await waitFor(() => expect(submitButton).toBeEnabled());
+    userEvent.click(submitButton);
     const dialog = getByRole('dialog');
     userEvent.click(within(dialog).getByRole('button', { name: 'Submit' }));
     await waitFor(() =>
@@ -170,8 +186,12 @@ describe('Summary', () => {
   });
 
   it('shows a success toast when submitting', async () => {
-    const { findByRole, getByRole, findByText } = render(<TestComponent />);
-    userEvent.click(await findByRole('button', { name: 'Submit' }));
+    const { findByRole, getByRole, findByText } = render(
+      <TestComponent newStaffQuestionnaire={filledDebtFields} />,
+    );
+    const submitButton = await findByRole('button', { name: 'Submit' });
+    await waitFor(() => expect(submitButton).toBeEnabled());
+    userEvent.click(submitButton);
     userEvent.click(
       within(getByRole('dialog')).getByRole('button', { name: 'Submit' }),
     );
@@ -179,5 +199,45 @@ describe('Summary', () => {
     expect(
       await findByText('Questionnaire submitted successfully.'),
     ).toBeInTheDocument();
+  });
+
+  it('disables Submit and warns when required fields are missing', async () => {
+    const { findByRole, getByRole } = render(<TestComponent />);
+
+    expect(await findByRole('alert')).toHaveTextContent(
+      'Your form is missing information.',
+    );
+    expect(getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('links only the incomplete sections in the warning', async () => {
+    const { findByRole, queryByRole } = render(<TestComponent />);
+
+    expect(
+      await findByRole('button', { name: 'Financial Information' }),
+    ).toBeInTheDocument();
+
+    // Completed sections are filtered out of the warning once the data loads.
+    await waitFor(() =>
+      expect(
+        queryByRole('button', { name: 'Ministry Information' }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      queryByRole('button', { name: 'NSO Information' }),
+    ).not.toBeInTheDocument();
+    expect(
+      queryByRole('button', { name: 'Personal Information' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('enables Submit and hides the warning when the form is complete', async () => {
+    const { findByRole, queryByRole } = render(
+      <TestComponent newStaffQuestionnaire={filledDebtFields} />,
+    );
+
+    const submitButton = await findByRole('button', { name: 'Submit' });
+    await waitFor(() => expect(submitButton).toBeEnabled());
+    expect(queryByRole('alert')).not.toBeInTheDocument();
   });
 });

--- a/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Summary/Summary.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
-import { Box, Divider, Stack, Typography } from '@mui/material';
+import { Alert, Box, Divider, Link, Stack, Typography } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
 import { Confirmation } from 'src/components/Shared/Modal/Confirmation/Confirmation';
@@ -9,6 +9,7 @@ import { BackButton } from '../Shared/BackButton';
 import { useNsoMpdQuestionnaire } from '../Shared/NsoMpdQuestionnaireContext';
 import { NsoMpdQuestionnaireLayout } from '../Shared/NsoMpdQuestionnaireLayout';
 import { QuestionnaireActionButton } from '../Shared/QuestionnaireActionButton';
+import { getIncompleteSteps } from '../Shared/stepCompletion';
 import { SummarySection } from './SummarySection';
 import { useSummarySections } from './useSummarySections';
 
@@ -17,11 +18,17 @@ export const Summary: React.FC = () => {
   const router = useRouter();
   const { enqueueSnackbar } = useSnackbar();
   const accountListId = useAccountListId();
-  const { handleStepChange, handleBack, completeQuestionnaire } =
+  const { questionnaire, handleStepChange, handleBack, completeQuestionnaire } =
     useNsoMpdQuestionnaire();
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const sections = useSummarySections();
+
+  const incompleteSteps = getIncompleteSteps(questionnaire);
+  const canSubmit = incompleteSteps.length === 0;
+  const incompleteSections = sections.filter((section) =>
+    incompleteSteps.includes(section.step),
+  );
 
   // Complete the questionnaire, then redirect to the dashboard on success.
   const handleSubmit = async () => {
@@ -56,9 +63,31 @@ export const Summary: React.FC = () => {
         </Stack>
       </Box>
 
+      {!canSubmit && (
+        <Alert severity="error" sx={{ mx: 4, '& ul': { m: 0, pl: 3 } }}>
+          {t('Your form is missing information.')}
+          <ul>
+            {incompleteSections.map((section) => (
+              <li key={section.step}>
+                <Link
+                  component="button"
+                  type="button"
+                  onClick={() => handleStepChange(section.step)}
+                >
+                  {section.title}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </Alert>
+      )}
+
       <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} mx={4}>
         <BackButton onClick={handleBack} />
-        <QuestionnaireActionButton onClick={() => setConfirmOpen(true)}>
+        <QuestionnaireActionButton
+          onClick={() => setConfirmOpen(true)}
+          disabled={!canSubmit}
+        >
           {t('Submit')}
         </QuestionnaireActionButton>
       </Stack>

--- a/src/components/HrTools/NsoMpdQuestionnaire/Summary/SummarySection.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Summary/SummarySection.test.tsx
@@ -43,4 +43,26 @@ describe('SummarySection', () => {
       getByRole('cell', { name: 'No value provided' }),
     ).toBeInTheDocument();
   });
+
+  it('renders a required empty value in the error color', () => {
+    const { getByText } = render(
+      <TestComponent
+        rows={[{ label: 'Ministry', value: null, required: true }]}
+      />,
+    );
+
+    expect(getByText('No value provided')).toHaveStyle({
+      color: theme.palette.error.main,
+    });
+  });
+
+  it('renders a non-required empty value in the secondary color', () => {
+    const { getByText } = render(
+      <TestComponent rows={[{ label: 'Tenure', value: null }]} />,
+    );
+
+    expect(getByText('No value provided')).toHaveStyle({
+      color: theme.palette.text.secondary,
+    });
+  });
 });

--- a/src/components/HrTools/NsoMpdQuestionnaire/Summary/SummarySection.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Summary/SummarySection.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Box,
   Button,
+  Divider,
   Stack,
   Table,
   TableBody,
@@ -95,6 +96,7 @@ export const SummarySection: React.FC<SummarySectionProps> = ({
           ))}
         </TableBody>
       </Table>
+      <Divider sx={{ mx: -4, mt: 4 }} />
     </Box>
   );
 };

--- a/src/components/HrTools/NsoMpdQuestionnaire/Summary/SummarySection.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Summary/SummarySection.tsx
@@ -23,6 +23,7 @@ const StyledStack = styled(Stack)(({ theme }) => ({
 export interface SummaryRow {
   label: string;
   value: React.ReactNode;
+  required?: boolean;
 }
 
 interface SummarySectionProps {
@@ -80,7 +81,11 @@ export const SummarySection: React.FC<SummarySectionProps> = ({
                     component="span"
                     variant="body2"
                     fontStyle="italic"
-                    color="text.secondary"
+                    sx={{
+                      color: row.required
+                        ? theme.palette.error.main
+                        : theme.palette.text.secondary,
+                    }}
                   >
                     {t('No value provided')}
                   </Typography>

--- a/src/components/HrTools/NsoMpdQuestionnaire/Summary/useSummarySections.ts
+++ b/src/components/HrTools/NsoMpdQuestionnaire/Summary/useSummarySections.ts
@@ -91,7 +91,7 @@ export const useSummarySections = (): SummarySectionData[] => {
     const isSpouseSeniorStaff =
       variant === NewStaffQuestionnaireVariantEnum.SpouseSeniorStaff;
 
-    return [
+    const sections: SummarySectionData[] = [
       {
         title: t('Personal Information'),
         step: NsoMpdQuestionnaireStepEnum.PersonalInformation,
@@ -216,5 +216,16 @@ export const useSummarySections = (): SummarySectionData[] => {
         ],
       },
     ];
+
+    // Personal Information is a read-only review step; every other section's rows are
+    // user-enterable and required, so an empty one should be flagged in the Summary.
+    return sections.map((section) =>
+      section.step === NsoMpdQuestionnaireStepEnum.PersonalInformation
+        ? section
+        : {
+            ...section,
+            rows: section.rows.map((row) => ({ ...row, required: true })),
+          },
+    );
   }, [questionnaire, hasSpouse, t, locale]);
 };


### PR DESCRIPTION
## Description

- Allow users to skip around the form, enforcing form completion before the submit button becomes enables
- Increase user awareness of unfilled fields through a warning about the submit button, and using error color font in the Summary tables.
- https://jira.cru.org/browse/MPDX-9862

Claude flagged this PR as critical so it cannot be merged until approved by a human.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to NSO MPD Questionnaire, preferably with an empty form
- Half fill the form
- Check the submission view and whether the design is sufficient for our needs.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
