### PR TITLE
Hide 'Last Updated' for offline organizations

### DIFF
--- a/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
+++ b/src/components/Settings/integrations/Organization/OrganizationAccordion.test.tsx
@@ -194,7 +194,10 @@ describe('OrganizationAccordion', () => {
           getByText(GetUsersOrganizationsAccountsMock[0].organization.name),
         ).toBeInTheDocument();
 
-        expect(getByText('Last Updated')).toBeInTheDocument();
+        // Offline orgs never download, so a "Last Updated" timestamp is
+        // meaningless for them and must not be shown; "Last Gift Date" is the
+        // honest signal and stays.
+        expect(queryByText('Last Updated')).not.toBeInTheDocument();
 
         expect(getByText('Last Gift Date')).toBeInTheDocument();
       });
@@ -237,6 +240,9 @@ describe('OrganizationAccordion', () => {
         expect(
           queryByText('Import TntConnect DataSync file'),
         ).not.toBeInTheDocument();
+
+        // Non-offline orgs really do download, so "Last Updated" stays.
+        expect(getByText('Last Updated')).toBeInTheDocument();
       });
 
       userEvent.click(getByText('Sync'));

--- a/src/components/Settings/integrations/Organization/OrganizationAccordion.tsx
+++ b/src/components/Settings/integrations/Organization/OrganizationAccordion.tsx
@@ -296,7 +296,7 @@ export const OrganizationAccordion: React.FC<AccordionProps> = ({
                   </Box>
                 </Box>
                 <Divider />
-                {lastDownloadedAt && (
+                {type !== OrganizationTypesEnum.OFFLINE && lastDownloadedAt && (
                   <Box sx={{ p: 2, display: 'flex' }}>
                     <Grid
                       container


### PR DESCRIPTION
## Problem

Offline organizations (e.g. "Wycliffe Bible Translators USA") never download data — they only ever receive a manually-uploaded TntConnect DataSync file. But the nightly import job still runs against them and stamps `person_organization_accounts.last_download` on that no-op run, so Settings → Integrations → Organizations showed a fresh **"Last Updated — X hours ago"** on cards that had never actually received anything.

For migrated Wycliffe users who hold both an offline "Wycliffe Bible Translators USA" card and the real "Wycliffe USA (DonorHub)" card, this made the offline card look healthy and masked a broken DonorHub sync — the exact confusion reported in HS-1683554 / HS-1686072.

## Root cause

In mpdx-api, `Person::OrganizationAccount#import_all_data` unconditionally writes `last_download: Time.current` after `import_donations`, even when the org's `import_all` is a no-op (`OfflineOrg#import_all` does nothing). The once-per-day import guard makes the value read as "earlier today," every day. That timestamp is a legitimate operational fact ("the import job last completed") for the code that consumes it, but the UI mislabels it as "Last Updated" for orgs where it means nothing.

## Fix

Gate the "Last Updated" row on the org `type` already computed in the component, matching the existing Sync/Import-button gating a few lines above:

```tsx
{type !== OrganizationTypesEnum.OFFLINE && lastDownloadedAt && (
```

"Last Gift Date" still renders for offline orgs — that's the honest signal for a file-import org.

This is deliberately a presentation-layer fix. `last_download` stays correct as "import job last completed" for the throttle (`future_last_download?`), fan-out ordering (`with_linked_org_accounts`), and login queue (`queue_imports`) that rely on it. A separate backend perf follow-up could stop queuing offline orgs for import at all, but that's out of scope here.

## Testing

- Flipped `should render Offline Organization` to assert "Last Updated" is **absent** for an offline org (it previously asserted present — the test encoded the bug).
- Added an assertion to `should render Ministry Account Organization` that "Last Updated" is **present** for a non-offline org (guards against over-gating).
- All 9 tests in `OrganizationAccordion.test.tsx` pass; verified red→green and that the change is caught if the gate is wrong in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HcHZJWUKidBEU4h6s8urtV
