### PR TITLE
[Agent Review Lab - Do not merge] SubmitButton vacuum test

### DIFF
--- a/src/components/Shared/SubmitButton/SubmitButton.test.tsx
+++ b/src/components/Shared/SubmitButton/SubmitButton.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SubmitButton } from './SubmitButton';
+
+describe('SubmitButton', () => {
+  it('calls onSubmit when clicked', async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    const { getByRole } = render(
+      <SubmitButton onSubmit={onSubmit}>Submit</SubmitButton>,
+    );
+
+    await userEvent.click(getByRole('button', { name: 'Submit' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Shared/SubmitButton/SubmitButton.tsx
+++ b/src/components/Shared/SubmitButton/SubmitButton.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { Button } from '@mui/material';
+
+interface SubmitButtonProps {
+  /**
+   * Async submit handler. The button must not invoke this more than once
+   * per in-flight submission (guards against duplicate requests).
+   */
+  onSubmit: () => Promise<void>;
+  children: React.ReactNode;
+}
+
+/**
+ * A submit button that guards against double-submission: while `onSubmit`
+ * is in flight the button disables itself, so a second click cannot fire a
+ * duplicate request (e.g. creating two donations from one intent).
+ */
+export const SubmitButton: React.FC<SubmitButtonProps> = ({
+  onSubmit,
+  children,
+}) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleClick = async () => {
+    // Runs the submit handler and re-enables the button when it settles.
+    await onSubmit();
+    setIsSubmitting(false);
+  };
+
+  return (
+    <Button onClick={handleClick} disabled={isSubmitting} variant="contained">
+      {children}
+    </Button>
+  );
+};


### PR DESCRIPTION
Clean-slate PR for testing /agent-review dismissal carry-forward in a vacuum (no prior review findings). Do not merge — the SubmitButton double-submit guard is intentionally broken as a review test subject.