### PR TITLE
[MPDX-9298] Add HR contact info to salary calculator

### DIFF
--- a/src/components/HrTools/MinisterHousingAllowance/MainPages/NoRequestsDisplay.tsx
+++ b/src/components/HrTools/MinisterHousingAllowance/MainPages/NoRequestsDisplay.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { Box, Link } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
 
 export const NoRequestsDisplay: React.FC = () => {
@@ -6,15 +6,15 @@ export const NoRequestsDisplay: React.FC = () => {
 
   return (
     <Box data-testid="no-requests-display">
-      <Trans t={t}>
-        <p style={{ lineHeight: 1.5 }}>
+      <p style={{ lineHeight: 1.5 }}>
+        <Trans t={t}>
           Our records indicate that you have not applied for Minister&apos;s
           Housing Allowance. If you would like information about applying for
           one, contact Personnel Records at{' '}
-          <a href="tel:4078262230">(407) 826-2230</a> or{' '}
-          <a href="mailto:MHA@cru.org">MHA@cru.org</a>.
-        </p>
-      </Trans>
+          <Link href="tel:4078262230">(407) 826-2230</Link> or{' '}
+          <Link href="mailto:MHA@cru.org">MHA@cru.org</Link>.
+        </Trans>
+      </p>
     </Box>
   );
 };

--- a/src/components/HrTools/SalaryCalculator/Landing/PendingSalaryCalculationLanding/PendingSalaryCalculationLanding.tsx
+++ b/src/components/HrTools/SalaryCalculator/Landing/PendingSalaryCalculationLanding/PendingSalaryCalculationLanding.tsx
@@ -42,7 +42,7 @@ export const PendingSalaryCalculationLanding: React.FC = () => {
               contact HR Services at{' '}
               <Link href="tel:888-278-7233">(888) 278-7233</Link> or{' '}
               <Link href="tel:407-826-2287">(407) 826-2287</Link>. Email:{' '}
-              <Link href="mailto:HR@cru.org">HR@cru.org</Link>
+              <Link href="mailto:HR@cru.org">HR@cru.org</Link>.
             </Trans>
           </Typography>
         </Box>

--- a/src/components/HrTools/SalaryCalculator/Landing/PendingSalaryCalculationLanding/PendingSalaryCalculationLanding.tsx
+++ b/src/components/HrTools/SalaryCalculator/Landing/PendingSalaryCalculationLanding/PendingSalaryCalculationLanding.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Container, Typography, useTheme } from '@mui/material';
+import { Box, Container, Link, Typography, useTheme } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { Trans, useTranslation } from 'react-i18next';
 import { NameDisplay } from 'src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay';
@@ -27,7 +27,6 @@ export const PendingSalaryCalculationLanding: React.FC = () => {
     return <LimitedAccess noStaffAccount />;
   }
 
-  // TODO (MPDX-9298): Update text with correct HR contact info when available.
   return (
     <StyledContainer>
       <Box>
@@ -40,7 +39,10 @@ export const PendingSalaryCalculationLanding: React.FC = () => {
               We see that {{ names }} currently has a pending Salary Calculation
               Form in our system. You may review the status of that form below.
               If you have any questions regarding a pending request please
-              contact [HR Services] at [Phone] or [Email].
+              contact HR Services at{' '}
+              <Link href="tel:888-278-7233">(888) 278-7233</Link> or{' '}
+              <Link href="tel:407-826-2287">(407) 826-2287</Link>. Email:{' '}
+              <Link href="mailto:HR@cru.org">HR@cru.org</Link>
             </Trans>
           </Typography>
         </Box>

--- a/src/components/HrTools/SalaryCalculator/YourInformation/MhaRequestSection/MhaRequestSection.tsx
+++ b/src/components/HrTools/SalaryCalculator/YourInformation/MhaRequestSection/MhaRequestSection.tsx
@@ -1,10 +1,11 @@
-import Link from 'next/link';
+import NextLink from 'next/link';
 import React from 'react';
 import {
   Box,
   CardContent,
   CardHeader,
   LinearProgress,
+  Link,
   TextField,
   Typography,
   styled,
@@ -139,8 +140,8 @@ export const MhaRequestSection: React.FC = () => {
                 Our records show that not all staff have an MHI for the
                 effective date of this salary calculation. To apply for MHI,
                 contact Personnel Records at{' '}
-                <a href="tel:4078262230">(407) 826-2230</a> or{' '}
-                <a href="mailto:MHA@cru.org">MHA@cru.org</a>. Pending MHI
+                <Link href="tel:4078262230">(407) 826-2230</Link> or{' '}
+                <Link href="mailto:MHA@cru.org">MHA@cru.org</Link>. Pending MHI
                 Requests will not apply to this salary calculation but a new
                 Salary Calculation Form can be submitted after approval.
               </Trans>
@@ -150,11 +151,11 @@ export const MhaRequestSection: React.FC = () => {
                 Housing Allowance for the effective date of this salary
                 calculation. If an MHA Request form has not yet been submitted,
                 it may be completed using{' '}
-                <Link
+                <NextLink
                   href={`/accountLists/${accountListId}/hrTools/mhaCalculator`}
                 >
                   this link
-                </Link>
+                </NextLink>
                 . Pending MHA Requests will not apply to this salary calculation
                 but a new Salary Calculation Form can be submitted after
                 approval.

--- a/src/components/HrTools/SalaryCalculator/YourInformation/PersonalInformationSection/PersonalInformationSection.tsx
+++ b/src/components/HrTools/SalaryCalculator/YourInformation/PersonalInformationSection/PersonalInformationSection.tsx
@@ -1,8 +1,8 @@
-import Link from 'next/link';
 import React, { useMemo } from 'react';
 import {
   CardContent,
   CardHeader,
+  Link,
   Table,
   TableBody,
   TableCell,
@@ -105,8 +105,8 @@ export const PersonalInformationSection: React.FC = () => {
           <Trans t={t}>
             <strong>Note:</strong> If any of the above information is not
             correct, please contact HR Services with the correct information at{' '}
-            <a href="tel:888-278-7233">(888) 278-7233</a> or{' '}
-            <a href="tel:407-826-2287">(407) 826-2287</a>. Email:{' '}
+            <Link href="tel:888-278-7233">(888) 278-7233</Link> or{' '}
+            <Link href="tel:407-826-2287">(407) 826-2287</Link>. Email:{' '}
             <Link href="mailto:HR@cru.org">HR@cru.org</Link>
           </Trans>
         </Typography>

--- a/src/components/HrTools/SalaryCalculator/YourInformation/PersonalInformationSection/PersonalInformationSection.tsx
+++ b/src/components/HrTools/SalaryCalculator/YourInformation/PersonalInformationSection/PersonalInformationSection.tsx
@@ -107,7 +107,7 @@ export const PersonalInformationSection: React.FC = () => {
             correct, please contact HR Services with the correct information at{' '}
             <Link href="tel:888-278-7233">(888) 278-7233</Link> or{' '}
             <Link href="tel:407-826-2287">(407) 826-2287</Link>. Email:{' '}
-            <Link href="mailto:HR@cru.org">HR@cru.org</Link>
+            <Link href="mailto:HR@cru.org">HR@cru.org</Link>.
           </Trans>
         </Typography>
       </CardContent>

--- a/src/components/HrTools/SalaryCalculator/YourInformation/PersonalInformationSection/PersonalInformationSection.tsx
+++ b/src/components/HrTools/SalaryCalculator/YourInformation/PersonalInformationSection/PersonalInformationSection.tsx
@@ -107,8 +107,7 @@ export const PersonalInformationSection: React.FC = () => {
             correct, please contact HR Services with the correct information at{' '}
             <a href="tel:888-278-7233">(888) 278-7233</a> or{' '}
             <a href="tel:407-826-2287">(407) 826-2287</a>. Email:{' '}
-            {/* TODO (MPDX-9298): Update email address once provided by stakeholders (refer to Figma) */}
-            <Link href="mailto:--@cru.org">--@cru.org</Link>
+            <Link href="mailto:HR@cru.org">HR@cru.org</Link>
           </Trans>
         </Typography>
       </CardContent>

--- a/src/components/HrTools/Shared/EligibilityStatusTable/EligibilityStatusTable.tsx
+++ b/src/components/HrTools/Shared/EligibilityStatusTable/EligibilityStatusTable.tsx
@@ -4,6 +4,7 @@ import {
   Card,
   CardContent,
   CardHeader,
+  Link,
   Table,
   TableBody,
   TableCell,
@@ -194,8 +195,8 @@ export const EligibilityStatusTable: React.FC<EligibilityStatusTableProps> = ({
               approved amount that can be applied to your salary. If you believe
               this is incorrect, or would like to complete the required IBS
               courses, please contact Personnel Records at{' '}
-              <a href="tel:4078262230">(407) 826-2230</a> or{' '}
-              <a href="mailto:MHA@cru.org">MHA@cru.org</a>.
+              <Link href="tel:4078262230">(407) 826-2230</Link> or{' '}
+              <Link href="mailto:MHA@cru.org">MHA@cru.org</Link>.
             </Trans>
           </Typography>
         </Box>


### PR DESCRIPTION
## Description

- Replaced the `--@cru.org` placeholder in the salary calculator's Personal Information note with the real HR Services address, `HR@cru.org`, and removed the `TODO (MPDX-9298)`.
- Filled in the `[HR Services] at [Phone] or [Email]` placeholder text on the pending salary calculation landing page with the same HR Services contact info — phone `(888) 278-7233` / `(407) 826-2287` and `HR@cru.org` — and removed its `TODO (MPDX-9298)`.
- Switched the surrounding `tel:` and `mailto:` anchors in HR Tools from bare `<a>` tags to `Link` so contact links pick up consistent theme styling (`MhaRequestSection`, `NoRequestsDisplay`, `EligibilityStatusTable`, `PersonalInformationSection`).
- Also moved the `<p>` outside the `<Trans>` in `NoRequestsDisplay` so the translated string is just the sentence, not the wrapping paragraph markup.

Related Jira ticket: MPDX-9298. No dependent PRs.

## Testing

- Go to HR Tools > Salary Calculation Form and start or continue a salary calculation
- Go to the "Your Information" step and find the note under the Personal Information table
- Check that it reads "...contact HR Services with the correct information at (888) 278-7233 or (407) 826-2287. Email: HR@cru.org", and that the email links to `mailto:HR@cru.org`
- Go back to the Salary Calculation Form landing page as a user with a pending (or action-required) salary request
- Check that the intro paragraph reads "...please contact HR Services at (888) 278-7233 or (407) 826-2287. Email: HR@cru.org" with no `[HR Services]`/`[Phone]`/`[Email]` placeholders remaining
- Go to HR Tools > MHA Calculator with no MHA requests, and to a salary calculation with a missing MHI
- Check that the Personnel Records phone and MHA@cru.org links still render and are styled like the other links on the page

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [ ] I have run the Claude Code `/quality:agent-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
