### PR TITLE
[No-Jira] Add transfer to subcategories

### DIFF
--- a/src/components/Reports/Shared/Helpers/transformStaffExpenseEnums.ts
+++ b/src/components/Reports/Shared/Helpers/transformStaffExpenseEnums.ts
@@ -29,7 +29,7 @@ export const getLocalizedCategory = (
   value: StaffExpenseCategoryEnum,
   t: TFunction,
 ): string => {
-  const categoryLabels: Record<StaffExpenseCategoryEnum, string> = {
+  const categoryLabels: Partial<Record<StaffExpenseCategoryEnum, string>> = {
     [StaffExpenseCategoryEnum.Donation]: t('Donation'),
     [StaffExpenseCategoryEnum.Transfer]: t('Transfer'),
     [StaffExpenseCategoryEnum.AccountTransfer]: t('Account Transfer'),
@@ -45,6 +45,7 @@ export const getLocalizedCategory = (
     [StaffExpenseCategoryEnum.Benefits]: t('Benefits'),
     [StaffExpenseCategoryEnum.Assessment]: t('Assessment'),
     [StaffExpenseCategoryEnum.Other]: t('Other'),
+    [StaffExpenseCategoryEnum.Unknown]: t('Unknown'),
   };
   return categoryLabels[value] ?? t('Unknown Category');
 };
@@ -53,12 +54,15 @@ export const getLocalizedSubCategory = (
   value: StaffExpensesSubCategoryEnum,
   t: TFunction,
 ): string => {
-  const subcategoryLabels: Record<StaffExpensesSubCategoryEnum, string> = {
+  const subcategoryLabels: Partial<
+    Record<StaffExpensesSubCategoryEnum, string>
+  > = {
     [StaffExpensesSubCategoryEnum.Donation]: t('Donation'),
     [StaffExpensesSubCategoryEnum.DonationInternalGift]: t('Internal Gift'),
     [StaffExpensesSubCategoryEnum.NonCash]: t('Non Cash'),
     [StaffExpensesSubCategoryEnum.Withdrawal]: t('Withdrawal'),
     [StaffExpensesSubCategoryEnum.Deposit]: t('Deposit'),
+    [StaffExpensesSubCategoryEnum.Transfer]: t('Transfer'),
     [StaffExpensesSubCategoryEnum.MinistryReimbursement]: t(
       'Ministry Reimbursement',
     ),
@@ -153,6 +157,7 @@ export const getLocalizedSubCategory = (
     [StaffExpensesSubCategoryEnum.SummerMission]: t('Summer Mission'),
     [StaffExpensesSubCategoryEnum.Staffcard]: t('StaffCard'),
     [StaffExpensesSubCategoryEnum.PaCard]: t('PA Card'),
+    [StaffExpensesSubCategoryEnum.Unknown]: t('Unknown'),
   };
 
   return subcategoryLabels[value] ?? t('Unknown Subcategory');


### PR DESCRIPTION
## Description

Add `transfer` subcategory to localized record list. It was accidentally missed from https://saa-uat-stage.cru.org/admin/sub_categories

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Example:
- Go to the dashboard
- Click on the search icon
- Check that the search box appears
-->

- Impersonate: keely.sleight@cru.org
- Go to `/reports/mpgaIncomeExpenses`
- In the expenses table, find "Transfers" and click on the breakdown
- Check that "Transfer" subcategory exists (no "Unknown subcategory" present)

## Checklist:

- [x] I have given my PR a title with the format "MPDX-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "Preview" to automatically create a preview environment_)
- [x] I have run the Claude Code `/quality:agent-review` command locally and fixed any relevant suggestions
- [ ] I have requested a review from another person on the project
- [x] I have tested my changes in preview or in staging
- [x] I have cleaned up my commit history
