### PR TITLE
[MPDX-9817] Add admin-editable other expenses field

### DIFF
--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
@@ -66,6 +66,7 @@ fragment NewStaffGoalCalculationFields on NewStaffGoalCalculation {
   staffConferenceTransfer
   accountTransfers
   advocacyTransfers
+  otherExpenses
   geographicLocation
   studentLoanMonthlyPayment
   carLoanMonthlyPayment

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/FinancialInformationSection.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/FinancialInformationSection.test.tsx
@@ -37,6 +37,7 @@ const TestComponent: React.FC<Partial<GoalSettingsSectionProps>> = (
         studentLoanMonthlyPayment: 0,
         carLoanMonthlyPayment: 0,
         creditCardDebtMonthlyPayment: 0,
+        otherExpenses: 0,
       }}
       onSubmit={jest.fn()}
     >
@@ -63,6 +64,9 @@ describe('FinancialInformationSection', () => {
     ).toBeInTheDocument();
     expect(
       getByRole('spinbutton', { name: 'Credit Card Payment' }),
+    ).toBeInTheDocument();
+    expect(
+      getByRole('spinbutton', { name: 'Other Expenses' }),
     ).toBeInTheDocument();
     expect(
       getByRole('combobox', { name: 'Geographic Location' }),

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/FinancialInformationSection.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/FinancialInformationSection.tsx
@@ -170,6 +170,17 @@ export const FinancialInformationSection: React.FC<
           adornment="currency"
         />
       </FieldRow>
+
+      <FieldRow
+        label={t('Other Expenses')}
+        helperText={t('Additional monthly needs not covered above')}
+      >
+        <GoalSettingsNumberField
+          name="otherExpenses"
+          label={t('Other Expenses')}
+          adornment="currency"
+        />
+      </FieldRow>
     </Section>
   );
 };

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.test.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.test.ts
@@ -40,6 +40,7 @@ const baseCalculation = gqlMock<NewStaffGoalCalculationFieldsFragment>(
       staffConferenceTransfer: 10,
       accountTransfers: 20,
       advocacyTransfers: 30,
+      otherExpenses: 40,
       assignmentType: GoalCalculationRole.Field,
       nsoSpecialNeedsSupportReceived: 15,
       healthcareExempt: false,
@@ -63,6 +64,7 @@ describe('calculationToFormValues', () => {
     expect(values.calculationsYear).toBe('2026');
     expect(values.nsoSpecialNeedsSupportReceived).toBe(15);
     expect(values.assignmentType).toBe(GoalCalculationRole.Field);
+    expect(values.otherExpenses).toBe(40);
   });
 
   it('converts booleans to Yes/No strings', () => {
@@ -221,6 +223,14 @@ describe('formValuesToAttributes', () => {
     expect(attributes.staffConferenceTransfer).toBeNull();
     expect(attributes.accountTransfers).toBeNull();
     expect(attributes.advocacyTransfers).toBeNull();
+  });
+
+  it('sends other expenses for everyone, not just senior staff', () => {
+    // Unlike the senior-staff-only transfers, the "Other" line (worksheet
+    // line 13) is a general monthly need, so it is sent even for a single
+    // person whose senior-staff fields are cleared.
+    expect(formValuesToAttributes(singleValues).otherExpenses).toBe(40);
+    expect(formValuesToAttributes(coupleValues).otherExpenses).toBe(40);
   });
 
   it('passes the age enum through to the API', () => {

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
@@ -69,6 +69,7 @@ export const calculationToFormValues = (
   staffConferenceTransfer: toNumberInput(calc.staffConferenceTransfer),
   accountTransfers: toNumberInput(calc.accountTransfers),
   advocacyTransfers: toNumberInput(calc.advocacyTransfers),
+  otherExpenses: toNumberInput(calc.otherExpenses),
   geographicLocation: calc.geographicLocation ?? '',
   studentLoanMonthlyPayment: toNumberInput(calc.studentLoanMonthlyPayment),
   carLoanMonthlyPayment: toNumberInput(calc.carLoanMonthlyPayment),
@@ -161,6 +162,7 @@ export const formValuesToAttributes = (
     advocacyTransfers: seniorStaff
       ? toNumberOrNull(values.advocacyTransfers)
       : null,
+    otherExpenses: toNumberOrNull(values.otherExpenses),
 
     geographicLocation: values.geographicLocation || null,
 

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
@@ -69,13 +69,13 @@ export const calculationToFormValues = (
   staffConferenceTransfer: toNumberInput(calc.staffConferenceTransfer),
   accountTransfers: toNumberInput(calc.accountTransfers),
   advocacyTransfers: toNumberInput(calc.advocacyTransfers),
-  otherExpenses: toNumberInput(calc.otherExpenses),
   geographicLocation: calc.geographicLocation ?? '',
   studentLoanMonthlyPayment: toNumberInput(calc.studentLoanMonthlyPayment),
   carLoanMonthlyPayment: toNumberInput(calc.carLoanMonthlyPayment),
   creditCardDebtMonthlyPayment: toNumberInput(
     calc.creditCardDebtMonthlyPayment,
   ),
+  otherExpenses: toNumberInput(calc.otherExpenses),
 
   benefitsPlan: calc.benefitsPlan ?? '',
   reimbursableExpenses: toNumberInput(calc.reimbursableExpenses),
@@ -162,7 +162,6 @@ export const formValuesToAttributes = (
     advocacyTransfers: seniorStaff
       ? toNumberOrNull(values.advocacyTransfers)
       : null,
-    otherExpenses: toNumberOrNull(values.otherExpenses),
 
     geographicLocation: values.geographicLocation || null,
 
@@ -171,6 +170,7 @@ export const formValuesToAttributes = (
     creditCardDebtMonthlyPayment: toNumberOrNull(
       values.creditCardDebtMonthlyPayment,
     ),
+    otherExpenses: toNumberOrNull(values.otherExpenses),
 
     // Healthcare
     benefitsPlan: values.benefitsPlan || null,

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsFormValues.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsFormValues.ts
@@ -60,12 +60,12 @@ export interface GoalSettingsFormValues {
   staffConferenceTransfer: number | '';
   accountTransfers: number | '';
   advocacyTransfers: number | '';
-  otherExpenses: number | '';
   // shared
   geographicLocation: string;
   studentLoanMonthlyPayment: number | '';
   carLoanMonthlyPayment: number | '';
   creditCardDebtMonthlyPayment: number | '';
+  otherExpenses: number | '';
 
   // --- 3. Healthcare Information (shared) ---
   benefitsPlan: MpdGoalBenefitsConstantPlanEnum | '';

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsFormValues.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsFormValues.ts
@@ -60,6 +60,7 @@ export interface GoalSettingsFormValues {
   staffConferenceTransfer: number | '';
   accountTransfers: number | '';
   advocacyTransfers: number | '';
+  otherExpenses: number | '';
   // shared
   geographicLocation: string;
   studentLoanMonthlyPayment: number | '';

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsSchema.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsSchema.ts
@@ -46,6 +46,7 @@ export const getGoalSettingsSchema = (t: TFunction) =>
     staffConferenceTransfer: optionalAmount(t('Staff Conference Transfer'), t),
     accountTransfers: optionalAmount(t('Account Transfers'), t),
     advocacyTransfers: optionalAmount(t('Advocacy Transfers'), t),
+    otherExpenses: optionalAmount(t('Other Expenses'), t),
     studentLoanMonthlyPayment: optionalAmount(t('Student Loan Payment'), t),
     carLoanMonthlyPayment: optionalAmount(t('Car Loan Payment'), t),
     creditCardDebtMonthlyPayment: optionalAmount(


### PR DESCRIPTION
## Description

- Add an admin-editable **Other Expenses** field to the New Staff Goal Calculator's Goal Settings (Financial Information section).
- Maps the field through the full stack: `NewStaffGoalCalculation` GraphQL fragment, `GoalSettingsFormValues`, the Yup schema (`optionalAmount`), and both `calculationToFormValues` / `formValuesToAttributes` mapping directions.
- Unlike the senior-staff-only transfer fields, Other Expenses (worksheet line 13, a general monthly need) is shown to and saved for everyone — it lives in the shared field region and is not gated behind `seniorStaff`.
- Requires the matching API change (adds `otherExpenses` to `NewStaffGoalCalculationAttributesInput` and feeds it into the computed calculation).

Depends on ~~https://github.com/CruGlobal/mpdx_api/pull/3471~~ merged 🚀

Jira: MPDX-9817

## Testing

- Go to the New Staff Goal Calculator → **Goal Settings** step → **Financial Information** section (e.g. `/accountLists/6bbc265f-ec81-4b23-b297-5bd298c4d619/coaching/90935daa-0e49-4b31-a41b-d6b46854ebca/nsGoalCalculator`)
- Confirm the **Other Expenses** field appears (currency adornment, helper text "Additional monthly needs not covered above") for both single and married calculations.
- Enter an amount, then **Save & Share**; reload and confirm the value persists.
- Go to the **Review Your Calculation** step and confirm the amount shows on the Monthly Needs worksheet, line 13 "Other", and is included in the subtotal.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)
