### PR TITLE
[MPDX-9866] - Disable all inputs of read-only goal calculations

### DIFF
--- a/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/Autosave/AutosaveTextField.test.tsx
+++ b/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/Autosave/AutosaveTextField.test.tsx
@@ -16,12 +16,14 @@ const mutationSpy = jest.fn();
 
 interface TestComponentProps {
   schema?: yup.Schema;
+  readOnly?: boolean;
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({
   schema = defaultSchema,
+  readOnly,
 }) => (
-  <GoalCalculatorTestWrapper onCall={mutationSpy}>
+  <GoalCalculatorTestWrapper onCall={mutationSpy} readOnly={readOnly}>
     <AutosaveTextField
       label="MHA Amount"
       fieldName="mhaAmount"
@@ -145,6 +147,14 @@ describe('AutosaveTextField', () => {
     expect(input).toHaveAccessibleDescription('');
   });
 
+  it('disables the input when the goal is read-only but still shows its value', async () => {
+    const { getByRole } = render(<TestComponent readOnly />);
+
+    const input = getByRole('textbox', { name: 'MHA Amount' });
+    await waitFor(() => expect(input).toHaveValue('1000'));
+    expect(input).toBeDisabled();
+  });
+
   it('shows validation error for invalid type', async () => {
     const { getByRole } = render(<TestComponent />);
 
@@ -195,6 +205,26 @@ describe('AutosaveTextField', () => {
       await waitFor(() =>
         expect(mutationSpy).not.toHaveGraphqlOperation('UpdateGoalCalculation'),
       );
+    });
+
+    it('disables the select when the goal is read-only but still shows its value', async () => {
+      const { getByRole } = render(
+        <GoalCalculatorTestWrapper onCall={mutationSpy} readOnly>
+          <AutosaveTextField
+            label="MHA Amount"
+            fieldName="mhaAmount"
+            schema={defaultSchema}
+            select
+          >
+            <MenuItem value={1000}>1000</MenuItem>
+            <MenuItem value={2000}>2000</MenuItem>
+          </AutosaveTextField>
+        </GoalCalculatorTestWrapper>,
+      );
+
+      const input = getByRole('combobox', { name: 'MHA Amount' });
+      await waitFor(() => expect(input).toHaveTextContent('1000'));
+      expect(input).toHaveAttribute('aria-disabled', 'true');
     });
   });
 });

