### PR TITLE
No-Jira - Add codecov-bypass job to handle coverage target skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       - name: 🧪 Test (chunk ${{ matrix.chunk }})
         run: yarn test:coverage --ci --shard ${{ matrix.chunk }}
       - name: Codecov
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'Skip Codecov') }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -190,6 +191,25 @@ jobs:
         env:
           # This secret is automatically injected by GitHub
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  codecov-bypass:
+    # `codecov/project` is a required status check, but sometimes a PR legitimately can't meet the
+    # coverage target. Adding the "Skip Codecov" label skips the upload above and posts a passing
+    # status under the same context.
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Skip Codecov') }}
+    permissions:
+      statuses: write
+    steps:
+      - name: Mark codecov/project as passing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -f state=success \
+            -f context=codecov/project \
+            -f description="Bypassed via Skip Codecov label"
 
   staging-api-block:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

_CLOSED in favor of https://github.com/CruGlobal/cru-terraform/pull/11386_

- Added a job to manually bypass the `codecov/project` check when the `Skip Codecov` label is applied. 
    - Should be used very sparingly and generally discouraged, preferably only ever used when codecov is experiencing issues. 

Job: https://github.com/CruGlobal/mpdx-react/actions/runs/29955623695/job/89045066148

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- There is a Skip Codecov label. I tested it, and it worked, however, Codecov has resolved the issues on their end.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/pr-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
