### PR TITLE
[MPDX-9909] Add loading spinners to slow request forms mutations

### DIFF
--- a/.claude/rules/code-review.md
+++ b/.claude/rules/code-review.md
@@ -221,11 +221,9 @@ Every item here is mandatory. The Standards agent must report compliance per ite
 **Code Quality**
 
 - [ ] Passes `yarn lint` and `yarn lint:ts`
-- [ ] No debug output (`console.log`, `console.debug`, `debugger`, `// TODO` without a Jira/MPDX ticket reference)
+- [ ] No `// TODO` without a Jira/MPDX ticket reference
 - [ ] No `new Date()` — use Luxon (`DateTime.now()`, `DateTime.local()`) per project convention
-- [ ] No unused imports or variables
 - [ ] No commented-out code blocks (delete, don't comment)
-- [ ] No empty `catch {}` blocks that swallow errors silently
 
 ## Security Focus Areas
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,6 +67,8 @@ module.exports = {
     curly: 'error',
     eqeqeq: 'error',
     'no-console': 'error',
+    'no-debugger': 'error',
+    'no-empty': 'error',
     '@typescript-eslint/no-loss-of-precision': 'warn',
     '@typescript-eslint/no-unused-vars': [
       'error',

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/RequestPage.test.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/RequestPage.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FormikProvider, useFormik } from 'formik';
 import { SnackbarProvider } from 'notistack';
@@ -675,17 +675,24 @@ describe('RequestPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows loading indicator when creating a new request', async () => {
+  it('disables the continue button and shows a spinner while creating a new request', async () => {
     mockUseAdditionalSalaryRequest.mockReturnValue({
       ...defaultMockContextValue,
       requestData: { latestAdditionalSalaryRequest: null },
     } as unknown as ReturnType<typeof useAdditionalSalaryRequest>);
 
-    const { getByRole, findByTestId } = render(<TestWrapper />);
+    const { getByRole } = render(<TestWrapper />);
 
-    userEvent.click(getByRole('button', { name: /continue/i }));
+    const continueButton = getByRole('button', { name: /continue/i });
+    userEvent.click(continueButton);
 
-    expect(await findByTestId('Loading')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(continueButton).toBeDisabled();
+      expect(continueButton).toHaveAttribute('aria-busy', 'true');
+      expect(
+        within(continueButton).getByRole('progressbar'),
+      ).toBeInTheDocument();
+    });
   });
 
   it('hides back href on About this Form step in New mode', () => {

--- a/src/components/HrTools/AdditionalSalaryRequest/RequestPage/RequestPage.tsx
+++ b/src/components/HrTools/AdditionalSalaryRequest/RequestPage/RequestPage.tsx
@@ -116,7 +116,7 @@ const MainContent: React.FC = () => {
     t,
   );
 
-  if (creatingRequest || (loading && !requestData)) {
+  if (loading && !requestData) {
     return <Loading loading />;
   }
 
@@ -175,6 +175,7 @@ const MainContent: React.FC = () => {
                   (exceedsCap && !!errors.additionalInfo)
                 }
                 overrideNext={isFirstFormPage ? handleContinue : undefined}
+                loadingNext={creatingRequest}
               />
             </Stack>
           )}

--- a/src/components/HrTools/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.tsx
+++ b/src/components/HrTools/MinisterHousingAllowance/SharedComponents/CurrentBoardApproved.tsx
@@ -103,7 +103,6 @@ export const CurrentBoardApproved: React.FC<CurrentBoardApprovedProps> = ({
       hideLinkTwoButton={hasOpenRequest}
       isRequest={false}
       handlePrint={handlePrint}
-      handleConfirmCancel={() => {}}
       styling={{ p: 0 }}
     >
       <TableContainer sx={{ padding: 0 }}>

--- a/src/components/HrTools/MinisterHousingAllowance/Steps/StepTwo/RentOwn.tsx
+++ b/src/components/HrTools/MinisterHousingAllowance/Steps/StepTwo/RentOwn.tsx
@@ -71,7 +71,9 @@ export const RentOwn: React.FC = () => {
         variant: 'success',
       });
       setHasCalcValues(false);
-    } catch (error) {}
+    } catch {
+      // The Apollo error link already notifies the user of the failure
+    }
   };
 
   const [pendingValue, setPendingValue] = useState<MhaRentOrOwnEnum | null>(

--- a/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/NewSalaryCalculatorLanding.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/NewSalaryCalculatorLanding.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   LandingTestWrapper,
@@ -154,7 +154,7 @@ describe('NewSalaryCalculatorLanding', () => {
     });
   });
 
-  it('disables button while mutation is in progress', async () => {
+  it('disables button and shows a spinner while mutation is in progress', async () => {
     const { findByRole } = render(<TestComponent hasApprovedCalculation />);
 
     const button = await findByRole('button', {
@@ -164,6 +164,8 @@ describe('NewSalaryCalculatorLanding', () => {
     userEvent.click(button);
     await waitFor(() => {
       expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('aria-busy', 'true');
+      expect(within(button).getByRole('progressbar')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/NewSalaryCalculatorLanding.tsx
+++ b/src/components/HrTools/SalaryCalculator/Landing/NewSalaryCalculationLanding/NewSalaryCalculatorLanding.tsx
@@ -1,7 +1,14 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React from 'react';
-import { Box, Button, Container, Typography, useTheme } from '@mui/material';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Typography,
+  useTheme,
+} from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { Trans, useTranslation } from 'react-i18next';
 import { NameDisplay } from 'src/components/HrTools/Shared/CalculationReports/NameDisplay/NameDisplay';
@@ -133,6 +140,12 @@ export const NewSalaryCalculatorLanding: React.FC = () => {
                 color="primary"
                 onClick={handleStartCalculation}
                 disabled={creatingCalculation}
+                aria-busy={creatingCalculation}
+                startIcon={
+                  creatingCalculation ? (
+                    <CircularProgress size={20} color="inherit" />
+                  ) : undefined
+                }
               >
                 {t('Calculate New Salary')}
               </Button>

--- a/src/components/HrTools/SalaryCalculator/Landing/PendingSalaryCalculationLanding/components/PendingRequestActions.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/Landing/PendingSalaryCalculationLanding/components/PendingRequestActions.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SalaryRequestStatusEnum } from 'src/graphql/types.generated';
 import { LandingTestWrapper } from '../../NewSalaryCalculationLanding/LandingTestWrapper';
@@ -79,6 +79,27 @@ describe('PendingRequestActions', () => {
     userEvent.click(await findByRole('button', { name: 'Delete request' }));
 
     userEvent.click(await findByText('Yes, Cancel'));
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('DeleteSalaryCalculation'),
+    );
+  });
+
+  it('disables the cancel buttons and shows spinners while cancelling', async () => {
+    const { findByRole, getByRole } = render(
+      <TestComponent calculation={mockCalculation} onCall={mutationSpy} />,
+    );
+
+    const deleteButton = await findByRole('button', { name: 'Delete request' });
+    userEvent.click(deleteButton);
+
+    const confirmButton = await findByRole('button', { name: /yes, cancel/i });
+    userEvent.click(confirmButton);
+
+    expect(confirmButton).toBeDisabled();
+    expect(confirmButton).toHaveAttribute('aria-busy', 'true');
+    expect(within(confirmButton).getByRole('progressbar')).toBeInTheDocument();
+    expect(getByRole('button', { name: 'GO BACK' })).toBeDisabled();
+
     await waitFor(() =>
       expect(mutationSpy).toHaveGraphqlOperation('DeleteSalaryCalculation'),
     );

--- a/src/components/HrTools/SalaryCalculator/Landing/PendingSalaryCalculationLanding/components/PendingRequestActions.tsx
+++ b/src/components/HrTools/SalaryCalculator/Landing/PendingSalaryCalculationLanding/components/PendingRequestActions.tsx
@@ -19,7 +19,7 @@ export const PendingRequestActions: React.FC<PendingRequestActionsProps> = ({
 }) => {
   const { t } = useTranslation();
   const accountListId = useAccountListId();
-  const { deleteSalaryCalculation } = useDeleteSalaryCalculation();
+  const { deleteSalaryCalculation, deleting } = useDeleteSalaryCalculation();
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
 
   const handleDelete = async () => {
@@ -67,6 +67,7 @@ export const PendingRequestActions: React.FC<PendingRequestActionsProps> = ({
           handleClose={() => setRemoveDialogOpen(false)}
           handleConfirm={handleDelete}
           isCancel
+          submitting={deleting}
         />
       )}
       <IconButton

--- a/src/components/HrTools/SalaryCalculator/Shared/useDeleteSalaryCalculation.ts
+++ b/src/components/HrTools/SalaryCalculator/Shared/useDeleteSalaryCalculation.ts
@@ -3,11 +3,12 @@ import { useDeleteSalaryCalculationMutation } from './DeleteSalaryCalculation.ge
 
 interface UseDeleteSalaryCalculationReturn {
   deleteSalaryCalculation: (calculationId: string) => Promise<void>;
+  deleting: boolean;
 }
 
 export const useDeleteSalaryCalculation =
   (): UseDeleteSalaryCalculationReturn => {
-    const [deleteSalaryCalculationMutation] =
+    const [deleteSalaryCalculationMutation, { loading: deleting }] =
       useDeleteSalaryCalculationMutation();
 
     const deleteSalaryCalculation = async (
@@ -20,8 +21,9 @@ export const useDeleteSalaryCalculation =
           },
         },
         refetchQueries: [LandingSalaryCalculationsDocument],
+        awaitRefetchQueries: true,
       });
     };
 
-    return { deleteSalaryCalculation };
+    return { deleteSalaryCalculation, deleting };
   };

--- a/src/components/HrTools/SalaryCalculator/StepNavigation/StepNavigation.test.tsx
+++ b/src/components/HrTools/SalaryCalculator/StepNavigation/StepNavigation.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AutosaveForm } from 'src/components/Shared/Autosave/AutosaveForm';
 import {
@@ -88,6 +88,28 @@ describe('DiscardButton', () => {
       }),
     );
   });
+
+  it('disables the modal buttons and shows a spinner while deleting', async () => {
+    const { findByRole, getByRole } = render(
+      <SalaryCalculatorTestWrapper onCall={mutationSpy} editing={true}>
+        <DiscardButton />
+      </SalaryCalculatorTestWrapper>,
+    );
+
+    userEvent.click(await findByRole('button', { name: 'Discard' }));
+
+    const confirmButton = await findByRole('button', { name: /yes, discard/i });
+    userEvent.click(confirmButton);
+
+    expect(confirmButton).toBeDisabled();
+    expect(confirmButton).toHaveAttribute('aria-busy', 'true');
+    expect(within(confirmButton).getByRole('progressbar')).toBeInTheDocument();
+    expect(getByRole('button', { name: 'GO BACK' })).toBeDisabled();
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('DeleteSalaryCalculation'),
+    );
+  });
 });
 
 describe('SubmitButton', () => {
@@ -105,6 +127,29 @@ describe('SubmitButton', () => {
       expect(mutationSpy).toHaveGraphqlOperation('SubmitSalaryCalculation', {
         input: { id: 'salary-request-1' },
       }),
+    );
+  });
+
+  it('disables the modal buttons and shows a spinner while submitting', async () => {
+    const { findByRole, getByRole } = render(
+      <SalaryCalculatorTestWrapper onCall={mutationSpy} editing={true}>
+        <SubmitButton />
+      </SalaryCalculatorTestWrapper>,
+    );
+
+    userEvent.click(await findByRole('button', { name: 'Submit' }));
+
+    const confirmButton = await findByRole('button', { name: 'Yes, Continue' });
+    userEvent.click(confirmButton);
+
+    expect(confirmButton).toBeDisabled();
+    expect(confirmButton).toHaveAttribute('aria-busy', 'true');
+    expect(within(confirmButton).getByRole('progressbar')).toBeInTheDocument();
+
+    expect(getByRole('button', { name: 'GO BACK' })).toBeDisabled();
+
+    await waitFor(() =>
+      expect(mutationSpy).toHaveGraphqlOperation('SubmitSalaryCalculation'),
     );
   });
 });

--- a/src/components/HrTools/SalaryCalculator/StepNavigation/StepNavigation.tsx
+++ b/src/components/HrTools/SalaryCalculator/StepNavigation/StepNavigation.tsx
@@ -18,7 +18,7 @@ export const DiscardButton: React.FC<ButtonProps> = (props) => {
   const { push } = useRouter();
   const accountListId = useAccountListId();
   const { calculation } = useSalaryCalculator();
-  const { deleteSalaryCalculation } = useDeleteSalaryCalculation();
+  const { deleteSalaryCalculation, deleting } = useDeleteSalaryCalculation();
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
 
   const handleDiscard = async () => {
@@ -48,6 +48,7 @@ export const DiscardButton: React.FC<ButtonProps> = (props) => {
           handleClose={() => setRemoveDialogOpen(false)}
           handleConfirm={handleDiscard}
           isDiscard
+          submitting={deleting}
         />
       )}
     </>
@@ -92,7 +93,8 @@ export const ContinueButton: React.FC<ButtonProps> = (props) => {
 export const SubmitButton: React.FC<ButtonProps> = (props) => {
   const { t } = useTranslation();
   const { handleNextStep, calculation } = useSalaryCalculator();
-  const [submit] = useSubmitSalaryCalculationMutation();
+  const [submit, { loading: submitting }] =
+    useSubmitSalaryCalculationMutation();
   const [submitDialogOpen, setSubmitDialogOpen] = useState(false);
   const { title, content, subContent } = useSubmitDialogContent();
 
@@ -132,6 +134,7 @@ export const SubmitButton: React.FC<ButtonProps> = (props) => {
           overrideTitle={title}
           overrideContent={content}
           overrideSubContent={subContent}
+          submitting={submitting}
         />
       )}
     </>

--- a/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.test.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material/styles';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Formik } from 'formik';
 import { SnackbarProvider } from 'notistack';
@@ -189,9 +189,8 @@ describe('DirectionButtons', () => {
 
     const savingButton = await findByRole('button', { name: 'Saving...' });
     expect(savingButton).toBeDisabled();
-    expect(
-      savingButton.querySelector('.MuiCircularProgress-root'),
-    ).toBeInTheDocument();
+    expect(savingButton).toHaveAttribute('aria-busy', 'true');
+    expect(within(savingButton).getByRole('progressbar')).toBeInTheDocument();
   });
 
   it('suppresses the disabledNextTooltip while loadingNext is true', async () => {

--- a/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/DirectionButtons/DirectionButtons.tsx
@@ -161,12 +161,15 @@ export const DirectionButtons: React.FC<DirectionButtonsProps> = ({
                 <Button
                   variant="contained"
                   color="primary"
-                  endIcon={loadingNext ? undefined : <ChevronRight />}
+                  endIcon={<ChevronRight />}
                   startIcon={
-                    loadingNext ? <CircularProgress size={20} /> : undefined
+                    loadingNext ? (
+                      <CircularProgress size={20} color="inherit" />
+                    ) : undefined
                   }
                   onClick={overrideNext ?? handleNextStep}
                   disabled={disableNext || loadingNext}
+                  aria-busy={loadingNext}
                 >
                   {loadingNext
                     ? (loadingNextTitle ?? buttonTitle ?? t('Continue'))

--- a/src/components/HrTools/Shared/CalculationReports/StatusCard/StatusCard.test.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/StatusCard/StatusCard.test.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from '@emotion/react';
 import { SvgIconProps } from '@mui/material/SvgIcon';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
-import { render } from '@testing-library/react';
+import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SnackbarProvider } from 'notistack';
 import TestRouter from '__tests__/util/TestRouter';
@@ -158,7 +158,7 @@ describe('CardSkeleton', () => {
 
     userEvent.click(getByRole('button', { name: /yes, cancel/i }));
 
-    expect(queryByRole('dialog')).not.toBeInTheDocument();
+    await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
   });
 
   it('hides print icon when hidePrint is true', () => {
@@ -201,7 +201,34 @@ describe('CardSkeleton', () => {
 
     expect(handleConfirmCancel).toHaveBeenCalled();
 
-    expect(queryByRole('dialog')).not.toBeInTheDocument();
+    await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it('disables the modal buttons and shows a spinner while cancelling', async () => {
+    let resolveCancel: () => void = () => {};
+    handleConfirmCancel.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCancel = resolve;
+        }),
+    );
+
+    const { getByRole, findByRole, queryByRole } = render(
+      <TestComponent isRequest={true} />,
+    );
+
+    userEvent.click(await findByRole('button', { name: 'Cancel Request' }));
+
+    const confirmButton = await findByRole('button', { name: /yes, cancel/i });
+    userEvent.click(confirmButton);
+
+    await waitFor(() => expect(confirmButton).toBeDisabled());
+    expect(confirmButton).toHaveAttribute('aria-busy', 'true');
+    expect(within(confirmButton).getByRole('progressbar')).toBeInTheDocument();
+    expect(getByRole('button', { name: 'GO BACK' })).toBeDisabled();
+
+    resolveCancel();
+    await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
   });
 
   it('should hide second button when hideLinkTwoButton is true', () => {

--- a/src/components/HrTools/Shared/CalculationReports/StatusCard/StatusCard.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/StatusCard/StatusCard.tsx
@@ -36,7 +36,7 @@ interface StatusCardProps {
   hideActions?: boolean;
   hideLinkTwoButton?: boolean;
   handlePrint?: () => void;
-  handleConfirmCancel: () => void;
+  handleConfirmCancel?: () => Promise<void>;
   handleLinkTwo?: () => void;
   styling?: SxProps<Theme>;
 }
@@ -66,10 +66,17 @@ export const StatusCard: React.FC<StatusCardProps> = ({
   const { t } = useTranslation();
 
   const [openCancel, setOpenCancel] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
 
-  const handleCancel = () => {
-    setOpenCancel(false);
-    handleConfirmCancel();
+  const handleCancel = async () => {
+    setCancelling(true);
+    try {
+      await handleConfirmCancel?.();
+      setOpenCancel(false);
+    } catch {
+    } finally {
+      setCancelling(false);
+    }
   };
 
   return (
@@ -168,6 +175,7 @@ export const StatusCard: React.FC<StatusCardProps> = ({
               handleClose={() => setOpenCancel(false)}
               handleConfirm={handleCancel}
               isCancel={true}
+              submitting={cancelling}
             />
           )}
         </Box>

--- a/src/components/HrTools/Shared/CalculationReports/StatusCard/StatusCard.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/StatusCard/StatusCard.tsx
@@ -74,6 +74,7 @@ export const StatusCard: React.FC<StatusCardProps> = ({
       await handleConfirmCancel?.();
       setOpenCancel(false);
     } catch {
+      // The Apollo error link already notifies the user of the failure
     } finally {
       setCancelling(false);
     }

--- a/src/components/HrTools/Shared/CalculationReports/SubmitModal/SubmitModal.tsx
+++ b/src/components/HrTools/Shared/CalculationReports/SubmitModal/SubmitModal.tsx
@@ -122,11 +122,11 @@ export const SubmitModal: React.FC<SubmitModalProps> = ({
             startIcon={
               submitting ? <CircularProgress size={20} color="inherit" /> : null
             }
+            endIcon={<ChevronRight />}
           >
             <b>
               {additionalApproval ? t('Submit For Approval') : cancelButtonText}
             </b>
-            {!submitting && <ChevronRight sx={{ ml: 1 }} />}
           </Button>
         )}
       </DialogActions>


### PR DESCRIPTION
## Description

Add loading spinners to slow request forms mutations that load HCM data on the backend or call out to SAA on the backend. This improves the UX by giving the user feedback that their request is in progress.

MPDX-9909

## Testing

- Salary Calc
  - Go to HR Tools > Salary Calculator with no request in progress
  - Click "Calculate New Salary"
  - Check that the button shows a spinner and is disabled until the form opens, and that clicking it repeatedly does not create multiple requests
  - Fill out the form through step 4 and click "Submit"
  - Check that the confirm button ("Yes, Continue") shows a spinner and is disabled while submitting, that "GO BACK" is disabled, and that the modal cannot be dismissed by clicking the backdrop
  - Check that the "Submit" button behind the modal does not show a spinner
  - Start another calculation, click "Discard", then confirm
  - Check that the modal's confirm button spins and disables the same way
  - Go back to the Salary Calculator landing with a pending request
  - Click the trash icon, then confirm the cancel
  - Check that the modal's confirm button spins and disables (the trash icon itself stays unchanged)

- ASR
  - Go to HR Tools > Additional Salary Request with no open request
  - On "About this Form", click "Continue"
  - Check that the Continue button shows a spinner and is disabled while the request is created, and that the page no longer blanks out to a full-page loading spinner
  - Complete the form, click "Submit", and confirm
  - Check that the modal's confirm button spins and disables, and that the "Submit" button behind it does not
  - From the pending-request card, click "Cancel Request" and confirm
  - Check that the modal's confirm button spins and disables, and that "Cancel Request" behind it does not

- MHA
  - Go to HR Tools > MHA Calculator with no blocking request
  - Click "Request New MHA"
  - Check that the button shows a spinner and is disabled while the request is created, and that the page no longer blanks out to a full-page loading spinner
  - Complete the form, click "Submit", and confirm
  - Check that the modal's confirm button spins and disables
  - From the pending-request card, click "Cancel Request" and confirm
  - Check that the modal's confirm button spins and disables

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/quality:agent-review` command locally and fixed any relevant suggestions
- [x] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