--- a/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/Autosave/useGoalAutosave.ts
+++ b/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/Autosave/useGoalAutosave.ts
@@ -17,13 +17,14 @@ export const useGoalAutoSave = ({
   const saveField = useSaveField();
   const {
     goalCalculationResult: { data },
+    isReadOnly,
   } = useGoalCalculator();
 
   return useAutoSave({
     value: data?.goalCalculation[fieldName],
     saveValue: (value) => saveField({ [fieldName]: value }),
     fieldName,
-    disabled: !data,
+    disabled: !data || isReadOnly,
     ...options,
   });
 };

--- a/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/Autosave/useSaveField.ts
+++ b/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/Autosave/useSaveField.ts
@@ -26,7 +26,7 @@ export const useSaveField = () => {
         return;
       }
 
-      return trackMutation(
+      return trackMutation(() =>
         updateGoalCalculation({
           variables: {
             input: {

--- a/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategory.test.tsx
+++ b/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategory.test.tsx
@@ -5,6 +5,7 @@ import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import {
   GoalCalculationAge,
+  MpdGoalBenefitsConstantPlanEnum,
   MpdGoalBenefitsConstantSizeEnum,
 } from 'src/graphql/types.generated';
 import { GoalCalculatorConstantsQuery } from 'src/hooks/goalCalculatorConstants.generated';
@@ -20,9 +21,15 @@ const mutationSpy = jest.fn();
 
 interface TestComponentProps {
   single?: boolean;
+  readOnly?: boolean;
+  benefitsPlan?: MpdGoalBenefitsConstantPlanEnum;
 }
 
-const TestComponent: React.FC<TestComponentProps> = ({ single = false }) => (
+const TestComponent: React.FC<TestComponentProps> = ({
+  single = false,
+  readOnly = false,
+  benefitsPlan = MpdGoalBenefitsConstantPlanEnum.Base,
+}) => (
   <GqlMockedProvider<{
     GoalCalculation: GoalCalculationQuery;
     GoalCalculatorConstants: GoalCalculatorConstantsQuery;
@@ -32,9 +39,11 @@ const TestComponent: React.FC<TestComponentProps> = ({ single = false }) => (
       GoalCalculation: {
         goalCalculation: {
           ...goalCalculationMock,
+          readOnly,
           familySize: single
             ? MpdGoalBenefitsConstantSizeEnum.Single
             : MpdGoalBenefitsConstantSizeEnum.MarriedNoChildren,
+          benefitsPlan,
         },
       },
       GoalCalculatorConstants: {
@@ -101,6 +110,23 @@ describe('InformationCategory', () => {
     });
   });
 
+  it('disables the SECA status select and geographic location autocomplete when the goal is read-only', async () => {
+    const { getByRole } = render(<TestComponent readOnly />);
+
+    // Wait for the goal calculation data to load so the fields aren't just
+    // disabled because data is missing
+    await waitFor(() =>
+      expect(getByRole('textbox', { name: 'First Name' })).toHaveValue('John'),
+    );
+
+    expect(
+      getByRole('combobox', { name: 'SECA (Social Security) Status' }),
+    ).toHaveAttribute('aria-disabled', 'true');
+    expect(
+      getByRole('combobox', { name: 'Geographic Location' }),
+    ).toBeDisabled();
+  });
+
   it("renders the user's avatar", async () => {
     const { findByRole } = render(<TestComponent />);
     expect(await findByRole('img')).toBeInTheDocument();
@@ -153,6 +179,26 @@ describe('InformationCategory', () => {
             },
           },
         }),
+      );
+    });
+
+    it('does not clear invalid benefits plan when the goal is read-only', async () => {
+      const { getByRole } = render(
+        // Married with no children only offers the Base plan, so Select is
+        // incompatible with the family size from the moment the goal loads
+        <TestComponent
+          readOnly
+          benefitsPlan={MpdGoalBenefitsConstantPlanEnum.Select}
+        />,
+      );
+
+      const input = getByRole('combobox', { name: 'Family Size' });
+      await waitFor(() =>
+        expect(input).toHaveTextContent('Married with no children'),
+      );
+
+      await waitFor(() =>
+        expect(mutationSpy).not.toHaveGraphqlOperation('UpdateGoalCalculation'),
       );
     });
 

--- a/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategoryForm/InformationCategoryFinancialForm.tsx
+++ b/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategoryForm/InformationCategoryFinancialForm.tsx
@@ -30,6 +30,7 @@ export const InformationCategoryFinancialForm: React.FC<
   const {
     setRightPanelContent,
     goalCalculationResult: { data },
+    isReadOnly,
   } = useGoalCalculator();
 
   const saveField = useSaveField();
@@ -89,6 +90,7 @@ export const InformationCategoryFinancialForm: React.FC<
             fullWidth
             size="small"
             select
+            disabled={!data || isReadOnly}
             label={
               isSpouse
                 ? t('Spouse SECA (Social Security) Status')

--- a/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategoryForm/InformationCategoryPersonalForm.tsx
+++ b/src/components/HrTools/GoalCalculator/CalculatorSettings/Categories/InformationCategory/InformationCategoryForm/InformationCategoryPersonalForm.tsx
@@ -42,6 +42,7 @@ export const InformationCategoryPersonalForm: React.FC<
   const { t } = useTranslation();
   const {
     goalCalculationResult: { data },
+    isReadOnly,
     setRightPanelContent,
   } = useGoalCalculator();
   const { goalGeographicConstantMap, goalBenefitsPlans } =
@@ -77,6 +78,11 @@ export const InformationCategoryPersonalForm: React.FC<
   }, [goalBenefitsPlans, familySize]);
 
   useEffect(() => {
+    // Read-only goals reject mutations, so don't try to fix an incompatible plan
+    if (isReadOnly) {
+      return;
+    }
+
     // Clear benefits plan if it's not compatible with selected family size
     if (familySize && benefitsPlan) {
       const isPlanValid = planOptions.some(([plan]) => plan === benefitsPlan);
@@ -84,7 +90,7 @@ export const InformationCategoryPersonalForm: React.FC<
         saveField({ benefitsPlan: null });
       }
     }
-  }, [familySize, benefitsPlan, planOptions]);
+  }, [isReadOnly, familySize, benefitsPlan, planOptions]);
 
   return (
     <>
@@ -134,7 +140,7 @@ export const InformationCategoryPersonalForm: React.FC<
               onChange={(_, newValue) =>
                 saveField({ geographicLocation: newValue })
               }
-              disabled={!data}
+              disabled={!data || isReadOnly}
               size="small"
               renderInput={(params) => (
                 <TextField

--- a/src/components/HrTools/GoalCalculator/GoalCalculatorTestWrapper.tsx
+++ b/src/components/HrTools/GoalCalculator/GoalCalculatorTestWrapper.tsx
@@ -34,6 +34,7 @@ export const goalCalculationMock = gqlMock<
     goalCalculation: {
       id: 'goal-calculation-1',
       name: 'Initial Goal Name',
+      readOnly: false,
       firstName: 'John',
       spouseFirstName: 'Jane',
       lastName: 'Doe',
@@ -270,19 +271,38 @@ export const constantsMock = gqlMock<
   },
 }).constant;
 
-interface GoalCalculatorTestWrapperProps {
+interface MockedGoalCalculatorTestWrapperProps {
+  noMocks?: false;
   onCall?: MockLinkCallHandler;
-  noMocks?: boolean;
+  readOnly?: boolean;
   /** Override the mocked goal calculation (defaults to `goalCalculationMock`). */
   goalCalculation?: GoalCalculationQuery['goalCalculation'];
   children?: React.ReactNode;
 }
+
+interface NoMocksGoalCalculatorTestWrapperProps {
+  /**
+   * Skip the `GqlMockedProvider` entirely (the test supplies its own Apollo
+   * provider). `onCall`, `readOnly`, and `goalCalculation` only configure the
+   * mocked provider, so they are disallowed here — they would silently no-op.
+   */
+  noMocks: true;
+  onCall?: never;
+  readOnly?: never;
+  goalCalculation?: never;
+  children?: React.ReactNode;
+}
+
+type GoalCalculatorTestWrapperProps =
+  | MockedGoalCalculatorTestWrapperProps
+  | NoMocksGoalCalculatorTestWrapperProps;
 
 export const GoalCalculatorTestWrapper: React.FC<
   GoalCalculatorTestWrapperProps
 > = ({
   onCall,
   noMocks = false,
+  readOnly = false,
   goalCalculation = goalCalculationMock,
   children,
 }) => {
@@ -307,7 +327,9 @@ export const GoalCalculatorTestWrapper: React.FC<
             }>
               mocks={{
                 GoalCalculation: {
-                  goalCalculation,
+                  goalCalculation: readOnly
+                    ? { ...goalCalculation, readOnly: true }
+                    : goalCalculation,
                 },
                 GoalCalculatorConstants: {
                   constant: constantsMock,

--- a/src/components/HrTools/GoalCalculator/GoalCard/MpdGoalCard.test.tsx
+++ b/src/components/HrTools/GoalCalculator/GoalCard/MpdGoalCard.test.tsx
@@ -14,7 +14,11 @@ import { MpdGoalCard } from './MpdGoalCard';
 
 const mutationSpy = jest.fn();
 
-const TestComponent: React.FC = () => (
+interface TestComponentProps {
+  readOnly?: boolean;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({ readOnly = false }) => (
   <TestRouter>
     <ThemeProvider theme={theme}>
       <GqlMockedProvider<{
@@ -27,7 +31,9 @@ const TestComponent: React.FC = () => (
           },
         }}
       >
-        <MpdGoalCard goal={{ ...goalCalculationMock, id: 'goal-1' }} />
+        <MpdGoalCard
+          goal={{ ...goalCalculationMock, id: 'goal-1', readOnly }}
+        />
       </GqlMockedProvider>
     </ThemeProvider>
   </TestRouter>
@@ -49,12 +55,13 @@ describe('MpdGoalCard', () => {
   });
 
   it('builds the View link with the goal calculator path', () => {
-    const { getByRole } = render(<TestComponent />);
+    const { getByRole, queryByText } = render(<TestComponent />);
 
     expect(getByRole('link', { name: 'View' })).toHaveAttribute(
       'href',
       '/accountLists/account-list-1/hrTools/goalCalculator/goal-1',
     );
+    expect(queryByText('Read-Only')).not.toBeInTheDocument();
   });
 
   it('calculates and displays the goal total', async () => {
@@ -69,5 +76,17 @@ describe('MpdGoalCard', () => {
     expect(
       getByTestId('goal-amount-value').querySelector('.MuiSkeleton-root'),
     ).toBeInTheDocument();
+  });
+
+  describe('read-only goal', () => {
+    it('hides the Delete button and shows the Read-Only badge', () => {
+      const { getByText, getByRole, queryByRole } = render(
+        <TestComponent readOnly />,
+      );
+
+      expect(queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+      expect(getByText('Read-Only')).toBeInTheDocument();
+      expect(getByRole('link', { name: 'View' })).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/HrTools/GoalCalculator/GoalCard/MpdGoalCard.tsx
+++ b/src/components/HrTools/GoalCalculator/GoalCard/MpdGoalCard.tsx
@@ -1,4 +1,6 @@
 import React, { useMemo } from 'react';
+import { Chip } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 import { GoalCard } from 'src/components/Reports/Shared/GoalCard/GoalCard';
 import { useAccountListId } from 'src/hooks/useAccountListId';
 import { useGoalCalculatorConstants } from 'src/hooks/useGoalCalculatorConstants';
@@ -13,6 +15,7 @@ export interface MpdGoalCardProps {
 }
 
 export const MpdGoalCard: React.FC<MpdGoalCardProps> = ({ goal }) => {
+  const { t } = useTranslation();
   const accountListId = useAccountListId();
   const constants = useGoalCalculatorConstants();
   const [deleteGoalCalculation] = useDeleteGoalCalculationMutation();
@@ -43,7 +46,13 @@ export const MpdGoalCard: React.FC<MpdGoalCardProps> = ({ goal }) => {
       loading={constants.loading}
       updatedAt={goal.updatedAt}
       viewHref={`/accountLists/${accountListId}/hrTools/goalCalculator/${goal.id}`}
-      onDelete={handleDelete}
+      // Read-only goals reject deletion, so don't offer it
+      onDelete={goal.readOnly ? undefined : handleDelete}
+      badge={
+        goal.readOnly ? (
+          <Chip label={t('Read-Only')} size="small" variant="outlined" />
+        ) : undefined
+      }
     />
   );
 };

--- a/src/components/HrTools/GoalCalculator/GoalsList/GoalCalculations.graphql
+++ b/src/components/HrTools/GoalCalculator/GoalsList/GoalCalculations.graphql
@@ -1,6 +1,7 @@
 fragment ListGoalCalculation on GoalCalculation {
   id
   name
+  readOnly
   role
   familySize
   benefitsPlan

--- a/src/components/HrTools/GoalCalculator/HouseholdExpenses/HouseholdExpensesHeader.test.tsx
+++ b/src/components/HrTools/GoalCalculator/HouseholdExpenses/HouseholdExpensesHeader.test.tsx
@@ -14,23 +14,28 @@ const mutationSpy = jest.fn();
 
 type TestComponentProps = {
   directInputNull?: boolean;
+  readOnly?: boolean;
 };
 
 const TestComponent: React.FC<TestComponentProps> = ({
   directInputNull = false,
+  readOnly = false,
 }) => (
   <GqlMockedProvider<{ GoalCalculation: GoalCalculationQuery }>
     mocks={{
       GoalCalculation: {
-        goalCalculation: directInputNull
-          ? {
-              ...goalCalculationMock,
-              householdFamily: {
-                ...goalCalculationMock.householdFamily,
-                directInput: null,
-              },
-            }
-          : goalCalculationMock,
+        goalCalculation: {
+          ...goalCalculationMock,
+          readOnly,
+          ...(directInputNull
+            ? {
+                householdFamily: {
+                  ...goalCalculationMock.householdFamily,
+                  directInput: null,
+                },
+              }
+            : {}),
+        },
       },
     }}
     onCall={mutationSpy}
@@ -186,6 +191,45 @@ describe('HouseholdExpensesHeader', () => {
           },
         ),
       );
+    });
+  });
+
+  describe('read-only goal', () => {
+    it('should hide the edit button and action buttons when direct input is set', async () => {
+      const { findByText, queryByRole } = render(<TestComponent readOnly />);
+
+      expect(await findByText('$5,500')).toBeInTheDocument();
+      expect(
+        queryByRole('button', { name: 'Edit monthly budget' }),
+      ).not.toBeInTheDocument();
+      expect(
+        queryByRole('button', { name: 'Use paycheck amount' }),
+      ).not.toBeInTheDocument();
+      expect(
+        queryByRole('button', { name: 'Use categories total' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should hide the action buttons when direct input is null', async () => {
+      const { findByText, queryByRole } = render(
+        <TestComponent readOnly directInputNull />,
+      );
+
+      expect(await findByText('$10,000')).toBeInTheDocument();
+      expect(
+        queryByRole('button', { name: 'Override paycheck amount' }),
+      ).not.toBeInTheDocument();
+      expect(
+        queryByRole('button', { name: 'Use categories total' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should still show the left to allocate toggle', async () => {
+      const { findByText, getByRole } = render(<TestComponent readOnly />);
+
+      expect(await findByText('9%')).toBeInTheDocument();
+      userEvent.click(getByRole('button', { name: 'Switch to amount' }));
+      expect(await findByText('$500')).toBeInTheDocument();
     });
   });
 

--- a/src/components/HrTools/GoalCalculator/HouseholdExpenses/HouseholdExpensesHeader.tsx
+++ b/src/components/HrTools/GoalCalculator/HouseholdExpenses/HouseholdExpensesHeader.tsx
@@ -48,6 +48,7 @@ export const HouseholdExpensesHeader: React.FC = () => {
   const {
     goalCalculationResult: { data, loading },
     goalTotals: { monthlyBudget },
+    isReadOnly,
     trackMutation,
   } = useGoalCalculator();
 
@@ -78,7 +79,7 @@ export const HouseholdExpensesHeader: React.FC = () => {
   const setDirectInput = async (directInput: number | null) => {
     const householdFamilyId = data?.goalCalculation.householdFamily.id;
     if (householdFamilyId) {
-      return trackMutation(
+      return trackMutation(() =>
         updateDirectInput({
           variables: {
             accountListId,
@@ -161,7 +162,7 @@ export const HouseholdExpensesHeader: React.FC = () => {
               <AmountTypography>
                 {currencyFormat(monthlyBudget, 'USD', locale)}
               </AmountTypography>
-              {typeof directInput === 'number' && (
+              {typeof directInput === 'number' && !isReadOnly && (
                 <IconButton
                   onClick={handleEditDirectInput}
                   aria-label={t('Edit monthly budget')}
@@ -172,7 +173,7 @@ export const HouseholdExpensesHeader: React.FC = () => {
             </Stack>
           )}
         </CardContent>
-        {!loading && (
+        {!loading && !isReadOnly && (
           <CardActions>
             {editing ? (
               <>

--- a/src/components/HrTools/GoalCalculator/Shared/GoalCalculation.graphql
+++ b/src/components/HrTools/GoalCalculator/Shared/GoalCalculation.graphql
@@ -1,5 +1,6 @@
 fragment GoalCalculationSettings on GoalCalculation {
   name
+  readOnly
   firstName
   spouseFirstName
   lastName

--- a/src/components/HrTools/GoalCalculator/Shared/GoalCalculatorContext.test.tsx
+++ b/src/components/HrTools/GoalCalculator/Shared/GoalCalculatorContext.test.tsx
@@ -8,6 +8,8 @@ import { useGoalCalculator } from './GoalCalculatorContext';
 const sleep = (duration: number) =>
   new Promise((resolve) => setTimeout(resolve, duration));
 
+const mutationThunk = jest.fn(() => sleep(100));
+
 const TestComponent: React.FC = () => {
   const {
     currentStep,
@@ -17,6 +19,7 @@ const TestComponent: React.FC = () => {
     toggleDrawer,
     trackMutation,
     isMutating,
+    isReadOnly,
   } = useGoalCalculator();
 
   return (
@@ -35,19 +38,33 @@ const TestComponent: React.FC = () => {
       <button onClick={handleContinue}>Continue</button>
       <button onClick={toggleDrawer}>Toggle Drawer</button>
 
-      <button onClick={() => trackMutation(sleep(100))}>Start mutation</button>
-      <button onClick={() => trackMutation(sleep(5000))}>
+      <button onClick={() => trackMutation(() => sleep(100))}>
+        Start mutation
+      </button>
+      <button onClick={() => trackMutation(() => sleep(5000))}>
         Start slow mutation
+      </button>
+      <button onClick={() => trackMutation(mutationThunk)}>
+        Track mutation thunk
       </button>
       <p data-testid="mutating-status">
         {isMutating ? 'Mutating' : 'Not mutating'}
+      </p>
+      <p data-testid="read-only-status">
+        {isReadOnly ? 'Read-only' : 'Editable'}
       </p>
     </div>
   );
 };
 
-const WrappedTestComponent: React.FC = () => (
-  <GoalCalculatorTestWrapper>
+interface WrappedTestComponentProps {
+  readOnly?: boolean;
+}
+
+const WrappedTestComponent: React.FC<WrappedTestComponentProps> = ({
+  readOnly,
+}) => (
+  <GoalCalculatorTestWrapper readOnly={readOnly}>
     <TestComponent />
   </GoalCalculatorTestWrapper>
 );
@@ -55,6 +72,7 @@ const WrappedTestComponent: React.FC = () => (
 describe('GoalCalculatorContext', () => {
   beforeEach(() => {
     jest.useFakeTimers();
+    mutationThunk.mockClear();
   });
 
   it('should provide initial state', () => {
@@ -101,5 +119,59 @@ describe('GoalCalculatorContext', () => {
     await waitFor(() =>
       expect(getByTestId('mutating-status')).toHaveTextContent('Not mutating'),
     );
+  });
+
+  it('isReadOnly defaults to false while the goal is loading', () => {
+    const { getByTestId } = render(<WrappedTestComponent />);
+
+    // Before the query resolves, goal data is absent and isReadOnly falls back to false
+    expect(getByTestId('read-only-status')).toHaveTextContent('Editable');
+  });
+
+  it('isReadOnly is true when the goal is read-only', async () => {
+    const { getByTestId } = render(
+      <GoalCalculatorTestWrapper readOnly>
+        <TestComponent />
+      </GoalCalculatorTestWrapper>,
+    );
+
+    await waitFor(() =>
+      expect(getByTestId('read-only-status')).toHaveTextContent('Read-only'),
+    );
+  });
+
+  describe('trackMutation read-only guard', () => {
+    it('invokes the mutation thunk when the goal is not read-only', async () => {
+      const { getByRole, getByTestId } = render(<WrappedTestComponent />);
+
+      await waitFor(() =>
+        expect(getByTestId('read-only-status')).toHaveTextContent('Editable'),
+      );
+
+      userEvent.click(getByRole('button', { name: 'Track mutation thunk' }));
+      expect(mutationThunk).toHaveBeenCalledTimes(1);
+      expect(getByTestId('mutating-status')).toHaveTextContent('Mutating');
+
+      jest.advanceTimersByTime(500);
+      await waitFor(() =>
+        expect(getByTestId('mutating-status')).toHaveTextContent(
+          'Not mutating',
+        ),
+      );
+    });
+
+    it('does not invoke the mutation thunk when the goal is read-only', async () => {
+      const { getByRole, getByTestId } = render(
+        <WrappedTestComponent readOnly />,
+      );
+
+      await waitFor(() =>
+        expect(getByTestId('read-only-status')).toHaveTextContent('Read-only'),
+      );
+
+      userEvent.click(getByRole('button', { name: 'Track mutation thunk' }));
+      expect(mutationThunk).not.toHaveBeenCalled();
+      expect(getByTestId('mutating-status')).toHaveTextContent('Not mutating');
+    });
   });
 });

--- a/src/components/HrTools/GoalCalculator/Shared/GoalCalculatorContext.tsx
+++ b/src/components/HrTools/GoalCalculator/Shared/GoalCalculatorContext.tsx
@@ -48,10 +48,18 @@ export type GoalCalculatorType = {
   goalCalculationResult: ReturnType<typeof useGoalCalculationQuery>;
   goalTotals: GoalTotals;
 
+  /** Whether the goal is read-only and all inputs should be disabled */
+  isReadOnly: boolean;
+
   /** Whether any mutations are currently in progress */
   isMutating: boolean;
-  /** Call with the mutation promise to track the start and end of mutations */
-  trackMutation: <T>(mutation: Promise<T>) => Promise<T>;
+  /**
+   * Call with a thunk that starts the mutation to track the start and end of
+   * mutations. As a defense-in-depth guard, the thunk is not invoked and the
+   * mutation does not fire when the goal is read-only; in that case the
+   * returned promise resolves to `undefined`.
+   */
+  trackMutation: <T>(mutate: () => Promise<T>) => Promise<T | undefined>;
   percentComplete: number;
 
   isMarried: boolean;
@@ -89,6 +97,9 @@ export const GoalCalculatorProvider: React.FC<Props> = ({ children }) => {
       id: goalCalculationId,
     },
   });
+
+  const isReadOnly =
+    goalCalculationResult.data?.goalCalculation?.readOnly ?? false;
 
   const role = goalCalculationResult.data?.goalCalculation?.role ?? null;
   const familySize =
@@ -140,7 +151,21 @@ export const GoalCalculatorProvider: React.FC<Props> = ({ children }) => {
   const [rightPanelContent, setRightPanelContent] =
     useState<JSX.Element | null>(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(true);
-  const { trackMutation, isMutating } = useTrackMutation();
+  const { trackMutation: trackMutationPromise, isMutating } =
+    useTrackMutation();
+
+  // Guard the mutation funnel: read-only goals reject mutations server-side, so
+  // don't even start them client-side. Every mutation in the goal calculator
+  // should flow through this wrapper.
+  const trackMutation = useCallback(
+    async <T,>(mutate: () => Promise<T>): Promise<T | undefined> => {
+      if (isReadOnly) {
+        return undefined;
+      }
+      return trackMutationPromise(mutate());
+    },
+    [isReadOnly, trackMutationPromise],
+  );
 
   const currentStep = steps[stepIndex];
 
@@ -191,6 +216,7 @@ export const GoalCalculatorProvider: React.FC<Props> = ({ children }) => {
       selectedReport,
       setSelectedReport,
       goalCalculationResult,
+      isReadOnly,
       isMutating,
       trackMutation,
       percentComplete,
@@ -213,6 +239,7 @@ export const GoalCalculatorProvider: React.FC<Props> = ({ children }) => {
       selectedReport,
       setSelectedReport,
       goalCalculationResult,
+      isReadOnly,
       isMutating,
       trackMutation,
       percentComplete,

--- a/src/components/HrTools/GoalCalculator/Shared/GoalCalculatorLayout.test.tsx
+++ b/src/components/HrTools/GoalCalculator/Shared/GoalCalculatorLayout.test.tsx
@@ -1,11 +1,16 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import theme from 'src/theme';
 import { GoalCalculatorTestWrapper } from '../GoalCalculatorTestWrapper';
 import { GoalCalculatorLayout } from './GoalCalculatorLayout';
 
-const TestComponent: React.FC = () => (
-  <GoalCalculatorTestWrapper>
+interface TestComponentProps {
+  readOnly?: boolean;
+  onCall?: jest.Mock;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({ readOnly, onCall }) => (
+  <GoalCalculatorTestWrapper readOnly={readOnly} onCall={onCall}>
     <GoalCalculatorLayout
       sectionListPanel={<h1>Section List</h1>}
       mainContent={<h1>Main Content</h1>}
@@ -19,6 +24,29 @@ describe('GoalCalculatorLayout', () => {
 
     expect(getByRole('heading', { name: 'Section List' })).toBeInTheDocument();
     expect(getByRole('heading', { name: 'Main Content' })).toBeInTheDocument();
+  });
+
+  describe('read-only alert', () => {
+    it('shows an explanation when the goal is read-only', async () => {
+      const { findByText } = render(<TestComponent readOnly />);
+
+      expect(
+        await findByText('This goal is finalized and read-only.'),
+      ).toBeInTheDocument();
+    });
+
+    it('does not show an explanation when the goal is editable', async () => {
+      const mutationSpy = jest.fn();
+      const { queryByText } = render(<TestComponent onCall={mutationSpy} />);
+
+      // Wait for the goal calculation query to load
+      await waitFor(() =>
+        expect(mutationSpy).toHaveGraphqlOperation('GoalCalculation'),
+      );
+      expect(
+        queryByText('This goal is finalized and read-only.'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('step icons', () => {

--- a/src/components/HrTools/GoalCalculator/Shared/GoalCalculatorLayout.tsx
+++ b/src/components/HrTools/GoalCalculator/Shared/GoalCalculatorLayout.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import React from 'react';
+import { Alert } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { PanelLayout } from '../../Shared/CalculationReports/PanelLayout/PanelLayout';
 import { PanelTypeEnum } from '../../Shared/CalculationReports/Shared/sharedTypes';
@@ -31,6 +32,7 @@ export const GoalCalculatorLayout: React.FC<GoalCalculatorLayoutProps> = ({
     setDrawerOpen,
     toggleDrawer,
     percentComplete,
+    isReadOnly,
   } = useGoalCalculator();
 
   const handleStepIconClick = (step: GoalCalculatorStepEnum) => {
@@ -59,7 +61,16 @@ export const GoalCalculatorLayout: React.FC<GoalCalculatorLayoutProps> = ({
       sidebarTitle={currentStep.title}
       isSidebarOpen={isDrawerOpen}
       sidebarAriaLabel={t('{{step}} Sections', { step: currentStep.title })}
-      mainContent={mainContent}
+      mainContent={
+        <>
+          {isReadOnly && (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              {t('This goal is finalized and read-only.')}
+            </Alert>
+          )}
+          {mainContent}
+        </>
+      }
       backHref={`/accountLists/${accountListId}/hrTools/goalCalculator`}
       backTitle={t('Go Back')}
     />

--- a/src/components/HrTools/GoalCalculator/SharedComponents/GoalCalculatorGrid/GoalCalculatorGrid.test.tsx
+++ b/src/components/HrTools/GoalCalculator/SharedComponents/GoalCalculatorGrid/GoalCalculatorGrid.test.tsx
@@ -356,4 +356,94 @@ describe('GoalCalculatorGrid', () => {
       await findByText('Only the portion not reimbursed as ministry expense.'),
     ).toBeInTheDocument();
   });
+
+  describe('read-only goal', () => {
+    it('disables the mode toggle and add buttons and hides the actions column', async () => {
+      const mutationSpy = jest.fn();
+      const { findByText, getAllByRole, getByRole, queryByLabelText } = render(
+        <GoalCalculatorTestWrapper readOnly onCall={mutationSpy}>
+          <TestComponent />
+        </GoalCalculatorTestWrapper>,
+      );
+
+      const otherMinistryRow = (await findByText('Other Ministry')).closest(
+        '[role="row"]',
+      );
+
+      expect(getByRole('button', { name: 'Lump Sum' })).toBeDisabled();
+      expect(getByRole('button', { name: 'Line Item' })).toBeDisabled();
+      expect(getByRole('button', { name: 'Add Line Item' })).toBeDisabled();
+
+      userEvent.hover(otherMinistryRow!);
+      expect(queryByLabelText('Delete')).not.toBeInTheDocument();
+
+      // The actions column is omitted entirely for read-only goals
+      expect(getAllByRole('columnheader')).toHaveLength(2);
+
+      expect(mutationSpy).not.toHaveGraphqlOperation(
+        'UpdatePrimaryBudgetCategory',
+      );
+      expect(mutationSpy).not.toHaveGraphqlOperation('CreateSubBudgetCategory');
+      expect(mutationSpy).not.toHaveGraphqlOperation('DeleteSubBudgetCategory');
+    });
+
+    it('does not open the cell editor', async () => {
+      const mutationSpy = jest.fn();
+      const { findByText, queryByDisplayValue } = render(
+        <GoalCalculatorTestWrapper readOnly onCall={mutationSpy}>
+          <TestComponent />
+        </GoalCalculatorTestWrapper>,
+      );
+
+      const nameCell = await findByText('Other Ministry');
+      userEvent.dblClick(nameCell);
+
+      expect(queryByDisplayValue('Other Ministry')).not.toBeInTheDocument();
+      expect(mutationSpy).not.toHaveGraphqlOperation('UpdateSubBudgetCategory');
+    });
+
+    it('still displays the calculated total without firing mutations', async () => {
+      const mutationSpy = jest.fn();
+      const { findByText } = render(
+        <GoalCalculatorTestWrapper readOnly onCall={mutationSpy}>
+          <TestComponent />
+        </GoalCalculatorTestWrapper>,
+      );
+
+      expect(await findByText('Total')).toBeInTheDocument();
+      expect(await findByText('$1,450')).toBeInTheDocument();
+
+      // Mounting a read-only grid must not fire any mutations, even from the
+      // line item defaults effect
+      await waitFor(() =>
+        expect(mutationSpy).not.toHaveGraphqlOperation(
+          'UpdateSubBudgetCategory',
+        ),
+      );
+      expect(mutationSpy).not.toHaveGraphqlOperation(
+        'UpdatePrimaryBudgetCategory',
+      );
+      expect(mutationSpy).not.toHaveGraphqlOperation('CreateSubBudgetCategory');
+      expect(mutationSpy).not.toHaveGraphqlOperation('DeleteSubBudgetCategory');
+    });
+
+    it('disables the lump sum total field', async () => {
+      const mutationSpy = jest.fn();
+      const { findByLabelText } = render(
+        <GoalCalculatorTestWrapper readOnly onCall={mutationSpy}>
+          <TestComponent primaryBudgetCategoryIndex={1} />
+        </GoalCalculatorTestWrapper>,
+      );
+
+      const totalField = await findByLabelText('Total');
+      expect(totalField).toBeDisabled();
+
+      userEvent.type(totalField, '123');
+      totalField.blur();
+
+      expect(mutationSpy).not.toHaveGraphqlOperation(
+        'UpdatePrimaryBudgetCategory',
+      );
+    });
+  });
 });

--- a/src/components/HrTools/GoalCalculator/SharedComponents/GoalCalculatorGrid/GoalCalculatorGrid.tsx
+++ b/src/components/HrTools/GoalCalculator/SharedComponents/GoalCalculatorGrid/GoalCalculatorGrid.tsx
@@ -91,6 +91,7 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
     trackMutation,
     defaultTypeChanged,
     clearDefaultTypeChanged,
+    isReadOnly,
     goalCalculationResult,
     isMutating,
   } = useGoalCalculator();
@@ -171,7 +172,7 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
   const directInput = category.directInput !== null;
 
   const updateDirectInput = (directInput: number | null) => {
-    return trackMutation(
+    return trackMutation(() =>
       updatePrimaryBudgetCategory({
         variables: {
           input: {
@@ -223,7 +224,8 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
 
   // Update line item defaults when defaultType changes (user changed role/family size)
   useEffect(() => {
-    if (!hasDefaultsForType) {
+    // Read-only goals reject mutations, and their role/family size can't change anyways
+    if (isReadOnly || !hasDefaultsForType) {
       return;
     }
 
@@ -242,23 +244,26 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
 
     gridData.forEach(async (row) => {
       if (row.category) {
-        await updateSubBudgetCategory({
-          variables: {
-            input: {
-              accountListId,
-              attributes: {
-                id: row.id,
-                label: row.label,
-                amount: newDefaultValue,
+        await trackMutation(() =>
+          updateSubBudgetCategory({
+            variables: {
+              input: {
+                accountListId,
+                attributes: {
+                  id: row.id,
+                  label: row.label,
+                  amount: newDefaultValue,
+                },
               },
             },
-          },
-        });
+          }),
+        );
       }
     });
 
     clearDefaultTypeChanged();
   }, [
+    isReadOnly,
     hasDefaultsForType,
     defaultTypeChanged,
     directInput,
@@ -267,6 +272,7 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
     goalCalculationResult.data,
     gridData,
     accountListId,
+    trackMutation,
     updateSubBudgetCategory,
     clearDefaultTypeChanged,
   ]);
@@ -276,12 +282,13 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
     saveValue: updateDirectInput,
     fieldName: 'amount',
     schema: directInputSchema,
+    disabled: isReadOnly,
     saveOnChange: false,
   });
   const addExpense = () => {
     const tempId = `temp-${Date.now()}`;
 
-    trackMutation(
+    trackMutation(() =>
       createSubBudgetCategory({
         variables: {
           input: {
@@ -333,7 +340,7 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
   const handleDelete = (id: string | number) => {
     const rowId = id.toString();
 
-    trackMutation(
+    trackMutation(() =>
       deleteSubBudgetCategory({
         variables: {
           input: {
@@ -395,7 +402,7 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
         return updated;
       });
 
-      trackMutation(
+      trackMutation(() =>
         updateSubBudgetCategory({
           variables: {
             input: {
@@ -491,40 +498,45 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
       headerAlign: 'center',
       renderCell: renderAmountCell,
     },
-    {
-      field: 'actions',
-      type: 'actions',
-      headerName: '',
-      width: 60,
-      getActions: (params) => {
-        // Don't show delete action for total row
-        if (params.id === 'total') {
-          return [];
-        }
+    // Read-only goals have no row actions, so omit the actions column entirely
+    ...(isReadOnly
+      ? []
+      : ([
+          {
+            field: 'actions',
+            type: 'actions',
+            headerName: '',
+            width: 60,
+            getActions: (params) => {
+              // Don't show delete action for total row
+              if (params.id === 'total') {
+                return [];
+              }
 
-        if (!params.row.canDelete) {
-          return [
-            <GridActionsCellItem
-              key="forbidden"
-              icon={<DoNotDisturbAltIcon />}
-              label="forbidden"
-              disabled
-              showInMenu={false}
-            />,
-          ];
-        }
+              if (!params.row.canDelete) {
+                return [
+                  <GridActionsCellItem
+                    key="forbidden"
+                    icon={<DoNotDisturbAltIcon />}
+                    label="forbidden"
+                    disabled
+                    showInMenu={false}
+                  />,
+                ];
+              }
 
-        return [
-          <GridActionsCellItem
-            key="delete"
-            icon={<DeleteIcon />}
-            label="Delete"
-            onClick={() => handleDelete(params.id)}
-            showInMenu={false}
-          />,
-        ];
-      },
-    },
+              return [
+                <GridActionsCellItem
+                  key="delete"
+                  icon={<DeleteIcon />}
+                  label="Delete"
+                  onClick={() => handleDelete(params.id)}
+                  showInMenu={false}
+                />,
+              ];
+            },
+          },
+        ] satisfies GridColDef[])),
   ];
 
   return (
@@ -538,6 +550,8 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
               size="small"
               onClick={() => handleDirectInputToggle(true)}
               startIcon={<FunctionsIcon />}
+              disabled={isReadOnly}
+              aria-pressed={directInput}
             >
               {t('Lump Sum')}
             </Button>
@@ -547,6 +561,8 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
             variant={!directInput ? 'contained' : 'outlined'}
             onClick={() => handleDirectInputToggle(false)}
             startIcon={<ViewHeadlineIcon />}
+            disabled={isReadOnly}
+            aria-pressed={!directInput}
           >
             {t('Line Item')}
           </Button>
@@ -577,6 +593,7 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
               onClick={addExpense}
               size="small"
               startIcon={<AddIcon />}
+              disabled={isReadOnly}
             >
               {t('Add Line Item')}
             </Button>
@@ -586,6 +603,10 @@ export const GoalCalculatorGrid: React.FC<GoalCalculatorGridProps> = ({
               columns={columns}
               processRowUpdate={processRowUpdate}
               isCellEditable={(params) => {
+                // Read-only goals reject all edits
+                if (isReadOnly) {
+                  return false;
+                }
                 // Don't allow editing the total row or label field when canDelete is false
                 if (params.id === 'total') {
                   return false;

--- a/src/components/Reports/Shared/GoalCard/GoalCard.test.tsx
+++ b/src/components/Reports/Shared/GoalCard/GoalCard.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import theme from 'src/theme';
 import { GoalCard, GoalCardProps } from './GoalCard';
 
-const mutationSpy = jest.fn();
+const mutationSpy = jest.fn().mockResolvedValue(undefined);
 
 const baseProps: GoalCardProps = {
   name: 'Test Goal',
@@ -110,5 +110,34 @@ describe('GoalCard', () => {
     const { queryByText } = renderCard();
 
     expect(queryByText('Default')).not.toBeInTheDocument();
+  });
+
+  it('hides the Delete button when onDelete is not provided', () => {
+    const { getByRole, queryByRole } = renderCard({ onDelete: undefined });
+
+    expect(queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+    expect(getByRole('link', { name: 'View' })).toBeInTheDocument();
+  });
+
+  it('does not mount the confirmation dialog when onDelete is not provided', () => {
+    const { queryByRole, queryByText } = renderCard({ onDelete: undefined });
+
+    expect(queryByRole('dialog')).not.toBeInTheDocument();
+    expect(queryByText('Delete Goal')).not.toBeInTheDocument();
+  });
+
+  it('unmounts an open confirmation dialog if onDelete becomes undefined', () => {
+    const { getByRole, queryByRole, rerender } = renderCard();
+
+    userEvent.click(getByRole('button', { name: 'Delete' }));
+    expect(getByRole('dialog')).toBeInTheDocument();
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <GoalCard {...baseProps} onDelete={undefined} />
+      </ThemeProvider>,
+    );
+
+    expect(queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Reports/Shared/GoalCard/GoalCard.tsx
+++ b/src/components/Reports/Shared/GoalCard/GoalCard.tsx
@@ -61,7 +61,8 @@ export interface GoalCardProps {
   loading?: boolean;
   updatedAt: string;
   viewHref: string;
-  onDelete: () => Promise<void>;
+  /** Omit to hide the delete button, e.g. for read-only goals */
+  onDelete?: () => Promise<void>;
   badge?: React.ReactNode;
 }
 
@@ -81,30 +82,30 @@ export const GoalCard: React.FC<GoalCardProps> = ({
 
   const displayName = name ?? t('Unnamed Goal');
 
-  const handleConfirmDelete = async () => onDelete();
-
   return (
     <>
-      <Confirmation
-        title={t('Delete Goal')}
-        isOpen={deleting}
-        mutation={handleConfirmDelete}
-        handleClose={() => setDeleting(false)}
-        confirmLabel={t('Delete Goal')}
-        cancelLabel={t('Cancel')}
-        message={
-          <Trans
-            t={t}
-            defaults="Are you sure you want to delete <strong>{{goalName}}</strong>? Deleting this goal will remove it permanently."
-            values={{ goalName: displayName }}
-          />
-        }
-        confirmButtonProps={{
-          variant: 'contained',
-          color: 'error',
-          children: t('Delete Goal'),
-        }}
-      />
+      {onDelete && (
+        <Confirmation
+          title={t('Delete Goal')}
+          isOpen={deleting}
+          mutation={onDelete}
+          handleClose={() => setDeleting(false)}
+          confirmLabel={t('Delete Goal')}
+          cancelLabel={t('Cancel')}
+          message={
+            <Trans
+              t={t}
+              defaults="Are you sure you want to delete <strong>{{goalName}}</strong>? Deleting this goal will remove it permanently."
+              values={{ goalName: displayName }}
+            />
+          }
+          confirmButtonProps={{
+            variant: 'contained',
+            color: 'error',
+            children: t('Delete Goal'),
+          }}
+        />
+      )}
 
       <StyledCard>
         <StyledHeaderBox
@@ -158,16 +159,19 @@ export const GoalCard: React.FC<GoalCardProps> = ({
         <Divider sx={{ mt: 2, mb: 1 }} />
 
         <StyledActionBox>
-          <Button onClick={() => setDeleting(true)}>
-            <Typography variant="body2" fontWeight="bold" color="error">
-              {t('Delete')}
-            </Typography>
-          </Button>
+          {onDelete && (
+            <Button onClick={() => setDeleting(true)}>
+              <Typography variant="body2" fontWeight="bold" color="error">
+                {t('Delete')}
+              </Typography>
+            </Button>
+          )}
           <Button
             LinkComponent={NextLink}
             href={viewHref}
             variant="contained"
             color="primary"
+            sx={{ marginLeft: 'auto' }}
           >
             <Typography
               variant="body2"

--- a/src/components/Shared/Autosave/useAutosave.test.tsx
+++ b/src/components/Shared/Autosave/useAutosave.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MenuItem, TextField } from '@mui/material';
-import { render } from '@testing-library/react';
+import { act, render, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as yup from 'yup';
 import i18n from 'src/lib/i18n';
@@ -160,6 +160,33 @@ describe('AutosaveTextField', () => {
     const input = getByRole('textbox', { name: 'Field' });
     expect(input).toBeDisabled();
     expect(input).toHaveAccessibleDescription('');
+  });
+
+  it('short-circuits onChange and onBlur when disabled', () => {
+    const schema = yup.object({
+      field: amount('Field', i18n.t),
+    });
+
+    const { result } = renderHook(() =>
+      useAutoSave({
+        value: 100,
+        saveValue,
+        fieldName: 'field',
+        schema,
+        disabled: true,
+        saveOnChange: true,
+      }),
+    );
+
+    act(() => {
+      result.current.onChange({
+        target: { value: '200' },
+      } as React.ChangeEvent<HTMLInputElement>);
+      result.current.onBlur();
+    });
+
+    expect(saveValue).not.toHaveBeenCalled();
+    expect(result.current.value).toBe('100');
   });
 
   it('shows validation error for invalid type after blur', () => {

--- a/src/components/Shared/Autosave/useAutosave.ts
+++ b/src/components/Shared/Autosave/useAutosave.ts
@@ -86,6 +86,10 @@ export const useAutoSave = <Value extends string | number>({
   return {
     value: internalValue,
     onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (disabled) {
+        return;
+      }
+
       const newValue = transformValue(event.target.value);
       setInternalValue(newValue);
 
@@ -98,6 +102,10 @@ export const useAutoSave = <Value extends string | number>({
       }
     },
     onBlur: () => {
+      if (disabled) {
+        return;
+      }
+
       setTouched(true);
       if (!saveOnChange && errorMessage === null && parsedValue !== value) {
         saveValue(parsedValue);


### PR DESCRIPTION
## Description

- Depends on CruGlobal/mpdx_api#3472, which adds the `GoalCalculation.readOnly` field and rejects all mutations (including deletion) against read-only goals. Read-only goals are created automatically when a new staff member reports (MPDX-9865).
- Fetch the new `readOnly` field in the goal calculator and goals list queries, and expose `isReadOnly` through `GoalCalculatorContext`.
- Disable every input of a read-only goal while still showing the inputs and calculated totals: all autosave fields (via the central `useGoalAutoSave` hook), the SECA status select, the geographic location autocomplete, budget grid cell editing, Add Line Item and delete line-item actions, the Lump Sum/Line Item mode toggle, and the lump sum total field.
- Guard the two effects that fire mutations automatically (incompatible benefits plan clearing and default line-item repopulation) so they don't run against read-only goals.
- Hide the Delete button and show a "Read-Only" chip on read-only goal cards in the goals list (`GoalCard.onDelete` is now optional).
- Related Jira: [MPDX-9866](https://jira.cru.org/browse/MPDX-9866), [MPDX-9865](https://jira.cru.org/browse/MPDX-9865)

Note: until the API PR reaches staging, `yarn gql` on this branch needs a staging schema snapshot with `readOnly` grafted on (`API_URL=<snapshot file> yarn gql`).

## Testing

- Mark a goal calculation as read-only (until MPDX-9865's conversion is live, set it directly: `UPDATE goal_calculations SET read_only = true WHERE id = '...'` on staging, or mock `readOnly: true` locally)
- Go to HR Tools → Goal Calculator
- Check that the read-only goal's card shows a "Read-Only" chip and no Delete button, while other goals still have one
- Open the read-only goal with View
- Check that every field in Calculator Settings (goal name, personal, financial) is disabled but still shows its saved value
- Check that in Household/Ministry Expenses the Lump Sum/Line Item toggle and Add Line Item are disabled, rows can't be edited by double-clicking, no delete icons appear on hover, and category totals still display
- Check that the Summary Report still renders the calculated totals
- Open a normal (non-read-only) goal and check everything is still editable

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)