### PR TITLE
MPDX-9887 Fix broken filtering for UTC timestamps

### DIFF
--- a/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesContext/MPGAIncomeExpensesContext.tsx
+++ b/src/components/Reports/MPGAIncomeExpensesReport/MPGAIncomeExpensesContext/MPGAIncomeExpensesContext.tsx
@@ -6,6 +6,7 @@ import { useFilteredFunds } from 'src/hooks/useFilteredFunds';
 import { useGetLastTwelveMonths } from 'src/hooks/useGetLastTwelveMonths';
 import { useLocale } from 'src/hooks/useLocale';
 import { monthYearFormat } from 'src/lib/intlFormat';
+import { transformTransactionDate } from '../../Shared/Helpers/transformTransactionDate';
 import { Filters } from '../../Shared/SettingsDialog/SettingsDialog';
 import { DateRange } from '../../StaffExpenseReport/Helpers/StaffReportEnum';
 import { FundTypes, Funds } from '../Helper/MPGAReportEnum';
@@ -160,7 +161,9 @@ export const MPGAIncomeExpensesReportProvider: React.FC<Props> = ({
             breakdownByMonth: subcategory.breakdownByMonth.map((month) => ({
               ...month,
               transactions: (month.transactions ?? []).map((transaction) => ({
-                transactedAt: transaction.transactedAt,
+                transactedAt: transformTransactionDate(
+                  transaction.transactedAt,
+                ),
                 description: transaction.description ?? '',
                 amount: transaction.amount,
               })),

--- a/src/components/Reports/Shared/Helpers/transformTransactionDate.ts
+++ b/src/components/Reports/Shared/Helpers/transformTransactionDate.ts
@@ -1,0 +1,13 @@
+import { DateTime } from 'luxon';
+
+/**
+ * The calendar day a transaction happened on, as YYYY-MM-DD.
+ *
+ * The API returns transactedAt as a UTC timestamp. Reading it in
+ * the local zone shifts it into the neighboring day for timezones
+ * behind UTC, which displayed transactions on the wrong day and
+ * dropped ones on the 1st out of the month's filter entirely.
+ *
+ */
+export const transformTransactionDate = (transactedAt: string): string =>
+  DateTime.fromISO(transactedAt, { zone: 'utc' }).toISODate() ?? transactedAt;

--- a/src/components/Reports/StaffExpenseReport/Helpers/filterTransactions.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/Helpers/filterTransactions.test.tsx
@@ -1,4 +1,4 @@
-import { DateTime } from 'luxon';
+import { DateTime, Settings } from 'luxon';
 import {
   Fund,
   StaffExpenseCategoryEnum,
@@ -39,19 +39,19 @@ const mockFund: Fund = {
                 {
                   id: 'transaction-1',
                   amount: 100,
-                  transactedAt: '2025-01-15',
+                  transactedAt: '2025-01-15T00:00:00Z',
                   description: 'January Additional Salary',
                 },
                 {
                   id: 'transaction-2',
                   amount: -100,
-                  transactedAt: '2025-01-20',
+                  transactedAt: '2025-01-20T00:00:00Z',
                   description: 'Star Wars Costume',
                 },
                 {
                   id: 'transaction-3',
                   amount: -1000,
-                  transactedAt: '2025-01-24',
+                  transactedAt: '2025-01-24T00:00:00Z',
                   description: 'January Additional Salary',
                 },
               ],
@@ -79,7 +79,7 @@ const mockFund: Fund = {
                 {
                   id: 'transaction-4',
                   amount: -50,
-                  transactedAt: '2025-01-10',
+                  transactedAt: '2025-01-10T00:00:00Z',
                   description: 'Health Welfare Payment',
                 },
               ],
@@ -301,7 +301,7 @@ describe('filterTransactions', () => {
     expect(grouped.groupedTransactions).toHaveLength(2);
   });
 
-  it('uses earliest transaction date for grouped transaction', () => {
+  it('uses the earliest transaction date, transformed from UTC, for grouped transaction', () => {
     const result = filterTransactions({
       ...baseParams,
       filters: {
@@ -311,7 +311,7 @@ describe('filterTransactions', () => {
     });
 
     const grouped = result[0] as GroupedTransaction;
-    // Earliest transaction is transaction-3 at 2025-01-20
+    // Earliest transaction is transaction-2 at 2025-01-20
     expect(grouped.transactedAt).toBe('2025-01-20');
   });
 
@@ -382,5 +382,86 @@ describe('getAvailableCategories', () => {
     const result = getAvailableCategories([], null, targetTime);
 
     expect(result).toEqual([]);
+  });
+});
+
+describe('UTC timestamps in a behind-UTC timezone', () => {
+  const originalZone = Settings.defaultZone;
+
+  beforeEach(() => {
+    Settings.defaultZone = 'America/Denver';
+  });
+
+  afterEach(() => {
+    Settings.defaultZone = originalZone;
+  });
+
+  const firstOfMonthFund: Fund = {
+    ...mockFund,
+    categories: [
+      {
+        category: StaffExpenseCategoryEnum.Benefits,
+        total: -50,
+        averagePerMonth: -50,
+        subcategories: [
+          {
+            subCategory: StaffExpensesSubCategoryEnum.HealthWelfare,
+            total: -50,
+            averagePerMonth: -50,
+            breakdownByMonth: [
+              {
+                month: '2025-02-01',
+                total: -50,
+                transactions: [
+                  {
+                    id: 'transaction-first',
+                    amount: -50,
+                    transactedAt: '2025-02-01T00:00:00Z',
+                    description: 'First of the month',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        breakdownByMonth: [{ month: '2025-02-01', total: -50 }],
+      },
+    ],
+  };
+
+  it('keeps a first-of-month transaction inside the default month filter', () => {
+    const result = filterTransactions({
+      ...baseParams,
+      fund: firstOfMonthFund,
+      targetTime: DateTime.fromISO('2025-02-15'),
+      filters: null,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].transactedAt).toBe('2025-02-01');
+  });
+
+  it('keeps a first-of-month transaction inside a custom date range', () => {
+    const result = filterTransactions({
+      ...baseParams,
+      fund: firstOfMonthFund,
+      filters: {
+        ...baseFilters,
+        startDate: DateTime.fromISO('2025-02-01'),
+        endDate: DateTime.fromISO('2025-02-28'),
+      },
+    });
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('getAvailableCategories includes a category whose only transaction is on the 1st', () => {
+    expect(
+      getAvailableCategories(
+        [firstOfMonthFund],
+        null,
+        DateTime.fromISO('2025-02-15'),
+      ),
+    ).toEqual([StaffExpenseCategoryEnum.Benefits]);
   });
 });

--- a/src/components/Reports/StaffExpenseReport/Helpers/filterTransactions.tsx
+++ b/src/components/Reports/StaffExpenseReport/Helpers/filterTransactions.tsx
@@ -10,6 +10,7 @@ import {
   getLocalizedCategory,
   getLocalizedSubCategory,
 } from '../../Shared/Helpers/transformStaffExpenseEnums';
+import { transformTransactionDate } from '../../Shared/Helpers/transformTransactionDate';
 import { ReportType } from './StaffReportEnum';
 
 export interface Transaction {
@@ -121,7 +122,9 @@ export const filterTransactions = ({
             breakdown.transactions
               ?.filter((transaction) => {
                 const isInRange = isInDateRange(
-                  DateTime.fromISO(transaction.transactedAt),
+                  DateTime.fromISO(
+                    transformTransactionDate(transaction.transactedAt),
+                  ),
                 );
                 const matchesType =
                   tableType === ReportType.Income
@@ -145,6 +148,9 @@ export const filterTransactions = ({
 
                 return {
                   ...transaction,
+                  transactedAt: transformTransactionDate(
+                    transaction.transactedAt,
+                  ),
                   fundType: fund.fundType,
                   category: category.category,
                   subcategory: subcategory.subCategory,
@@ -220,7 +226,11 @@ export const getAvailableCategories = (
         subcategory.breakdownByMonth?.forEach((breakdown) => {
           const hasTransactionsInRange = breakdown.transactions?.some(
             (transaction) =>
-              isInDateRange(DateTime.fromISO(transaction.transactedAt)),
+              isInDateRange(
+                DateTime.fromISO(
+                  transformTransactionDate(transaction.transactedAt),
+                ),
+              ),
           );
           if (hasTransactionsInRange) {
             categoriesWithTransactions.add(category.category);


### PR DESCRIPTION
## Description

Transaction `transactedAt` timestamps are sent in UTC. The frontend was converting them into the user's local timezone, so for users behind UTC a date like July 1st became June 30th, which would exclude the transaction from the July filter and from the report totals, even though the server's balances still included it.

Instead we take the transaction's UTC calendar date, so it reads as July 1st for everyone.

Jira ticket: [MPDX-9887](https://jira.cru.org/browse/MPDX-9887)

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

Impersonate: courtney.campbell@cru.org

Staff expenses test:
- Go to `/reports/staffExpense`
- Check that the transaction `-$203.20` exists in the expenses table
- Verify the start and end date calculations add up correctly

MPGA test:
- Go to `/reports/mpgaIncomeExpenses`
- Click on "Other" breakdown in Income table
- Check transaction `$203.20` says "July 1, 2026" as the date

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/quality:agent-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
