### PR TITLE
Ignore the root tasks/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ node_modules
 .lighthouseci
 lighthouse-results.md
 
+# Local scratch/process notes (todo lists, plans, specs) written while working.
+# Root-level only, so the tasks/ source directories under pages/ and src/ still track.
+/tasks/
+
 # AI Code Review - Temporary Files
 # These are working files that get regenerated each review
 .ai-review.json


### PR DESCRIPTION
## Description

Adds `/tasks/` to `.gitignore`.

Development process files — todo lists, plans, specs — get written to a root-level `tasks/` directory while working, and they shouldn't ride along into feature PRs. This came up while building #1949: `tasks/todo.md` showed as untracked and had to be avoided by staging each file by hand, which is easy to get wrong.

### Why `/tasks/` and not `tasks/`

The leading slash anchors the pattern to the repo root. Without it, gitignore matches a directory of that name at **any** depth, which would also cover two unrelated source directories:

- `pages/accountLists/[accountListId]/tasks/`
- `src/lib/tasks/`

Files already committed there would keep tracking either way, but any **new** file added to them would be silently ignored — a confusing failure to run into later. Anchoring avoids that entirely.

## Testing

- `git check-ignore -v tasks/todo.md` → matches `.gitignore:60:/tasks/`
- `git check-ignore` on a hypothetical new file in `pages/accountLists/[accountListId]/tasks/` and in `src/lib/tasks/` → not ignored, both still track
- `git status` reports no change to any currently-tracked file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
