### PR TITLE
[no-Jira] Force reauthentication for old sessions to fix ministry partner reminders

### DIFF
--- a/src/components/RouterGuard/RouterGuard.test.tsx
+++ b/src/components/RouterGuard/RouterGuard.test.tsx
@@ -76,5 +76,54 @@ describe('RouterGuard', () => {
 
       await waitFor(() => expect(signIn).toHaveBeenCalledWith('okta'));
     });
+
+    // Remove alongside the reauth-cutoff effect in RouterGuard after 2026-08-10.
+    it('should reauthenticate when the API token predates the reauth cutoff', async () => {
+      (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
+        // Future session expiry so the token-expiry effect does not fire; the
+        // API token exp is 1000000000 / 2001-09-09, before the 2026-08-10 cutoff.
+        data: {
+          ...session,
+          expires: '2099-01-01T00:00:00Z',
+          user: {
+            ...session.user,
+            apiToken:
+              'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjEwMDAwMDAwMDB9.h2Qk01iTa6nH_U-OpImeSecS7owIx6YMqeh6yfWO7Xg',
+          },
+        },
+        status: 'authenticated',
+        update: () => Promise.resolve(null),
+      });
+
+      render(<TestComponent pathname="/authRoute">Authed route</TestComponent>);
+
+      await waitFor(() => expect(signIn).toHaveBeenCalledWith('okta'));
+    });
+
+    it('should not reauthenticate when the API token is after the cutoff', async () => {
+      (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
+        // API token exp is 2000000000 / 2033-05-18, after the 2026-08-10 cutoff.
+        data: {
+          ...session,
+          expires: '2099-01-01T00:00:00Z',
+          user: {
+            ...session.user,
+            apiToken:
+              'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjIwMDAwMDAwMDB9.XIy4tZ8x7c86GgrOHqwZwR_i28BWxknyjPpHpklBw4U',
+          },
+        },
+        status: 'authenticated',
+        update: () => Promise.resolve(null),
+      });
+
+      const { getByText } = render(
+        <TestComponent pathname="/authRoute">Authed route</TestComponent>,
+      );
+
+      await waitFor(() =>
+        expect(getByText('Authed route')).toBeInTheDocument(),
+      );
+      expect(signIn).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/RouterGuard/RouterGuard.tsx
+++ b/src/components/RouterGuard/RouterGuard.tsx
@@ -27,6 +27,30 @@ export const RouterGuard: React.FC<Props> = ({ children = null }) => {
     }
   }, [session]);
 
+  // cru-terraform#11223 (merged 2026-07-10T18:42:16Z) added Okta profile
+  // claims. Sessions that authenticated before the merge must reauthenticate to
+  // receive them and fix partner reminders. Remove this effect after 2026-08-10,
+  // once every pre-merge token has expired on its own and this check can no longer match.
+  useEffect(() => {
+    if (session.status !== 'authenticated') {
+      return;
+    }
+    const reauthCutoff = DateTime.fromISO('2026-08-10T00:00:00Z').toSeconds();
+    let apiTokenExp: number | null = null;
+    try {
+      const payload = session.data.user.apiToken.split('.')[1];
+      apiTokenExp = JSON.parse(
+        atob(payload.replace(/-/g, '+').replace(/_/g, '/')),
+      ).exp;
+    } catch {
+      // Ignore malformed JWTs
+    }
+
+    if (typeof apiTokenExp === 'number' && apiTokenExp < reauthCutoff) {
+      signIn('okta');
+    }
+  }, [session]);
+
   return session.status === 'authenticated' ? (
     children
   ) : (


### PR DESCRIPTION
## Description

Force reauthentication for any user who logged in before https://github.com/CruGlobal/cru-terraform/pull/11223. Reauthentication will ensure that `mpdx_api` has their primary designation account and update their information in the database so that partner reminders works.

## Testing

*It's hard to test the reauth flow unless you have an old token*

- Login
- Check that you aren't logged out

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/quality:agent-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [ ] I have cleaned up my commit history
