### PR TITLE
MPDX-9867 Remove dead ministry expenses field from admin view

### DIFF
--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/NewStaffGoalCalculation.graphql
@@ -81,7 +81,6 @@ fragment NewStaffGoalCalculationFields on NewStaffGoalCalculation {
   ministryName
   ministryLocation
   assignmentType
-  ministryExpenses
 
   # NSO
   nsoHousing

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/MinistryInformationSection.tsx
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/Sections/MinistryInformationSection.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { GoalCalculationRole } from 'src/graphql/types.generated';
 import { getLocalizedRole } from 'src/lib/functions/getLocalizedRole';
-import { GoalSettingsNumberField } from '../Fields/GoalSettingsNumberField';
 import { GoalSettingsPlaceholder } from '../Fields/GoalSettingsPlaceholder';
 import { GoalSettingsSelect, SelectOption } from '../Fields/GoalSettingsSelect';
 import { GoalSettingsTextField } from '../Fields/GoalSettingsTextField';
@@ -44,14 +43,6 @@ export const MinistryInformationSection: React.FC<GoalSettingsSectionProps> = ({
           name="assignmentType"
           label={t('Field or Office')}
           options={roleOptions}
-        />
-      </FieldRow>
-
-      <FieldRow label={t('Ministry Expenses')}>
-        <GoalSettingsNumberField
-          name="ministryExpenses"
-          label={t('Ministry Expenses')}
-          adornment="currency"
         />
       </FieldRow>
     </Section>

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsApiMapping.ts
@@ -84,7 +84,6 @@ export const calculationToFormValues = (
   ministryLocation: calc.ministryLocation ?? '',
   ministryName: calc.ministryName ?? '',
   assignmentType: calc.assignmentType ?? '',
-  ministryExpenses: toNumberInput(calc.ministryExpenses),
 
   nsoHousing: calc.nsoHousing ?? '',
   nsoSessions: calc.nsoSessions ?? '',
@@ -181,7 +180,6 @@ export const formValuesToAttributes = (
     ministryName: values.ministryName || null,
     ministryLocation: values.ministryLocation || null,
     assignmentType: values.assignmentType || null,
-    ministryExpenses: toNumberOrNull(values.ministryExpenses),
 
     // NSO
     nsoHousing: values.nsoHousing || null,

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsCompletion.test.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsCompletion.test.ts
@@ -39,7 +39,6 @@ const emptyValues: GoalSettingsFormValues = {
   ministryLocation: '',
   ministryName: '',
   assignmentType: '',
-  ministryExpenses: '',
   nsoHousing: '',
   nsoSessions: '',
   childcareChildrenCount: '',

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsFormValues.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsFormValues.ts
@@ -76,7 +76,6 @@ export interface GoalSettingsFormValues {
   ministryLocation: string;
   ministryName: string;
   assignmentType: GoalCalculationRole | '';
-  ministryExpenses: number | '';
 
   // --- 5. NSO Information (shared) ---
   nsoHousing: NewStaffQuestionnaireNsoHousingEnum | '';

--- a/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsSchema.ts
+++ b/src/components/HrTools/NsGoalCalculator/GoalSettings/goalSettingsSchema.ts
@@ -58,9 +58,6 @@ export const getGoalSettingsSchema = (t: TFunction) =>
     reimbursableExpenses: optionalAmount(t('Reimbursable Expenses'), t),
     healthcareDependentsCount: optionalInteger(t('Healthcare Dependents'), t),
 
-    // Ministry
-    ministryExpenses: optionalAmount(t('Ministry Expenses'), t),
-
     // NSO
     childcareChildrenCount: optionalInteger(t('Childcare Children'), t),
     nsoSpecialNeedsSupportReceived: optionalAmount(


### PR DESCRIPTION
## Description

- Removes the unused, manually-input `ministryExpenses` field from the New Staff Goal Calculator → Goal Settings admin view. Ministry expenses are calculated from role and family size, never manually entered, so this field was dead.
- Dropped the field from: the Ministry Information form section, the form-values type, the Yup validation schema, the API read/write mapping, and the `NewStaffGoalCalculationFields` GraphQL fragment.
- Kept the calculated ministry-expense path (`totalMinistryExpenses`, `ministryExpensesTotal`, the calculator step, and goal-presentation rows) — the goal continues to use calculated ministry expenses.
- Server-side removal of the field (model + GraphQL) is the API half of the ticket, handled separately. `src/graphql/schema.graphql` still mirrors the live server until then; the client no longer queries or sends the field.
- Jira: [MPDX-9867](https://jira.cru.org/browse/MPDX-9867)

## Testing

- Go to HR Tools → New Staff Goal Calculator → a staff member's Goal Settings (admin view)
- Open the **Ministry Information** section
- Check that there is no longer a **Ministry Expenses** input field
- Save the goal settings and confirm the save succeeds
- Open the goal preview / Presenting Your Goal and confirm the calculated ministry expenses still appear in the totals

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
