### PR TITLE
MPDX-9826 Hide Re-Entry and Return Travel

### DIFF
--- a/src/components/HrTools/CLAUDE.md
+++ b/src/components/HrTools/CLAUDE.md
@@ -47,6 +47,11 @@ server-side, and resolvers scope data to the user's own account lists.
   `UserTypeAccess` guard. The group is resolved server-side from HCM; the client
   only sees the resolved `UsStaffGroupEnum` — don't reintroduce raw HCM codes.
 
+**`SeniorStaff` and `NewStaff` below include their international and stint
+variants.** `useIneligibleByGroup.ts` treats `SeniorInternationalStaff` and
+`SeniorStaffStint` as `SeniorStaff`, and `NewInternationalStaff` and
+`NewStaffStint` as `NewStaff`, before any eligibility check runs.
+
 The table below is an orientation aid — verify against each tool's
 `UserTypeAccess` guard, which is authoritative and can lag this list.
 

--- a/src/components/HrTools/SavingsFundTransfer/BalanceCard/BalanceCard.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/BalanceCard/BalanceCard.test.tsx
@@ -92,12 +92,12 @@ describe('BalanceCard', () => {
       expect(getByTestId('SavingsIcon')).toBeInTheDocument();
     });
 
-    it('should display group icon', () => {
+    it('should display conference savings icon', () => {
       const { getByTestId } = render(
         <Components
           fund={{
             ...defaultFund,
-            fundType: 'Conference Savings',
+            fundType: FundTypeEnum.ConferenceSavings,
           }}
         />,
       );
@@ -116,6 +116,45 @@ describe('BalanceCard', () => {
       );
 
       expect(getByTestId('WalletIcon')).toBeInTheDocument();
+    });
+
+    it('should display return travel icon', () => {
+      const { getByTestId } = render(
+        <Components
+          fund={{
+            ...defaultFund,
+            fundType: FundTypeEnum.ReturnTravel,
+          }}
+        />,
+      );
+
+      expect(getByTestId('FlightIcon')).toBeInTheDocument();
+    });
+
+    it('should display re-entry icon', () => {
+      const { getByTestId } = render(
+        <Components
+          fund={{
+            ...defaultFund,
+            fundType: FundTypeEnum.ReEntry,
+          }}
+        />,
+      );
+
+      expect(getByTestId('HomeIcon')).toBeInTheDocument();
+    });
+
+    it('should display the fallback icon for an unknown fund type', () => {
+      const { getByTestId } = render(
+        <Components
+          fund={{
+            ...defaultFund,
+            fundType: 'Unknown Fund',
+          }}
+        />,
+      );
+
+      expect(getByTestId('GroupsIcon')).toBeInTheDocument();
     });
   });
 

--- a/src/components/HrTools/SavingsFundTransfer/BalanceCard/BalanceCard.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/BalanceCard/BalanceCard.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
-import { Diversity1, Outbox, Savings, Wallet } from '@mui/icons-material';
+import { Outbox } from '@mui/icons-material';
 import { Box, Button, Card, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { SimpleScreenOnly } from 'src/components/Reports/styledComponents';
 import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat } from 'src/lib/intlFormat';
 import theme from 'src/theme';
+import {
+  getIconColorForFundType,
+  getIconForFundType,
+} from '../../../Reports/StaffExpenseReport/Helpers/fundTypeHelpers';
 import { FundFieldsFragment } from '../ReportsSavingsFund.generated';
-import { FundTypeEnum, TransferModalData } from '../mockData';
+import { TransferModalData } from '../mockData';
 
 export interface BalanceCardProps {
   fund: FundFieldsFragment;
@@ -24,18 +28,8 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
   const locale = useLocale();
 
   const title = t('{{ name }} Account Balance', { name: fund.fundType });
-  const Icon =
-    fund.fundType === FundTypeEnum.Primary
-      ? Wallet
-      : fund.fundType === FundTypeEnum.Savings
-        ? Savings
-        : Diversity1;
-  const iconBgColor =
-    fund.fundType === FundTypeEnum.Primary
-      ? theme.palette.chartOrange.main
-      : fund.fundType === FundTypeEnum.Savings
-        ? theme.palette.chartBlueDark.main
-        : theme.palette.chartBlue.main;
+  const Icon = getIconForFundType(fund.fundType);
+  const iconBgColor = getIconColorForFundType(fund.fundType, theme);
 
   const handleTransferFrom = () => {
     handleOpenTransferModal({
@@ -60,7 +54,7 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
         flexDirection: 'column',
       }}
     >
-      <Box display={'flex'} flexDirection="row" alignItems="center" gap={1}>
+      <Box display={'flex'} flexDirection="row" alignItems="flex-start" gap={1}>
         <Box
           sx={{
             backgroundColor: iconBgColor || 'primary.main',
@@ -88,8 +82,6 @@ export const BalanceCard: React.FC<BalanceCardProps> = ({
               fontWeight: 500,
               fontSize: '13pt',
               minHeight: '3em',
-              display: 'flex',
-              alignItems: 'center',
             }}
           >
             {title}

--- a/src/components/HrTools/SavingsFundTransfer/Helper/TransferIcons.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/TransferIcons.test.tsx
@@ -1,0 +1,31 @@
+import { ThemeProvider } from '@mui/material/styles';
+import { render } from '@testing-library/react';
+import theme from 'src/theme';
+import { FundTypeEnum } from '../mockData';
+import { getFundIcon } from './TransferIcons';
+
+const Components = ({ fundType }: { fundType: string | undefined }) => (
+  <ThemeProvider theme={theme}>{getFundIcon(fundType)}</ThemeProvider>
+);
+
+describe('getFundIcon', () => {
+  it.each([
+    [FundTypeEnum.Primary, 'Primary Account'],
+    [FundTypeEnum.Savings, 'Savings Account'],
+    [FundTypeEnum.ConferenceSavings, 'Staff Conference Savings Account'],
+    [FundTypeEnum.ReturnTravel, 'Return Travel Account'],
+    [FundTypeEnum.ReEntry, 'Re-Entry Account'],
+  ])('renders an accessible icon for %s', (fundType, name) => {
+    const { getByRole } = render(<Components fundType={fundType} />);
+
+    expect(getByRole('img', { name })).toBeInTheDocument();
+  });
+
+  it('returns undefined for an unknown fund type', () => {
+    expect(getFundIcon('staffAccount')).toBeUndefined();
+  });
+
+  it('matches fund types case sensitively', () => {
+    expect(getFundIcon('primary')).toBeUndefined();
+  });
+});

--- a/src/components/HrTools/SavingsFundTransfer/Helper/TransferIcons.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/TransferIcons.tsx
@@ -1,47 +1,53 @@
-import { Groups, Savings, Wallet } from '@mui/icons-material';
+import {
+  getIconColorForFundType,
+  getIconForFundType,
+} from 'src/components/Reports/StaffExpenseReport/Helpers/fundTypeHelpers';
+import theme from 'src/theme';
+import { FundTypeEnum } from '../mockData';
 
-export const PrimaryAccount = (
-  <Wallet
-    titleAccess="Primary Account"
-    sx={{
-      backgroundColor: '#F08020',
-      color: 'primary.contrastText',
-      borderRadius: 1,
-      p: 0.25,
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      mr: 1,
-    }}
-  />
-);
-export const SavingsAccount = (
-  <Savings
-    titleAccess="Savings Account"
-    sx={{
-      backgroundColor: '#007890',
-      color: 'primary.contrastText',
-      borderRadius: 1,
-      p: 0.25,
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      mr: 1,
-    }}
-  />
-);
-export const ConferenceSavingsAccount = (
-  <Groups
-    titleAccess="Staff Conference Savings Account"
-    sx={{
-      backgroundColor: '#00C0D8',
-      color: 'primary.contrastText',
-      borderRadius: 1,
-      p: 0.25,
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      mr: 1,
-    }}
-  />
-);
+const createFundIcon = (fundType: FundTypeEnum, titleAccess: string) => {
+  const Icon = getIconForFundType(fundType);
+
+  return (
+    <Icon
+      titleAccess={titleAccess}
+      sx={{
+        backgroundColor: getIconColorForFundType(fundType, theme),
+        color: 'primary.contrastText',
+        borderRadius: 1,
+        p: 0.25,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        mr: 1,
+      }}
+    />
+  );
+};
+
+const fundIcons: Record<FundTypeEnum, JSX.Element> = {
+  [FundTypeEnum.Primary]: createFundIcon(
+    FundTypeEnum.Primary,
+    'Primary Account',
+  ),
+  [FundTypeEnum.Savings]: createFundIcon(
+    FundTypeEnum.Savings,
+    'Savings Account',
+  ),
+  [FundTypeEnum.ConferenceSavings]: createFundIcon(
+    FundTypeEnum.ConferenceSavings,
+    'Staff Conference Savings Account',
+  ),
+  [FundTypeEnum.ReturnTravel]: createFundIcon(
+    FundTypeEnum.ReturnTravel,
+    'Return Travel Account',
+  ),
+  [FundTypeEnum.ReEntry]: createFundIcon(
+    FundTypeEnum.ReEntry,
+    'Re-Entry Account',
+  ),
+};
+
+export const getFundIcon = (
+  fundType: string | undefined,
+): JSX.Element | undefined => fundIcons[fundType as FundTypeEnum];

--- a/src/components/HrTools/SavingsFundTransfer/Helper/getFundLabel.test.ts
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/getFundLabel.test.ts
@@ -17,6 +17,16 @@ describe('getFundLabel', () => {
     );
   });
 
+  it('returns the Return Travel Account label', () => {
+    expect(getFundLabel(FundTypeEnum.ReturnTravel, i18n.t)).toBe(
+      'Return Travel Account',
+    );
+  });
+
+  it('returns the Re-Entry Account label', () => {
+    expect(getFundLabel(FundTypeEnum.ReEntry, i18n.t)).toBe('Re-Entry Account');
+  });
+
   it('returns an empty string for an unknown fund', () => {
     expect(getFundLabel('staffAccount', i18n.t)).toBe('N/A');
   });

--- a/src/components/HrTools/SavingsFundTransfer/Helper/getFundLabel.ts
+++ b/src/components/HrTools/SavingsFundTransfer/Helper/getFundLabel.ts
@@ -11,5 +11,11 @@ export const getFundLabel = (fund: string | undefined, t: TFunction) => {
   if (fund === FundTypeEnum.ConferenceSavings) {
     return t('Staff Conference Savings Account');
   }
+  if (fund === FundTypeEnum.ReturnTravel) {
+    return t('Return Travel Account');
+  }
+  if (fund === FundTypeEnum.ReEntry) {
+    return t('Re-Entry Account');
+  }
   return t('N/A');
 };

--- a/src/components/HrTools/SavingsFundTransfer/Table/Row/createTableRow.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/Table/Row/createTableRow.tsx
@@ -13,15 +13,15 @@ import {
 } from '@mui/material';
 import { TFunction } from 'react-i18next';
 import { currencyFormat } from 'src/lib/intlFormat';
+import { getFundIcon } from '../../Helper/TransferIcons';
 import {
-  FundTypeEnum,
   ScheduleEnum,
   StatusEnum,
   TableTypeEnum,
   Transfers,
 } from '../../mockData';
 import { RenderCell } from '../TransfersTable';
-import { chipStyle, iconMap } from './createTableRowHelper';
+import { chipStyle } from './createTableRowHelper';
 
 type Options = {
   type: TableTypeEnum;
@@ -57,23 +57,8 @@ export function populateTransferRows(options: Options) {
   }, []);
 
   const transfers: RenderCell = ({ row }) => {
-    const fromIconName =
-      row.transferFrom?.toLowerCase() ===
-      FundTypeEnum.ConferenceSavings.toLowerCase()
-        ? 'conference'
-        : row.transferFrom
-          ? row.transferFrom.toLowerCase()
-          : 'primary';
-    const toIconName =
-      row.transferTo?.toLowerCase() ===
-      FundTypeEnum.ConferenceSavings.toLowerCase()
-        ? 'conference'
-        : row.transferTo
-          ? row.transferTo.toLowerCase()
-          : 'savings';
-
-    const fromIcon = iconMap[fromIconName];
-    const toIcon = iconMap[toIconName];
+    const fromIcon = getFundIcon(row.transferFrom);
+    const toIcon = getFundIcon(row.transferTo);
 
     if (fromIcon && toIcon) {
       return (

--- a/src/components/HrTools/SavingsFundTransfer/Table/Row/createTableRowHelper.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/Table/Row/createTableRowHelper.tsx
@@ -1,16 +1,5 @@
 import theme from 'src/theme';
-import {
-  ConferenceSavingsAccount,
-  PrimaryAccount,
-  SavingsAccount,
-} from '../../Helper/TransferIcons';
 import { StatusEnum } from '../../mockData';
-
-export const iconMap: Record<string, React.ReactElement> = {
-  primary: PrimaryAccount,
-  conference: ConferenceSavingsAccount,
-  savings: SavingsAccount,
-};
 
 export const chipStyle: Record<
   StatusEnum,

--- a/src/components/HrTools/SavingsFundTransfer/TransferModal/Helper/FundInfoDisplay.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransferModal/Helper/FundInfoDisplay.tsx
@@ -1,13 +1,8 @@
 import { Box, Typography } from '@mui/material';
 import { useLocale } from 'src/hooks/useLocale';
 import { currencyFormat } from 'src/lib/intlFormat';
-import {
-  ConferenceSavingsAccount,
-  PrimaryAccount,
-  SavingsAccount,
-} from '../../Helper/TransferIcons';
+import { getFundIcon } from '../../Helper/TransferIcons';
 import { FundFieldsFragment } from '../../ReportsSavingsFund.generated';
-import { FundTypeEnum } from '../../mockData';
 
 type Fund = Pick<FundFieldsFragment, 'fundType' | 'endBalance'>;
 
@@ -24,11 +19,7 @@ export const FundInfoDisplay: React.FC<FundInfoDisplayProps> = ({ fund }) => {
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center' }}>
-      {fund.fundType === FundTypeEnum.Primary
-        ? PrimaryAccount
-        : fund.fundType === FundTypeEnum.Savings
-          ? SavingsAccount
-          : ConferenceSavingsAccount}
+      {getFundIcon(fund.fundType)}
       <Box
         sx={{
           overflow: 'hidden',

--- a/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.test.tsx
@@ -9,6 +9,8 @@ import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { StaffAccountQuery } from 'src/components/Shared/StaffAccount/StaffAccount.generated';
+import { GetUserQuery } from 'src/components/User/GetUser.generated';
+import { UsStaffGroupEnum } from 'src/graphql/types.generated';
 import theme from 'src/theme';
 import { StaffSavingFundContext } from '../../StaffSavingFund/StaffSavingFundContext';
 import {
@@ -207,8 +209,10 @@ jest.mock('notistack', () => ({
 
 const Components = ({
   title = 'Staff Savings Fund Transfers',
+  usStaffGroup = UsStaffGroupEnum.SeniorStaff,
 }: {
   title?: string;
+  usStaffGroup?: UsStaffGroupEnum;
 }) => (
   <SnackbarProvider>
     <ThemeProvider theme={theme}>
@@ -218,8 +222,9 @@ const Components = ({
             StaffAccount: StaffAccountQuery;
             ReportsSavingsFundTransfer: ReportsSavingsFundTransferQuery;
             FundBalances: FundBalancesQuery;
+            GetUser: GetUserQuery;
           }>
-            mocks={mock}
+            mocks={{ ...mock, GetUser: { user: { usStaffGroup } } }}
             onCall={mutationSpy}
           >
             <MockStaffSavingFundProvider>
@@ -268,7 +273,7 @@ describe('TransfersPage', () => {
     expect(getByText('$25,000.00')).toBeInTheDocument();
   });
 
-  it('should sort fund cards in ascending order by id', async () => {
+  it('should sort fund cards into fund type display order', async () => {
     const { findAllByText } = render(<Components />);
 
     const fundCards = await findAllByText(/Account Balance/i);
@@ -294,6 +299,44 @@ describe('TransfersPage', () => {
     expect(tables.length).toBe(2);
 
     expect(within(tables[0]).getAllByRole('columnheader')).toHaveLength(8);
+  });
+
+  it.each([
+    UsStaffGroupEnum.SeniorInternationalStaff,
+    UsStaffGroupEnum.NewInternationalStaff,
+    UsStaffGroupEnum.SeniorStaffStint,
+    UsStaffGroupEnum.NewStaffStint,
+  ])('requests re-entry and return travel for %s', async (usStaffGroup) => {
+    render(<Components usStaffGroup={usStaffGroup} />);
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('FundBalances', {
+        fundTypes: [
+          'Primary',
+          'Savings',
+          'Staff Conference Savings',
+          'Return Travel',
+          'Re-Entry',
+        ],
+      }),
+    );
+  });
+
+  it('never requests re-entry and return travel for everyone else', async () => {
+    const { findByText } = render(<Components />);
+
+    await waitFor(() => expect(mutationSpy).toHaveGraphqlOperation('GetUser'));
+    expect(await findByText('Primary Account Balance')).toBeInTheDocument();
+
+    expect(mutationSpy).not.toHaveGraphqlOperation('FundBalances', {
+      fundTypes: [
+        'Primary',
+        'Savings',
+        'Staff Conference Savings',
+        'Return Travel',
+        'Re-Entry',
+      ],
+    });
   });
 
   it('should display stopped recurring transfers in history with a stopped status and no actions', async () => {

--- a/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/TransfersPage/TransfersPage.tsx
@@ -24,7 +24,10 @@ import {
   MultiPageHeader,
 } from 'src/components/Shared/MultiPageLayout/MultiPageHeader';
 import { useStaffAccountQuery } from 'src/components/Shared/StaffAccount/StaffAccount.generated';
+import { useGetUserQuery } from 'src/components/User/GetUser.generated';
+import { UsStaffGroupEnum } from 'src/graphql/types.generated';
 import theme from 'src/theme';
+import { compareFundTypes } from '../../../Reports/StaffExpenseReport/Helpers/fundTypeHelpers';
 import {
   StaffSavingFundContext,
   StaffSavingFundType,
@@ -41,7 +44,6 @@ import { PrintTable } from '../Table/PrintTable';
 import { TransfersTable } from '../Table/TransfersTable';
 import { DynamicTransferModal } from '../TransferModal/DynamicTransferModal';
 import {
-  FundTypeEnum,
   ScheduleEnum,
   StatusEnum,
   TableTypeEnum,
@@ -70,7 +72,7 @@ interface TransfersPageProps {
 
 const StyledCardsBox = styled(Box)({
   flex: 1,
-  minWidth: 250,
+  minWidth: 215,
   display: 'flex',
   gap: theme.spacing(4),
 });
@@ -82,6 +84,24 @@ export const TransfersPage: React.FC<TransfersPageProps> = ({ title }) => {
     StaffSavingFundContext,
   ) as StaffSavingFundType;
 
+  const { data: userData, loading: userLoading } = useGetUserQuery();
+  const usStaffGroup = userData?.user.usStaffGroup;
+  const hideFunds =
+    usStaffGroup !== UsStaffGroupEnum.SeniorInternationalStaff &&
+    usStaffGroup !== UsStaffGroupEnum.NewInternationalStaff &&
+    usStaffGroup !== UsStaffGroupEnum.SeniorStaffStint &&
+    usStaffGroup !== UsStaffGroupEnum.NewStaffStint;
+
+  const fundTypes = hideFunds
+    ? ['Primary', 'Savings', 'Staff Conference Savings']
+    : [
+        'Primary',
+        'Savings',
+        'Staff Conference Savings',
+        'Return Travel',
+        'Re-Entry',
+      ];
+
   const { data: staffAccountData, error: staffAccountError } =
     useStaffAccountQuery();
 
@@ -89,18 +109,15 @@ export const TransfersPage: React.FC<TransfersPageProps> = ({ title }) => {
     useReportsSavingsFundTransferQuery();
   const { data: fundsData, error: fundsError } = useFundBalancesQuery({
     variables: {
-      fundTypes: [
-        FundTypeEnum.Primary,
-        FundTypeEnum.Savings,
-        FundTypeEnum.ConferenceSavings,
-      ],
+      fundTypes,
     },
+    skip: userLoading,
   });
 
   const funds = useMemo(
     () =>
       (fundsData?.reportsStaffExpenses?.funds ?? []).toSorted((a, b) =>
-        a.id.localeCompare(b.id),
+        compareFundTypes(a.fundType, b.fundType),
       ),
     [fundsData],
   );
@@ -312,11 +329,12 @@ export const TransfersPage: React.FC<TransfersPageProps> = ({ title }) => {
                 </StyledCardsBox>
               ) : (
                 funds.map((fund) => (
-                  <BalanceCard
-                    fund={fund}
-                    key={fund.id}
-                    handleOpenTransferModal={handleOpenTransferModal}
-                  />
+                  <StyledCardsBox key={fund.id}>
+                    <BalanceCard
+                      fund={fund}
+                      handleOpenTransferModal={handleOpenTransferModal}
+                    />
+                  </StyledCardsBox>
                 ))
               )}
             </Box>

--- a/src/components/HrTools/SavingsFundTransfer/mockData.ts
+++ b/src/components/HrTools/SavingsFundTransfer/mockData.ts
@@ -19,6 +19,8 @@ export enum FundTypeEnum {
   Primary = 'Primary',
   Savings = 'Savings',
   ConferenceSavings = 'Staff Conference Savings',
+  ReEntry = 'Re-Entry',
+  ReturnTravel = 'Return Travel',
 }
 
 export enum TransferTypeEnum {

--- a/src/components/Reports/StaffExpenseReport/Helpers/fundTypeHelpers.test.ts
+++ b/src/components/Reports/StaffExpenseReport/Helpers/fundTypeHelpers.test.ts
@@ -1,0 +1,21 @@
+import { compareFundTypes } from './fundTypeHelpers';
+
+describe('compareFundTypes', () => {
+  it('sorts known fund types into their display order', () => {
+    expect(
+      [
+        'Re-Entry',
+        'Savings',
+        'Return Travel',
+        'Primary',
+        'Staff Conference Savings',
+      ].toSorted(compareFundTypes),
+    ).toEqual([
+      'Primary',
+      'Staff Conference Savings',
+      'Savings',
+      'Return Travel',
+      'Re-Entry',
+    ]);
+  });
+});

--- a/src/components/Reports/StaffExpenseReport/Helpers/fundTypeHelpers.ts
+++ b/src/components/Reports/StaffExpenseReport/Helpers/fundTypeHelpers.ts
@@ -37,6 +37,18 @@ const fundTypeConfig: Record<string, FundTypeConfig> = {
   },
 };
 
+const fundTypeOrder: Record<string, number> = {
+  Primary: 0,
+  'Staff Conference Savings': 1,
+  Savings: 2,
+  'Return Travel': 3,
+  'Re-Entry': 4,
+};
+
+export const compareFundTypes = (a: string, b: string): number => {
+  return fundTypeOrder[a] - fundTypeOrder[b] || a.localeCompare(b);
+};
+
 const defaultFundTypeConfig: FundTypeConfig = {
   icon: Groups,
   getColor: (theme) => theme.palette.chartBlue.main,

--- a/src/components/Reports/StaffExpenseReport/Helpers/fundTypeHelpers.ts
+++ b/src/components/Reports/StaffExpenseReport/Helpers/fundTypeHelpers.ts
@@ -46,7 +46,7 @@ const fundTypeOrder: Record<string, number> = {
 };
 
 export const compareFundTypes = (a: string, b: string): number => {
-  return fundTypeOrder[a] - fundTypeOrder[b] || a.localeCompare(b);
+  return fundTypeOrder[a] - fundTypeOrder[b];
 };
 
 const defaultFundTypeConfig: FundTypeConfig = {

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
@@ -290,50 +290,45 @@ describe('StaffExpenseReport', () => {
     expect(queryByText('-$200')).not.toBeInTheDocument();
   });
 
-  it('requests re-entry and return travel funds when user is international staff', async () => {
-    render(
-      <TestComponent
-        usStaffGroup={UsStaffGroupEnum.SeniorInternationalStaff}
-      />,
-    );
+  it.each([
+    UsStaffGroupEnum.SeniorInternationalStaff,
+    UsStaffGroupEnum.NewInternationalStaff,
+    UsStaffGroupEnum.SeniorStaffStint,
+    UsStaffGroupEnum.NewStaffStint,
+  ])(
+    'requests re-entry and return travel funds when user is %s',
+    async (usStaffGroup) => {
+      render(<TestComponent usStaffGroup={usStaffGroup} />);
 
-    await waitFor(() =>
-      expect(mutationSpy).toHaveGraphqlOperation('ReportsStaffExpenses', {
-        fundTypes: [
-          'Primary',
-          'Savings',
-          'Staff Conference Savings',
-          'Return Travel',
-          'Re-Entry',
-        ],
-      }),
-    );
-  });
+      await waitFor(() =>
+        expect(mutationSpy).toHaveGraphqlOperation('ReportsStaffExpenses', {
+          fundTypes: [
+            'Primary',
+            'Savings',
+            'Staff Conference Savings',
+            'Return Travel',
+            'Re-Entry',
+          ],
+        }),
+      );
+    },
+  );
 
-  it('requests re-entry and return travel funds when user is staff stint', async () => {
-    render(<TestComponent usStaffGroup={UsStaffGroupEnum.SeniorStaffStint} />);
+  it('never requests re-entry and return travel funds for everyone else', async () => {
+    const { findByRole } = render(<TestComponent />);
 
-    await waitFor(() =>
-      expect(mutationSpy).toHaveGraphqlOperation('ReportsStaffExpenses', {
-        fundTypes: [
-          'Primary',
-          'Savings',
-          'Staff Conference Savings',
-          'Return Travel',
-          'Re-Entry',
-        ],
-      }),
-    );
-  });
+    await waitFor(() => expect(mutationSpy).toHaveGraphqlOperation('GetUser'));
+    await findByRole('heading', { name: 'Primary' });
 
-  it('does not request re-entry and return travel funds for everyone else', async () => {
-    render(<TestComponent />);
-
-    await waitFor(() =>
-      expect(mutationSpy).toHaveGraphqlOperation('ReportsStaffExpenses', {
-        fundTypes: ['Primary', 'Savings', 'Staff Conference Savings'],
-      }),
-    );
+    expect(mutationSpy).not.toHaveGraphqlOperation('ReportsStaffExpenses', {
+      fundTypes: [
+        'Primary',
+        'Savings',
+        'Staff Conference Savings',
+        'Return Travel',
+        'Re-Entry',
+      ],
+    });
   });
 
   it('shows month title and navigation when only category filters are applied', async () => {

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.test.tsx
@@ -13,10 +13,12 @@ import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
 import { GqlMockedProvider } from '__tests__/util/graphqlMocking';
 import { StaffAccountQuery } from 'src/components/Shared/StaffAccount/StaffAccount.generated';
+import { GetUserQuery } from 'src/components/User/GetUser.generated';
 import {
   StaffAccountStatusEnum,
   StaffExpenseCategoryEnum,
   StaffExpensesSubCategoryEnum,
+  UsStaffGroupEnum,
 } from 'src/graphql/types.generated';
 import theme from 'src/theme';
 import { ReportsStaffExpensesQuery } from './GetStaffExpense.generated';
@@ -25,6 +27,7 @@ import { StaffExpenseReport } from './StaffExpenseReport';
 interface TestComponentProps {
   isEmpty?: boolean;
   routerMonth?: string;
+  usStaffGroup?: UsStaffGroupEnum;
 }
 
 const mutationSpy = jest.fn();
@@ -41,6 +44,7 @@ const router = {
 const TestComponent: React.FC<TestComponentProps> = ({
   isEmpty,
   routerMonth,
+  usStaffGroup = UsStaffGroupEnum.SeniorStaff,
 }) => (
   <ThemeProvider theme={theme}>
     <TestRouter
@@ -59,6 +63,7 @@ const TestComponent: React.FC<TestComponentProps> = ({
             <GqlMockedProvider<{
               ReportsStaffExpenses: ReportsStaffExpensesQuery;
               StaffAccount: StaffAccountQuery;
+              GetUser: GetUserQuery;
             }>
               mocks={{
                 ReportsStaffExpenses: {
@@ -202,6 +207,11 @@ const TestComponent: React.FC<TestComponentProps> = ({
                     status: StaffAccountStatusEnum.Active,
                   },
                 },
+                GetUser: {
+                  user: {
+                    usStaffGroup,
+                  },
+                },
               }}
               onCall={mutationSpy}
             >
@@ -278,6 +288,52 @@ describe('StaffExpenseReport', () => {
     userEvent.click(await findByRole('button', { name: 'View Account' }));
 
     expect(queryByText('-$200')).not.toBeInTheDocument();
+  });
+
+  it('requests re-entry and return travel funds when user is international staff', async () => {
+    render(
+      <TestComponent
+        usStaffGroup={UsStaffGroupEnum.SeniorInternationalStaff}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('ReportsStaffExpenses', {
+        fundTypes: [
+          'Primary',
+          'Savings',
+          'Staff Conference Savings',
+          'Return Travel',
+          'Re-Entry',
+        ],
+      }),
+    );
+  });
+
+  it('requests re-entry and return travel funds when user is staff stint', async () => {
+    render(<TestComponent usStaffGroup={UsStaffGroupEnum.SeniorStaffStint} />);
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('ReportsStaffExpenses', {
+        fundTypes: [
+          'Primary',
+          'Savings',
+          'Staff Conference Savings',
+          'Return Travel',
+          'Re-Entry',
+        ],
+      }),
+    );
+  });
+
+  it('does not request re-entry and return travel funds for everyone else', async () => {
+    render(<TestComponent />);
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('ReportsStaffExpenses', {
+        fundTypes: ['Primary', 'Savings', 'Staff Conference Savings'],
+      }),
+    );
   });
 
   it('shows month title and navigation when only category filters are applied', async () => {

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
@@ -19,7 +19,8 @@ import {
   MultiPageHeader,
 } from 'src/components/Shared/MultiPageLayout/MultiPageHeader';
 import { useStaffAccountQuery } from 'src/components/Shared/StaffAccount/StaffAccount.generated';
-import { Fund } from 'src/graphql/types.generated';
+import { useGetUserQuery } from 'src/components/User/GetUser.generated';
+import { Fund, UsStaffGroupEnum } from 'src/graphql/types.generated';
 import { useLocale } from 'src/hooks/useLocale';
 import theme from 'src/theme';
 import { AccountInfoBox } from '../../HrTools/Shared/AccountInfoBox/AccountInfoBox';
@@ -84,6 +85,14 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
   const [filters, setFilters] = useState<Filters | null>(null);
   const [time, setTime] = useState(DateTime.now().startOf('month'));
 
+  const { data: userData } = useGetUserQuery();
+  const usStaffGroup = userData?.user.usStaffGroup;
+  const hideFunds =
+    usStaffGroup !== UsStaffGroupEnum.SeniorInternationalStaff &&
+    usStaffGroup !== UsStaffGroupEnum.NewInternationalStaff &&
+    usStaffGroup !== UsStaffGroupEnum.SeniorStaffStint &&
+    usStaffGroup !== UsStaffGroupEnum.NewStaffStint;
+
   const isFilterDateSelected = useMemo(() => {
     return Boolean(
       filters &&
@@ -91,15 +100,19 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
     );
   }, [filters]);
 
-  const { data, loading } = useReportsStaffExpensesQuery({
-    variables: {
-      fundTypes: [
+  const fundTypes = hideFunds
+    ? ['Primary', 'Savings', 'Staff Conference Savings']
+    : [
         'Primary',
         'Savings',
         'Staff Conference Savings',
         'Return Travel',
         'Re-Entry',
-      ],
+      ];
+
+  const { data, loading } = useReportsStaffExpensesQuery({
+    variables: {
+      fundTypes,
       ...getStaffExpenseMonthRange(filters, time),
     },
   });

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
@@ -47,6 +47,7 @@ import {
   getFormattedDateString,
 } from './Helpers/formatDate';
 import {
+  compareFundTypes,
   getIconColorForFundType,
   getIconForFundType,
 } from './Helpers/fundTypeHelpers';
@@ -132,7 +133,7 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
   const allFunds: Fund[] = useMemo(
     () =>
       (data?.reportsStaffExpenses?.funds ?? []).toSorted((a, b) =>
-        a.id.localeCompare(b.id),
+        compareFundTypes(a.fundType, b.fundType),
       ),
     [data],
   );

--- a/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
+++ b/src/components/Reports/StaffExpenseReport/StaffExpenseReport.tsx
@@ -86,7 +86,7 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
   const [filters, setFilters] = useState<Filters | null>(null);
   const [time, setTime] = useState(DateTime.now().startOf('month'));
 
-  const { data: userData } = useGetUserQuery();
+  const { data: userData, loading: userLoading } = useGetUserQuery();
   const usStaffGroup = userData?.user.usStaffGroup;
   const hideFunds =
     usStaffGroup !== UsStaffGroupEnum.SeniorInternationalStaff &&
@@ -116,6 +116,7 @@ export const StaffExpenseReport: React.FC<StaffExpenseReportProps> = ({
       fundTypes,
       ...getStaffExpenseMonthRange(filters, time),
     },
+    skip: userLoading,
   });
 
   const { data: accountData } = useStaffAccountQuery();

--- a/src/hooks/useIneligibleByGroup.test.tsx
+++ b/src/hooks/useIneligibleByGroup.test.tsx
@@ -175,6 +175,74 @@ describe('useIneligibleByGroup', () => {
       });
     });
 
+    it('senior international staff eligibility', async () => {
+      const { result } = renderUseIneligibleByGroup({
+        usStaffGroup: UsStaffGroupEnum.SeniorInternationalStaff,
+        spouseUsStaffGroup: null,
+      });
+
+      await waitFor(() => expect(result.current.userLoading).toBe(false));
+      expect(result.current).toMatchObject({
+        inAsrIneligibleGroup: false,
+        inSalaryCalcIneligibleGroup: false,
+        inMhaIneligibleGroup: false,
+        inMpdGoalCalcIneligibleGroup: false,
+        inNsGoalCalcIneligibleGroup: true,
+        inPdsGoalCalcIneligibleGroup: true,
+      });
+    });
+
+    it('new international staff eligibility', async () => {
+      const { result } = renderUseIneligibleByGroup({
+        usStaffGroup: UsStaffGroupEnum.NewInternationalStaff,
+        spouseUsStaffGroup: null,
+      });
+
+      await waitFor(() => expect(result.current.userLoading).toBe(false));
+      expect(result.current).toMatchObject({
+        inAsrIneligibleGroup: false,
+        inSalaryCalcIneligibleGroup: true,
+        inMhaIneligibleGroup: true,
+        inMpdGoalCalcIneligibleGroup: true,
+        inNsGoalCalcIneligibleGroup: false,
+        inPdsGoalCalcIneligibleGroup: true,
+      });
+    });
+
+    it('senior staff stint eligibility', async () => {
+      const { result } = renderUseIneligibleByGroup({
+        usStaffGroup: UsStaffGroupEnum.SeniorStaffStint,
+        spouseUsStaffGroup: null,
+      });
+
+      await waitFor(() => expect(result.current.userLoading).toBe(false));
+      expect(result.current).toMatchObject({
+        inAsrIneligibleGroup: false,
+        inSalaryCalcIneligibleGroup: false,
+        inMhaIneligibleGroup: false,
+        inMpdGoalCalcIneligibleGroup: false,
+        inNsGoalCalcIneligibleGroup: true,
+        inPdsGoalCalcIneligibleGroup: true,
+      });
+    });
+
+    it('new staff stint eligibility', async () => {
+      const { result } = renderUseIneligibleByGroup({
+        usStaffGroup: UsStaffGroupEnum.NewStaffStint,
+        spouseUsStaffGroup: null,
+      });
+
+      await waitFor(() => expect(result.current.userLoading).toBe(false));
+      expect(result.current).toMatchObject({
+        inAsrIneligibleGroup: false,
+        inSalaryCalcIneligibleGroup: true,
+        inMhaIneligibleGroup: true,
+        inMpdGoalCalcIneligibleGroup: true,
+        inNsGoalCalcIneligibleGroup: false,
+        inPdsGoalCalcIneligibleGroup: true,
+      });
+    });
+
     describe('spouse us staff group', () => {
       it('user is null and spouse is senior staff', async () => {
         const { result } = renderUseIneligibleByGroup({

--- a/src/hooks/useIneligibleByGroup.test.tsx
+++ b/src/hooks/useIneligibleByGroup.test.tsx
@@ -260,6 +260,40 @@ describe('useIneligibleByGroup', () => {
           inPdsGoalCalcIneligibleGroup: true,
         });
       });
+
+      it('user is null and spouse is senior international staff', async () => {
+        const { result } = renderUseIneligibleByGroup({
+          usStaffGroup: null,
+          spouseUsStaffGroup: UsStaffGroupEnum.SeniorInternationalStaff,
+        });
+
+        await waitFor(() => expect(result.current.userLoading).toBe(false));
+        expect(result.current).toMatchObject({
+          inAsrIneligibleGroup: false,
+          inSalaryCalcIneligibleGroup: true,
+          inMhaIneligibleGroup: false,
+          inMpdGoalCalcIneligibleGroup: true,
+          inNsGoalCalcIneligibleGroup: true,
+          inPdsGoalCalcIneligibleGroup: true,
+        });
+      });
+
+      it('user is null and spouse is new staff stint', async () => {
+        const { result } = renderUseIneligibleByGroup({
+          usStaffGroup: null,
+          spouseUsStaffGroup: UsStaffGroupEnum.NewStaffStint,
+        });
+
+        await waitFor(() => expect(result.current.userLoading).toBe(false));
+        expect(result.current).toMatchObject({
+          inAsrIneligibleGroup: false,
+          inSalaryCalcIneligibleGroup: true,
+          inMhaIneligibleGroup: true,
+          inMpdGoalCalcIneligibleGroup: true,
+          inNsGoalCalcIneligibleGroup: true,
+          inPdsGoalCalcIneligibleGroup: true,
+        });
+      });
     });
 
     it('no us staff group eligibility', async () => {

--- a/src/hooks/useIneligibleByGroup.ts
+++ b/src/hooks/useIneligibleByGroup.ts
@@ -2,6 +2,20 @@ import { useMemo } from 'react';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import { UsStaffGroupEnum } from 'src/graphql/types.generated';
 
+const BASE_GROUPS: Partial<Record<UsStaffGroupEnum, UsStaffGroupEnum>> = {
+  [UsStaffGroupEnum.SeniorInternationalStaff]: UsStaffGroupEnum.SeniorStaff,
+  [UsStaffGroupEnum.NewInternationalStaff]: UsStaffGroupEnum.NewStaff,
+  [UsStaffGroupEnum.SeniorStaffStint]: UsStaffGroupEnum.SeniorStaff,
+  [UsStaffGroupEnum.NewStaffStint]: UsStaffGroupEnum.NewStaff,
+};
+
+const getBaseGroup = (group: UsStaffGroupEnum | null | undefined) => {
+  if (!group) {
+    return null;
+  }
+  return BASE_GROUPS[group] || group;
+};
+
 const isInEligibleGroup = (
   group: UsStaffGroupEnum | null | undefined,
   eligibleGroups: UsStaffGroupEnum[],
@@ -12,8 +26,8 @@ const isInEligibleGroup = (
 export function useIneligibleByGroup() {
   const { data, loading: userLoading, error: userError } = useGetUserQuery();
 
-  const usStaffGroup = data?.user.usStaffGroup;
-  const spouseUsStaffGroup = data?.user.spouseUsStaffGroup;
+  const usStaffGroup = getBaseGroup(data?.user.usStaffGroup);
+  const spouseUsStaffGroup = getBaseGroup(data?.user.spouseUsStaffGroup);
   const userType = data?.user.userType;
   const hasNoStaffAccount = !data?.user.staffAccountId;
 

--- a/src/hooks/useIneligibleByGroup.ts
+++ b/src/hooks/useIneligibleByGroup.ts
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 import { useGetUserQuery } from 'src/components/User/GetUser.generated';
 import { UsStaffGroupEnum } from 'src/graphql/types.generated';
 
+// International staff and staff stints are senior or new staff for eligibility
+// purposes, so resolve them to that group before any check below runs
 const BASE_GROUPS: Partial<Record<UsStaffGroupEnum, UsStaffGroupEnum>> = {
   [UsStaffGroupEnum.SeniorInternationalStaff]: UsStaffGroupEnum.SeniorStaff,
   [UsStaffGroupEnum.NewInternationalStaff]: UsStaffGroupEnum.NewStaff,


### PR DESCRIPTION
## Description

On Staff expenses report, hide Re-Entry and Return Travel fund types unless a user is an international staff or staff stint. These new US staff groups have already been added on the backend.

Extra:
- Reorder fund types on staff expenses AND savings fund transfer: Primary, Conference Savings, Savings, ...
- Add Re-entry and Return Travel funds to savings fund transfer

Jira ticket: [MPDX-9826](https://jira.cru.org/browse/MPDX-9826)

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

International Staff: ✅
- Impersonate: barrett.harkins@cru.org
- Go to `/reports/staffExpense`
- Check that all 5 fund types appear
- Verify the order is correct: Primary, Conference, Savings, Return Travel, Re-Entry
- Go to `/hrTools/staffSavingFund/transfers`
- Check that all 5 fund types appear
- Verify the order is correct: Primary, Conference, Savings, Return Travel, Re-Entry

Senior Staff: ✅
- Impersonate: courtney.campbell@cru.org
- Go to `/reports/staffExpense`
- Check that only 3 fund types appear
- Verify the order is correct: Primary, Conference, Savings
- Go to `/hrTools/staffSavingFund/transfers`
- Check that only 3 fund types appear
- Verify the order is correct: Primary, Conference, Savings

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/quality:agent-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
