### PR TITLE
MPDX-9833 Remove unused category and subcategory enums

### DIFF
--- a/src/components/Reports/Shared/Helpers/transformStaffExpenseEnums.ts
+++ b/src/components/Reports/Shared/Helpers/transformStaffExpenseEnums.ts
@@ -8,8 +8,8 @@ import {
 export const getLocalizedCategory = (
   value: StaffExpenseCategoryEnum,
   t: TFunction,
-) => {
-  const categoryLabels: Record<StaffExpenseCategoryEnum, string> = {
+): string => {
+  const categoryLabels: Partial<Record<StaffExpenseCategoryEnum, string>> = {
     [StaffExpenseCategoryEnum.Donation]: t('Donation'),
     [StaffExpenseCategoryEnum.Transfer]: t('Transfer'),
     [StaffExpenseCategoryEnum.AccountTransfer]: t('Account Transfer'),
@@ -23,8 +23,6 @@ export const getLocalizedCategory = (
     [StaffExpenseCategoryEnum.AdditionalSalary]: t('Additional Salary'),
     [StaffExpenseCategoryEnum.Salary]: t('Salary'),
     [StaffExpenseCategoryEnum.Benefits]: t('Benefits'),
-    [StaffExpenseCategoryEnum.Deductions]: t('Deductions'),
-    [StaffExpenseCategoryEnum.TaxDeductions]: t('Tax Deductions'),
     [StaffExpenseCategoryEnum.Assessment]: t('Assessment'),
     [StaffExpenseCategoryEnum.Other]: t('Other'),
   };
@@ -34,14 +32,14 @@ export const getLocalizedCategory = (
 export const getLocalizedSubCategory = (
   value: StaffExpensesSubCategoryEnum,
   t: TFunction,
-) => {
-  const subcategoryLabels: Record<StaffExpensesSubCategoryEnum, string> = {
+): string => {
+  const subcategoryLabels: Partial<
+    Record<StaffExpensesSubCategoryEnum, string>
+  > = {
     [StaffExpensesSubCategoryEnum.Donation]: t('Donation'),
-    [StaffExpensesSubCategoryEnum.Gift]: t('Gift'),
     [StaffExpensesSubCategoryEnum.NonCash]: t('Non Cash'),
     [StaffExpensesSubCategoryEnum.Withdrawal]: t('Withdrawal'),
     [StaffExpensesSubCategoryEnum.Deposit]: t('Deposit'),
-    [StaffExpensesSubCategoryEnum.Transfer]: t('Transfer'),
     [StaffExpensesSubCategoryEnum.MinistryReimbursement]: t(
       'Ministry Reimbursement',
     ),
@@ -59,8 +57,6 @@ export const getLocalizedSubCategory = (
     [StaffExpensesSubCategoryEnum.RetroactivePay]: t('Retroactive Pay'),
     [StaffExpensesSubCategoryEnum.SpecialPay]: t('Special Pay'),
     [StaffExpensesSubCategoryEnum.SalaryAdvance]: t('Salary Advance'),
-    [StaffExpensesSubCategoryEnum.EarningsMha]: t('Earnings MHA'),
-    [StaffExpensesSubCategoryEnum.EarningsReg]: t('Earnings REG'),
     [StaffExpensesSubCategoryEnum.EarningsNumeric]: t('Earnings Numeric'),
     [StaffExpensesSubCategoryEnum.DisabilityEarnings]: t('Disability Earnings'),
     [StaffExpensesSubCategoryEnum.OtherStandardEarnings]: t(
@@ -68,19 +64,15 @@ export const getLocalizedSubCategory = (
     ),
     [StaffExpensesSubCategoryEnum.TaxFederal]: t('Tax Federal'),
     [StaffExpensesSubCategoryEnum.TaxState]: t('Tax State'),
-    [StaffExpensesSubCategoryEnum.TaxDeductions]: t('Tax Deductions'),
     [StaffExpensesSubCategoryEnum.PayrollTaxes]: t('Payroll Taxes'),
     [StaffExpensesSubCategoryEnum.Deduction_403BPretax]: t(
       'Deduction 403b Pretax',
     ),
     [StaffExpensesSubCategoryEnum.Deduction_403BRoth]: t('Deduction 403b Roth'),
     [StaffExpensesSubCategoryEnum.DeductionMedical]: t('Deduction Medical'),
-    [StaffExpensesSubCategoryEnum.Deductions]: t('Deductions'),
-    [StaffExpensesSubCategoryEnum.SalaryOther]: t('Salary Other'),
     [StaffExpensesSubCategoryEnum.MedicalDeduction]: t('Medical Deduction'),
     [StaffExpensesSubCategoryEnum.NumericDeduction]: t('Numeric Deduction'),
     [StaffExpensesSubCategoryEnum.ProgramBased]: t('Program Based'),
-    [StaffExpensesSubCategoryEnum.BenefitsOther]: t('Benefits Other'),
     [StaffExpensesSubCategoryEnum.MinistryBenefits]: t('Ministry Benefits'),
     [StaffExpensesSubCategoryEnum.RetirementContributions]: t(
       'Retirement Contributions',

--- a/src/components/Reports/StaffExpenseReport/CategoryBreakdownDialog/CategoryBreakdownDialog.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/CategoryBreakdownDialog/CategoryBreakdownDialog.test.tsx
@@ -21,8 +21,8 @@ const mockTransactions: Transaction[] = [
     description: 'Salary Payment 1',
     fundType: 'Primary',
     category: StaffExpenseCategoryEnum.Salary,
-    subcategory: StaffExpensesSubCategoryEnum.SalaryOther,
-    displayCategory: 'Salary - Salary Other',
+    subcategory: StaffExpensesSubCategoryEnum.Bereavement,
+    displayCategory: 'Salary - Bereavement',
   },
   {
     id: 'transaction-2',
@@ -31,8 +31,8 @@ const mockTransactions: Transaction[] = [
     description: 'Salary Payment 2',
     fundType: 'Primary',
     category: StaffExpenseCategoryEnum.Salary,
-    subcategory: StaffExpensesSubCategoryEnum.SalaryOther,
-    displayCategory: 'Salary - Salary Other',
+    subcategory: StaffExpensesSubCategoryEnum.Bonuses,
+    displayCategory: 'Salary - Bonuses',
   },
 ];
 
@@ -78,9 +78,9 @@ describe('CategoryBreakdownDialog', () => {
 
     expect(
       getAllByRole('cell', {
-        name: 'Salary - Salary Other',
+        name: 'Salary - Bereavement',
       }),
-    ).toHaveLength(2);
+    ).toHaveLength(1);
 
     expect(getByRole('cell', { name: '$500' })).toBeInTheDocument();
     expect(getByRole('cell', { name: '$300' })).toBeInTheDocument();
@@ -114,7 +114,7 @@ describe('CategoryBreakdownDialog', () => {
     const firstRowCells = within(getAllByRole('row')[1]).getAllByRole('cell');
     // Columns: Date | Description | Category | Amount
     expect(firstRowCells[1]).toHaveTextContent('Salary Payment 1');
-    expect(firstRowCells[2]).toHaveTextContent('Salary - Salary Other');
+    expect(firstRowCells[2]).toHaveTextContent('Salary - Bereavement');
   });
 
   it('displays total amount', () => {

--- a/src/components/Reports/StaffExpenseReport/Helpers/filterTransactions.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/Helpers/filterTransactions.test.tsx
@@ -68,7 +68,7 @@ const mockFund: Fund = {
       averagePerMonth: -50,
       subcategories: [
         {
-          subCategory: StaffExpensesSubCategoryEnum.BenefitsOther,
+          subCategory: StaffExpensesSubCategoryEnum.HealthWelfare,
           total: -100,
           averagePerMonth: -50,
           breakdownByMonth: [
@@ -80,7 +80,7 @@ const mockFund: Fund = {
                   id: 'transaction-4',
                   amount: -50,
                   transactedAt: '2025-01-10',
-                  description: 'Benefits Payment',
+                  description: 'Health Welfare Payment',
                 },
               ],
             },
@@ -362,7 +362,7 @@ describe('filterTransactions', () => {
       const different = result.find(
         (r) => r.category === StaffExpenseCategoryEnum.Benefits,
       );
-      expect(different?.displayCategory).toBe('Benefits - Benefits Other');
+      expect(different?.displayCategory).toBe('Benefits - Health & Welfare');
       expect(different?.displayCategory).toContain(' - ');
     });
   });

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
@@ -79,7 +79,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
                                 subcategories: [
                                   {
                                     subCategory:
-                                      StaffExpensesSubCategoryEnum.BenefitsOther,
+                                      StaffExpensesSubCategoryEnum.CreditCardFee,
                                     total: -200,
                                     averagePerMonth: -50,
                                     breakdownByMonth: [
@@ -164,7 +164,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
                                 subcategories: [
                                   {
                                     subCategory:
-                                      StaffExpensesSubCategoryEnum.BenefitsOther,
+                                      StaffExpensesSubCategoryEnum.CreditCardFee,
                                     total: -100,
                                     averagePerMonth: -50,
                                     breakdownByMonth: [


### PR DESCRIPTION
## Description

Remove unused category and subcategory enums from the frontend.

_This is the final PR of [MPDX-9833](https://jira.cru.org/browse/MPDX-9833)._

MERGE ORDER:
- **THIS PR**
- Backend PR ([#3467](https://github.com/CruGlobal/mpdx_api/pull/3467))
- Frontend PR (#1920) --> remove `Partial` from both localized functions first

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to `/reports/mpgaIncomeExpenses` and `/reports/staffExpense`
- Check that nothing is broken

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
