### PR TITLE
[no-Jira] Add HR email address to failed transfer modal

### DIFF
--- a/src/components/HrTools/SavingsFundTransfer/FailedTransferModal/FailedTransferModal.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/FailedTransferModal/FailedTransferModal.tsx
@@ -3,15 +3,17 @@ import {
   Chip,
   DialogActions,
   DialogContent,
+  Link,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
   TableRow,
+  Typography,
 } from '@mui/material';
 import { DateTime } from 'luxon';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { CancelButton } from 'src/components/Shared/Modal/ActionButtons/ActionButtons';
 import Modal from 'src/components/Shared/Modal/Modal';
 import { useLocale } from 'src/hooks/useLocale';
@@ -121,6 +123,12 @@ export const FailedTransferModal: React.FC<FailedTransferModalProps> = ({
             </TableBody>
           </Table>
         </TableContainer>
+        <Typography variant="body2" sx={{ mt: 2 }}>
+          <Trans t={t}>
+            For more information about failed transfers, email{' '}
+            <Link href="mailto:HR@cru.org">HR@cru.org</Link>.
+          </Trans>
+        </Typography>
       </DialogContent>
       <DialogActions>
         <CancelButton onClick={handleClose}>{t('Close')}</CancelButton>

--- a/src/components/HrTools/SavingsFundTransfer/IntroPage/IntroPage.tsx
+++ b/src/components/HrTools/SavingsFundTransfer/IntroPage/IntroPage.tsx
@@ -137,15 +137,15 @@ export const SavingsFundTransfer: React.FC<SavingsFundTransferProps> = ({
             </Typography>
             <Typography variant="body1" sx={{ mt: 2 }}>
               {t(
-                'If you have any questions, please contact Crystal Dunaway in Staff Services at ',
+                'If you have any questions, please contact Staff Services at ',
               )}
               <Link
-                href="mailto:Crystal.Dunaway@cru.org"
+                href="mailto:HR@cru.org"
                 underline="hover"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Crystal.Dunaway@cru.org
+                HR@cru.org
               </Link>
               .
             </Typography>


### PR DESCRIPTION
## Description

- Add a help line to the bottom of the Savings Fund Transfer failed transfer modal directing users to email HR for more information about failed transfers.
- The email address is rendered as a `mailto:HR@cru.org` link inside a `<Trans>` so the surrounding sentence stays translatable.

## Testing

- Go to HR Tools > Savings Fund Transfer
- Find a transfer in the transfer history table that has failed transfers and click on it to open the failed transfer modal
- Check that below the table of failed transfers there is a line reading "For more information about failed transfers, email HR@cru.org."
- Check that `HR@cru.org` is a link and clicking it opens a new email to that address

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/quality:agent-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
