### PR TITLE
No-Jira - Add validation for 403(b) contribution percentage to cap at 99%

### DIFF
--- a/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/VariantQuestions.test.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/VariantQuestions.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MockLinkCallHandler } from 'graphql-ergonomock/dist/apollo/MockLink';
 import { NewStaffQuestionnaireVariantEnum } from 'src/graphql/types.generated';
 import { NsoMpdQuestionnaireTestWrapper } from '../NsoMpdQuestionnaireTestWrapper';
@@ -112,6 +113,49 @@ describe('VariantQuestions', () => {
           name: 'How many total dependents would you like to cover by your Cru healthcare?',
         }),
       ).not.toBeInTheDocument();
+    });
+
+    it('rejects a 403(b) percentage of 100', async () => {
+      const { findByRole, findByText } = render(
+        <TestComponent
+          onCall={mutationSpy}
+          newStaffQuestionnaire={{
+            variant: NewStaffQuestionnaireVariantEnum.SpouseSeniorStaff,
+          }}
+        />,
+      );
+
+      const field = await findByRole('spinbutton', {
+        name: "What is Jane's 403(b) contribution percentage?",
+      });
+      userEvent.clear(field);
+      userEvent.type(field, '100');
+      userEvent.tab();
+
+      expect(
+        await findByText(
+          '403(b) contribution percentage must be less than 100%',
+        ),
+      ).toBeInTheDocument();
+      expect(mutationSpy).not.toHaveGraphqlOperation(
+        'UpdateNewStaffQuestionnaire',
+      );
+
+      userEvent.clear(field);
+      userEvent.type(field, '99.99');
+      userEvent.tab();
+
+      await waitFor(() =>
+        expect(mutationSpy).toHaveGraphqlOperation(
+          'UpdateNewStaffQuestionnaire',
+          {
+            input: {
+              accountListId: 'account-list-1',
+              attributes: { spouseContribution403bPercentage: 99.99 },
+            },
+          },
+        ),
+      );
     });
 
     it("interpolates the spouse's first name into the questions", async () => {

--- a/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/VariantQuestions.tsx
+++ b/src/components/HrTools/NsoMpdQuestionnaire/FinancialInformation/VariantQuestions.tsx
@@ -22,7 +22,9 @@ export const getVariantQuestionsSchema = (t: TFunction) =>
     spouseContribution403bPercentage: percentage(
       t('403(b) contribution percentage'),
       t,
-    ).required(t('Please enter a percentage, or 0 if you contribute none.')),
+    )
+      .lessThan(100, t('403(b) contribution percentage must be less than 100%'))
+      .required(t('Please enter a percentage, or 0 if you contribute none.')),
     spouseMhaAmount: getAmountSchema(t),
     staffConferenceTransfer: getAmountSchema(t),
     accountTransfers: getAmountSchema(t),
@@ -75,7 +77,9 @@ export const VariantQuestions: React.FC = () => {
                 spouseName,
               },
             )}
-            helperText={t('Enter a percentage between 0 and 100.')}
+            helperText={t(
+              'Enter a percentage greater than or equal to 0 and less than 100.',
+            )}
             endAdornment={<PercentageAdornment />}
           />
           <NumberQuestion


### PR DESCRIPTION
## Description

This stops a runtime error from occurring when a user enters a 403b contribution that is equal to 100. The backend has validation to stop a divide by zero error.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Go to Step 3 of the NSO MPD Questionnaire
- Using the test account, go to the question 'What is Min's 403(b) contribution percentage? *' and try to enter 100 or greater.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
