### PR TITLE
[No-Jira] Update Donations rows per page

### DIFF
--- a/src/components/DonationTable/DonationTable.tsx
+++ b/src/components/DonationTable/DonationTable.tsx
@@ -148,7 +148,7 @@ export const DonationTable: React.FC<DonationTableProps> = ({
 
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
     page: 0,
-    pageSize: 25,
+    pageSize: 100,
   });
 
   // pageSize is intentionally omitted from the dependencies array so that the query isn't rerun when the page size changes


### PR DESCRIPTION
## Description

HelpScout [#1684480](https://secure.helpscout.net/conversation/3392149824/1684480) is a suggestion to increase the default number of rows shown on the "My Donations" page. We currently show 25, which is small compared to the number donors many staff members manage. 

Since the current version of MUI DataGrid does not allow pages over 100, we should keep the options the same (25, 50, and 100) but default to 100 rows.

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Impersonate: courtney.campbell@cru.org
- Go to `/reports/donations`
- Go to "August 2024"
- Check that the rows per page default is 100

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/quality:agent-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
