### PR TITLE
[no-Jira] Skip reauth for impersonators

### DIFF
--- a/src/components/RouterGuard/RouterGuard.test.tsx
+++ b/src/components/RouterGuard/RouterGuard.test.tsx
@@ -100,6 +100,34 @@ describe('RouterGuard', () => {
       await waitFor(() => expect(signIn).toHaveBeenCalledWith('okta'));
     });
 
+    // Remove alongside the reauth-cutoff effect in RouterGuard after 2026-08-10.
+    it('should not reauthenticate an impersonated pre-cutoff token', async () => {
+      (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
+        data: {
+          ...session,
+          expires: '2099-01-01T00:00:00Z',
+          user: {
+            ...session.user,
+            impersonating: true,
+            apiToken:
+              'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjEwMDAwMDAwMDB9.h2Qk01iTa6nH_U-OpImeSecS7owIx6YMqeh6yfWO7Xg',
+          },
+        },
+        status: 'authenticated',
+        update: () => Promise.resolve(null),
+      });
+
+      const { getByText } = render(
+        <TestComponent pathname="/authRoute">Authed route</TestComponent>,
+      );
+
+      await waitFor(() =>
+        expect(getByText('Authed route')).toBeInTheDocument(),
+      );
+      expect(signIn).not.toHaveBeenCalled();
+    });
+
+    // Remove alongside the reauth-cutoff effect in RouterGuard after 2026-08-10.
     it('should not reauthenticate when the API token is after the cutoff', async () => {
       (useSession as jest.MockedFn<typeof useSession>).mockReturnValue({
         // API token exp is 2000000000 / 2033-05-18, after the 2026-08-10 cutoff.

--- a/src/components/RouterGuard/RouterGuard.tsx
+++ b/src/components/RouterGuard/RouterGuard.tsx
@@ -35,6 +35,10 @@ export const RouterGuard: React.FC<Props> = ({ children = null }) => {
     if (session.status !== 'authenticated') {
       return;
     }
+    // Ignore short-lived impersonation tokens
+    if (session.data.user.impersonating) {
+      return;
+    }
     const reauthCutoff = DateTime.fromISO('2026-08-10T00:00:00Z').toSeconds();
     let apiTokenExp: number | null = null;
     try {


### PR DESCRIPTION
## Description

- The forced-reauthentication effect added in #1938 (fix MPD partner reminders for pre-cutoff sessions) also caught impersonated sessions and bounced impersonators to Okta.
- Impersonation tokens are short-lived and can't be reauthenticated the same way, so this skips the reauth-cutoff check when `session.data.user.impersonating` is true.
- Adds a `RouterGuard` test covering an impersonated pre-cutoff token that should not trigger reauth.

No Jira ticket. Related to #1938 (the reauth-cutoff effect this guards against); both should be removed after 2026-08-10.

## Testing

- Impersonate another user from the admin/organization impersonation UI.
- Confirm you land on an authenticated route (e.g. the dashboard) and are **not** redirected to the Okta sign-in.
- As a non-impersonated user with a pre-cutoff token, confirm the existing forced-reauth behavior still fires.

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/quality:agent-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
