### PR TITLE
[MPDX-9870] Complete status chip when required goal fields are filled

### DIFF
--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.test.tsx
@@ -5,7 +5,12 @@ import userEvent from '@testing-library/user-event';
 import { ApolloErgonoMockMap } from 'graphql-ergonomock';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
-import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
+import {
+  GoalCalculationAge,
+  GoalCalculationRole,
+  MpdGoalBenefitsConstantPlanEnum,
+  NewStaffQuestionnaireMaritalStatusEnum,
+} from 'src/graphql/types.generated';
 import theme from 'src/theme';
 import {
   NsGoalCalculatorTestWrapper,
@@ -443,6 +448,85 @@ describe('GoalSettingsForm', () => {
     expect(
       await findByRole('button', { name: 'Save & Share' }),
     ).toBeInTheDocument();
+  });
+
+  describe('status chip', () => {
+    // A married calculation with every required field filled in.
+    const completeMock = {
+      newStaffGoalCalculation: {
+        ...defaultGoalCalculation,
+        maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Married,
+        spouseJoining: true,
+        age: GoalCalculationAge.ThirtyToThirtyFour,
+        spouseAge: GoalCalculationAge.OverForty,
+        tenure: 5,
+        spouseTenure: 3,
+        assignmentType: GoalCalculationRole.Field,
+        benefitsPlan: MpdGoalBenefitsConstantPlanEnum.Base,
+      },
+    };
+
+    it('shows a Complete chip when the required fields are filled', async () => {
+      const { findByText, queryByText } = render(
+        <TestComponent goalCalculationMock={completeMock} />,
+      );
+
+      expect(await findByText('Complete')).toBeInTheDocument();
+      expect(queryByText('Incomplete')).not.toBeInTheDocument();
+    });
+
+    it('shows an Incomplete chip when a required field is missing', async () => {
+      const { findByText, queryByText } = render(
+        <TestComponent
+          goalCalculationMock={{
+            newStaffGoalCalculation: {
+              ...completeMock.newStaffGoalCalculation,
+              benefitsPlan: null,
+            },
+          }}
+        />,
+      );
+
+      expect(await findByText('Incomplete')).toBeInTheDocument();
+      expect(queryByText('Complete')).not.toBeInTheDocument();
+    });
+
+    it('shows an Incomplete chip when the spouse required fields are missing', async () => {
+      const { findByText } = render(
+        <TestComponent
+          goalCalculationMock={{
+            newStaffGoalCalculation: {
+              ...completeMock.newStaffGoalCalculation,
+              spouseAge: null,
+            },
+          }}
+        />,
+      );
+
+      expect(await findByText('Incomplete')).toBeInTheDocument();
+    });
+
+    it('flips to Complete when the last required field is filled', async () => {
+      const { findByText, findByRole } = render(
+        <TestComponent
+          goalCalculationMock={{
+            newStaffGoalCalculation: {
+              ...completeMock.newStaffGoalCalculation,
+              tenure: null,
+            },
+          }}
+        />,
+      );
+
+      expect(await findByText('Incomplete')).toBeInTheDocument();
+
+      const tenure = await findByRole('spinbutton', {
+        name: 'Full Time Years on Staff — John',
+      });
+      userEvent.type(tenure, '4');
+
+      expect(await findByText('Complete')).toBeInTheDocument();
+    });
   });
 
   describe('Senior Staff Only fields', () => {

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.test.tsx
@@ -492,7 +492,7 @@ describe('GoalSettingsForm', () => {
     });
 
     it('shows an Incomplete chip when the spouse required fields are missing', async () => {
-      const { findByText } = render(
+      const { findByText, queryByText } = render(
         <TestComponent
           goalCalculationMock={{
             newStaffGoalCalculation: {
@@ -504,6 +504,7 @@ describe('GoalSettingsForm', () => {
       );
 
       expect(await findByText('Incomplete')).toBeInTheDocument();
+      expect(queryByText('Complete')).not.toBeInTheDocument();
     });
 
     it('flips to Complete when the last required field is filled', async () => {

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsForm.tsx
@@ -23,6 +23,7 @@ import {
   calculationToFormValues,
   formValuesToAttributes,
 } from './goalSettingsApiMapping';
+import { isGoalSettingsComplete } from './goalSettingsCompletion';
 import {
   GoalSettingsFormValues,
   GoalSettingsPerson,
@@ -166,6 +167,7 @@ export const GoalSettingsForm: React.FC<GoalSettingsFormProps> = (props) => {
                 mpdGoal={mpdGoal}
                 joinedStaffYear={calculation.joinedStaffYear}
                 isScenario={isScenario}
+                isComplete={isGoalSettingsComplete(values)}
               />
 
               <Divider sx={{ mb: 3 }} />

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.test.tsx
@@ -39,8 +39,8 @@ const TestComponent: React.FC<TestComponentProps> = ({
   spouse = spousePerson,
   mpdGoal = 50000,
   joinedStaffYear = 2018,
-  isScenario = false,
-  isComplete = false,
+  isScenario,
+  isComplete,
 }) => (
   <ThemeProvider theme={theme}>
     <SnackbarProvider>

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.test.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.test.tsx
@@ -32,6 +32,7 @@ interface TestComponentProps {
   mpdGoal?: number;
   joinedStaffYear?: number | null;
   isScenario?: boolean;
+  isComplete?: boolean;
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({
@@ -39,6 +40,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
   mpdGoal = 50000,
   joinedStaffYear = 2018,
   isScenario = false,
+  isComplete = false,
 }) => (
   <ThemeProvider theme={theme}>
     <SnackbarProvider>
@@ -56,6 +58,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
               mpdGoal={mpdGoal}
               joinedStaffYear={joinedStaffYear}
               isScenario={isScenario}
+              isComplete={isComplete}
             />
           </Form>
         </Formik>
@@ -82,10 +85,18 @@ describe('GoalSettingsHeader', () => {
     ).toBeInTheDocument();
   });
 
-  it('marks the calculation as incomplete', () => {
-    const { getByText } = render(<TestComponent />);
+  it('marks the calculation as incomplete when required fields are unfilled', () => {
+    const { getByText, queryByText } = render(<TestComponent />);
 
     expect(getByText('Incomplete')).toBeInTheDocument();
+    expect(queryByText('Complete')).not.toBeInTheDocument();
+  });
+
+  it('marks the calculation as complete when required fields are filled', () => {
+    const { getByText, queryByText } = render(<TestComponent isComplete />);
+
+    expect(getByText('Complete')).toBeInTheDocument();
+    expect(queryByText('Incomplete')).not.toBeInTheDocument();
   });
 
   it('formats the MPD goal as currency', () => {

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/GoalSettingsHeader.tsx
@@ -80,6 +80,10 @@ interface GoalSettingsHeaderProps {
    * Scenario goals hide the read-only person cards
    */
   isScenario?: boolean;
+  /**
+   * Whether the required fields are filled in.
+   */
+  isComplete?: boolean;
 }
 
 export const GoalSettingsHeader: React.FC<GoalSettingsHeaderProps> = ({
@@ -90,6 +94,7 @@ export const GoalSettingsHeader: React.FC<GoalSettingsHeaderProps> = ({
   mpdGoal,
   joinedStaffYear,
   isScenario = false,
+  isComplete = false,
 }) => {
   const { t } = useTranslation();
   const yearLabelId = useId();
@@ -124,6 +129,13 @@ export const GoalSettingsHeader: React.FC<GoalSettingsHeaderProps> = ({
             color="info"
             variant="outlined"
             label={t('Scenario Only')}
+            size="small"
+          />
+        ) : isComplete ? (
+          <Chip
+            color="success"
+            variant="outlined"
+            label={t('Complete')}
             size="small"
           />
         ) : (

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsCompletion.test.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsCompletion.test.ts
@@ -1,0 +1,121 @@
+import {
+  GoalCalculationAge,
+  GoalCalculationRole,
+  MpdGoalBenefitsConstantPlanEnum,
+  NewStaffQuestionnaireMaritalStatusEnum,
+} from 'src/graphql/types.generated';
+import { isGoalSettingsComplete } from './goalSettingsCompletion';
+import { GoalSettingsFormValues } from './goalSettingsFormValues';
+
+const emptyValues: GoalSettingsFormValues = {
+  calculationsYear: '2020',
+  firstName: '',
+  lastName: '',
+  emailAddress: '',
+  spouseFirstName: '',
+  spouseEmailAddress: '',
+  maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Single,
+  spouseJoining: 'false',
+  age: '',
+  spouseAge: '',
+  tenure: '',
+  spouseTenure: '',
+  annualRequestedSalary: '',
+  spouseRequestedAnnualSalary: '',
+  contribution403bPercentage: '',
+  spouseContribution403bPercentage: '',
+  spouseMhaAmount: '',
+  staffConferenceTransfer: '',
+  accountTransfers: '',
+  advocacyTransfers: '',
+  geographicLocation: '',
+  studentLoanMonthlyPayment: '',
+  carLoanMonthlyPayment: '',
+  creditCardDebtMonthlyPayment: '',
+  otherExpenses: '',
+  benefitsPlan: '',
+  reimbursableExpenses: '',
+  healthcareDependentsCount: '',
+  ministryLocation: '',
+  ministryName: '',
+  assignmentType: '',
+  ministryExpenses: '',
+  nsoHousing: '',
+  nsoSessions: '',
+  childcareChildrenCount: '',
+  nsoSpecialNeedsSupportReceived: '',
+  healthcareExempt: 'false',
+  spouseHealthcareExempt: 'false',
+  secaExempt: 'false',
+  spouseSecaExempt: 'false',
+  allowSalaryOverCap: '',
+  allowDebtOverCap: 'false',
+};
+
+const filledSingle: GoalSettingsFormValues = {
+  ...emptyValues,
+  age: GoalCalculationAge.ThirtyToThirtyFour,
+  tenure: 5,
+  assignmentType: GoalCalculationRole.Field,
+  benefitsPlan: MpdGoalBenefitsConstantPlanEnum.Base,
+};
+
+describe('isGoalSettingsComplete', () => {
+  it('is false when required fields are empty', () => {
+    expect(isGoalSettingsComplete(emptyValues)).toBe(false);
+  });
+
+  it('is true when a single staff has age, tenure, role, and benefits plan', () => {
+    expect(isGoalSettingsComplete(filledSingle)).toBe(true);
+  });
+
+  it('treats zero years on staff as filled', () => {
+    expect(isGoalSettingsComplete({ ...filledSingle, tenure: 0 })).toBe(true);
+  });
+
+  it.each([
+    ['calculation year', { calculationsYear: '' }],
+    ['age', { age: '' }],
+    ['tenure', { tenure: '' }],
+    ['role', { assignmentType: '' }],
+    ['benefits plan', { benefitsPlan: '' }],
+  ] as Array<[string, Partial<GoalSettingsFormValues>]>)(
+    'is false when %s is missing',
+    (_label, missing) => {
+      expect(isGoalSettingsComplete({ ...filledSingle, ...missing })).toBe(
+        false,
+      );
+    },
+  );
+
+  describe('married', () => {
+    const filledMarried: GoalSettingsFormValues = {
+      ...filledSingle,
+      maritalStatus: NewStaffQuestionnaireMaritalStatusEnum.Married,
+      spouseAge: GoalCalculationAge.OverForty,
+      spouseTenure: 3,
+    };
+
+    it('is true when both spouses have age and tenure', () => {
+      expect(isGoalSettingsComplete(filledMarried)).toBe(true);
+    });
+
+    it('is false when the spouse age is missing', () => {
+      expect(isGoalSettingsComplete({ ...filledMarried, spouseAge: '' })).toBe(
+        false,
+      );
+    });
+
+    it('is false when the spouse tenure is missing', () => {
+      expect(
+        isGoalSettingsComplete({ ...filledMarried, spouseTenure: '' }),
+      ).toBe(false);
+    });
+
+    it('ignores empty spouse fields when single', () => {
+      // Spouse fields left blank, but the staff is single, so they are not
+      // required.
+      expect(isGoalSettingsComplete(filledSingle)).toBe(true);
+    });
+  });
+});

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsCompletion.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsCompletion.ts
@@ -1,0 +1,30 @@
+import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
+import { GoalSettingsFormValues } from './goalSettingsFormValues';
+
+const isFilled = (value: string | number | null | undefined): boolean =>
+  value !== '' && value !== null && value !== undefined;
+
+/**
+ * Whether the Goal Settings form has the fields required to produce a valid
+ * goal. Age, full-time years on staff, and role (field/office) are required for
+ * each person on the calculation — both spouses when married — and a
+ * calculation year and benefits plan are required for the household. Drives the
+ * header's Complete/Incomplete status chip.
+ */
+export const isGoalSettingsComplete = (
+  values: GoalSettingsFormValues,
+): boolean => {
+  const isMarried =
+    values.maritalStatus === NewStaffQuestionnaireMaritalStatusEnum.Married;
+
+  const requiredFields: Array<string | number | null | undefined> = [
+    values.calculationsYear,
+    values.age,
+    values.tenure,
+    values.assignmentType,
+    values.benefitsPlan,
+    ...(isMarried ? [values.spouseAge, values.spouseTenure] : []),
+  ];
+
+  return requiredFields.every(isFilled);
+};

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsCompletion.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsCompletion.ts
@@ -1,9 +1,6 @@
 import { NewStaffQuestionnaireMaritalStatusEnum } from 'src/graphql/types.generated';
 import { GoalSettingsFormValues } from './goalSettingsFormValues';
 
-const isFilled = (value: string | number | null | undefined): boolean =>
-  value !== '' && value !== null && value !== undefined;
-
 /**
  * Whether the Goal Settings form has the fields required to produce a valid
  * goal. Age, full-time years on staff, and role (field/office) are required for
@@ -17,7 +14,7 @@ export const isGoalSettingsComplete = (
   const isMarried =
     values.maritalStatus === NewStaffQuestionnaireMaritalStatusEnum.Married;
 
-  const requiredFields: Array<string | number | null | undefined> = [
+  const requiredFields: Array<string | number> = [
     values.calculationsYear,
     values.age,
     values.tenure,
@@ -26,5 +23,5 @@ export const isGoalSettingsComplete = (
     ...(isMarried ? [values.spouseAge, values.spouseTenure] : []),
   ];
 
-  return requiredFields.every(isFilled);
+  return requiredFields.every((value) => value !== '');
 };


### PR DESCRIPTION
## Description

- The Goal Settings (Admin) header status chip was hard-coded to an amber "Incomplete" and never changed.
- It now shows a green "Complete" chip once the required fields are filled, and "Incomplete" otherwise.
- Required fields: calculation year, benefits plan, and — for each person on the calculation (both spouses when married) — age, full-time years on staff, and role (Field/Office).
- Added `isGoalSettingsComplete(values)` helper (pure, unit-tested) driven by the live Formik values, so the chip updates as fields are edited.

Jira: MPDX-9870

## Testing

- Go to a coaching account's New Staff Goal Calculator, Admin **Goal Settings** view (`?view=goal-settings`) (e.g. `/accountLists/6bbc265f-ec81-4b23-b297-5bd298c4d619/coaching/90935daa-0e49-4b31-a41b-d6b46854ebca/nsGoalCalculator?view=goal-settings`).
- With a required field empty (e.g. **Benefits Selection**), confirm the header chip reads **Incomplete** (amber).
- Fill in the remaining required fields — calculation year, age + full-time years on staff (both spouses if married), Field/Office, and Benefits Selection.
- Check that the chip flips to a green **Complete** chip once the last required field is set **before saving**.
- For a married couple, confirm the chip stays **Incomplete** until both spouses' age and years-on-staff are filled.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
